### PR TITLE
portals: add support for default company DDI #6

### DIFF
--- a/library/IvozProvider/Klear/Filter/OutgoingDDI.php
+++ b/library/IvozProvider/Klear/Filter/OutgoingDDI.php
@@ -1,0 +1,26 @@
+<?php
+class IvozProvider_Klear_Filter_OutgoingDDI implements KlearMatrix_Model_Field_Select_Filter_Interface
+{
+    protected $_condition = array();
+
+    public function setRouteDispatcher(KlearMatrix_Model_RouteDispatcher $routeDispatcher)
+    {
+        // Get current object id
+        $currentScreen = $routeDispatcher->getCurrentItemName();
+        $pk = $routeDispatcher->getParam("pk", false);
+
+        // Only display DDIs belonging to edited company
+        $this->_condition[] = "`companyId` = '" . $pk . "'";
+
+        return true;
+    }
+
+    public function getCondition()
+    {
+        if (count($this->_condition) > 0) {
+            return '(' . implode(" AND ", $this->_condition) . ')';
+        }
+        return;
+    }
+
+}

--- a/library/IvozProvider/Mapper/Sql/DbTable/Companies.php
+++ b/library/IvozProvider/Mapper/Sql/DbTable/Companies.php
@@ -69,6 +69,11 @@ class Companies extends TableAbstract
             'columns' => 'defaultTimezoneId',
             'refTableClass' => 'IvozProvider\\Mapper\\Sql\\DbTable\\Timezones',
             'refColumns' => 'id'
+        ),
+        'CompaniesIbfk13' => array(
+            'columns' => 'outgoingDDIId',
+            'refTableClass' => 'IvozProvider\\Mapper\\Sql\\DbTable\\DDIs',
+            'refColumns' => 'id'
         )
     );
     protected $_dependentTables = array(
@@ -509,6 +514,23 @@ class Companies extends TableAbstract
 	    'SCALE' => NULL,
 	    'PRECISION' => NULL,
 	    'UNSIGNED' => NULL,
+	    'PRIMARY' => false,
+	    'PRIMARY_POSITION' => NULL,
+	    'IDENTITY' => false,
+	  ),
+	  'outgoingDDIId' => 
+	  array (
+	    'SCHEMA_NAME' => NULL,
+	    'TABLE_NAME' => 'Companies',
+	    'COLUMN_NAME' => 'outgoingDDIId',
+	    'COLUMN_POSITION' => 25,
+	    'DATA_TYPE' => 'int',
+	    'DEFAULT' => NULL,
+	    'NULLABLE' => true,
+	    'LENGTH' => NULL,
+	    'SCALE' => NULL,
+	    'PRECISION' => NULL,
+	    'UNSIGNED' => true,
 	    'PRIMARY' => false,
 	    'PRIMARY_POSITION' => NULL,
 	    'IDENTITY' => false,

--- a/library/IvozProvider/Mapper/Sql/DbTable/DDIs.php
+++ b/library/IvozProvider/Mapper/Sql/DbTable/DDIs.php
@@ -107,6 +107,7 @@ class DDIs extends TableAbstract
         )
     );
     protected $_dependentTables = array(
+        'IvozProvider\\Mapper\\Sql\\DbTable\\Companies',
         'IvozProvider\\Mapper\\Sql\\DbTable\\Faxes',
         'IvozProvider\\Mapper\\Sql\\DbTable\\Friends',
         'IvozProvider\\Mapper\\Sql\\DbTable\\Users'

--- a/library/IvozProvider/Mapper/Sql/Raw/Companies.php
+++ b/library/IvozProvider/Mapper/Sql/Raw/Companies.php
@@ -72,6 +72,7 @@ class Companies extends MapperAbstract
                 'externallyExtraOpts' => $model->getExternallyExtraOpts(),
                 'recordingsLimitMB' => $model->getRecordingsLimitMB(),
                 'recordingsLimitEmail' => $model->getRecordingsLimitEmail(),
+                'outgoingDDIId' => $model->getOutgoingDDIId(),
             );
         } else {
             $result = array();
@@ -1026,7 +1027,8 @@ class Companies extends MapperAbstract
                   ->setAreaCode($data['areaCode'])
                   ->setExternallyExtraOpts($data['externallyExtraOpts'])
                   ->setRecordingsLimitMB($data['recordingsLimitMB'])
-                  ->setRecordingsLimitEmail($data['recordingsLimitEmail']);
+                  ->setRecordingsLimitEmail($data['recordingsLimitEmail'])
+                  ->setOutgoingDDIId($data['outgoingDDIId']);
         } else if ($data instanceof \Zend_Db_Table_Row_Abstract || $data instanceof \stdClass) {
             $entry->setId($data->{'id'})
                   ->setBrandId($data->{'brandId'})
@@ -1051,7 +1053,8 @@ class Companies extends MapperAbstract
                   ->setAreaCode($data->{'areaCode'})
                   ->setExternallyExtraOpts($data->{'externallyExtraOpts'})
                   ->setRecordingsLimitMB($data->{'recordingsLimitMB'})
-                  ->setRecordingsLimitEmail($data->{'recordingsLimitEmail'});
+                  ->setRecordingsLimitEmail($data->{'recordingsLimitEmail'})
+                  ->setOutgoingDDIId($data->{'outgoingDDIId'});
 
         } else if ($data instanceof \IvozProvider\Model\Raw\Companies) {
             $entry->setId($data->getId())
@@ -1077,7 +1080,8 @@ class Companies extends MapperAbstract
                   ->setAreaCode($data->getAreaCode())
                   ->setExternallyExtraOpts($data->getExternallyExtraOpts())
                   ->setRecordingsLimitMB($data->getRecordingsLimitMB())
-                  ->setRecordingsLimitEmail($data->getRecordingsLimitEmail());
+                  ->setRecordingsLimitEmail($data->getRecordingsLimitEmail())
+                  ->setOutgoingDDIId($data->getOutgoingDDIId());
 
         }
 

