### PR TITLE
agi: error notifications over progress feature

### DIFF
--- a/asterisk/agi/library/Agi/Action/ExternalFriendCallAction.php
+++ b/asterisk/agi/library/Agi/Action/ExternalFriendCallAction.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Agi\Action;
+use \IvozProvider\Model\Features;
 
 /**
  * @class ExternalFriendCallAction
@@ -45,6 +46,10 @@ class ExternalFriendCallAction extends ExternalCallAction
         // Check the user has this call allowed in its ACL
         if (!$friend->isAllowedToCall($e164number)) {
             $this->agi->error("User is not allowed to call %s", $e164number);
+            // Play error notification over progress
+            if ($company->hasFeature(Features::PROGRESS)) {
+                $this->agi->progress("ivozprovider/notAllowed");
+            }
             $this->agi->decline();
             return;
         }
@@ -52,6 +57,10 @@ class ExternalFriendCallAction extends ExternalCallAction
         // Check if outgoing call can be tarificated
         if (!$this->checkTarificable($e164number)) {
             $this->agi->error("Destination %s can not be billed.", $e164number);
+            // Play error notification over progress
+            if ($company->hasFeature(Features::PROGRESS)) {
+                $this->agi->progress("ivozprovider/notBillable");
+            }
             $this->agi->decline();
             return;
         }

--- a/asterisk/agi/library/Agi/Action/ExternalUserCallAction.php
+++ b/asterisk/agi/library/Agi/Action/ExternalUserCallAction.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Agi\Action;
+use \IvozProvider\Model\Features;
 
 /**
  * @class ExternalUserCallAction
@@ -46,6 +47,10 @@ class ExternalUserCallAction extends ExternalCallAction
         // Check the user has this call allowed in its ACL
         if (!$user->isAllowedToCall($e164number)) {
             $this->agi->error("User is not allowed to call %s", $e164number);
+            // Play error notification over progress
+            if ($company->hasFeature(Features::PROGRESS)) {
+                $this->agi->progress("ivozprovider/notAllowed");
+            }
             $this->agi->decline();
             return;
         }
@@ -53,6 +58,10 @@ class ExternalUserCallAction extends ExternalCallAction
         // Check if outgoing call can be tarificated
         if (!$this->checkTarificable($e164number)) {
             $this->agi->error("Destination %s can not be billed.", $e164number);
+            // Play error notification over progress
+            if ($company->hasFeature(Features::PROGRESS)) {
+                $this->agi->progress("ivozprovider/notBillable");
+            }
             $this->agi->decline();
             return;
         }

--- a/library/IvozProvider/Model/Features.php
+++ b/library/IvozProvider/Model/Features.php
@@ -17,10 +17,22 @@
  * @subpackage Model
  * @author Luis Felipe Garcia
  */
- 
+
 namespace IvozProvider\Model;
 class Features extends Raw\Features
 {
+    /**
+     * Available features Ids
+     */
+    const QUEUES            = 1;
+    const RECORDINGS        = 2;
+    const FAXES             = 3;
+    const FRIENDS           = 4;
+    const CONFERENCES       = 5;
+    const BILLING           = 6;
+    const INVOICES          = 7;
+    const PROGRESS          = 8;
+
     /**
 
      * This method is called just after parent's constructor

--- a/scheme/deltas/038-voice-error-notifications.sql
+++ b/scheme/deltas/038-voice-error-notifications.sql
@@ -1,0 +1,1 @@
+INSERT INTO Features VALUES (8, 'progress', '', 'Voice Notifications', 'Notificaciones de voz');


### PR DESCRIPTION
This introduces a new Brand and Company feature 'Voice Notifications'. When
enabled, some errors will play a locution to the caller over progress (not
answering the call).

This provides extra information to the administrators in order to detect why
a call is not being processed.

It may also introduce some other weird scenarios where a user fordwards its
call to a destination that can not actually call and the locution is played to
the caller rather than the user who configured the call fordward (at least
provides extra information of why the fordward is not being done).