### PR TITLE
mappers: fixed foreign key order

### DIFF
--- a/library/IvozProvider/Mapper/Sql/DbTable/Companies.php
+++ b/library/IvozProvider/Mapper/Sql/DbTable/Companies.php
@@ -40,21 +40,6 @@ class Companies extends TableAbstract
 
     protected $_sequence = true; // int
     protected $_referenceMap = array(
-        'CompaniesIbfk10' => array(
-            'columns' => 'languageId',
-            'refTableClass' => 'IvozProvider\\Mapper\\Sql\\DbTable\\Languages',
-            'refColumns' => 'id'
-        ),
-        'CompaniesIbfk11' => array(
-            'columns' => 'mediaRelaySetsId',
-            'refTableClass' => 'IvozProvider\\Mapper\\Sql\\DbTable\\MediaRelaySets',
-            'refColumns' => 'id'
-        ),
-        'CompaniesIbfk12' => array(
-            'columns' => 'defaultTimezoneId',
-            'refTableClass' => 'IvozProvider\\Mapper\\Sql\\DbTable\\Timezones',
-            'refColumns' => 'id'
-        ),
         'CompaniesIbfk4' => array(
             'columns' => 'brandId',
             'refTableClass' => 'IvozProvider\\Mapper\\Sql\\DbTable\\Brands',
@@ -68,6 +53,21 @@ class Companies extends TableAbstract
         'CompaniesIbfk9' => array(
             'columns' => 'countryId',
             'refTableClass' => 'IvozProvider\\Mapper\\Sql\\DbTable\\Countries',
+            'refColumns' => 'id'
+        ),
+        'CompaniesIbfk10' => array(
+            'columns' => 'languageId',
+            'refTableClass' => 'IvozProvider\\Mapper\\Sql\\DbTable\\Languages',
+            'refColumns' => 'id'
+        ),
+        'CompaniesIbfk11' => array(
+            'columns' => 'mediaRelaySetsId',
+            'refTableClass' => 'IvozProvider\\Mapper\\Sql\\DbTable\\MediaRelaySets',
+            'refColumns' => 'id'
+        ),
+        'CompaniesIbfk12' => array(
+            'columns' => 'defaultTimezoneId',
+            'refTableClass' => 'IvozProvider\\Mapper\\Sql\\DbTable\\Timezones',
             'refColumns' => 'id'
         )
     );

--- a/library/IvozProvider/Mapper/Sql/DbTable/DDIs.php
+++ b/library/IvozProvider/Mapper/Sql/DbTable/DDIs.php
@@ -45,26 +45,6 @@ class DDIs extends TableAbstract
             'refTableClass' => 'IvozProvider\\Mapper\\Sql\\DbTable\\Companies',
             'refColumns' => 'id'
         ),
-        'DDIsIbfk10' => array(
-            'columns' => 'brandId',
-            'refTableClass' => 'IvozProvider\\Mapper\\Sql\\DbTable\\Brands',
-            'refColumns' => 'id'
-        ),
-        'DDIsIbfk11' => array(
-            'columns' => 'conferenceRoomId',
-            'refTableClass' => 'IvozProvider\\Mapper\\Sql\\DbTable\\ConferenceRooms',
-            'refColumns' => 'id'
-        ),
-        'DDIsIbfk12' => array(
-            'columns' => 'languageId',
-            'refTableClass' => 'IvozProvider\\Mapper\\Sql\\DbTable\\Languages',
-            'refColumns' => 'id'
-        ),
-        'DDIsIbfk13' => array(
-            'columns' => 'queueId',
-            'refTableClass' => 'IvozProvider\\Mapper\\Sql\\DbTable\\Queues',
-            'refColumns' => 'id'
-        ),
         'DDIsIbfk2' => array(
             'columns' => 'externalCallFilterId',
             'refTableClass' => 'IvozProvider\\Mapper\\Sql\\DbTable\\ExternalCallFilters',
@@ -103,6 +83,26 @@ class DDIs extends TableAbstract
         'DDIsIbfk9' => array(
             'columns' => 'countryId',
             'refTableClass' => 'IvozProvider\\Mapper\\Sql\\DbTable\\Countries',
+            'refColumns' => 'id'
+        ),
+        'DDIsIbfk10' => array(
+            'columns' => 'brandId',
+            'refTableClass' => 'IvozProvider\\Mapper\\Sql\\DbTable\\Brands',
+            'refColumns' => 'id'
+        ),
+        'DDIsIbfk11' => array(
+            'columns' => 'conferenceRoomId',
+            'refTableClass' => 'IvozProvider\\Mapper\\Sql\\DbTable\\ConferenceRooms',
+            'refColumns' => 'id'
+        ),
+        'DDIsIbfk12' => array(
+            'columns' => 'languageId',
+            'refTableClass' => 'IvozProvider\\Mapper\\Sql\\DbTable\\Languages',
+            'refColumns' => 'id'
+        ),
+        'DDIsIbfk13' => array(
+            'columns' => 'queueId',
+            'refTableClass' => 'IvozProvider\\Mapper\\Sql\\DbTable\\Queues',
             'refColumns' => 'id'
         )
     );

--- a/library/IvozProvider/Mapper/Sql/DbTable/Terminals.php
+++ b/library/IvozProvider/Mapper/Sql/DbTable/Terminals.php
@@ -40,14 +40,14 @@ class Terminals extends TableAbstract
 
     protected $_sequence = true; // int
     protected $_referenceMap = array(
-        'TerminalsCompanyIdIbfk2' => array(
-            'columns' => 'companyId',
-            'refTableClass' => 'IvozProvider\\Mapper\\Sql\\DbTable\\Companies',
-            'refColumns' => 'id'
-        ),
         'TerminalsIbfk1' => array(
             'columns' => 'TerminalModelId',
             'refTableClass' => 'IvozProvider\\Mapper\\Sql\\DbTable\\TerminalModels',
+            'refColumns' => 'id'
+        ),
+        'TerminalsCompanyIdIbfk2' => array(
+            'columns' => 'companyId',
+            'refTableClass' => 'IvozProvider\\Mapper\\Sql\\DbTable\\Companies',
             'refColumns' => 'id'
         )
     );

--- a/library/IvozProvider/Mapper/Sql/DbTable/Users.php
+++ b/library/IvozProvider/Mapper/Sql/DbTable/Users.php
@@ -45,26 +45,6 @@ class Users extends TableAbstract
             'refTableClass' => 'IvozProvider\\Mapper\\Sql\\DbTable\\Companies',
             'refColumns' => 'id'
         ),
-        'UsersIbfk10' => array(
-            'columns' => 'callACLId',
-            'refTableClass' => 'IvozProvider\\Mapper\\Sql\\DbTable\\CallACL',
-            'refColumns' => 'id'
-        ),
-        'UsersIbfk11' => array(
-            'columns' => 'bossAssistantId',
-            'refTableClass' => 'IvozProvider\\Mapper\\Sql\\DbTable\\Users',
-            'refColumns' => 'id'
-        ),
-        'UsersIbfk12' => array(
-            'columns' => 'countryId',
-            'refTableClass' => 'IvozProvider\\Mapper\\Sql\\DbTable\\Countries',
-            'refColumns' => 'id'
-        ),
-        'UsersIbfk13' => array(
-            'columns' => 'languageId',
-            'refTableClass' => 'IvozProvider\\Mapper\\Sql\\DbTable\\Languages',
-            'refColumns' => 'id'
-        ),
         'UsersIbfk3' => array(
             'columns' => 'terminalId',
             'refTableClass' => 'IvozProvider\\Mapper\\Sql\\DbTable\\Terminals',
@@ -83,6 +63,26 @@ class Users extends TableAbstract
         'UsersIbfk9' => array(
             'columns' => 'outgoingDDIId',
             'refTableClass' => 'IvozProvider\\Mapper\\Sql\\DbTable\\DDIs',
+            'refColumns' => 'id'
+        ),
+        'UsersIbfk10' => array(
+            'columns' => 'callACLId',
+            'refTableClass' => 'IvozProvider\\Mapper\\Sql\\DbTable\\CallACL',
+            'refColumns' => 'id'
+        ),
+        'UsersIbfk11' => array(
+            'columns' => 'bossAssistantId',
+            'refTableClass' => 'IvozProvider\\Mapper\\Sql\\DbTable\\Users',
+            'refColumns' => 'id'
+        ),
+        'UsersIbfk12' => array(
+            'columns' => 'countryId',
+            'refTableClass' => 'IvozProvider\\Mapper\\Sql\\DbTable\\Countries',
+            'refColumns' => 'id'
+        ),
+        'UsersIbfk13' => array(
+            'columns' => 'languageId',
+            'refTableClass' => 'IvozProvider\\Mapper\\Sql\\DbTable\\Languages',
             'refColumns' => 'id'
         )
     );

