### PR TITLE
voicemail: use voicemail context when checking destination email

### DIFF
--- a/asterisk/config/voicemail.conf
+++ b/asterisk/config/voicemail.conf
@@ -35,6 +35,7 @@ attachfmt=wav
 ; ${VM_CATEGORY}        * Sets voicemail category
 ; ${VM_NAME}            * Full name in voicemail
 ; ${VM_MAILBOX}         * Mailbox Number
+; ${VM_CONTEXT}         * Mailbox Context
 ; ${VM_DUR}             * Voicemail duration
 ; ${VM_MSGNUM}          * Number of voicemail message in mailbox
 ; ${VM_CALLERID}        * Voicemail Caller ID (Person leaving vm)
@@ -42,7 +43,7 @@ attachfmt=wav
 ; ${VM_CIDNUM}          * Voicemail Caller ID Number
 ; ${VM_DATE}            * Voicemail Date
 ; ${VM_MESSAGEFILE}     * Path to message left by caller
-emailbody=${VM_CATEGORY}\n${VM_NAME}\n${VM_MAILBOX}\n${VM_DUR}\n${VM_MSGNUM}\n${VM_CALLERID}\n${VM_CIDNAME}\n${VM_CIDNUM}\n${VM_DATE}\n${VM_MESSAGEFILE}
+emailbody=${VM_CATEGORY}\n${VM_NAME}\n${VM_MAILBOX}\n${VM_CONTEXT}\n${VM_DUR}\n${VM_MSGNUM}\n${VM_CALLERID}\n${VM_CIDNAME}\n${VM_CIDNUM}\n${VM_DATE}\n${VM_MESSAGEFILE}
 
 ; Using the mailcmd option, you can specify what command is called for
 ; outbound E-mail. The default is shown below.


### PR DESCRIPTION
Voicemal handler for sending notifications was only checking the voicemail
number but not the context, sending the nofications to first user found with
same voicemail number that the expected destination.

This changes includes the context in voicemail notification so we can get the
destination user properly.

There's also included a couple of minor fixes, formatting cleanup and extra
checks.