--- a/library/IvozProvider/Mapper/Sql/Raw/DDIs.php
+++ b/library/IvozProvider/Mapper/Sql/Raw/DDIs.php
@@ -465,6 +465,20 @@ class DDIs extends MapperAbstract
 
 
             if ($recursive) {
+                if ($model->getCompanies(null, null, true) !== null) {
+                    $companies = $model->getCompanies();
+
+                    if (!is_array($companies)) {
+
+                        $companies = array($companies);
+                    }
+
+                    foreach ($companies as $value) {
+                        $value->setOutgoingDDIId($primaryKey)
+                              ->saveRecursive(false, $transactionTag);
+                    }
+                }
+
                 if ($model->getFaxes(null, null, true) !== null) {
                     $faxes = $model->getFaxes();
 

--- a/library/IvozProvider/Model/Faxes.php
+++ b/library/IvozProvider/Model/Faxes.php
@@ -17,7 +17,7 @@
  * @subpackage Model
  * @author Luis Felipe Garcia
  */
- 
+
 namespace IvozProvider\Model;
 class Faxes extends Raw\Faxes
 {
@@ -27,4 +27,19 @@ class Faxes extends Raw\Faxes
     public function init()
     {
     }
+
+    /**
+     * Get Fax outgoingDDI
+     * If no DDI is assigned, retrieve company's default DDI
+     * @return \IvozProvider\Model\Raw\DDIs or NULL
+     */
+    public function getOutgoingDDI($where = null, $orderBy = null, $avoidLoading = false)
+    {
+        $ddi = parent::getOutgoingDDI($where, $orderBy, $avoidLoading);
+        if (empty($ddi)) {
+            $ddi = $this->getCompany()->getOutgoingDDI($where, $orderBy, $avoidLoading);
+        }
+        return $ddi;
+    }
+
 }

--- a/library/IvozProvider/Model/Friends.php
+++ b/library/IvozProvider/Model/Friends.php
@@ -157,4 +157,19 @@ class Friends extends Raw\Friends
         }
         return $language->getIden();
     }
+
+    /**
+     * Get Friend outgoingDDI
+     * If no DDI is assigned, retrieve company's default DDI
+     * @return \IvozProvider\Model\Raw\DDIs or NULL
+     */
+    public function getOutgoingDDI($where = null, $orderBy = null, $avoidLoading = false)
+    {
+        $ddi = parent::getOutgoingDDI($where, $orderBy, $avoidLoading);
+        if (empty($ddi)) {
+            $ddi = $this->getCompany()->getOutgoingDDI($where, $orderBy, $avoidLoading);
+        }
+        return $ddi;
+    }
+
 }

--- a/library/IvozProvider/Model/Raw/Companies.php
+++ b/library/IvozProvider/Model/Raw/Companies.php
@@ -191,6 +191,13 @@ class Companies extends ModelAbstract
      */
     protected $_recordingsLimitEmail;
 
+    /**
+     * Database var type int
+     *
+     * @var int
+     */
+    protected $_outgoingDDIId;
+
 
     /**
      * Parent relation Companies_ibfk_4
@@ -233,6 +240,13 @@ class Companies extends ModelAbstract
      * @var \IvozProvider\Model\Raw\Timezones
      */
     protected $_DefaultTimezone;
