### PR TITLE
as: use brand notification address for received faxes

### DIFF
--- a/asterisk/agi/application/configs/application.ini
+++ b/asterisk/agi/application/configs/application.ini
@@ -36,6 +36,7 @@ resources.locale.force = true
 mail.fromname = 'IvozProvider Notifications'
 mail.fromuser = 'IvozProvider'
 voicemail.template = 'default'
+faxmail.template = 'default'
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;; FSO ;;;;;;;;;;;;;;;;;

--- a/asterisk/agi/templates/faxmail/default/en/body
+++ b/asterisk/agi/templates/faxmail/default/en/body
@@ -1,0 +1,11 @@
+Greetings!
+
+    A new fax has been received at ${FAX_NAME} (see attachment).
+
+    Date: ${FAX_DATE}
+    Name: ${FAX_PDFNAME}
+    Pages: ${FAX_PAGES}
+
+Best Regards,
+IvozProvider Virtual Fax System
+

--- a/asterisk/agi/templates/faxmail/default/en/subject
+++ b/asterisk/agi/templates/faxmail/default/en/subject
@@ -1,0 +1,1 @@
+New Fax from ${FAX_SRC} received in ${FAX_NAME} (${FAX_DST})

--- a/asterisk/agi/templates/faxmail/default/es/body
+++ b/asterisk/agi/templates/faxmail/default/es/body
@@ -1,0 +1,11 @@
+Buenas,
+
+    Un nuevo Fax ha sido recibido en ${FAX_NAME} (ver adjunto).
+
+    Fecha: ${FAX_DATE}
+    Nombre: ${FAX_PDFNAME}
+    Páginas: ${FAX_PAGES}
+
+Un saludo,
+IvozProvider Virtual Fax System
+

--- a/asterisk/agi/templates/faxmail/default/es/subject
+++ b/asterisk/agi/templates/faxmail/default/es/subject
@@ -1,0 +1,1 @@
+Nuevo Fax desde ${FAX_SRC} recibido en ${FAX_NAME} (${FAX_DST})


### PR DESCRIPTION
When a Fax is received and the send email option is enabled, the PBX will send
a notification with the fax converted to PDF attached.

The goal of this change is to use the email notification name and address
configurable at brand screen to customize email From header. We have also used
the template logics like we already do for voicemail notifications.

This also removes the extra mail notification that was being sent when an
outgoing fax failed to be sent as it's already displayed in the screen that is
used to send the fax. If this is not clear enough we can change the description
of the send email Fax field to 'send received fax to email'.

This PR aims to fix issue #55