### PR TITLE
mappers: Ensure valid domain value and remove unnecessary mapper logic

### DIFF
--- a/library/IvozProvider/Mapper/Sql/Companies.php
+++ b/library/IvozProvider/Mapper/Sql/Companies.php
@@ -86,24 +86,16 @@ class Companies extends Raw\Companies
         $domainMapper = new \IvozProvider\Mapper\Sql\Domains();
         $domains = $domainMapper->fetchList("companyId=$pk AND PointsTo='proxyusers'");
 
-        $name = trim($model->getDomainUsers());
-        // Empty domain field, delete any related domain
-        if (!$name) {
-            foreach ($domains as $domain) {
-                $domain->delete();
-            }
-            return;
+        // If domain field is filled, look for brand domains or create a new one
+        if (empty($domains)) {
+            $domain = new \IvozProvider\Model\Domains();
         } else {
-            // If domain field is filled, look for brand domains or create a new one
-            if (empty($domains)) {
-                $domain = new \IvozProvider\Model\Domains();
-            } else {
-                $domain = $domains[0];
-                $this->_updateTerminalsDomain($model, $domain);
-                $this->_updateFriendsDomain($model, $domain);
-            }
+            $domain = $domains[0];
+            $this->_updateTerminalsDomain($model, $domain);
+            $this->_updateFriendsDomain($model, $domain);
         }
 
+        $name = $model->getDomainUsers();
         $domain->setDomain($name)
                ->setScope('company')
                ->setPointsTo('proxyusers')

--- a/library/IvozProvider/Model/Companies.php
+++ b/library/IvozProvider/Model/Companies.php
@@ -21,6 +21,7 @@ namespace IvozProvider\Model;
 
 class Companies extends Raw\Companies
 {
+    const EMPTY_DOMAIN_EXCEPTION = 2001;
 
     /**
      * This method is called just after parent's constructor
@@ -151,6 +152,24 @@ class Companies extends Raw\Companies
         }
 
         return "default";
+    }
+
+    /**
+     * Ensures valid domain value
+     * @param string $data
+     * @return \IvozProvider\Model\Raw\Companies
+     */
+    public function setDomainUsers($data)
+    {
+        if (is_string($data)) {
+            $data = trim($data);
+        }
+
+        if (empty($data)) {
+            throw new \Exception("Domain can't be empty", self::EMPTY_DOMAIN_EXCEPTION);
+        }
+
+        return parent::setDomainUsers($data);
     }
 
     /**

--- a/portals/application/configs/klear/errors.yaml
+++ b/portals/application/configs/klear/errors.yaml
@@ -25,6 +25,7 @@ production:
     90000: _("Inbound Calls cannot be billed as PeeringContract is not externally rated.")
     90001: _("Externally rated cannot be disabled as some DDIs wants to bill inbound calls.")
   adminErrors: 
+    2001: _("SIP Domain can't be empty")
 staging: 
   _extends: production
 testing: 


### PR DESCRIPTION
Added sip domain value verification in the model.
Removed empty sip domain value checker in the mapper because It's not necessary any more.