+
+    /**
+     * Parent relation Companies_ibfk_13
+     *
+     * @var \IvozProvider\Model\Raw\DDIs
+     */
+    protected $_OutgoingDDI;
 
 
     /**
@@ -508,6 +522,7 @@ class Companies extends ModelAbstract
         'externallyExtraOpts'=>'externallyExtraOpts',
         'recordingsLimitMB'=>'recordingsLimitMB',
         'recordingsLimitEmail'=>'recordingsLimitEmail',
+        'outgoingDDIId'=>'outgoingDDIId',
     );
 
     /**
@@ -547,6 +562,10 @@ class Companies extends ModelAbstract
             'CompaniesIbfk12'=> array(
                     'property' => 'DefaultTimezone',
                     'table_name' => 'Timezones',
+                ),
+            'CompaniesIbfk13'=> array(
+                    'property' => 'OutgoingDDI',
+                    'table_name' => 'DDIs',
                 ),
         ));
 
@@ -1564,6 +1583,40 @@ class Companies extends ModelAbstract
     }
 
     /**
+     * Sets column Stored in ISO 8601 format.     *
+     * @param int $data
+     * @return \IvozProvider\Model\Raw\Companies
+     */
+    public function setOutgoingDDIId($data)
+    {
+
+        if ($this->_outgoingDDIId != $data) {
+            $this->_logChange('outgoingDDIId', $this->_outgoingDDIId, $data);
+        }
+
+        if ($data instanceof \Zend_Db_Expr) {
+            $this->_outgoingDDIId = $data;
+
+        } else if (!is_null($data)) {
+            $this->_outgoingDDIId = (int) $data;
+
+        } else {
+            $this->_outgoingDDIId = $data;
+        }
+        return $this;
+    }
+
+    /**
+     * Gets column outgoingDDIId
+     *
+     * @return int
+     */
+    public function getOutgoingDDIId()
+    {
+        return $this->_outgoingDDIId;
+    }
+
+    /**
      * Sets parent relation Brand
      *
      * @param \IvozProvider\Model\Raw\Brands $data
@@ -1867,6 +1920,57 @@ class Companies extends ModelAbstract
         }
 
         return $this->_DefaultTimezone;
+    }
+
+    /**
+     * Sets parent relation OutgoingDDI
+     *
+     * @param \IvozProvider\Model\Raw\DDIs $data
+     * @return \IvozProvider\Model\Raw\Companies
+     */
+    public function setOutgoingDDI(\IvozProvider\Model\Raw\DDIs $data)
+    {
+        $this->_OutgoingDDI = $data;
+
+        $primaryKey = $data->getPrimaryKey();
+        if (is_array($primaryKey)) {
+            $primaryKey = $primaryKey['id'];
+        }
+
+        if (!is_null($primaryKey)) {
+            $this->setOutgoingDDIId($primaryKey);
+        }
+
+        $this->_setLoaded('CompaniesIbfk13');
+        return $this;
+    }
+
+    /**
+     * Gets parent OutgoingDDI
+     * TODO: Mejorar esto para los casos en que la relación no exista. Ahora mismo siempre se pediría el padre
+     * @return \IvozProvider\Model\Raw\DDIs
+     */
+    public function getOutgoingDDI($where = null, $orderBy = null, $avoidLoading = false)
+    {
+        $fkName = 'CompaniesIbfk13';
+
+        $usingDefaultArguments = is_null($where) && is_null($orderBy);
+        if (!$usingDefaultArguments) {
+            $this->setNotLoaded($fkName);
+        }
+
+        $dontSkipLoading = !($avoidLoading);
+        $notLoadedYet = !($this->_isLoaded($fkName));
+
+        if ($dontSkipLoading && $notLoadedYet) {
+            $related = $this->getMapper()->loadRelated('parent', $fkName, $this, $where, $orderBy);
+            $this->_OutgoingDDI = array_shift($related);
+            if ($usingDefaultArguments) {
+                $this->_setLoaded($fkName);
+            }
+        }
+
+        return $this->_OutgoingDDI;
     }
 
     /**

--- a/library/IvozProvider/Model/Raw/DDIs.php
+++ b/library/IvozProvider/Model/Raw/DDIs.php
@@ -282,6 +282,14 @@ class DDIs extends ModelAbstract
 
 
     /**
+     * Dependent relation Companies_ibfk_13
+     * Type: One-to-Many relationship
+     *
+     * @var \IvozProvider\Model\Raw\Companies[]
+     */
+    protected $_Companies;
+
+    /**
      * Dependent relation Faxes_ibfk_2
      * Type: One-to-Many relationship
      *
@@ -400,6 +408,10 @@ class DDIs extends ModelAbstract
         ));
 
         $this->setDependentList(array(
+            'CompaniesIbfk13' => array(
+                    'property' => 'Companies',
+                    'table_name' => 'Companies',
+                ),
             'FaxesIbfk2' => array(
                     'property' => 'Faxes',
                     'table_name' => 'Faxes',
@@ -415,6 +427,9 @@ class DDIs extends ModelAbstract
         ));
 
 
+        $this->setOnDeleteSetNullRelationships(array(
+            'Companies_ibfk_13'
+        ));
 
 
         $this->_defaultValues = array(
@@ -1843,6 +1858,96 @@ class DDIs extends ModelAbstract
         }
 
         return $this->_Queue;
+    }
+
+    /**
+     * Sets dependent relations Companies_ibfk_13
+     *
+     * @param array $data An array of \IvozProvider\Model\Raw\Companies
+     * @return \IvozProvider\Model\Raw\DDIs
+     */
+    public function setCompanies(array $data, $deleteOrphans = false)
+    {
+        if ($deleteOrphans === true) {
+
+            if ($this->_Companies === null) {
+
+                $this->getCompanies();
+            }
+
+            $oldRelations = $this->_Companies;
+
+            if (is_array($oldRelations)) {
+
+                $dataPKs = array();
+
+                foreach ($data as $newItem) {
+
+                    $pk = $newItem->getPrimaryKey();
+                    if (!empty($pk)) {
+                        $dataPKs[] = $pk;
+                    }
+                }
+
+                foreach ($oldRelations as $oldItem) {
+
+                    if (!in_array($oldItem->getPrimaryKey(), $dataPKs)) {
+
+                        $this->_orphans[] = $oldItem;
+                    }
+                }
+            }
+        }
+
+        $this->_Companies = array();
+
+        foreach ($data as $object) {
+            $this->addCompanies($object);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Sets dependent relations Companies_ibfk_13
+     *
+     * @param \IvozProvider\Model\Raw\Companies $data
+     * @return \IvozProvider\Model\Raw\DDIs
+     */
+    public function addCompanies(\IvozProvider\Model\Raw\Companies $data)
+    {
+        $this->_Companies[] = $data;
+        $this->_setLoaded('CompaniesIbfk13');
+        return $this;
+    }
+
+    /**
+     * Gets dependent Companies_ibfk_13
+     *
+     * @param string or array $where
+     * @param string or array $orderBy
+     * @param boolean $avoidLoading skip data loading if it is not already
+     * @return array The array of \IvozProvider\Model\Raw\Companies
+     */
+    public function getCompanies($where = null, $orderBy = null, $avoidLoading = false)
+    {
+        $fkName = 'CompaniesIbfk13';
+
+        $usingDefaultArguments = is_null($where) && is_null($orderBy);
+        if (!$usingDefaultArguments) {
+            $this->setNotLoaded($fkName);
+        }
+
+        $dontSkipLoading = !($avoidLoading);
+        $notLoadedYet = !($this->_isLoaded($fkName));
+
+        if ($dontSkipLoading && $notLoadedYet) {
+            $related = $this->getMapper()->loadRelated('dependent', $fkName, $this, $where, $orderBy);
+            $this->_Companies = $related;
+            $this->_setLoaded($fkName);
+        }
+
+        return $this->_Companies;
     }
 
     /**

--- a/library/IvozProvider/Model/Users.php
+++ b/library/IvozProvider/Model/Users.php
@@ -129,6 +129,21 @@ class Users extends Raw\Users
         return $valueIfEmpty;
     }
 
+
+    /**
+     * Get User outgoingDDI
+     * If no DDI is assigned, retrieve company's default DDI
+     * @return \IvozProvider\Model\Raw\DDIs or NULL
+     */
+    public function getOutgoingDDI($where = null, $orderBy = null, $avoidLoading = false)
+    {
+        $ddi = parent::getOutgoingDDI($where, $orderBy, $avoidLoading);
+        if (empty($ddi)) {
+            $ddi = $this->getCompany()->getOutgoingDDI($where, $orderBy, $avoidLoading);
+        }
+        return $ddi;
+    }
+
     /**
      * @return string
      */

--- a/portals/application/configs/klear/CompaniesList.yaml
+++ b/portals/application/configs/klear/CompaniesList.yaml
@@ -41,6 +41,7 @@ production:
           province: true
           country: true
           areaCode: true
+          outgoingDDIId: true
           registryData: true
           externalMaxCalls: true
           defaultTimezoneId: true
@@ -104,6 +105,7 @@ production:
           externalMaxCalls: true
           countryId: true
           areaCode: true
+          outgoingDDIId: true
           languageId: true
           defaultTimezoneId: true
           externallyExtraOpts: true
@@ -154,14 +156,15 @@ production:
           colsPerRow: 12
           label: _("Server data")
           fields:
-            outbound_prefix: 6
-            mediaRelaySetsId: 6
-            applicationServerId: 6
-            domain_users: 6
+            outbound_prefix: 3
+            outgoingDDIId: 5
+            externalMaxCalls: 4
+            domain_users: 12
             countryId: 6
             areaCode: 6
-            ipFilter: 6
-            externalMaxCalls: 6
+            mediaRelaySetsId: 4
+            applicationServerId: 4
+            ipFilter: 4
         group3:
           colsPerRow: 2
           label: _("Invoice data")

--- a/portals/application/configs/klear/model/Companies.yaml
+++ b/portals/application/configs/klear/model/Companies.yaml
@@ -132,7 +132,6 @@ production:
       title: _('Outbound prefix')
       type: text
       trim: both
-      maxLength: 255
     countryId:
       title: _('Country code')
       type: select
@@ -158,6 +157,26 @@ production:
         position: left
         icon: help
         text: _("Default Area code for users in this company")
+        label: _("Need help?")
+    outgoingDDIId:
+      title: _('Outgoing DDI')
+      type: select
+      source:
+        data: mapper
+        config:
+          mapperName: \IvozProvider\Mapper\Sql\DDIs
+          filterClass: IvozProvider_Klear_Filter_OutgoingDDI
+          fieldName:
+            fields:
+              - DDIE164
+            template: '+%DDIE164%'
+          order: DDIE164
+        'null': _("Unassigned")
+      info:
+        type: box
+        position: left
+        icon: help
+        text: _("Default outgoing DDI. This can be overriden in caller's edit screen.")
         label: _("Need help?")
     languageId:
       title: _('Language')

--- a/portals/application/configs/klear/model/Faxes.yaml
+++ b/portals/application/configs/klear/model/Faxes.yaml
@@ -56,7 +56,7 @@ production:
               - DDIE164
             template: '+%DDIE164%'
           order: DDIE164
-        'null': _("Unassigned")
+        'null': _("Company's default")
 staging: 
   _extends: production
 testing: 

--- a/portals/application/configs/klear/model/Friends.yaml
+++ b/portals/application/configs/klear/model/Friends.yaml
@@ -150,7 +150,7 @@ production:
               - DDIE164
             template: '+%DDIE164%'
           order: DDIE164
-        'null': _("Unassigned")
+        'null': _("Company's default")
       info:
         type: box
         position: left

--- a/portals/application/configs/klear/model/Users.yaml
+++ b/portals/application/configs/klear/model/Users.yaml
@@ -111,13 +111,7 @@ production:
               - DDIE164
             template: '+%DDIE164%'
           order: DDIE164
-        'null': _("Unassigned")
-      info:
-        type: box
-        position: left
-        icon: help
-        text: _("No outgoing calls will be allowed if this field is unassigned")
-        label: _("Need help?")
+        'null': _("Company's default")
     callACLId:
       title: _('Call ACL')
       type: select

--- a/portals/application/configs/klearRaw/DDIsList.yaml
+++ b/portals/application/configs/klearRaw/DDIsList.yaml
@@ -1,5 +1,6 @@
 #include conf.d/mapperList.yaml
 #include conf.d/actions.yaml
+#include CompaniesList.yaml
 #include FaxesList.yaml
 #include FriendsList.yaml
 #include UsersList.yaml
@@ -22,6 +23,7 @@ production:
           title: _("Options")
           screens: 
             dDIsEdit_screen: true
+            companiesList_screen: true
             faxesList_screen: true
             friendsList_screen: true
             usersList_screen: true
@@ -52,8 +54,21 @@ production:
       label: false
       labelOnPostAction: _("Edit %s %2s", ngettext('Ddi', 'Ddis', 1), "[format| (%item%)]")
       title: _("Edit %s %2s", ngettext('Ddi', 'Ddis', 1), "[format| (%item%)]")
+    #companies: 
+    <<: *companies_screensLink
+    companiesList_screen: 
+      <<: *companiesList_screenLink
+      filterField: outgoingDDIId
+      parentOptionCustomizer: 
+        - recordCount
+    companiesNew_screen: 
+      <<: *companiesNew_screenLink
+      filterField: outgoingDDIId
+    companiesEdit_screen: 
+      <<: *companiesEdit_screenLink
+      filterField: outgoingDDIId
+
     #faxes: 
-    <<: *faxes_screensLink
     faxesList_screen: 
       <<: *faxesList_screenLink
       filterField: outgoingDDIId
@@ -103,6 +118,8 @@ production:
       message: _("%s successfully deleted.", ngettext('Ddi', 'Ddis', 1))
       multiItem: 1
       labelOnList: 1
+  # companies dialogs: 
+    <<: *companies_dialogsLink
   # faxes dialogs: 
     <<: *faxes_dialogsLink
   # friends dialogs: 

--- a/portals/application/configs/klearRaw/model/Companies.yaml
+++ b/portals/application/configs/klearRaw/model/Companies.yaml
@@ -173,6 +173,19 @@ production:
       title: _('Recordingslimitemail')
       type: text
       maxLength: 250
+    outgoingDDIId: 
+      title: _('Outgoingddiid')
+      type: select
+      source: 
+        data: mapper
+        config: 
+          mapperName: \IvozProvider\Mapper\Sql\DDIs
+          fieldName: 
+            fields: 
+              - DDI
+            template: '%DDI%'
+          order: DDI
+        'null': _("Unassigned")
 staging: 
   _extends: production
 testing: 

--- a/portals/application/languages/en_US/en_US.po
+++ b/portals/application/languages/en_US/en_US.po
@@ -5321,7 +5321,18 @@ msgstr "Area code"
 msgid "Default Area code for users in this company"
 msgstr "Default Area code for users in this company"
 
-#: application/configs/klear/model/Companies.yaml:176
+#: application/configs/klear/model/Companies.yaml:162
+#: application/configs/klear/model/Faxes.yaml:47
+#: application/configs/klear/model/Friends.yaml:141
+#: application/configs/klear/model/Users.yaml:102
+msgid "Outgoing DDI"
+msgstr "Outgoing DDI"
+
+#: application/configs/klear/model/Companies.yaml:179
+msgid "Default outgoing DDI. This can be overriden in caller's edit screen."
+msgstr "Default outgoing DDI. This can be overriden in caller's edit screen."
+
+#: application/configs/klear/model/Companies.yaml:195
 msgid "Media relay Set"
 msgstr "Media relay Set"
 

--- a/portals/application/languages/es_ES/es_ES.po
+++ b/portals/application/languages/es_ES/es_ES.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: oasis\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-16 18:19+0200\n"
-"PO-Revision-Date: 2017-05-16 18:19+0200\n"
+"POT-Creation-Date: 2017-05-16 16:13+0200\n"
+"PO-Revision-Date: 2017-05-16 16:19+0200\n"
 "Last-Translator: IvozProvider Translator <vozip@irontec.com>\n"
 "Language-Team: \n"
 "Language: es_ES\n"
@@ -5374,7 +5374,20 @@ msgstr "Código de Area"
 msgid "Default Area code for users in this company"
 msgstr "Código de Area por defecto para los usuarios de esta compañía"
 
-#: application/configs/klear/model/Companies.yaml:176
+#: application/configs/klear/model/Companies.yaml:162
+#: application/configs/klear/model/Faxes.yaml:47
+#: application/configs/klear/model/Friends.yaml:141
+#: application/configs/klear/model/Users.yaml:102
+msgid "Outgoing DDI"
+msgstr "DDI de salida"
+
+#: application/configs/klear/model/Companies.yaml:179
+msgid "Default outgoing DDI. This can be overriden in caller's edit screen."
+msgstr ""
+"DDI saliente por defecto. Esta opción puede ser especificada en la pantalla "
+"de edición de cada llamante."
+
+#: application/configs/klear/model/Companies.yaml:195
 msgid "Media relay Set"
 msgstr "Servidores de Media"
 
@@ -5754,12 +5767,6 @@ msgstr ""
 #: application/configs/klear/model/Faxes.yaml:32
 msgid "Send by email"
 msgstr "Enviar por email"
-
-#: application/configs/klear/model/Faxes.yaml:47
-#: application/configs/klear/model/Friends.yaml:141
-#: application/configs/klear/model/Users.yaml:102
-msgid "Outgoing DDI"
-msgstr "DDI de salida"
 
 #: application/configs/klear/model/FaxesInOut.yaml:5
 #: application/configs/klear/model/KamAccCdrs.yaml:10

--- a/portals/application/languages/es_ES/es_ES.po
+++ b/portals/application/languages/es_ES/es_ES.po
@@ -5384,7 +5384,7 @@ msgstr "DDI de salida"
 #: application/configs/klear/model/Companies.yaml:179
 msgid "Default outgoing DDI. This can be overriden in caller's edit screen."
 msgstr ""
-"DDI saliente por defecto. Esta opción puede ser especificada en la pantalla "
+"DDI saliente por defecto. Esta opción puede ser sobrescrita en la pantalla "
 "de edición de cada llamante."
 
 #: application/configs/klear/model/Companies.yaml:195

--- a/portals/application/modules/rest/controllers/CompaniesController.php
+++ b/portals/application/modules/rest/controllers/CompaniesController.php
@@ -55,7 +55,8 @@ class Rest_CompaniesController extends Iron_Controller_Rest_BaseController
      *     'areaCode': '', 
      *     'externallyExtraOpts': '', 
      *     'recordingsLimitMB': '', 
-     *     'recordingsLimitEmail': ''
+     *     'recordingsLimitEmail': '', 
+     *     'outgoingDDIId': ''
      * },{
      *     'id': '', 
      *     'brandId': '', 
@@ -80,7 +81,8 @@ class Rest_CompaniesController extends Iron_Controller_Rest_BaseController
      *     'areaCode': '', 
      *     'externallyExtraOpts': '', 
      *     'recordingsLimitMB': '', 
-     *     'recordingsLimitEmail': ''
+     *     'recordingsLimitEmail': '', 
+     *     'outgoingDDIId': ''
      * }]")
      */
     public function indexAction()
