### PR TITLE
agi: support extension in voicemail check services

### DIFF
--- a/asterisk/agi/library/Agi/Wrapper.php
+++ b/asterisk/agi/library/Agi/Wrapper.php
@@ -252,9 +252,9 @@ class Agi_Wrapper
         return $this->_fastagi->exec('VoiceMail', "$mailbox,$opts");
     }
 
-    public function checkVoicemail($mailbox)
+    public function checkVoicemail($mailbox, $options = "")
     {
-        return $this->_fastagi->exec('VoiceMailMain', "$mailbox,s");
+        return $this->_fastagi->exec('VoiceMailMain', $mailbox . ',' . $options);
     }
 
     public function setCallType($value)


### PR DESCRIPTION
Prior to this change the Voicemail check service only allowed checking the caller voicemail.

This changes allows to provide an extra extension after the service code, to check other user's.
voicemail (p.e. *981001 to check user 1001 voicemail).

Users can still secure their voicemails using the voicemail settings menu and configure a password.
Password won't be requested when the caller checks its own voicemail.


This PR is related with #15 and fixes #136