### PR TITLE
Simplify kam users view

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -571,6 +571,7 @@ route[GENERATE_PUBLISH] {
         if ($xavp(rp=>extension) != $null) {
             if ($dlg_var(log)) xlog("L_INFO", "[b$dlg_var(brandId)][$dlg_var(cidhash)] GENERATE-PUBLISH: Set '$xavp(rp=>extension)' as caller instead of '$fU'\n");
             $avp(pubruri_caller)= "sip:" + $xavp(rp=>extension) + "@" + $fd;
+            $dlg_var(caller) = $xavp(rp=>extension); # Update accounting dlg_var too
         }
     }
 }
@@ -722,20 +723,9 @@ route[RETAILS] {
 
 route[GET_INFO_FROM_CALLER] {
     # Get needed information from terminal name
-    sql_xquery("cb", "SELECT KU.type AS callerType, EXT.number AS userExtension, C.id AS companyId, C.brandId AS brandId, C.name AS companyName, C.mediaRelaySetsId, C.ipFilter, AppS.ip AS asAddress, C.onDemandRecord, C.onDemandRecordCode FROM kam_users KU LEFT JOIN Users U ON U.terminalId=KU.terminalId LEFT JOIN Extensions EXT ON EXT.Id=U.extensionId LEFT JOIN Companies C ON KU.companyId=C.id LEFT JOIN ApplicationServers AppS ON AppS.id=C.applicationServerId WHERE KU.name='$fU' AND KU.domain='$fd'", "ra");
+    sql_xquery("cb", "SELECT KU.type AS callerType, C.id AS companyId, C.brandId AS brandId, C.name AS companyName, C.mediaRelaySetsId, C.ipFilter, AppS.ip AS asAddress, C.onDemandRecord, C.onDemandRecordCode FROM kam_users KU LEFT JOIN Companies C ON C.id=KU.companyId LEFT JOIN ApplicationServers AppS ON AppS.id=C.applicationServerId WHERE KU.name='$fU' AND KU.domain='$fd'", "ra");
 
     if ($dlg_var(log)) xlog("L_INFO", "[b$dlg_var(brandId)][$dlg_var(cidhash)] GET-INFO-FROM-CALLER: callerType: $xavp(ra=>callerType)\n");
-
-    if ($xavp(ra=>userExtension) == $null) {
-        if ($xavp(ra=>callerType) == 'terminal') {
-            if ($dlg_var(log)) xlog("L_WARN", "[b$dlg_var(brandId)][$dlg_var(cidhash)] GET-INFO-FROM-CALLER: extension not found for terminal, keep $dlg_var(caller) as caller\n");
-        } else {
-            if ($dlg_var(log)) xlog("L_INFO", "[b$dlg_var(brandId)][$dlg_var(cidhash)] GET-INFO-FROM-CALLER: friend/retail calling, keep $dlg_var(caller) as caller\n");
-        }
-    } else {
-        if ($dlg_var(log)) xlog("L_INFO", "[b$dlg_var(brandId)][$dlg_var(cidhash)] GET-INFO-FROM-CALLER: $xavp(ra=>callerType) calling, set $xavp(ra=>userExtension) as caller\n");
-        $dlg_var(caller) = $xavp(ra=>userExtension);
-    }
 
     if ($dlg_var(log)) xlog("L_INFO", "[b$dlg_var(brandId)][$dlg_var(cidhash)] GET-INFO-FROM-CALLER: brandId: $xavp(ra=>brandId)\n");
     $dlg_var(brandId) = $xavp(ra=>brandId);

--- a/scheme/deltas/059-simplify-kam_users-view.sql
+++ b/scheme/deltas/059-simplify-kam_users-view.sql
@@ -1,0 +1,9 @@
+/** kam_users: Update view **/
+DROP VIEW IF EXISTS `kam_users`;
+
+CREATE VIEW `kam_users` AS
+SELECT 'friend' AS type, name, domain, password, companyId FROM Friends
+UNION
+SELECT 'terminal' AS type, name, domain, password, companyId FROM Terminals
+UNION
+SELECT 'retail' AS type, name, domain, password, companyId FROM RetailAccounts;


### PR DESCRIPTION
$terminalName -> $extension conversion is now made in GENERATE_PUBLISH route, so both main query and kam_users view can be simplified.