### PR TITLE
Remove stats on delete

### DIFF
--- a/library/IvozProvider/Mapper/Sql/DbTable/KamAccCdrs.php
+++ b/library/IvozProvider/Mapper/Sql/DbTable/KamAccCdrs.php
@@ -55,14 +55,14 @@ class KamAccCdrs extends TableAbstract
             'refTableClass' => 'IvozProvider\\Mapper\\Sql\\DbTable\\Invoices',
             'refColumns' => 'id'
         ),
+        'KamAccCdrsIbfk4' => array(
+            'columns' => 'companyId',
+            'refTableClass' => 'IvozProvider\\Mapper\\Sql\\DbTable\\Companies',
+            'refColumns' => 'id'
+        ),
         'KamAccCdrsIbfk5' => array(
             'columns' => 'brandId',
             'refTableClass' => 'IvozProvider\\Mapper\\Sql\\DbTable\\Brands',
-            'refColumns' => 'id'
-        ),
-        'KamAccCdrsIbfk6' => array(
-            'columns' => 'companyId',
-            'refTableClass' => 'IvozProvider\\Mapper\\Sql\\DbTable\\Companies',
             'refColumns' => 'id'
         )
     );

--- a/library/IvozProvider/Model/Raw/Brands.php
+++ b/library/IvozProvider/Model/Raw/Brands.php
@@ -290,7 +290,7 @@ class Brands extends ModelAbstract
     protected $_OutgoingRouting;
 
     /**
-     * Dependent relation parsedCDRs_ibfk_1
+     * Dependent relation ParsedCDRs_ibfk_1
      * Type: One-to-Many relationship
      *
      * @var \IvozProvider\Model\Raw\ParsedCDRs[]
@@ -2712,7 +2712,7 @@ class Brands extends ModelAbstract
     }
 
     /**
-     * Sets dependent relations parsedCDRs_ibfk_1
+     * Sets dependent relations ParsedCDRs_ibfk_1
      *
      * @param array $data An array of \IvozProvider\Model\Raw\ParsedCDRs
      * @return \IvozProvider\Model\Raw\Brands
@@ -2760,7 +2760,7 @@ class Brands extends ModelAbstract
     }
 
     /**
-     * Sets dependent relations parsedCDRs_ibfk_1
+     * Sets dependent relations ParsedCDRs_ibfk_1
      *
      * @param \IvozProvider\Model\Raw\ParsedCDRs $data
      * @return \IvozProvider\Model\Raw\Brands
@@ -2773,7 +2773,7 @@ class Brands extends ModelAbstract
     }
 
     /**
-     * Gets dependent parsedCDRs_ibfk_1
+     * Gets dependent ParsedCDRs_ibfk_1
      *
      * @param string or array $where
      * @param string or array $orderBy

--- a/library/IvozProvider/Model/Raw/Companies.php
+++ b/library/IvozProvider/Model/Raw/Companies.php
@@ -422,7 +422,7 @@ class Companies extends ModelAbstract
     protected $_OutgoingRouting;
 
     /**
-     * Dependent relation parsedCDRs_ibfk_2
+     * Dependent relation ParsedCDRs_ibfk_2
      * Type: One-to-Many relationship
      *
      * @var \IvozProvider\Model\Raw\ParsedCDRs[]
@@ -494,7 +494,7 @@ class Companies extends ModelAbstract
     protected $_Users;
 
     /**
-     * Dependent relation kam_acc_cdrs_ibfk_6
+     * Dependent relation kam_acc_cdrs_ibfk_4
      * Type: One-to-Many relationship
      *
      * @var \IvozProvider\Model\Raw\KamAccCdrs[]
@@ -700,7 +700,7 @@ class Companies extends ModelAbstract
                     'property' => 'Users',
                     'table_name' => 'Users',
                 ),
-            'KamAccCdrsIbfk6' => array(
+            'KamAccCdrsIbfk4' => array(
                     'property' => 'KamAccCdrs',
                     'table_name' => 'kam_acc_cdrs',
                 ),
@@ -3823,7 +3823,7 @@ class Companies extends ModelAbstract
     }
 
     /**
-     * Sets dependent relations parsedCDRs_ibfk_2
+     * Sets dependent relations ParsedCDRs_ibfk_2
      *
      * @param array $data An array of \IvozProvider\Model\Raw\ParsedCDRs
      * @return \IvozProvider\Model\Raw\Companies
@@ -3871,7 +3871,7 @@ class Companies extends ModelAbstract
     }
 
     /**
-     * Sets dependent relations parsedCDRs_ibfk_2
+     * Sets dependent relations ParsedCDRs_ibfk_2
      *
      * @param \IvozProvider\Model\Raw\ParsedCDRs $data
      * @return \IvozProvider\Model\Raw\Companies
@@ -3884,7 +3884,7 @@ class Companies extends ModelAbstract
     }
 
     /**
-     * Gets dependent parsedCDRs_ibfk_2
+     * Gets dependent ParsedCDRs_ibfk_2
      *
      * @param string or array $where
      * @param string or array $orderBy
@@ -4633,7 +4633,7 @@ class Companies extends ModelAbstract
     }
 
     /**
-     * Sets dependent relations kam_acc_cdrs_ibfk_6
+     * Sets dependent relations kam_acc_cdrs_ibfk_4
      *
      * @param array $data An array of \IvozProvider\Model\Raw\KamAccCdrs
      * @return \IvozProvider\Model\Raw\Companies
@@ -4681,7 +4681,7 @@ class Companies extends ModelAbstract
     }
 
     /**
-     * Sets dependent relations kam_acc_cdrs_ibfk_6
+     * Sets dependent relations kam_acc_cdrs_ibfk_4
      *
      * @param \IvozProvider\Model\Raw\KamAccCdrs $data
      * @return \IvozProvider\Model\Raw\Companies
@@ -4689,12 +4689,12 @@ class Companies extends ModelAbstract
     public function addKamAccCdrs(\IvozProvider\Model\Raw\KamAccCdrs $data)
     {
         $this->_KamAccCdrs[] = $data;
-        $this->_setLoaded('KamAccCdrsIbfk6');
+        $this->_setLoaded('KamAccCdrsIbfk4');
         return $this;
     }
 
     /**
-     * Gets dependent kam_acc_cdrs_ibfk_6
+     * Gets dependent kam_acc_cdrs_ibfk_4
      *
      * @param string or array $where
      * @param string or array $orderBy
@@ -4703,7 +4703,7 @@ class Companies extends ModelAbstract
      */
     public function getKamAccCdrs($where = null, $orderBy = null, $avoidLoading = false)
     {
-        $fkName = 'KamAccCdrsIbfk6';
+        $fkName = 'KamAccCdrsIbfk4';
 
         $usingDefaultArguments = is_null($where) && is_null($orderBy);
         if (!$usingDefaultArguments) {

--- a/library/IvozProvider/Model/Raw/KamAccCdrs.php
+++ b/library/IvozProvider/Model/Raw/KamAccCdrs.php
@@ -297,18 +297,18 @@ class KamAccCdrs extends ModelAbstract
     protected $_Invoice;
 
     /**
+     * Parent relation kam_acc_cdrs_ibfk_4
+     *
+     * @var \IvozProvider\Model\Raw\Companies
+     */
+    protected $_Company;
+
+    /**
      * Parent relation kam_acc_cdrs_ibfk_5
      *
      * @var \IvozProvider\Model\Raw\Brands
      */
     protected $_Brand;
-
-    /**
-     * Parent relation kam_acc_cdrs_ibfk_6
-     *
-     * @var \IvozProvider\Model\Raw\Companies
-     */
-    protected $_Company;
 
 
     protected $_columnsList = array(
@@ -374,13 +374,13 @@ class KamAccCdrs extends ModelAbstract
                     'property' => 'Invoice',
                     'table_name' => 'Invoices',
                 ),
+            'KamAccCdrsIbfk4'=> array(
+                    'property' => 'Company',
+                    'table_name' => 'Companies',
+                ),
             'KamAccCdrsIbfk5'=> array(
                     'property' => 'Brand',
                     'table_name' => 'Brands',
-                ),
-            'KamAccCdrsIbfk6'=> array(
-                    'property' => 'Company',
-                    'table_name' => 'Companies',
                 ),
         ));
 