@@ -122,6 +124,7 @@ class Rest_CompaniesController extends Iron_Controller_Rest_BaseController
                 'externallyExtraOpts',
                 'recordingsLimitMB',
                 'recordingsLimitEmail',
+                'outgoingDDIId',
             );
         }
 
@@ -218,7 +221,8 @@ class Rest_CompaniesController extends Iron_Controller_Rest_BaseController
      *     'areaCode': '', 
      *     'externallyExtraOpts': '', 
      *     'recordingsLimitMB': '', 
-     *     'recordingsLimitEmail': ''
+     *     'recordingsLimitEmail': '', 
+     *     'outgoingDDIId': ''
      * }")
      */
     public function getAction()
@@ -259,6 +263,7 @@ class Rest_CompaniesController extends Iron_Controller_Rest_BaseController
                 'externallyExtraOpts',
                 'recordingsLimitMB',
                 'recordingsLimitEmail',
+                'outgoingDDIId',
             );
         }
 
@@ -322,6 +327,7 @@ class Rest_CompaniesController extends Iron_Controller_Rest_BaseController
      * @ApiParams(name="externallyExtraOpts", nullable=true, type="varchar", sample="", description="")
      * @ApiParams(name="recordingsLimitMB", nullable=true, type="int", sample="", description="")
      * @ApiParams(name="recordingsLimitEmail", nullable=true, type="varchar", sample="", description="")