--- a/library/IvozProvider/Model/Raw/Companies.php
+++ b/library/IvozProvider/Model/Raw/Companies.php
@@ -193,27 +193,6 @@ class Companies extends ModelAbstract
 
 
     /**
-     * Parent relation Companies_ibfk_10
-     *
-     * @var \IvozProvider\Model\Raw\Languages
-     */
-    protected $_Language;
-
-    /**
-     * Parent relation Companies_ibfk_11
-     *
-     * @var \IvozProvider\Model\Raw\MediaRelaySets
-     */
-    protected $_MediaRelaySets;
-
-    /**
-     * Parent relation Companies_ibfk_12
-     *
-     * @var \IvozProvider\Model\Raw\Timezones
-     */
-    protected $_DefaultTimezone;
-
-    /**
      * Parent relation Companies_ibfk_4
      *
      * @var \IvozProvider\Model\Raw\Brands
@@ -233,6 +212,27 @@ class Companies extends ModelAbstract
      * @var \IvozProvider\Model\Raw\Countries
      */
     protected $_Countries;
+
+    /**
+     * Parent relation Companies_ibfk_10
+     *
+     * @var \IvozProvider\Model\Raw\Languages
+     */
+    protected $_Language;
+
+    /**
+     * Parent relation Companies_ibfk_11
+     *
+     * @var \IvozProvider\Model\Raw\MediaRelaySets
+     */
+    protected $_MediaRelaySets;
+
+    /**
+     * Parent relation Companies_ibfk_12
+     *
+     * @var \IvozProvider\Model\Raw\Timezones
+     */
+    protected $_DefaultTimezone;
 
 
     /**
@@ -524,18 +524,6 @@ class Companies extends ModelAbstract
         $this->setAvailableLangs(array('es', 'en'));
 
         $this->setParentList(array(
-            'CompaniesIbfk10'=> array(
-                    'property' => 'Language',
-                    'table_name' => 'Languages',
-                ),
-            'CompaniesIbfk11'=> array(
-                    'property' => 'MediaRelaySets',
-                    'table_name' => 'MediaRelaySets',
-                ),
-            'CompaniesIbfk12'=> array(
-                    'property' => 'DefaultTimezone',
-                    'table_name' => 'Timezones',
-                ),
             'CompaniesIbfk4'=> array(
                     'property' => 'Brand',
                     'table_name' => 'Brands',
@@ -547,6 +535,18 @@ class Companies extends ModelAbstract
             'CompaniesIbfk9'=> array(
                     'property' => 'Countries',
                     'table_name' => 'Countries',
+                ),
+            'CompaniesIbfk10'=> array(
+                    'property' => 'Language',
+                    'table_name' => 'Languages',
+                ),
+            'CompaniesIbfk11'=> array(
+                    'property' => 'MediaRelaySets',
+                    'table_name' => 'MediaRelaySets',
+                ),
+            'CompaniesIbfk12'=> array(
+                    'property' => 'DefaultTimezone',
+                    'table_name' => 'Timezones',
                 ),
         ));
 
@@ -1564,159 +1564,6 @@ class Companies extends ModelAbstract
     }
 
     /**
-     * Sets parent relation Language
-     *
-     * @param \IvozProvider\Model\Raw\Languages $data
-     * @return \IvozProvider\Model\Raw\Companies
-     */
-    public function setLanguage(\IvozProvider\Model\Raw\Languages $data)
-    {
-        $this->_Language = $data;
-
-        $primaryKey = $data->getPrimaryKey();
-        if (is_array($primaryKey)) {
-            $primaryKey = $primaryKey['id'];
-        }
-
-        if (!is_null($primaryKey)) {
-            $this->setLanguageId($primaryKey);
-        }
-
-        $this->_setLoaded('CompaniesIbfk10');
-        return $this;
-    }
-
-    /**
-     * Gets parent Language
-     * TODO: Mejorar esto para los casos en que la relación no exista. Ahora mismo siempre se pediría el padre
-     * @return \IvozProvider\Model\Raw\Languages
-     */
-    public function getLanguage($where = null, $orderBy = null, $avoidLoading = false)
-    {
-        $fkName = 'CompaniesIbfk10';
-
-        $usingDefaultArguments = is_null($where) && is_null($orderBy);
-        if (!$usingDefaultArguments) {
-            $this->setNotLoaded($fkName);
-        }
-
-        $dontSkipLoading = !($avoidLoading);
-        $notLoadedYet = !($this->_isLoaded($fkName));
-
-        if ($dontSkipLoading && $notLoadedYet) {
-            $related = $this->getMapper()->loadRelated('parent', $fkName, $this, $where, $orderBy);
-            $this->_Language = array_shift($related);
-            if ($usingDefaultArguments) {
-                $this->_setLoaded($fkName);
-            }
-        }
-
-        return $this->_Language;
-    }
-
-    /**
-     * Sets parent relation MediaRelaySets
-     *
-     * @param \IvozProvider\Model\Raw\MediaRelaySets $data
-     * @return \IvozProvider\Model\Raw\Companies
-     */
-    public function setMediaRelaySets(\IvozProvider\Model\Raw\MediaRelaySets $data)
-    {
-        $this->_MediaRelaySets = $data;
-
-        $primaryKey = $data->getPrimaryKey();
-        if (is_array($primaryKey)) {
-            $primaryKey = $primaryKey['id'];
-        }
-
-        if (!is_null($primaryKey)) {
-            $this->setMediaRelaySetsId($primaryKey);
-        }
-
-        $this->_setLoaded('CompaniesIbfk11');
-        return $this;
-    }
-
-    /**
-     * Gets parent MediaRelaySets
-     * TODO: Mejorar esto para los casos en que la relación no exista. Ahora mismo siempre se pediría el padre
-     * @return \IvozProvider\Model\Raw\MediaRelaySets
-     */
-    public function getMediaRelaySets($where = null, $orderBy = null, $avoidLoading = false)
-    {
-        $fkName = 'CompaniesIbfk11';
-
-        $usingDefaultArguments = is_null($where) && is_null($orderBy);
-        if (!$usingDefaultArguments) {
-            $this->setNotLoaded($fkName);
-        }
-
-        $dontSkipLoading = !($avoidLoading);
-        $notLoadedYet = !($this->_isLoaded($fkName));
-
-        if ($dontSkipLoading && $notLoadedYet) {
-            $related = $this->getMapper()->loadRelated('parent', $fkName, $this, $where, $orderBy);
-            $this->_MediaRelaySets = array_shift($related);
-            if ($usingDefaultArguments) {
-                $this->_setLoaded($fkName);
-            }
-        }
-
-        return $this->_MediaRelaySets;
-    }
-
-    /**
-     * Sets parent relation DefaultTimezone
-     *
-     * @param \IvozProvider\Model\Raw\Timezones $data
-     * @return \IvozProvider\Model\Raw\Companies
-     */
-    public function setDefaultTimezone(\IvozProvider\Model\Raw\Timezones $data)
-    {
-        $this->_DefaultTimezone = $data;
-
-        $primaryKey = $data->getPrimaryKey();
-        if (is_array($primaryKey)) {
-            $primaryKey = $primaryKey['id'];
-        }
-
-        if (!is_null($primaryKey)) {
-            $this->setDefaultTimezoneId($primaryKey);
-        }
-
-        $this->_setLoaded('CompaniesIbfk12');
-        return $this;
-    }
-
-    /**
-     * Gets parent DefaultTimezone
-     * TODO: Mejorar esto para los casos en que la relación no exista. Ahora mismo siempre se pediría el padre
-     * @return \IvozProvider\Model\Raw\Timezones
-     */
-    public function getDefaultTimezone($where = null, $orderBy = null, $avoidLoading = false)
-    {
-        $fkName = 'CompaniesIbfk12';
-
-        $usingDefaultArguments = is_null($where) && is_null($orderBy);
-        if (!$usingDefaultArguments) {
-            $this->setNotLoaded($fkName);
-        }
-
-        $dontSkipLoading = !($avoidLoading);
-        $notLoadedYet = !($this->_isLoaded($fkName));
-
-        if ($dontSkipLoading && $notLoadedYet) {
-            $related = $this->getMapper()->loadRelated('parent', $fkName, $this, $where, $orderBy);
-            $this->_DefaultTimezone = array_shift($related);
-            if ($usingDefaultArguments) {
-                $this->_setLoaded($fkName);
-            }
-        }
-
-        return $this->_DefaultTimezone;
-    }
-
-    /**
      * Sets parent relation Brand
      *
      * @param \IvozProvider\Model\Raw\Brands $data
@@ -1867,6 +1714,159 @@ class Companies extends ModelAbstract
         }
 
         return $this->_Countries;
+    }
+
+    /**
+     * Sets parent relation Language
+     *
+     * @param \IvozProvider\Model\Raw\Languages $data
+     * @return \IvozProvider\Model\Raw\Companies
+     */
+    public function setLanguage(\IvozProvider\Model\Raw\Languages $data)
+    {
+        $this->_Language = $data;
+
+        $primaryKey = $data->getPrimaryKey();
+        if (is_array($primaryKey)) {
+            $primaryKey = $primaryKey['id'];
+        }
+
+        if (!is_null($primaryKey)) {
+            $this->setLanguageId($primaryKey);
+        }
+
+        $this->_setLoaded('CompaniesIbfk10');
+        return $this;
+    }
+
+    /**
+     * Gets parent Language
+     * TODO: Mejorar esto para los casos en que la relación no exista. Ahora mismo siempre se pediría el padre
+     * @return \IvozProvider\Model\Raw\Languages
+     */
+    public function getLanguage($where = null, $orderBy = null, $avoidLoading = false)
+    {
+        $fkName = 'CompaniesIbfk10';
+
+        $usingDefaultArguments = is_null($where) && is_null($orderBy);
+        if (!$usingDefaultArguments) {
+            $this->setNotLoaded($fkName);
+        }
+
+        $dontSkipLoading = !($avoidLoading);
+        $notLoadedYet = !($this->_isLoaded($fkName));
+
+        if ($dontSkipLoading && $notLoadedYet) {
+            $related = $this->getMapper()->loadRelated('parent', $fkName, $this, $where, $orderBy);
+            $this->_Language = array_shift($related);
+            if ($usingDefaultArguments) {
+                $this->_setLoaded($fkName);
+            }
+        }
+
+        return $this->_Language;
+    }
+
+    /**
+     * Sets parent relation MediaRelaySets
+     *
+     * @param \IvozProvider\Model\Raw\MediaRelaySets $data
+     * @return \IvozProvider\Model\Raw\Companies
+     */
+    public function setMediaRelaySets(\IvozProvider\Model\Raw\MediaRelaySets $data)
+    {
+        $this->_MediaRelaySets = $data;
+
+        $primaryKey = $data->getPrimaryKey();
+        if (is_array($primaryKey)) {
+            $primaryKey = $primaryKey['id'];
+        }
+
+        if (!is_null($primaryKey)) {
+            $this->setMediaRelaySetsId($primaryKey);
+        }
+
+        $this->_setLoaded('CompaniesIbfk11');
+        return $this;
+    }
+
+    /**
+     * Gets parent MediaRelaySets
+     * TODO: Mejorar esto para los casos en que la relación no exista. Ahora mismo siempre se pediría el padre
+     * @return \IvozProvider\Model\Raw\MediaRelaySets
+     */
+    public function getMediaRelaySets($where = null, $orderBy = null, $avoidLoading = false)
+    {
+        $fkName = 'CompaniesIbfk11';
+
+        $usingDefaultArguments = is_null($where) && is_null($orderBy);
+        if (!$usingDefaultArguments) {
+            $this->setNotLoaded($fkName);
+        }
+
+        $dontSkipLoading = !($avoidLoading);
+        $notLoadedYet = !($this->_isLoaded($fkName));
+
+        if ($dontSkipLoading && $notLoadedYet) {
+            $related = $this->getMapper()->loadRelated('parent', $fkName, $this, $where, $orderBy);
+            $this->_MediaRelaySets = array_shift($related);
+            if ($usingDefaultArguments) {
+                $this->_setLoaded($fkName);
+            }
+        }
+
+        return $this->_MediaRelaySets;
+    }
+
+    /**
+     * Sets parent relation DefaultTimezone
+     *
+     * @param \IvozProvider\Model\Raw\Timezones $data
+     * @return \IvozProvider\Model\Raw\Companies
+     */
+    public function setDefaultTimezone(\IvozProvider\Model\Raw\Timezones $data)
+    {
+        $this->_DefaultTimezone = $data;
+
+        $primaryKey = $data->getPrimaryKey();
+        if (is_array($primaryKey)) {
+            $primaryKey = $primaryKey['id'];
+        }
+
+        if (!is_null($primaryKey)) {
+            $this->setDefaultTimezoneId($primaryKey);
+        }
+
+        $this->_setLoaded('CompaniesIbfk12');
+        return $this;
+    }
+
+    /**
+     * Gets parent DefaultTimezone
+     * TODO: Mejorar esto para los casos en que la relación no exista. Ahora mismo siempre se pediría el padre
+     * @return \IvozProvider\Model\Raw\Timezones
+     */
+    public function getDefaultTimezone($where = null, $orderBy = null, $avoidLoading = false)
+    {
+        $fkName = 'CompaniesIbfk12';
+
+        $usingDefaultArguments = is_null($where) && is_null($orderBy);
+        if (!$usingDefaultArguments) {
+            $this->setNotLoaded($fkName);
+        }
+
+        $dontSkipLoading = !($avoidLoading);
+        $notLoadedYet = !($this->_isLoaded($fkName));
+
+        if ($dontSkipLoading && $notLoadedYet) {
+            $related = $this->getMapper()->loadRelated('parent', $fkName, $this, $where, $orderBy);
+            $this->_DefaultTimezone = array_shift($related);
+            if ($usingDefaultArguments) {
+                $this->_setLoaded($fkName);
+            }
+        }
+
+        return $this->_DefaultTimezone;
     }
 
     /**

--- a/library/IvozProvider/Model/Raw/DDIs.php
+++ b/library/IvozProvider/Model/Raw/DDIs.php
@@ -197,34 +197,6 @@ class DDIs extends ModelAbstract
     protected $_Company;
 
     /**
-     * Parent relation DDIs_ibfk_10
-     *
-     * @var \IvozProvider\Model\Raw\Brands
-     */
-    protected $_Brand;
-
-    /**
-     * Parent relation DDIs_ibfk_11
-     *
-     * @var \IvozProvider\Model\Raw\ConferenceRooms
-     */
-    protected $_ConferenceRoom;
-
-    /**
-     * Parent relation DDIs_ibfk_12
-     *
-     * @var \IvozProvider\Model\Raw\Languages
-     */
-    protected $_Language;
-
-    /**
-     * Parent relation DDIs_ibfk_13
-     *
-     * @var \IvozProvider\Model\Raw\Queues
-     */
-    protected $_Queue;
-
-    /**
      * Parent relation DDIs_ibfk_2
      *
      * @var \IvozProvider\Model\Raw\ExternalCallFilters
@@ -279,6 +251,34 @@ class DDIs extends ModelAbstract
      * @var \IvozProvider\Model\Raw\Countries
      */
     protected $_Country;