@@ -1881,6 +1881,57 @@ class KamAccCdrs extends ModelAbstract
     }
 
     /**
+     * Sets parent relation Company
+     *
+     * @param \IvozProvider\Model\Raw\Companies $data
+     * @return \IvozProvider\Model\Raw\KamAccCdrs
+     */
+    public function setCompany(\IvozProvider\Model\Raw\Companies $data)
+    {
+        $this->_Company = $data;
+
+        $primaryKey = $data->getPrimaryKey();
+        if (is_array($primaryKey)) {
+            $primaryKey = $primaryKey['id'];
+        }
+
+        if (!is_null($primaryKey)) {
+            $this->setCompanyId($primaryKey);
+        }
+
+        $this->_setLoaded('KamAccCdrsIbfk4');
+        return $this;
+    }
+
+    /**
+     * Gets parent Company
+     * TODO: Mejorar esto para los casos en que la relación no exista. Ahora mismo siempre se pediría el padre
+     * @return \IvozProvider\Model\Raw\Companies
+     */
+    public function getCompany($where = null, $orderBy = null, $avoidLoading = false)
+    {
+        $fkName = 'KamAccCdrsIbfk4';
+
+        $usingDefaultArguments = is_null($where) && is_null($orderBy);
+        if (!$usingDefaultArguments) {
+            $this->setNotLoaded($fkName);
+        }
+
+        $dontSkipLoading = !($avoidLoading);
+        $notLoadedYet = !($this->_isLoaded($fkName));
+
+        if ($dontSkipLoading && $notLoadedYet) {
+            $related = $this->getMapper()->loadRelated('parent', $fkName, $this, $where, $orderBy);
+            $this->_Company = array_shift($related);
+            if ($usingDefaultArguments) {
+                $this->_setLoaded($fkName);
+            }
+        }
+
+        return $this->_Company;
+    }
+
+    /**
      * Sets parent relation Brand
      *
      * @param \IvozProvider\Model\Raw\Brands $data
@@ -1929,57 +1980,6 @@ class KamAccCdrs extends ModelAbstract
         }
 
         return $this->_Brand;
-    }
-
-    /**
-     * Sets parent relation Company
-     *
-     * @param \IvozProvider\Model\Raw\Companies $data
-     * @return \IvozProvider\Model\Raw\KamAccCdrs
-     */
-    public function setCompany(\IvozProvider\Model\Raw\Companies $data)
-    {
-        $this->_Company = $data;
-
-        $primaryKey = $data->getPrimaryKey();
-        if (is_array($primaryKey)) {
-            $primaryKey = $primaryKey['id'];
-        }
-
-        if (!is_null($primaryKey)) {
-            $this->setCompanyId($primaryKey);
-        }
-
-        $this->_setLoaded('KamAccCdrsIbfk6');
-        return $this;
-    }
-
-    /**
-     * Gets parent Company
-     * TODO: Mejorar esto para los casos en que la relación no exista. Ahora mismo siempre se pediría el padre
-     * @return \IvozProvider\Model\Raw\Companies
-     */
-    public function getCompany($where = null, $orderBy = null, $avoidLoading = false)
-    {
-        $fkName = 'KamAccCdrsIbfk6';
-
-        $usingDefaultArguments = is_null($where) && is_null($orderBy);
-        if (!$usingDefaultArguments) {
-            $this->setNotLoaded($fkName);
-        }
-
-        $dontSkipLoading = !($avoidLoading);
-        $notLoadedYet = !($this->_isLoaded($fkName));
-
-        if ($dontSkipLoading && $notLoadedYet) {
-            $related = $this->getMapper()->loadRelated('parent', $fkName, $this, $where, $orderBy);
-            $this->_Company = array_shift($related);
-            if ($usingDefaultArguments) {
-                $this->_setLoaded($fkName);
-            }
-        }
-
-        return $this->_Company;
     }
 
     /**

--- a/library/IvozProvider/Model/Raw/ParsedCDRs.php
+++ b/library/IvozProvider/Model/Raw/ParsedCDRs.php
@@ -221,14 +221,14 @@ class ParsedCDRs extends ModelAbstract
 
 
     /**
-     * Parent relation parsedCDRs_ibfk_1
+     * Parent relation ParsedCDRs_ibfk_1
      *
      * @var \IvozProvider\Model\Raw\Brands
      */
     protected $_Brand;
 
     /**
-     * Parent relation parsedCDRs_ibfk_2
+     * Parent relation ParsedCDRs_ibfk_2
      *
      * @var \IvozProvider\Model\Raw\Companies
      */