+     * @ApiParams(name="outgoingDDIId", nullable=true, type="int", sample="", description="")
      * @ApiReturnHeaders(sample="HTTP 201")
      * @ApiReturnHeaders(sample="Location: /rest/companies/{id}")
      * @ApiReturn(type="object", sample="{}")
@@ -380,6 +386,7 @@ class Rest_CompaniesController extends Iron_Controller_Rest_BaseController
      * @ApiParams(name="externallyExtraOpts", nullable=true, type="varchar", sample="", description="")
      * @ApiParams(name="recordingsLimitMB", nullable=true, type="int", sample="", description="")
      * @ApiParams(name="recordingsLimitEmail", nullable=true, type="varchar", sample="", description="")
+     * @ApiParams(name="outgoingDDIId", nullable=true, type="int", sample="", description="")
      * @ApiReturnHeaders(sample="HTTP 200")
      * @ApiReturn(type="object", sample="{}")
      */
@@ -589,6 +596,11 @@ class Rest_CompaniesController extends Iron_Controller_Rest_BaseController
                     'required' => false,
                     'comment' => '',
                 ),
+                'outgoingDDIId' => array(
+                    'type' => "int",
+                    'required' => false,
+                    'comment' => '',
+                ),
             )
         );
 
@@ -712,6 +724,11 @@ class Rest_CompaniesController extends Iron_Controller_Rest_BaseController
                 ),
                 'recordingsLimitEmail' => array(
                     'type' => "varchar",
+                    'required' => false,
+                    'comment' => '',
+                ),
+                'outgoingDDIId' => array(
+                    'type' => "int",
                     'required' => false,
                     'comment' => '',
                 ),