+
+    /**
+     * Parent relation DDIs_ibfk_10
+     *
+     * @var \IvozProvider\Model\Raw\Brands
+     */
+    protected $_Brand;
+
+    /**
+     * Parent relation DDIs_ibfk_11
+     *
+     * @var \IvozProvider\Model\Raw\ConferenceRooms
+     */
+    protected $_ConferenceRoom;
+
+    /**
+     * Parent relation DDIs_ibfk_12
+     *
+     * @var \IvozProvider\Model\Raw\Languages
+     */
+    protected $_Language;
+
+    /**
+     * Parent relation DDIs_ibfk_13
+     *
+     * @var \IvozProvider\Model\Raw\Queues
+     */
+    protected $_Queue;
 
 
     /**
@@ -349,22 +349,6 @@ class DDIs extends ModelAbstract
                     'property' => 'Company',
                     'table_name' => 'Companies',
                 ),
-            'DDIsIbfk10'=> array(
-                    'property' => 'Brand',
-                    'table_name' => 'Brands',
-                ),
-            'DDIsIbfk11'=> array(
-                    'property' => 'ConferenceRoom',
-                    'table_name' => 'ConferenceRooms',
-                ),
-            'DDIsIbfk12'=> array(
-                    'property' => 'Language',
-                    'table_name' => 'Languages',
-                ),
-            'DDIsIbfk13'=> array(
-                    'property' => 'Queue',
-                    'table_name' => 'Queues',
-                ),
             'DDIsIbfk2'=> array(
                     'property' => 'ExternalCallFilter',
                     'table_name' => 'ExternalCallFilters',
@@ -396,6 +380,22 @@ class DDIs extends ModelAbstract
             'DDIsIbfk9'=> array(
                     'property' => 'Country',
                     'table_name' => 'Countries',
+                ),
+            'DDIsIbfk10'=> array(
+                    'property' => 'Brand',
+                    'table_name' => 'Brands',
+                ),
+            'DDIsIbfk11'=> array(
+                    'property' => 'ConferenceRoom',
+                    'table_name' => 'ConferenceRooms',
+                ),
+            'DDIsIbfk12'=> array(
+                    'property' => 'Language',
+                    'table_name' => 'Languages',
+                ),
+            'DDIsIbfk13'=> array(
+                    'property' => 'Queue',
+                    'table_name' => 'Queues',
                 ),
         ));
 
@@ -1234,210 +1234,6 @@ class DDIs extends ModelAbstract
     }
 
     /**
-     * Sets parent relation Brand
-     *
-     * @param \IvozProvider\Model\Raw\Brands $data
-     * @return \IvozProvider\Model\Raw\DDIs
-     */
-    public function setBrand(\IvozProvider\Model\Raw\Brands $data)
-    {
-        $this->_Brand = $data;
-
-        $primaryKey = $data->getPrimaryKey();
-        if (is_array($primaryKey)) {
-            $primaryKey = $primaryKey['id'];
-        }
-
-        if (!is_null($primaryKey)) {
-            $this->setBrandId($primaryKey);
-        }
-
-        $this->_setLoaded('DDIsIbfk10');
-        return $this;
-    }
-
-    /**
-     * Gets parent Brand
-     * TODO: Mejorar esto para los casos en que la relación no exista. Ahora mismo siempre se pediría el padre
-     * @return \IvozProvider\Model\Raw\Brands
-     */
-    public function getBrand($where = null, $orderBy = null, $avoidLoading = false)
-    {
-        $fkName = 'DDIsIbfk10';
-
-        $usingDefaultArguments = is_null($where) && is_null($orderBy);
-        if (!$usingDefaultArguments) {
-            $this->setNotLoaded($fkName);
-        }
-
-        $dontSkipLoading = !($avoidLoading);
-        $notLoadedYet = !($this->_isLoaded($fkName));
-
-        if ($dontSkipLoading && $notLoadedYet) {
-            $related = $this->getMapper()->loadRelated('parent', $fkName, $this, $where, $orderBy);
-            $this->_Brand = array_shift($related);
-            if ($usingDefaultArguments) {
-                $this->_setLoaded($fkName);
-            }
-        }
-
-        return $this->_Brand;
-    }
-
-    /**
-     * Sets parent relation ConferenceRoom
-     *
-     * @param \IvozProvider\Model\Raw\ConferenceRooms $data
-     * @return \IvozProvider\Model\Raw\DDIs
-     */
-    public function setConferenceRoom(\IvozProvider\Model\Raw\ConferenceRooms $data)
-    {
-        $this->_ConferenceRoom = $data;
-
-        $primaryKey = $data->getPrimaryKey();
-        if (is_array($primaryKey)) {
-            $primaryKey = $primaryKey['id'];
-        }
-
-        if (!is_null($primaryKey)) {
-            $this->setConferenceRoomId($primaryKey);
-        }
-
-        $this->_setLoaded('DDIsIbfk11');
-        return $this;
-    }
-
-    /**
-     * Gets parent ConferenceRoom
-     * TODO: Mejorar esto para los casos en que la relación no exista. Ahora mismo siempre se pediría el padre
-     * @return \IvozProvider\Model\Raw\ConferenceRooms
-     */
-    public function getConferenceRoom($where = null, $orderBy = null, $avoidLoading = false)
-    {
-        $fkName = 'DDIsIbfk11';
-
-        $usingDefaultArguments = is_null($where) && is_null($orderBy);
-        if (!$usingDefaultArguments) {
-            $this->setNotLoaded($fkName);
-        }
-
-        $dontSkipLoading = !($avoidLoading);
-        $notLoadedYet = !($this->_isLoaded($fkName));
-
-        if ($dontSkipLoading && $notLoadedYet) {
-            $related = $this->getMapper()->loadRelated('parent', $fkName, $this, $where, $orderBy);
-            $this->_ConferenceRoom = array_shift($related);
-            if ($usingDefaultArguments) {
-                $this->_setLoaded($fkName);
-            }
-        }
-
-        return $this->_ConferenceRoom;
-    }
-
-    /**
-     * Sets parent relation Language
-     *
-     * @param \IvozProvider\Model\Raw\Languages $data
-     * @return \IvozProvider\Model\Raw\DDIs
-     */
-    public function setLanguage(\IvozProvider\Model\Raw\Languages $data)
-    {
-        $this->_Language = $data;
-
-        $primaryKey = $data->getPrimaryKey();
-        if (is_array($primaryKey)) {
-            $primaryKey = $primaryKey['id'];
-        }
-
-        if (!is_null($primaryKey)) {
-            $this->setLanguageId($primaryKey);
-        }
-
-        $this->_setLoaded('DDIsIbfk12');
-        return $this;
-    }
-
-    /**
-     * Gets parent Language
-     * TODO: Mejorar esto para los casos en que la relación no exista. Ahora mismo siempre se pediría el padre
-     * @return \IvozProvider\Model\Raw\Languages
-     */
-    public function getLanguage($where = null, $orderBy = null, $avoidLoading = false)
-    {
-        $fkName = 'DDIsIbfk12';
-
-        $usingDefaultArguments = is_null($where) && is_null($orderBy);
-        if (!$usingDefaultArguments) {
-            $this->setNotLoaded($fkName);
-        }
-
-        $dontSkipLoading = !($avoidLoading);
-        $notLoadedYet = !($this->_isLoaded($fkName));
-
-        if ($dontSkipLoading && $notLoadedYet) {
-            $related = $this->getMapper()->loadRelated('parent', $fkName, $this, $where, $orderBy);
-            $this->_Language = array_shift($related);
-            if ($usingDefaultArguments) {
-                $this->_setLoaded($fkName);
-            }
-        }
-
-        return $this->_Language;
-    }
-
-    /**
-     * Sets parent relation Queue
-     *
-     * @param \IvozProvider\Model\Raw\Queues $data
-     * @return \IvozProvider\Model\Raw\DDIs
-     */
-    public function setQueue(\IvozProvider\Model\Raw\Queues $data)
-    {
-        $this->_Queue = $data;
-
-        $primaryKey = $data->getPrimaryKey();
-        if (is_array($primaryKey)) {
-            $primaryKey = $primaryKey['id'];
-        }
-
-        if (!is_null($primaryKey)) {
-            $this->setQueueId($primaryKey);
-        }
-
-        $this->_setLoaded('DDIsIbfk13');
-        return $this;
-    }
-
-    /**
-     * Gets parent Queue
-     * TODO: Mejorar esto para los casos en que la relación no exista. Ahora mismo siempre se pediría el padre
-     * @return \IvozProvider\Model\Raw\Queues
-     */
-    public function getQueue($where = null, $orderBy = null, $avoidLoading = false)
-    {
-        $fkName = 'DDIsIbfk13';
-
-        $usingDefaultArguments = is_null($where) && is_null($orderBy);
-        if (!$usingDefaultArguments) {
-            $this->setNotLoaded($fkName);
-        }
-
-        $dontSkipLoading = !($avoidLoading);
-        $notLoadedYet = !($this->_isLoaded($fkName));
-
-        if ($dontSkipLoading && $notLoadedYet) {
-            $related = $this->getMapper()->loadRelated('parent', $fkName, $this, $where, $orderBy);
-            $this->_Queue = array_shift($related);
-            if ($usingDefaultArguments) {
-                $this->_setLoaded($fkName);
-            }
-        }
-
-        return $this->_Queue;
-    }
-
-    /**
      * Sets parent relation ExternalCallFilter
      *
      * @param \IvozProvider\Model\Raw\ExternalCallFilters $data
@@ -1843,6 +1639,210 @@ class DDIs extends ModelAbstract
         }
 
         return $this->_Country;
+    }
+
+    /**
+     * Sets parent relation Brand
+     *
+     * @param \IvozProvider\Model\Raw\Brands $data
+     * @return \IvozProvider\Model\Raw\DDIs
+     */
+    public function setBrand(\IvozProvider\Model\Raw\Brands $data)
+    {
+        $this->_Brand = $data;
+
+        $primaryKey = $data->getPrimaryKey();
+        if (is_array($primaryKey)) {
+            $primaryKey = $primaryKey['id'];
+        }
+
+        if (!is_null($primaryKey)) {
+            $this->setBrandId($primaryKey);
+        }
+
+        $this->_setLoaded('DDIsIbfk10');
+        return $this;
+    }
+
+    /**
+     * Gets parent Brand
+     * TODO: Mejorar esto para los casos en que la relación no exista. Ahora mismo siempre se pediría el padre
+     * @return \IvozProvider\Model\Raw\Brands
+     */
+    public function getBrand($where = null, $orderBy = null, $avoidLoading = false)
+    {
+        $fkName = 'DDIsIbfk10';
+
+        $usingDefaultArguments = is_null($where) && is_null($orderBy);
+        if (!$usingDefaultArguments) {
+            $this->setNotLoaded($fkName);
+        }
+
+        $dontSkipLoading = !($avoidLoading);
+        $notLoadedYet = !($this->_isLoaded($fkName));
+
+        if ($dontSkipLoading && $notLoadedYet) {
+            $related = $this->getMapper()->loadRelated('parent', $fkName, $this, $where, $orderBy);
+            $this->_Brand = array_shift($related);
+            if ($usingDefaultArguments) {
+                $this->_setLoaded($fkName);
+            }
+        }
+
+        return $this->_Brand;
+    }
+
+    /**
+     * Sets parent relation ConferenceRoom
+     *
+     * @param \IvozProvider\Model\Raw\ConferenceRooms $data
+     * @return \IvozProvider\Model\Raw\DDIs
+     */
+    public function setConferenceRoom(\IvozProvider\Model\Raw\ConferenceRooms $data)
+    {
+        $this->_ConferenceRoom = $data;
+
+        $primaryKey = $data->getPrimaryKey();
+        if (is_array($primaryKey)) {
+            $primaryKey = $primaryKey['id'];
+        }
+
+        if (!is_null($primaryKey)) {
+            $this->setConferenceRoomId($primaryKey);
+        }
+
+        $this->_setLoaded('DDIsIbfk11');
+        return $this;
+    }
+
+    /**
+     * Gets parent ConferenceRoom
+     * TODO: Mejorar esto para los casos en que la relación no exista. Ahora mismo siempre se pediría el padre
+     * @return \IvozProvider\Model\Raw\ConferenceRooms
+     */
+    public function getConferenceRoom($where = null, $orderBy = null, $avoidLoading = false)
+    {
+        $fkName = 'DDIsIbfk11';
+
+        $usingDefaultArguments = is_null($where) && is_null($orderBy);
+        if (!$usingDefaultArguments) {
+            $this->setNotLoaded($fkName);
+        }
+
+        $dontSkipLoading = !($avoidLoading);
+        $notLoadedYet = !($this->_isLoaded($fkName));
+
+        if ($dontSkipLoading && $notLoadedYet) {
+            $related = $this->getMapper()->loadRelated('parent', $fkName, $this, $where, $orderBy);
+            $this->_ConferenceRoom = array_shift($related);
+            if ($usingDefaultArguments) {
+                $this->_setLoaded($fkName);
+            }
+        }
+
+        return $this->_ConferenceRoom;
+    }
+
+    /**
+     * Sets parent relation Language
+     *
+     * @param \IvozProvider\Model\Raw\Languages $data
+     * @return \IvozProvider\Model\Raw\DDIs
+     */
+    public function setLanguage(\IvozProvider\Model\Raw\Languages $data)
+    {
+        $this->_Language = $data;
+
+        $primaryKey = $data->getPrimaryKey();
+        if (is_array($primaryKey)) {
+            $primaryKey = $primaryKey['id'];
+        }
+
+        if (!is_null($primaryKey)) {
+            $this->setLanguageId($primaryKey);
+        }
+
+        $this->_setLoaded('DDIsIbfk12');
+        return $this;
+    }
+
+    /**
+     * Gets parent Language
+     * TODO: Mejorar esto para los casos en que la relación no exista. Ahora mismo siempre se pediría el padre
+     * @return \IvozProvider\Model\Raw\Languages
+     */
+    public function getLanguage($where = null, $orderBy = null, $avoidLoading = false)
+    {
+        $fkName = 'DDIsIbfk12';
+
+        $usingDefaultArguments = is_null($where) && is_null($orderBy);
+        if (!$usingDefaultArguments) {
+            $this->setNotLoaded($fkName);
+        }
+
+        $dontSkipLoading = !($avoidLoading);
+        $notLoadedYet = !($this->_isLoaded($fkName));
+
+        if ($dontSkipLoading && $notLoadedYet) {
+            $related = $this->getMapper()->loadRelated('parent', $fkName, $this, $where, $orderBy);
+            $this->_Language = array_shift($related);
+            if ($usingDefaultArguments) {
+                $this->_setLoaded($fkName);
+            }
+        }
+
+        return $this->_Language;
+    }
+
+    /**
+     * Sets parent relation Queue
+     *
+     * @param \IvozProvider\Model\Raw\Queues $data
+     * @return \IvozProvider\Model\Raw\DDIs
+     */
+    public function setQueue(\IvozProvider\Model\Raw\Queues $data)
+    {
+        $this->_Queue = $data;
+
+        $primaryKey = $data->getPrimaryKey();
+        if (is_array($primaryKey)) {
+            $primaryKey = $primaryKey['id'];
+        }
+
+        if (!is_null($primaryKey)) {
+            $this->setQueueId($primaryKey);
+        }
+
+        $this->_setLoaded('DDIsIbfk13');
+        return $this;
+    }
+
+    /**
+     * Gets parent Queue
+     * TODO: Mejorar esto para los casos en que la relación no exista. Ahora mismo siempre se pediría el padre
+     * @return \IvozProvider\Model\Raw\Queues
+     */
+    public function getQueue($where = null, $orderBy = null, $avoidLoading = false)
+    {
+        $fkName = 'DDIsIbfk13';
+
+        $usingDefaultArguments = is_null($where) && is_null($orderBy);
+        if (!$usingDefaultArguments) {
+            $this->setNotLoaded($fkName);
+        }
+
+        $dontSkipLoading = !($avoidLoading);
+        $notLoadedYet = !($this->_isLoaded($fkName));
+
+        if ($dontSkipLoading && $notLoadedYet) {
+            $related = $this->getMapper()->loadRelated('parent', $fkName, $this, $where, $orderBy);
+            $this->_Queue = array_shift($related);
+            if ($usingDefaultArguments) {
+                $this->_setLoaded($fkName);
+            }
+        }
+
+        return $this->_Queue;
     }
 
     /**

--- a/library/IvozProvider/Model/Raw/Terminals.php
+++ b/library/IvozProvider/Model/Raw/Terminals.php
@@ -109,18 +109,18 @@ class Terminals extends ModelAbstract
 
 
     /**
-     * Parent relation Terminals_CompanyId_ibfk_2
-     *
-     * @var \IvozProvider\Model\Raw\Companies
-     */
-    protected $_Company;
-
-    /**
      * Parent relation Terminals_ibfk_1
      *
      * @var \IvozProvider\Model\Raw\TerminalModels
      */
     protected $_TerminalModel;