--- a/scheme/deltas/056-delete-stats-on-delete.sql
+++ b/scheme/deltas/056-delete-stats-on-delete.sql
@@ -1,0 +1,18 @@
+/* Delete stats from deleted companies/brands */
+DELETE FROM `ParsedCDRs` WHERE `brandId` IS NULL;
+DELETE FROM `ParsedCDRs` WHERE `companyId` IS NULL;
+
+ALTER TABLE `ParsedCDRs` DROP FOREIGN KEY `parsedCDRs_ibfk_1`;
+ALTER TABLE `ParsedCDRs` DROP FOREIGN KEY `parsedCDRs_ibfk_2`;
+
+ALTER TABLE `ParsedCDRs` ADD FOREIGN KEY (`brandId`) REFERENCES `Brands` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE `ParsedCDRs` ADD FOREIGN KEY (`companyId`) REFERENCES `Companies` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+DELETE FROM `kam_acc_cdrs` WHERE `brandId` IS NULL;
+DELETE FROM `kam_acc_cdrs` WHERE `companyId` IS NULL;
+
+ALTER TABLE `kam_acc_cdrs` DROP FOREIGN KEY `kam_acc_cdrs_ibfk_5`;
+ALTER TABLE `kam_acc_cdrs` DROP FOREIGN KEY `kam_acc_cdrs_ibfk_6`;
+
+ALTER TABLE `kam_acc_cdrs` ADD FOREIGN KEY (`companyId`) REFERENCES `Companies` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE `kam_acc_cdrs` ADD FOREIGN KEY (`brandId`) REFERENCES `Brands` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;


### PR DESCRIPTION
This PR aims to fix the problem of the tarificator process when parsing calls of deleted brands/companies.

The goal of this delta file is to remove all the stats related to deleted companies/brands, as saving them is not really useful.