--- a/portals/application/modules/rest/controllersRaw/CompaniesController.php
+++ b/portals/application/modules/rest/controllersRaw/CompaniesController.php
@@ -55,7 +55,8 @@ class Rest_CompaniesController extends Iron_Controller_Rest_BaseController
      *     'areaCode': '', 
      *     'externallyExtraOpts': '', 
      *     'recordingsLimitMB': '', 
-     *     'recordingsLimitEmail': ''
+     *     'recordingsLimitEmail': '', 
+     *     'outgoingDDIId': ''
      * },{
      *     'id': '', 
      *     'brandId': '', 
@@ -80,7 +81,8 @@ class Rest_CompaniesController extends Iron_Controller_Rest_BaseController
      *     'areaCode': '', 
      *     'externallyExtraOpts': '', 
      *     'recordingsLimitMB': '', 
-     *     'recordingsLimitEmail': ''
+     *     'recordingsLimitEmail': '', 
+     *     'outgoingDDIId': ''
      * }]")
      */
     public function indexAction()
@@ -122,6 +124,7 @@ class Rest_CompaniesController extends Iron_Controller_Rest_BaseController
                 'externallyExtraOpts',
                 'recordingsLimitMB',
                 'recordingsLimitEmail',
+                'outgoingDDIId',
             );
         }
 
