### PR TITLE
trunks+as: bounced faxes are not negociating T.38.

### DIFF
--- a/asterisk/config/dialplan/bouncer.conf
+++ b/asterisk/config/dialplan/bouncer.conf
@@ -10,7 +10,7 @@
 [bouncer]
 exten => bounce,1,NoOp(Intra Oasis bounced call)
     same => n,Set(DEST=${PJSIP_HEADER(read,"X-Info-BounceDDI")})
-    same => n,Dial(PJSIP/${DEST}@proxytrunks,,b(bounce-headers^${DEST}^1))
+    same => n,Dial(PJSIP/${DEST}@proxybouncer,,b(bounce-headers^${DEST}^1))
 
 [bounce-headers]
 exten => _X.,1,NoOp(Adding Bounced headers)

--- a/asterisk/config/pjsip.conf
+++ b/asterisk/config/pjsip.conf
@@ -44,6 +44,20 @@ type=identify
 endpoint=proxytrunks
 match=trunks.ivozprovider.local
 
+[proxybouncer]
+type=endpoint
+aors=proxytrunks
+disallow=all
+allow=alaw,g729
+direct_media=no
+dtmf_mode=rfc4733
+send_pai=no
+100rel=no
+t38_udptl=yes
+t38_udptl_ec=redundancy
+allow_transfer=no
+allow_subscribe=no
+
 ;;
 ;; Replacer endpoint
 ;; Send/Received Remote attended tranfers

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -398,7 +398,6 @@ request_route {
     $var(header) = 'X-Info-Bounced';
     route(PARSE_OPTIONAL_X_HEADER);
     if ($var(header-value) == 'yes') {
-        $dlg_var(provideralike) = 'yes';
         $dlg_var(bounced) = 'yes';
     } else {
         $dlg_var(bounced) = 'no';
@@ -407,7 +406,7 @@ request_route {
     # Easy routing:
     # (a) From ASs ----> Choose GW (except bounced calls)
     # (b) To my domains ----> Dispatch to AS
-    if (ds_is_from_list("1") && $dlg_var(provideralike) != 'yes') {
+    if (ds_is_from_list("1") && $dlg_var(bounced) == 'no') {
         if ($dlg_var(log)) xlog("L_INFO", "[b$dlg_var(brandId)][$dlg_var(cidhash)] Source: Known AS, route to corresponding GW\n");
         $dlg_var(direction) = 'outbound';
 
@@ -903,55 +902,9 @@ route[GET_INFO_FROM_MATCHED_DDI] {
     $dlg_var(mediaRelaySetsId) = $xavp(ra=>mediaRelaySetsId);
 }
 
-route[MEDIALIBERATION] {
-    if ($dlg_var(bounced) != 'yes') {
-        return;
-    }
-
-    # Bounced calls do not propagate liberation reINVITEs
-    if (is_method("ACK") && $dlg_var(discardack) == '1') {
-        if ($dlg_var(log)) xlog("L_INFO", "[b$dlg_var(brandId)][$dlg_var(cidhash)] MEDIALIBERATION: Drop ACK, magic part 2 of 2!\n");
-        $dlg_var(discardack) = $null;
-        exit;
-    }
-
-    # Extract selected audio codec
-    if (sdp_get_line_startswith("$avp(mline)", "m=audio")) {
-        $dlg_var(codec_reinvite) = $(avp(mline){s.select,3, });
-        if ($dlg_var(log)) xlog("L_INFO", "[b$dlg_var(brandId)][$dlg_var(cidhash)] MEDIALIBERATION: Codec seleccionado: $dlg_var(codec_reinvite)\n");
-    }
-
-    if (is_method("INVITE|UPDATE") && has_body("application/sdp") && ds_is_from_list("1")) {
-        if ($dlg_var(log)) xlog("L_INFO", "[b$dlg_var(brandId)][$dlg_var(cidhash)] MEDIALIBERATION: Re-$rm from AS, evaluate doing magic\n");
-        if ($dlg_var(codec_reinvite) != $dlg_var(codec)) {
-            if ($dlg_var(log)) xlog("L_INFO", "[b$dlg_var(brandId)][$dlg_var(cidhash)] MEDIALIBERATION: Codec changed, abort magic\n");
-            return;
-        } else {
-            if ($dlg_var(log)) xlog("L_INFO", "[b$dlg_var(brandId)][$dlg_var(cidhash)] MEDIALIBERATION: Codec not changed, continue\n");
-        }
-
-        if (!sdp_get_line_startswith("$avp(cline)", "c=IN IP4 " + $si)) {
-            if ($dlg_var(log)) xlog("L_INFO", "[b$dlg_var(brandId)][$dlg_var(cidhash)] MEDIALIBERATION: RTPproxy on SDP, start magic!\n");
-            if ($dlg_var(log)) xlog("L_INFO", "[b$dlg_var(brandId)][$dlg_var(cidhash)] MEDIALIBERATION: Mangle RTPproxy ports and reply 200, magic part 1 of 2!\n");
-            if (is_method("INVITE"))
-                $dlg_var(discardack) = '1'; # Set dlg_flag to discard subsequent ACK
-            route(RTPRELAY); # Call RTPRELAY to link ports accordingly
-            send_reply("200", "I agree");
-            exit;
-        } else {
-            if ($dlg_var(log)) xlog("L_INFO", "[b$dlg_var(brandId)][$dlg_var(cidhash)] MEDIALIBERATION: SDP does not contain RTPproxy ($avp(cline)), abort magic\n");
-        }
-    }
-
-    return;
-}
-
 # Handle within-dialog messages
 route[WITHINDLG] {
     if (!$dlg_var(confirmed) && is_method("UPDATE|INVITE")) drop;
-
-    # Do not forward media liberation reinvite
-    route(MEDIALIBERATION);
 
     # Reinvite handling
     if (is_method("INVITE")) {
@@ -1224,13 +1177,6 @@ onreply_route {
 
 # Common for both AS and GW replies
 onreply_route[MANAGE_REPLY] {
-
-    # Bounced calls do not propagate liberation reINVITEs
-    if ($dlg_var(bounced) == 'yes' && sdp_get_line_startswith("$avp(mline)", "m=audio")) {
-        $dlg_var(codec) = $(avp(mline){s.select,3, });
-        if ($dlg_var(log)) xlog("L_INFO", "[b$dlg_var(brandId)][$dlg_var(cidhash)] MANAGE-REPLY: Selected codec: $dlg_var(codec)\n");
-    }
-
     # Manage RTP
     if ($rs =~ "[12][0-9][0-9]") {
         if ($dlg_var(log)) xlog("L_INFO", "[b$dlg_var(brandId)][$dlg_var(cidhash)] MANAGE-REPLY: Non-error reply $rs, call RTPRELAY\n");


### PR DESCRIPTION
Proxytrunks implements a logic that avoids forwarding medialiberation re-invites
in bounced calls. The reason behind this logic was that forwarding this re-invites
lead to a loop (as they were forwarded to AS, that was the source of this requests).

This commits deletes this logic and avoids this loop with a different approach:

- 'proxybouncer' pjsip endpoint is used to bounce calls.

- This new endpoint has direct_media to 'no', stopping the loop.

Deleted logic prevented T.38 reinvites too, so this change fixes #99 too.