### PR TITLE
portals: Avoid brand/company emulation when god portal url is used

### DIFF
--- a/library/IvozProvider/Klear/Dynamic/Builder.php
+++ b/library/IvozProvider/Klear/Dynamic/Builder.php
@@ -91,6 +91,10 @@ class Builder
             return false;
         }
 
+        if (self::$_brandURL->getUrlType() === 'god') {
+            return false;
+        }
+
         self::$_brand = self::$_brandURL->getBrand();
     }
 


### PR DESCRIPTION
This changes completes #104 PR that was only considering reaching Main administration portal using the fallback matching (that only redirects to that portal if URL doesn't match any BrandURL at all)