@@ -218,7 +221,8 @@ class Rest_CompaniesController extends Iron_Controller_Rest_BaseController
      *     'areaCode': '', 
      *     'externallyExtraOpts': '', 
      *     'recordingsLimitMB': '', 
-     *     'recordingsLimitEmail': ''
+     *     'recordingsLimitEmail': '', 
+     *     'outgoingDDIId': ''
      * }")
      */
     public function getAction()
@@ -259,6 +263,7 @@ class Rest_CompaniesController extends Iron_Controller_Rest_BaseController
                 'externallyExtraOpts',
                 'recordingsLimitMB',
                 'recordingsLimitEmail',
+                'outgoingDDIId',
             );
         }
 
@@ -322,6 +327,7 @@ class Rest_CompaniesController extends Iron_Controller_Rest_BaseController
      * @ApiParams(name="externallyExtraOpts", nullable=true, type="varchar", sample="", description="")
      * @ApiParams(name="recordingsLimitMB", nullable=true, type="int", sample="", description="")
      * @ApiParams(name="recordingsLimitEmail", nullable=true, type="varchar", sample="", description="")
+     * @ApiParams(name="outgoingDDIId", nullable=true, type="int", sample="", description="")
      * @ApiReturnHeaders(sample="HTTP 201")
      * @ApiReturnHeaders(sample="Location: /rest/companies/{id}")
      * @ApiReturn(type="object", sample="{}")
