### PR TITLE
Locution record service

### DIFF
--- a/asterisk/agi/application/configs/application.ini
+++ b/asterisk/agi/application/configs/application.ini
@@ -46,6 +46,12 @@ Iron.fso.localStoragePath  = "/opt/irontec/ivozprovider/storage"
 Iron.fso.entity.oasis_model_musicOnHold.adapters.storagePathResolver.driver = '\IvozProvider\Model\Fso\Adapter\StoragePathResolver\MusicOnHold'
 Iron.fso.localStorageChmod = "0777"
 
+;;;;;;;;;;;;;;;;
+;; GEARMAND!! ;;
+;;;;;;;;;;;;;;;;
+gearmand.servers[] = "jobs.ivozprovider.local"
+gearmand.client.timeout = 5000
+
 [staging : production]
 
 [testing : production]

--- a/asterisk/agi/library/Agi/Wrapper.php
+++ b/asterisk/agi/library/Agi/Wrapper.php
@@ -172,6 +172,11 @@ class Agi_Wrapper
         return $this->_fastagi->get_variable("PRESSED");
     }
 
+    public function record($file, $options = "")
+    {
+        $this->_fastagi->exec("Record", $file . "," . $options);
+    }
+
     public function getDeviceState($interface, $prefix = "PJSIP/")
     {
         return $this->getVariable("DEVICE_STATE($prefix$interface)");

--- a/asterisk/config/modules.conf
+++ b/asterisk/config/modules.conf
@@ -118,4 +118,5 @@ load => app_directed_pickup.so
 load => app_confbridge.so
 load => app_sendtext.so
 load => app_mixmonitor.so
+load => app_record.so
 load => func_groupcount.so

--- a/doc/sphinx/locale/es/LC_MESSAGES/pbx_features.po
+++ b/doc/sphinx/locale/es/LC_MESSAGES/pbx_features.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: IvozProvider 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-06-05 14:56+0200\n"
+"POT-Creation-Date: 2017-06-12 17:09+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -703,7 +703,7 @@ msgstr ""
 #: ../../pbx_features/conference_rooms.rst:17
 #: ../../pbx_features/external_filters.rst:74 ../../pbx_features/friends.rst:69
 #: ../../pbx_features/ivrs.rst:24 ../../pbx_features/queues.rst:28
-#: ../../pbx_features/terminals.rst:17 ../../pbx_features/users.rst:23
+#: ../../pbx_features/terminals.rst:24 ../../pbx_features/users.rst:23
 msgid "Name"
 msgstr "Nombre"
 
@@ -1345,7 +1345,7 @@ msgstr ""
 "un *friend*, **se encaminará la llamada al que tenga menor valor de "
 "prioridad**."
 
-#: ../../pbx_features/friends.rst:81 ../../pbx_features/terminals.rst:21
+#: ../../pbx_features/friends.rst:81 ../../pbx_features/terminals.rst:28
 #: ../../pbx_features/users.rst:46
 msgid "Password"
 msgstr "Contraseña"
@@ -2283,6 +2283,14 @@ msgstr ""
 
 #: ../../pbx_features/sounds.rst:14
 msgid ""
+"Locutions can be recorded from any terminal by dialing the Recording "
+"extension displayed in their edit screen."
+msgstr ""
+"Las locuciones pueden ser grabadas desde cualquier terminal marcando "
+"la extensión de grabado que se muestra en su pantalla de edición."
+
+#: ../../pbx_features/sounds.rst:17
+msgid ""
 "The main difference between a **locution** and **music on hold** is that "
 "the administrator chooses when the first one will be played (out of "
 "schedule, IVRs, and so on) and the second one will be played when a call "
@@ -2315,7 +2323,7 @@ msgstr ""
 "La mejor forma de entender la sección es crear uno nuevo y ver los campos"
 " que tenemos que cumplimentar:"
 
-#: ../../pbx_features/terminals.rst:19
+#: ../../pbx_features/terminals.rst:26
 msgid ""
 "Username that will use the terminal during the SIP authentication phase "
 "with IvozProvider."
@@ -2323,7 +2331,7 @@ msgstr ""
 "Usuario que utilizará el terminal para presentarse ante IvozProvider y "
 "para realizar la fase de autenticación SIP."
 
-#: ../../pbx_features/terminals.rst:23
+#: ../../pbx_features/terminals.rst:30
 msgid ""
 "Password that will use the terminal to answer the SIP authentication "
 "challenge. You can use the automatic password generator to fullfill the "
@@ -2333,19 +2341,19 @@ msgstr ""
 "autenticación SIP. Utilizar el generador automático de contraseñas para "
 "cumplir los criterios de seguridad exigidos."
 
-#: ../../pbx_features/terminals.rst:26
+#: ../../pbx_features/terminals.rst:33
 msgid "Allowed/Disallowed codecs"
 msgstr "Codecs rechazados/permitidos"
 
-#: ../../pbx_features/terminals.rst:28
+#: ../../pbx_features/terminals.rst:35
 msgid "Determines what audio and video codecs will be used with the terminal."
 msgstr "Determina que codecs de audio y video serán empleados con el terminal."
 
-#: ../../pbx_features/terminals.rst:29
+#: ../../pbx_features/terminals.rst:36
 msgid "CallerID update method"
 msgstr "Modo de actualización"
 
-#: ../../pbx_features/terminals.rst:31
+#: ../../pbx_features/terminals.rst:38
 msgid ""
 "Choose the SIP method the terminal prefers to received the session update"
 " information: INVITE or UPDATE. The help hint can be used as guide to "
@@ -2356,11 +2364,11 @@ msgstr ""
 "actualizar la sesión. La sección de ayuda indica qué terminales suelen "
 "requerir qué método. En caso de duda, utilizar *invite*."
 
-#: ../../pbx_features/terminals.rst:35
+#: ../../pbx_features/terminals.rst:42
 msgid "Terminal model"
 msgstr "Modelo de terminal"
 
-#: ../../pbx_features/terminals.rst:37
+#: ../../pbx_features/terminals.rst:44
 msgid ""
 "Determines the provisioning type that will receive this terminal. The "
 "section :ref:`terminal provisioning <provisioning>` will explain in depth"
@@ -2373,11 +2381,11 @@ msgstr ""
 " y se explicará todo en profundidad. En caso de no necesitar provisión, "
 "utilizar *Generic*."
 
-#: ../../pbx_features/terminals.rst:41
+#: ../../pbx_features/terminals.rst:48
 msgid "MAC"
 msgstr "MAC"
 
-#: ../../pbx_features/terminals.rst:43
+#: ../../pbx_features/terminals.rst:50
 msgid ""
 "Optional field that is only required if you plan to use IvozProvider "
 ":ref:`terminal provisioning <provisioning>`. This is the `phisical "
@@ -2389,7 +2397,7 @@ msgstr ""
 "física <https://es.wikipedia.org/wiki/Direcci%C3%B3n_MAC>`_ del  "
 "adaptador de red del dispositivo SIP."
 
-#: ../../pbx_features/terminals.rst:48
+#: ../../pbx_features/terminals.rst:55
 msgid ""
 "For **most of devices** that doesn't require provisioning just filling "
 "**username** and **password** will be enough."
@@ -2397,7 +2405,7 @@ msgstr ""
 "**En la mayoría** de dispositivos, siempre que no requieran provisión, "
 "**bastará con rellenar el nombre y contraseña**."
 
-#: ../../pbx_features/terminals.rst:51
+#: ../../pbx_features/terminals.rst:58
 msgid ""
 "Once the terminal has been created, most devices will only require the "
 "name, password and :ref:`Company SIP domain <domain_per_company>` in "

--- a/doc/sphinx/pbx_features/sounds.rst
+++ b/doc/sphinx/pbx_features/sounds.rst
@@ -11,6 +11,9 @@ accross the platform.
 
 .. image:: img/sounds.png
 
+.. attention:: Locutions can be recorded from any terminal by dialing the
+   Recording extension displayed in their edit screen.
+
 .. hint:: The main difference between a **locution** and **music on hold** is 
    that the administrator chooses when the first one will be played (out of 
    schedule, IVRs, and so on) and the second one will be played when a call is

--- a/library/IvozProvider/Klear/Ghost/RecordLocution.php
+++ b/library/IvozProvider/Klear/Ghost/RecordLocution.php
@@ -1,0 +1,19 @@
+<?php
+
+class IvozProvider_Klear_Ghost_RecordLocution extends KlearMatrix_Model_Field_Ghost_Abstract
+{
+    public function getRecordingExtension($model)
+    {
+        // Get Locution Service code
+        $company = $model->getCompany();
+        $services = $company->getCompanyServices();
+
+        // Get Recording number for this locution
+        foreach ($services as $service) {
+            if ($service->getService()->getIden() === "RecordLocution") {
+                return "*" . $service->getCode() . $model->getId();
+            }
+        }
+    }
+
+}

--- a/portals/application/configs/klear/LocutionsList.yaml
+++ b/portals/application/configs/klear/LocutionsList.yaml
@@ -27,6 +27,7 @@ production:
           companyId: true
           name: true
           originalFile: true
+          recordingExtension: true
         blacklist:
           encodedFile: true
       options: 
@@ -51,6 +52,7 @@ production:
         blacklist:
           encodedFile: true
           status: true
+          recordingExtension: true
       fixedPositions:
         group0:
           colsPerRow: 2
@@ -80,6 +82,7 @@ production:
           fields:
             companyId: 1
             name: 1
+            recordingExtension: 1
         group1:
           colsPerRow: 1
           fields:

--- a/portals/application/configs/klear/model/Locutions.yaml
+++ b/portals/application/configs/klear/model/Locutions.yaml
@@ -66,6 +66,12 @@ production:
       trim: both
       required: true
       default: true
+    recordingExtension:
+      title: _('Recording extension')
+      type: ghost
+      source:
+        class: IvozProvider_Klear_Ghost_RecordLocution
+        method: getRecordingExtension
 staging: 
   _extends: production
 testing: 

--- a/scheme/deltas/055-record-locution-service.sql
+++ b/scheme/deltas/055-record-locution-service.sql
@@ -1,0 +1,8 @@
+-- Add extra service to record company locutions from terminal
+INSERT INTO `Services` VALUES (4,'RecordLocution','', 'Record Locution','Grabar Locucion','', 'Add the locution code after the service code','Añada el código de locución tras el código de servicio','00', 1);
+
+-- Enable Service for all Brands
+INSERT INTO BrandServices (serviceId, brandId, code) SELECT 4, id, '00' FROM Brands;
+
+-- Enable Service for all Companies
+INSERT INTO CompanyServices (serviceId, companyId, code) SELECT 4, id, '00' FROM Companies;


### PR DESCRIPTION
Introduced a new service to record existing locutions by dialing an specific extension.

This change includes a new service with iden RecordLocution configurable at Brand and Company
levels. By default, the Service is enabled in all existing companies with code *00

This allows dialing a specific code followed by the locution id to record the locution sound.

Converting from the original recorded format into asterisk specific format is done by the
existing gearmand multimedia worker.

This change requires record-*.wav files in ivozprovider-asterisk-sounds package in order to
reproduce recording instructions.

This PR fixes #52 
This PR must be merged **AFTER** #133 (due to scheme changes)