+
+    /**
+     * Parent relation Terminals_CompanyId_ibfk_2
+     *
+     * @var \IvozProvider\Model\Raw\Companies
+     */
+    protected $_Company;
 
 
     /**
@@ -169,13 +169,13 @@ class Terminals extends ModelAbstract
         $this->setAvailableLangs(array('es', 'en'));
 
         $this->setParentList(array(
-            'TerminalsCompanyIdIbfk2'=> array(
-                    'property' => 'Company',
-                    'table_name' => 'Companies',
-                ),
             'TerminalsIbfk1'=> array(
                     'property' => 'TerminalModel',
                     'table_name' => 'TerminalModels',
+                ),
+            'TerminalsCompanyIdIbfk2'=> array(
+                    'property' => 'Company',
+                    'table_name' => 'Companies',
                 ),
         ));
 
@@ -634,57 +634,6 @@ class Terminals extends ModelAbstract
     }
 
     /**
-     * Sets parent relation Company
-     *
-     * @param \IvozProvider\Model\Raw\Companies $data
-     * @return \IvozProvider\Model\Raw\Terminals
-     */
-    public function setCompany(\IvozProvider\Model\Raw\Companies $data)
-    {
-        $this->_Company = $data;
-
-        $primaryKey = $data->getPrimaryKey();
-        if (is_array($primaryKey)) {
-            $primaryKey = $primaryKey['id'];
-        }
-
-        if (!is_null($primaryKey)) {
-            $this->setCompanyId($primaryKey);
-        }
-
-        $this->_setLoaded('TerminalsCompanyIdIbfk2');
-        return $this;
-    }
-
-    /**
-     * Gets parent Company
-     * TODO: Mejorar esto para los casos en que la relación no exista. Ahora mismo siempre se pediría el padre
-     * @return \IvozProvider\Model\Raw\Companies
-     */
-    public function getCompany($where = null, $orderBy = null, $avoidLoading = false)
-    {
-        $fkName = 'TerminalsCompanyIdIbfk2';
-
-        $usingDefaultArguments = is_null($where) && is_null($orderBy);
-        if (!$usingDefaultArguments) {
-            $this->setNotLoaded($fkName);
-        }
-
-        $dontSkipLoading = !($avoidLoading);
-        $notLoadedYet = !($this->_isLoaded($fkName));
-
-        if ($dontSkipLoading && $notLoadedYet) {
-            $related = $this->getMapper()->loadRelated('parent', $fkName, $this, $where, $orderBy);
-            $this->_Company = array_shift($related);
-            if ($usingDefaultArguments) {
-                $this->_setLoaded($fkName);
-            }
-        }
-
-        return $this->_Company;
-    }
-
-    /**
      * Sets parent relation TerminalModel
      *
      * @param \IvozProvider\Model\Raw\TerminalModels $data
@@ -733,6 +682,57 @@ class Terminals extends ModelAbstract
         }
 
         return $this->_TerminalModel;
+    }
+
+    /**
+     * Sets parent relation Company
+     *
+     * @param \IvozProvider\Model\Raw\Companies $data
+     * @return \IvozProvider\Model\Raw\Terminals
+     */
+    public function setCompany(\IvozProvider\Model\Raw\Companies $data)
+    {
+        $this->_Company = $data;
+
+        $primaryKey = $data->getPrimaryKey();
+        if (is_array($primaryKey)) {
+            $primaryKey = $primaryKey['id'];
+        }
+
+        if (!is_null($primaryKey)) {
+            $this->setCompanyId($primaryKey);
+        }
+
+        $this->_setLoaded('TerminalsCompanyIdIbfk2');
+        return $this;
+    }
+
+    /**
+     * Gets parent Company
+     * TODO: Mejorar esto para los casos en que la relación no exista. Ahora mismo siempre se pediría el padre
+     * @return \IvozProvider\Model\Raw\Companies
+     */
+    public function getCompany($where = null, $orderBy = null, $avoidLoading = false)
+    {
+        $fkName = 'TerminalsCompanyIdIbfk2';
+
+        $usingDefaultArguments = is_null($where) && is_null($orderBy);
+        if (!$usingDefaultArguments) {
+            $this->setNotLoaded($fkName);
+        }
+
+        $dontSkipLoading = !($avoidLoading);
+        $notLoadedYet = !($this->_isLoaded($fkName));
+
+        if ($dontSkipLoading && $notLoadedYet) {
+            $related = $this->getMapper()->loadRelated('parent', $fkName, $this, $where, $orderBy);
+            $this->_Company = array_shift($related);
+            if ($usingDefaultArguments) {
+                $this->_setLoaded($fkName);
+            }
+        }
+
+        return $this->_Company;
     }
 
     /**

--- a/library/IvozProvider/Model/Raw/Users.php
+++ b/library/IvozProvider/Model/Raw/Users.php
@@ -215,34 +215,6 @@ class Users extends ModelAbstract
     protected $_Company;
 
     /**
-     * Parent relation Users_ibfk_10
-     *
-     * @var \IvozProvider\Model\Raw\CallACL
-     */
-    protected $_CallACL;
-
-    /**
-     * Parent relation Users_ibfk_11
-     *
-     * @var \IvozProvider\Model\Raw\Users
-     */
-    protected $_BossAssistant;
-
-    /**
-     * Parent relation Users_ibfk_12
-     *
-     * @var \IvozProvider\Model\Raw\Countries
-     */
-    protected $_Country;
-
-    /**
-     * Parent relation Users_ibfk_13
-     *
-     * @var \IvozProvider\Model\Raw\Languages
-     */
-    protected $_Language;
-
-    /**
      * Parent relation Users_ibfk_3
      *
      * @var \IvozProvider\Model\Raw\Terminals
@@ -269,6 +241,34 @@ class Users extends ModelAbstract
      * @var \IvozProvider\Model\Raw\DDIs
      */
     protected $_OutgoingDDI;