@@ -380,6 +386,7 @@ class Rest_CompaniesController extends Iron_Controller_Rest_BaseController
      * @ApiParams(name="externallyExtraOpts", nullable=true, type="varchar", sample="", description="")
      * @ApiParams(name="recordingsLimitMB", nullable=true, type="int", sample="", description="")
      * @ApiParams(name="recordingsLimitEmail", nullable=true, type="varchar", sample="", description="")
+     * @ApiParams(name="outgoingDDIId", nullable=true, type="int", sample="", description="")
      * @ApiReturnHeaders(sample="HTTP 200")
      * @ApiReturn(type="object", sample="{}")
      */
@@ -589,6 +596,11 @@ class Rest_CompaniesController extends Iron_Controller_Rest_BaseController
                     'required' => false,
                     'comment' => '',
                 ),
+                'outgoingDDIId' => array(
+                    'type' => "int",
+                    'required' => false,
+                    'comment' => '',
+                ),
             )
         );
 
@@ -712,6 +724,11 @@ class Rest_CompaniesController extends Iron_Controller_Rest_BaseController
                 ),
                 'recordingsLimitEmail' => array(
                     'type' => "varchar",
+                    'required' => false,
+                    'comment' => '',
+                ),
+                'outgoingDDIId' => array(
+                    'type' => "int",
                     'required' => false,
                     'comment' => '',
                 ),

--- a/scheme/deltas/043-company-outgoing-ddi.sql
+++ b/scheme/deltas/043-company-outgoing-ddi.sql
@@ -1,0 +1,6 @@
+/**
+ * Add outgoingDDI to the company.
+ * This DDI will be used by Users/Friends when they have no specific outgoingDDI
+ */
+ALTER TABLE `Companies` ADD `outgoingDDIId` int(10) unsigned DEFAULT NULL;
+ALTER TABLE `Companies` ADD FOREIGN KEY (`outgoingDDIId`) REFERENCES `DDIs` (`id`) ON DELETE SET NULL;


### PR DESCRIPTION
When Company has only one DDI for all their Users/Faxes, it can be handy to
have it defined in the Company configuration rather than per caller.

This commit adds a new a DDI field at company level that will be used if the
caller (User/Friend/Fax/...) has no outgoing DDI defined.


This PR aims to fix #6

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/irontec/ivozprovider/93)
<!-- Reviewable:end -->
