### PR TITLE
scheme: replace kamailio version table with kam_version

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -68,6 +68,7 @@ memlog=5
 
 log_stderror=no
 fork=yes
+version_table="kam_version"
 
 # Enable asynchronous framework (for delayed ACC inserts)
 async_workers=4

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -117,6 +117,7 @@ memlog=5
 
 log_stderror=no
 fork=yes
+version_table="kam_version"
 
 # Enable asynchronous framework (for delayed ACC inserts)
 async_workers=4

--- a/scheme/deltas/040-kamailio-version.sql
+++ b/scheme/deltas/040-kamailio-version.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `kam_version` (
+  `table_name` varchar(32) NOT NULL,
+  `table_version` int(10) unsigned NOT NULL DEFAULT '0',
+  UNIQUE KEY `table_name_idx` (`table_name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='[ignore]';
+
+INSERT INTO `kam_version` SELECT * from `version`;
+DROP TABLE `version`;


### PR DESCRIPTION
All the tables that proxies use start with kam_ followed by the proxy name (users or trunks)
There are also some views and tables shared by both proxies but they still have kam_ prefix.

One exception to this is the table version who belongs to the proxies but doesn't have prefix.