### PR TITLE
portals: cache file thumbnails

### DIFF
--- a/library/IvozProvider/Klear/Options/OptionsCustomizerFilterForFax.php
+++ b/library/IvozProvider/Klear/Options/OptionsCustomizerFilterForFax.php
@@ -41,19 +41,32 @@ class IvozProvider_Klear_Options_OptionsCustomizerFilterForFax implements \Klear
     {
         $show = true;
 
-        if ($this->_option->getName() == 'forwardFax_dialog' && $parentModel->getStatus() != 'error') {
+        $optionName = $this->_option->getName();
+        $status = $parentModel->getStatus();
+        $errorStatus = $status === 'error';
+
+        if ($optionName == 'forwardFax_dialog' && !$errorStatus) {
             $show = false;
         }
 
-        if ($show) {
-            return null;
-        } else {
+        if ($optionName === 'faxesOutView_screen' && $errorStatus) {
+            $show = false;
+        }
+
+        if ($optionName === 'faxesOutEdit_screen' && !$errorStatus) {
+            $show = false;
+        }
+
+        if (!$show) {
             /* Para no mostrarlo iniciamos una respuesta vacía */
             $response = new \KlearMatrix_Model_ParentOptionCustomizer_Response();
-            $response->setParentWrapper($this->_resultWrapper)
-            ->setParentCssClass($this->_cssClass);
+            $response
+                ->setParentWrapper($this->_resultWrapper)
+                ->setParentCssClass($this->_cssClass);
 
             return $response;
         }
+
+        return null;
     }
 }

--- a/library/IvozProvider/Mapper/Sql/FaxesInOut.php
+++ b/library/IvozProvider/Mapper/Sql/FaxesInOut.php
@@ -32,10 +32,26 @@ class FaxesInOut extends Raw\FaxesInOut
 
         if ($isOutgoingFax && $statusHaschanged && $isPending) {
             $ari = new \Asterisk\ARI\Connector();
-            $ari->sendFaxfileRequest($model);
+
+            try {
+                $ari->sendFaxfileRequest($model);
+            } catch (\Exception $e) {
+                $this->_setErrorStatus($model);
+                throw $e;
+            }
         }
 
         return $result;
     }
 
+    /**
+     * @param \IvozProvider\Model\Raw\FaxesInOut $model
+     */
+    protected function _setErrorStatus(\IvozProvider\Model\Raw\FaxesInOut $model)
+    {
+        try {
+            $model->setStatus('error');
+            $model->save();
+        } catch (\Exception $e) {}
+    }
 }

--- a/portals/application/configs/klear/FaxesInOutList.yaml
+++ b/portals/application/configs/klear/FaxesInOutList.yaml
@@ -71,6 +71,9 @@ production:
       controller: File
       action: preview
       mainColumn: file
+      arguments:
+        cache:
+          enabled: true
 staging:
   _extends: production
 testing:

--- a/portals/application/configs/klear/FaxesList.yaml
+++ b/portals/application/configs/klear/FaxesList.yaml
@@ -115,6 +115,7 @@ production:
         options:
           title: _("Options")
           screens:
+            faxesOutView_screen: true
             faxesOutEdit_screen: true
           dialogs:
             forwardFax_dialog: true
@@ -137,6 +138,15 @@ production:
       class: ui-silk-eye
       disableSave: true
 
+    faxesOutView_screen:
+      <<: *faxesInOutEdit_screenLink
+      parentOptionCustomizer:
+        - IvozProvider_Klear_Options_OptionsCustomizerFilterForFax
+      title: _("View Outgoing %s %s", ngettext('Faxfile', 'Faxefiles', 0), "[format| (%item%)]")
+      filterField: faxId
+      class: ui-silk-eye
+      disableSave: true
+
     faxesOutNew_screen:
       <<: *faxesInOutNew_screenLink
       filterField: faxId
@@ -153,6 +163,8 @@ production:
 
     faxesOutEdit_screen:
       <<: *faxesInOutEdit_screenLink
+      parentOptionCustomizer:
+        - IvozProvider_Klear_Options_OptionsCustomizerFilterForFax
       forcedValues:
         type: 'Out'
       filterField: faxId
@@ -166,6 +178,7 @@ production:
           src: true
         readOnly:
           status: true
+          file: true
 
   dialogs: &faxes_dialogsLink
     faxesDel_dialog: &faxesDel_dialogLink

--- a/portals/application/configs/klear/InvoicesList.yaml
+++ b/portals/application/configs/klear/InvoicesList.yaml
@@ -177,7 +177,9 @@ production:
       controller: File
       action: preview
       mainColumn: pdfFile
-  
+      arguments:
+        cache:
+          enabled: true
   
 staging: 
   _extends: production

