### PR TITLE
portals: provisioning editor and tester enhandments

### DIFF
--- a/portals/application/bin/template.php
+++ b/portals/application/bin/template.php
@@ -61,6 +61,7 @@ class TemplateWrapper
 
     public function run()
     {
+        error_reporting( error_reporting() & ~E_NOTICE );
 
         ?>
 

--- a/portals/application/configs/klear/TerminalModelsList.yaml
+++ b/portals/application/configs/klear/TerminalModelsList.yaml
@@ -92,42 +92,42 @@ production:
       labelOnEdit: true
       action: download-file
       class: ui-silk-arrow-down
-    genericBackup_dialog: &genericBackup_dialog
+    genericBackup_dialog: &genericBackup_dialogLink
       title: _("Restore last backup")
       module: default
       controller: klear-custom-restore-backup
       labelOnEdit: true
       action: restore-generic-backup
       class: ui-silk-arrow-undo
-    specificBackup_dialog: &specificcBackup_dialog
+    specificBackup_dialog: &specificcBackup_dialogLink
       title: _("Restore last backup")
       module: default
       controller: klear-custom-restore-backup
       labelOnEdit: true
       action: restore-specific-backup
       class: ui-silk-arrow-undo
-    genericDefault_dialog: &genericDefault_dialog
+    genericDefault_dialog: &genericDefault_dialogLink
       title: _("Restore default template")
       module: default
       controller: klear-custom-restore-default
       labelOnEdit: true
       action: restore-generic-default
       class: ui-silk-page-white-star
-    specificDefault_dialog: &specificDefault_dialog
+    specificDefault_dialog: &specificDefault_dialogLink
       title: _("Restore default template")
       module: default
       controller: klear-custom-restore-default
       labelOnEdit: true
       action: restore-specific-default
       class: ui-silk-page-white-star
-    runGenericCode_dialog: &runGenericCode_dialog
+    runGenericCode_dialog: &runGenericCode_dialogLink
       title: _("Run template")
       module: default
       controller: klear-custom-run-code
       labelOnEdit: true
       action: run-generic-code
       class: ui-silk-control-play-blue
-    runSpecificCode_dialog:
+    runSpecificCode_dialog: &runSpecificCode_dialogLink
       title: _("Run template")
       module: default
       controller: klear-custom-run-code

--- a/portals/application/configs/klear/model/InvoiceTemplates.yaml
+++ b/portals/application/configs/klear/model/InvoiceTemplates.yaml
@@ -22,7 +22,9 @@ production:
       source:
         control: Codemirror
         settings:
-          mode: xml
+          mode:
+            - application/xml
+            - xml
           lineNumbers: true
           matchBrackets: true
       <<: *invoiceTemplateHelp

--- a/portals/application/configs/klear/model/TerminalModels.yaml
+++ b/portals/application/configs/klear/model/TerminalModels.yaml
@@ -48,7 +48,11 @@ production:
       source:
         control: Codemirror
         settings:
-          mode: php
+          mode:
+            - application/x-httpd-php
+            - htmlmixed
+            - xml
+            - php
           lineNumbers: true
           matchBrackets: true
       options:
@@ -80,7 +84,11 @@ production:
       source:
         control: Codemirror
         settings:
-          mode: php
+          mode:
+            - application/x-httpd-php
+            - htmlmixed
+            - xml
+            - php
           lineNumbers: true
           matchBrackets: true
       options:
@@ -90,7 +98,7 @@ production:
           downloadFile_dialog: true
           specificBackup_dialog: true
           specificDefault_dialog: true
-          runSpecificCode_dialog: false
+          runSpecificCode_dialog: true
       info:
         type: box
         position: left

--- a/portals/application/controllers/KlearCustomRunCodeController.php
+++ b/portals/application/controllers/KlearCustomRunCodeController.php
@@ -82,8 +82,12 @@ class KlearCustomRunCodeController extends Zend_Controller_Action
                 exec($command, $output, $resultCode);
                 unlink($route . DIRECTORY_SEPARATOR . $filename);
 
-                $message = implode("<br>", $output); //ojo que aquí hemos quitado la llamada a gettext
+                array_walk($output, function (&$value, $key) {
+                    //Ensure xml's are readable in browser
+                    $value = htmlentities($value);
+                });
 
+                $message = implode("<br>", $output);
             }
             else{
                 $message = _('This template is going to be tested<br /><textarea name="currentCode" rows="8" cols="80" readonly></textarea>' . $inputMac . $error);
@@ -119,8 +123,8 @@ class KlearCustomRunCodeController extends Zend_Controller_Action
         }
 
         // There is no SERVER_NAME in console commands, inject it
-        $serverName = '<?php $_SERVER["SERVER_NAME"] = "' . $_SERVER["SERVER_NAME"] . '"; ?>';
-        $currentCode = $serverName . $this->getParam("currentCode");
+        $serverVars = '<?php $_SERVER["SERVER_NAME"] = "' . $_SERVER["SERVER_NAME"] . '"; ?>';
+        $currentCode = $serverVars . $this->getParam("currentCode");
 
         $currentCodePost = " <?php  } }";
         try {


### PR DESCRIPTION
Fixed multiple break lines issue in provisioning template editor
Scaped xml alike templates in provisioning tester
Disabled warnings in provisioning tester
Requires klear to be updated