+
+    /**
+     * Parent relation Users_ibfk_10
+     *
+     * @var \IvozProvider\Model\Raw\CallACL
+     */
+    protected $_CallACL;
+
+    /**
+     * Parent relation Users_ibfk_11
+     *
+     * @var \IvozProvider\Model\Raw\Users
+     */
+    protected $_BossAssistant;
+
+    /**
+     * Parent relation Users_ibfk_12
+     *
+     * @var \IvozProvider\Model\Raw\Countries
+     */
+    protected $_Country;
+
+    /**
+     * Parent relation Users_ibfk_13
+     *
+     * @var \IvozProvider\Model\Raw\Languages
+     */
+    protected $_Language;
 
 
     /**
@@ -471,22 +471,6 @@ class Users extends ModelAbstract
                     'property' => 'Company',
                     'table_name' => 'Companies',
                 ),
-            'UsersIbfk10'=> array(
-                    'property' => 'CallACL',
-                    'table_name' => 'CallACL',
-                ),
-            'UsersIbfk11'=> array(
-                    'property' => 'BossAssistant',
-                    'table_name' => 'Users',
-                ),
-            'UsersIbfk12'=> array(
-                    'property' => 'Country',
-                    'table_name' => 'Countries',
-                ),
-            'UsersIbfk13'=> array(
-                    'property' => 'Language',
-                    'table_name' => 'Languages',
-                ),
             'UsersIbfk3'=> array(
                     'property' => 'Terminal',
                     'table_name' => 'Terminals',
@@ -502,6 +486,22 @@ class Users extends ModelAbstract
             'UsersIbfk9'=> array(
                     'property' => 'OutgoingDDI',
                     'table_name' => 'DDIs',
+                ),
+            'UsersIbfk10'=> array(
+                    'property' => 'CallACL',
+                    'table_name' => 'CallACL',
+                ),
+            'UsersIbfk11'=> array(
+                    'property' => 'BossAssistant',
+                    'table_name' => 'Users',
+                ),
+            'UsersIbfk12'=> array(
+                    'property' => 'Country',
+                    'table_name' => 'Countries',
+                ),
+            'UsersIbfk13'=> array(
+                    'property' => 'Language',
+                    'table_name' => 'Languages',
                 ),
         ));
 
@@ -1596,210 +1596,6 @@ class Users extends ModelAbstract
     }
 
     /**
-     * Sets parent relation CallACL
-     *
-     * @param \IvozProvider\Model\Raw\CallACL $data
-     * @return \IvozProvider\Model\Raw\Users
-     */
-    public function setCallACL(\IvozProvider\Model\Raw\CallACL $data)
-    {
-        $this->_CallACL = $data;
-
-        $primaryKey = $data->getPrimaryKey();
-        if (is_array($primaryKey)) {
-            $primaryKey = $primaryKey['id'];
-        }
-
-        if (!is_null($primaryKey)) {
-            $this->setCallACLId($primaryKey);
-        }
-
-        $this->_setLoaded('UsersIbfk10');
-        return $this;
-    }
-
-    /**
-     * Gets parent CallACL
-     * TODO: Mejorar esto para los casos en que la relación no exista. Ahora mismo siempre se pediría el padre
-     * @return \IvozProvider\Model\Raw\CallACL
-     */
-    public function getCallACL($where = null, $orderBy = null, $avoidLoading = false)
-    {
-        $fkName = 'UsersIbfk10';
-
-        $usingDefaultArguments = is_null($where) && is_null($orderBy);
-        if (!$usingDefaultArguments) {
-            $this->setNotLoaded($fkName);
-        }
-
-        $dontSkipLoading = !($avoidLoading);
-        $notLoadedYet = !($this->_isLoaded($fkName));
-
-        if ($dontSkipLoading && $notLoadedYet) {
-            $related = $this->getMapper()->loadRelated('parent', $fkName, $this, $where, $orderBy);
-            $this->_CallACL = array_shift($related);
-            if ($usingDefaultArguments) {
-                $this->_setLoaded($fkName);
-            }
-        }
-
-        return $this->_CallACL;
-    }
-
-    /**
-     * Sets parent relation BossAssistant
-     *
-     * @param \IvozProvider\Model\Raw\Users $data
-     * @return \IvozProvider\Model\Raw\Users
-     */
-    public function setBossAssistant(\IvozProvider\Model\Raw\Users $data)
-    {
-        $this->_BossAssistant = $data;
-
-        $primaryKey = $data->getPrimaryKey();
-        if (is_array($primaryKey)) {
-            $primaryKey = $primaryKey['id'];
-        }
-
-        if (!is_null($primaryKey)) {
-            $this->setBossAssistantId($primaryKey);
-        }
-
-        $this->_setLoaded('UsersIbfk11');
-        return $this;
-    }
-
-    /**
-     * Gets parent BossAssistant
-     * TODO: Mejorar esto para los casos en que la relación no exista. Ahora mismo siempre se pediría el padre
-     * @return \IvozProvider\Model\Raw\Users
-     */
-    public function getBossAssistant($where = null, $orderBy = null, $avoidLoading = false)
-    {
-        $fkName = 'UsersIbfk11';
-
-        $usingDefaultArguments = is_null($where) && is_null($orderBy);
-        if (!$usingDefaultArguments) {
-            $this->setNotLoaded($fkName);
-        }
-
-        $dontSkipLoading = !($avoidLoading);
-        $notLoadedYet = !($this->_isLoaded($fkName));
-
-        if ($dontSkipLoading && $notLoadedYet) {
-            $related = $this->getMapper()->loadRelated('parent', $fkName, $this, $where, $orderBy);
-            $this->_BossAssistant = array_shift($related);
-            if ($usingDefaultArguments) {
-                $this->_setLoaded($fkName);
-            }
-        }
-
-        return $this->_BossAssistant;
-    }
-
-    /**
-     * Sets parent relation Country
-     *
-     * @param \IvozProvider\Model\Raw\Countries $data
-     * @return \IvozProvider\Model\Raw\Users
-     */
-    public function setCountry(\IvozProvider\Model\Raw\Countries $data)
-    {
-        $this->_Country = $data;
-
-        $primaryKey = $data->getPrimaryKey();
-        if (is_array($primaryKey)) {
-            $primaryKey = $primaryKey['id'];
-        }
-
-        if (!is_null($primaryKey)) {
-            $this->setCountryId($primaryKey);
-        }
-
-        $this->_setLoaded('UsersIbfk12');
-        return $this;
-    }
-
-    /**
-     * Gets parent Country
-     * TODO: Mejorar esto para los casos en que la relación no exista. Ahora mismo siempre se pediría el padre
-     * @return \IvozProvider\Model\Raw\Countries
-     */
-    public function getCountry($where = null, $orderBy = null, $avoidLoading = false)
-    {
-        $fkName = 'UsersIbfk12';
-
-        $usingDefaultArguments = is_null($where) && is_null($orderBy);
-        if (!$usingDefaultArguments) {
-            $this->setNotLoaded($fkName);
-        }
-
-        $dontSkipLoading = !($avoidLoading);
-        $notLoadedYet = !($this->_isLoaded($fkName));
-
-        if ($dontSkipLoading && $notLoadedYet) {
-            $related = $this->getMapper()->loadRelated('parent', $fkName, $this, $where, $orderBy);
-            $this->_Country = array_shift($related);
-            if ($usingDefaultArguments) {
-                $this->_setLoaded($fkName);
-            }
-        }
-
-        return $this->_Country;
-    }
-
-    /**
-     * Sets parent relation Language
-     *
-     * @param \IvozProvider\Model\Raw\Languages $data
-     * @return \IvozProvider\Model\Raw\Users
-     */
-    public function setLanguage(\IvozProvider\Model\Raw\Languages $data)
-    {
-        $this->_Language = $data;
-
-        $primaryKey = $data->getPrimaryKey();
-        if (is_array($primaryKey)) {
-            $primaryKey = $primaryKey['id'];
-        }
-
-        if (!is_null($primaryKey)) {
-            $this->setLanguageId($primaryKey);
-        }
-
-        $this->_setLoaded('UsersIbfk13');
-        return $this;
-    }
-
-    /**
-     * Gets parent Language
-     * TODO: Mejorar esto para los casos en que la relación no exista. Ahora mismo siempre se pediría el padre
-     * @return \IvozProvider\Model\Raw\Languages
-     */
-    public function getLanguage($where = null, $orderBy = null, $avoidLoading = false)
-    {
-        $fkName = 'UsersIbfk13';
-
-        $usingDefaultArguments = is_null($where) && is_null($orderBy);
-        if (!$usingDefaultArguments) {
-            $this->setNotLoaded($fkName);
-        }
-
-        $dontSkipLoading = !($avoidLoading);
-        $notLoadedYet = !($this->_isLoaded($fkName));
-
-        if ($dontSkipLoading && $notLoadedYet) {
-            $related = $this->getMapper()->loadRelated('parent', $fkName, $this, $where, $orderBy);
-            $this->_Language = array_shift($related);
-            if ($usingDefaultArguments) {
-                $this->_setLoaded($fkName);
-            }
-        }
-
-        return $this->_Language;
-    }
-
-    /**
      * Sets parent relation Terminal
      *
      * @param \IvozProvider\Model\Raw\Terminals $data
@@ -2001,6 +1797,210 @@ class Users extends ModelAbstract
         }
 
         return $this->_OutgoingDDI;
+    }
+
+    /**
+     * Sets parent relation CallACL
+     *
+     * @param \IvozProvider\Model\Raw\CallACL $data
+     * @return \IvozProvider\Model\Raw\Users
+     */
+    public function setCallACL(\IvozProvider\Model\Raw\CallACL $data)
+    {
+        $this->_CallACL = $data;
+
+        $primaryKey = $data->getPrimaryKey();
+        if (is_array($primaryKey)) {
+            $primaryKey = $primaryKey['id'];
+        }
+
+        if (!is_null($primaryKey)) {
+            $this->setCallACLId($primaryKey);
+        }
+
+        $this->_setLoaded('UsersIbfk10');
+        return $this;
+    }
+
+    /**
+     * Gets parent CallACL
+     * TODO: Mejorar esto para los casos en que la relación no exista. Ahora mismo siempre se pediría el padre
+     * @return \IvozProvider\Model\Raw\CallACL
+     */
+    public function getCallACL($where = null, $orderBy = null, $avoidLoading = false)
+    {
+        $fkName = 'UsersIbfk10';
+
+        $usingDefaultArguments = is_null($where) && is_null($orderBy);
+        if (!$usingDefaultArguments) {
+            $this->setNotLoaded($fkName);
+        }
+
+        $dontSkipLoading = !($avoidLoading);
+        $notLoadedYet = !($this->_isLoaded($fkName));
+
+        if ($dontSkipLoading && $notLoadedYet) {
+            $related = $this->getMapper()->loadRelated('parent', $fkName, $this, $where, $orderBy);
+            $this->_CallACL = array_shift($related);
+            if ($usingDefaultArguments) {
+                $this->_setLoaded($fkName);
+            }
+        }
+
+        return $this->_CallACL;
+    }
+
+    /**
+     * Sets parent relation BossAssistant
+     *
+     * @param \IvozProvider\Model\Raw\Users $data
+     * @return \IvozProvider\Model\Raw\Users
+     */
+    public function setBossAssistant(\IvozProvider\Model\Raw\Users $data)
+    {
+        $this->_BossAssistant = $data;
+
+        $primaryKey = $data->getPrimaryKey();
+        if (is_array($primaryKey)) {
+            $primaryKey = $primaryKey['id'];
+        }
+
+        if (!is_null($primaryKey)) {
+            $this->setBossAssistantId($primaryKey);
+        }
+
+        $this->_setLoaded('UsersIbfk11');
+        return $this;
+    }
+
+    /**
+     * Gets parent BossAssistant
+     * TODO: Mejorar esto para los casos en que la relación no exista. Ahora mismo siempre se pediría el padre
+     * @return \IvozProvider\Model\Raw\Users
+     */
+    public function getBossAssistant($where = null, $orderBy = null, $avoidLoading = false)
+    {
+        $fkName = 'UsersIbfk11';
+
+        $usingDefaultArguments = is_null($where) && is_null($orderBy);
+        if (!$usingDefaultArguments) {
+            $this->setNotLoaded($fkName);
+        }
+
+        $dontSkipLoading = !($avoidLoading);
+        $notLoadedYet = !($this->_isLoaded($fkName));
+
+        if ($dontSkipLoading && $notLoadedYet) {
+            $related = $this->getMapper()->loadRelated('parent', $fkName, $this, $where, $orderBy);
+            $this->_BossAssistant = array_shift($related);
+            if ($usingDefaultArguments) {
+                $this->_setLoaded($fkName);
+            }
+        }
+
+        return $this->_BossAssistant;
+    }
+
+    /**
+     * Sets parent relation Country
+     *
+     * @param \IvozProvider\Model\Raw\Countries $data
+     * @return \IvozProvider\Model\Raw\Users
+     */
+    public function setCountry(\IvozProvider\Model\Raw\Countries $data)
+    {
+        $this->_Country = $data;
+
+        $primaryKey = $data->getPrimaryKey();
+        if (is_array($primaryKey)) {
+            $primaryKey = $primaryKey['id'];
+        }
+
+        if (!is_null($primaryKey)) {
+            $this->setCountryId($primaryKey);
+        }
+
+        $this->_setLoaded('UsersIbfk12');
+        return $this;
+    }
+
+    /**
+     * Gets parent Country
+     * TODO: Mejorar esto para los casos en que la relación no exista. Ahora mismo siempre se pediría el padre
+     * @return \IvozProvider\Model\Raw\Countries
+     */
+    public function getCountry($where = null, $orderBy = null, $avoidLoading = false)
+    {
+        $fkName = 'UsersIbfk12';
+
+        $usingDefaultArguments = is_null($where) && is_null($orderBy);
+        if (!$usingDefaultArguments) {
+            $this->setNotLoaded($fkName);
+        }
+
+        $dontSkipLoading = !($avoidLoading);
+        $notLoadedYet = !($this->_isLoaded($fkName));
+
+        if ($dontSkipLoading && $notLoadedYet) {
+            $related = $this->getMapper()->loadRelated('parent', $fkName, $this, $where, $orderBy);
+            $this->_Country = array_shift($related);
+            if ($usingDefaultArguments) {
+                $this->_setLoaded($fkName);
+            }
+        }
+
+        return $this->_Country;
+    }
+
+    /**
+     * Sets parent relation Language
+     *
+     * @param \IvozProvider\Model\Raw\Languages $data
+     * @return \IvozProvider\Model\Raw\Users
+     */
+    public function setLanguage(\IvozProvider\Model\Raw\Languages $data)
+    {
+        $this->_Language = $data;
+
+        $primaryKey = $data->getPrimaryKey();
+        if (is_array($primaryKey)) {
+            $primaryKey = $primaryKey['id'];
+        }
+
+        if (!is_null($primaryKey)) {
+            $this->setLanguageId($primaryKey);
+        }
+
+        $this->_setLoaded('UsersIbfk13');
+        return $this;
+    }
+
+    /**
+     * Gets parent Language
+     * TODO: Mejorar esto para los casos en que la relación no exista. Ahora mismo siempre se pediría el padre
+     * @return \IvozProvider\Model\Raw\Languages
+     */
+    public function getLanguage($where = null, $orderBy = null, $avoidLoading = false)
+    {
+        $fkName = 'UsersIbfk13';
+
+        $usingDefaultArguments = is_null($where) && is_null($orderBy);
+        if (!$usingDefaultArguments) {
+            $this->setNotLoaded($fkName);
+        }
+
+        $dontSkipLoading = !($avoidLoading);
+        $notLoadedYet = !($this->_isLoaded($fkName));
+
+        if ($dontSkipLoading && $notLoadedYet) {
+            $related = $this->getMapper()->loadRelated('parent', $fkName, $this, $where, $orderBy);
+            $this->_Language = array_shift($related);
+            if ($usingDefaultArguments) {
+                $this->_setLoaded($fkName);
+            }
+        }
+
+        return $this->_Language;
     }
 
     /**


### PR DESCRIPTION
Alphabetically ordered foreign keys in models and mappers so that they don't change randomly on every regeneration.

Depends on sorted-foreign-keys branch on https://github.com/irontec/klear-generator.git