--- a/portals/application/configs/klear/model/Invoices.yaml
+++ b/portals/application/configs/klear/model/Invoices.yaml
@@ -44,21 +44,7 @@ production:
       type: text
       trim: both
       sufix: "€"
-#    languageId: 
-#      title: _('Language')
-#      type: select
-#      required: true
-#      source: 
-#        data: mapper
-#        config: 
-#          mapperName: \IvozProvider\Mapper\Sql\Languages
-#          fieldName: 
-#            fields: 
-#              - name
-#            template: '%name%'
-#          order: iden
-#        'null': _("Unassigned")
-    status: 
+    status:
       title: _('Status')
       type: select
       source: 
@@ -75,14 +61,7 @@ production:
         data: fso
         size_limit: 20M
         options: 
-#          download:
-#            external: true
-#            type: command
-#            target: invoicesPdfFileDownload_command
-#            icon: ui-silk-bullet-disk
-#            title: _("Download file")
-#            onNull: hide
-          preview: 
+          preview:
             target: invoicesPdfFilePreview_command
             type: command
             class: filePreview
@@ -90,17 +69,6 @@ production:
             props: 
               width: 150
               height: 150
-              crop: false
-            onNull: hide
-          previewList: 
-            target: invoicesPdfFilePreview_command
-            type: command
-            class: filePreview
-            listController: 1
-            external: 1
-            props: 
-              width: 30
-              height: 30
               crop: false
             onNull: hide
       options:

--- a/portals/application/languages/en_US/en_US.po
+++ b/portals/application/languages/en_US/en_US.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: IvozProvider 1.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-17 16:00+0200\n"
-"PO-Revision-Date: 2017-05-17 16:00+0200\n"
+"POT-Creation-Date: 2017-05-19 11:56+0200\n"
+"PO-Revision-Date: 2017-05-19 11:57+0200\n"
 "Last-Translator: IvozProvider Translator <<vozip@irontec.com>>\n"
 "Language-Team: IvozProvider I18N Team <dev.lists-ivozprovider@irontec.com>\n"
 "Language: en_US\n"
@@ -18,6 +18,7 @@ msgstr ""
 "X-Poedit-SearchPath-0: .\n"
 "X-Poedit-SearchPathExcluded-0: public/scripts\n"
 "X-Poedit-SearchPathExcluded-1: application/configs/klearRaw\n"
+"X-Poedit-SearchPathExcluded-2: library/vendor\n"
 
 msgid "Please, chose a file to import"
 msgstr "Please, chose a file to import"
@@ -1263,6 +1264,10 @@ msgstr "List of Outgoing %s %s"
 msgid "View Incoming %s %s"
 msgstr "View Incoming %s %s"
 
+#, python-format
+msgid "View Outgoing %s %s"
+msgstr "View Outgoing %s %s"
+
 msgid "Forward Fax"
 msgstr "Forward Fax"
 
@@ -2030,7 +2035,7 @@ msgstr "Strategy"
 
 #, fuzzy
 msgid "ringall"
-msgstr "A todos"
+msgstr "Ring all"
 
 #, fuzzy
 msgid "leastrecent"

--- a/portals/application/languages/es_ES/es_ES.po
+++ b/portals/application/languages/es_ES/es_ES.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: oasis\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-17 15:59+0200\n"
-"PO-Revision-Date: 2017-05-17 15:59+0200\n"
+"POT-Creation-Date: 2017-05-19 11:58+0200\n"
+"PO-Revision-Date: 2017-05-19 11:59+0200\n"
 "Last-Translator: IvozProvider Translator <<vozip@irontec.com>>\n"
 "Language-Team: \n"
 "Language: es_ES\n"
@@ -18,6 +18,7 @@ msgstr ""
 "X-Poedit-SearchPath-0: .\n"
 "X-Poedit-SearchPathExcluded-0: public/scripts\n"
 "X-Poedit-SearchPathExcluded-1: application/configs/klearRaw\n"
+"X-Poedit-SearchPathExcluded-2: library/vendor\n"
 
 msgid "Please, chose a file to import"
 msgstr "Por favor, seleccione un fichero a importar"
@@ -1323,6 +1324,10 @@ msgstr "Listado de %s salientes %2s"
 #, python-format
 msgid "View Incoming %s %s"
 msgstr "Ver entrantes %s %s"
+
+#, python-format
+msgid "View Outgoing %s %s"
+msgstr "Ver salientes %s %s"
 
 #, fuzzy
 msgid "Forward Fax"


### PR DESCRIPTION
This PR aims to fix #81

**Requires klear to be updated.**

Faxes with no error are not editable anymore, read only screen is shown instead.
The pdf in faxes is not editable anymore
Fixed: set fax status to error when an exception is thrown
Removed invoice thumbnails from lists

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/irontec/ivozprovider/96)
<!-- Reviewable:end -->
