### PR TITLE
agi: implemented IVRCustom success locution and entry welcome

### DIFF
--- a/asterisk/agi/library/Agi/Action/IVRCustomAction.php
+++ b/asterisk/agi/library/Agi/Action/IVRCustomAction.php
@@ -45,6 +45,12 @@ class IVRCustomAction extends IVRAction
         foreach ($entries as $entry) {
             // Found a matching entry
             if (preg_match('/' . $entry->getEntry() . '/', $userPressed)) {
+                // Entered data matched one of the entries, play success (if any)
+                $this->agi->playback($ivr->getSuccessLocution());
+
+                // Play entry success (if any)
+                $this->agi->playback($entry->getWelcomeLocution());
+
                 // For extension, use extension routing to apply timeout
                 if ($entry->getTargetType() == 'extension') {
                     $extension = $entry->getTargetExtension();

--- a/asterisk/agi/library/Agi/Wrapper.php
+++ b/asterisk/agi/library/Agi/Wrapper.php
@@ -139,6 +139,10 @@ class Agi_Wrapper
         // FIXME Allow PhraseID instead of Filepath?
         //return $this->_fastagi->exec("Playback", $file);
 
+        if (is_null($file) || empty($file)) {
+            return;
+        }
+
         if ($file instanceof \IvozProvider\Model\Raw\Locutions) {
             $file = $file->getLocutionPath();
         }


### PR DESCRIPTION
This locutions where implmented in the portal interface but was not being
actually used. This changes also includes an improvement in playback wrapper
function to ignore playback requests on not configured locutions.

IVRCustom Success locution can be used to indicate a generic message to confirm
the entered input has been accepted. IVRCustom Entry Welcome locution can be
used to provide specific information what destination is being contacted.

Take into account that if both locutions are specified, both will be played.


This can be safely cherry-picked into _oasis_ branch.
