### PR TITLE
tests: add initial bbs SIP tests

### DIFF
--- a/tests/bbs/0500-test-extension.yaml
+++ b/tests/bbs/0500-test-extension.yaml
@@ -1,0 +1,28 @@
+# test-ddi.yaml
+#
+# Simple scenario for testing a call between alice and bob
+# Bob must have the extension 1001 assigned
+#
+# ----------------------------------------------------------------------------
+scenarios:
+  - name: call from alice to bob at 1001
+    timeout: 20
+    sessions:
+
+      - call_uac_alice:
+          - credentials:
+              <<: *alice_cred
+          - wait
+          - call: 1001
+          - waitfor: CONFIRMED
+          - wait: 2
+          - hangup
+          - waitfor: DISCONNCTD
+
+      - call_uas_bob:
+          - register:
+              <<: *bob_cred
+          - waitfor: INCOMING
+          - answer
+          - waitfor: DISCONNCTD
+          - unregister

--- a/tests/bbs/1000-test-ddi.yaml
+++ b/tests/bbs/1000-test-ddi.yaml
@@ -1,0 +1,28 @@
+# test-extension.yaml
+#
+# Simple scenario for testing a call between alice and bob
+# Bob must have the extension 946946946 routed to him
+#
+# ----------------------------------------------------------------------------
+scenarios:
+  - name: call from alice to bob at 946946946
+    timeout: 20
+    sessions:
+
+      - call_uac_alice:
+          - credentials:
+              <<: *alice_cred
+          - wait
+          - call: 946946946
+          - waitfor: CONFIRMED
+          - wait: 2
+          - hangup
+          - waitfor: DISCONNCTD
+
+      - call_uas_bob:
+          - register:
+              <<: *bob_cred
+          - waitfor: INCOMING
+          - answer
+          - waitfor: DISCONNCTD
+          - unregister

--- a/tests/bbs/2000-test-ivr-common.yaml
+++ b/tests/bbs/2000-test-ivr-common.yaml
@@ -1,0 +1,31 @@
+# test-ivr.yaml
+#
+# Simple scenario for testing a call from bob to alice through a IVR
+# IVR must have the extension 600 assigned
+# Bob must have the extension 1001 assigned
+#
+# ----------------------------------------------------------------------------
+scenarios:
+  - name: call from bob to alice using IVR common
+    type: simple
+    timeout: 20
+    sessions:
+      - ivr_uac_bob:
+          - credentials:
+              <<: *bob_cred
+          - call: 600             # IVR common extension
+          - waitfor: CONFIRMED
+          - wait: 3
+          - dtmf: 1000
+          - waitfor: DISCONNCTD
+      - ivr_uas_alice:
+          - register:
+              <<: *alice_cred
+          - waitfor: INCOMING
+          - ringing
+          - wait
+          - answer
+          - waitfor: CONFIRMED
+          - wait
+          - hangup
+          - waitfor: DISCONNCTD

--- a/tests/bbs/2010-test-ivr-custom.yaml
+++ b/tests/bbs/2010-test-ivr-custom.yaml
@@ -1,0 +1,31 @@
+# test-ivr.yaml
+#
+# Simple scenario for testing a call from bob to alice through a IVR
+# IVR must have the extension 600 assigned
+# Bob must have the extension 1001 assigned
+#
+# ----------------------------------------------------------------------------
+  - name: call from bob to alice using IVR custom
+    type: simple
+    timeout: 20
+    sessions:
+      - ivr_uac_bob:
+          - credentials:
+              <<: *bob_cred
+          - call: 601             # IVR custom extension
+          - waitfor: CONFIRMED
+          - wait: 3
+          - dtmf: 1
+          - waitfor: DISCONNCTD
+      - ivr_uas_alice:
+          - register:
+              <<: *alice_cred
+          - waitfor: INCOMING
+          - ringing
+          - wait
+          - answer
+          - waitfor: CONFIRMED
+          - wait
+          - hangup
+          - waitfor: DISCONNCTD
+

--- a/tests/bbs/2100-test-voicemail.yaml
+++ b/tests/bbs/2100-test-voicemail.yaml
@@ -1,0 +1,18 @@
+# test-voicemail.yaml
+#
+# Simple scenario for testing voicemail check extension
+# Voicemail check service mut be *98
+#
+# ----------------------------------------------------------------------------
+scenarios:
+  - name: call from alice to voicemail
+    timeout: 30
+    sessions:
+      - voicemail_test_uac:
+          - credentials:
+              <<: *alice_cred
+          - call: "*98"
+          - waitfor: CONFIRMED
+          - wait: 20
+          - dtmf: "#"
+          - waitfor: DISCONNCTD

--- a/tests/bbs/2200-test-pickup-group.yaml
+++ b/tests/bbs/2200-test-pickup-group.yaml
@@ -1,0 +1,35 @@
+# test-pickup.yaml
+#
+# Simple scenario for testing a call pickup
+# Bob must have the extension 1001 assigned
+# Group Pickup service must be configured with *7
+# Direct Pickup service must be configured with *95
+#
+# ----------------------------------------------------------------------------
+scenarios:
+  # Group pickup
+  - name: call from alice to bob picked up by charlie
+    timeout: 20
+    sessions:
+      - caller_alice:
+          - credentials:
+              <<: *alice_cred
+          - call: 1001
+          - waitfor: CONFIRMED
+          - wait: 3
+          - hangup
+          - waitfor: DISCONNCTD
+      - callee_bob:
+          - register:
+              <<: *bob_cred
+          - waitfor: INCOMING
+          - ringing
+          - waitfor: DISCONNCTD
+      - pickuper_charlie:
+          - credentials:
+              <<: *charlie_cred
+          - wait: 5
+          - call: '*7'
+          - waitfor: CONFIRMED
+          - waitfor: DISCONNCTD
+

--- a/tests/bbs/2210-test-pickup-direct.yaml
+++ b/tests/bbs/2210-test-pickup-direct.yaml
@@ -1,0 +1,34 @@
+# test-pickup.yaml
+#
+# Simple scenario for testing a call pickup
+# Bob must have the extension 1001 assigned
+# Group Pickup service must be configured with *7
+# Direct Pickup service must be configured with *95
+#
+# ----------------------------------------------------------------------------
+  # Direct pickup
+  - name: call from alice to bob direct picked up by charlie
+    timeout: 20
+    sessions:
+      - caller_alice:
+          - credentials:
+              <<: *alice_cred
+          - call: 1001
+          - waitfor: CONFIRMED
+          - wait: 3
+          - hangup
+          - waitfor: DISCONNCTD
+      - callee_bob:
+          - register:
+              <<: *bob_cred
+          - waitfor: INCOMING
+          - ringing
+          - waitfor: DISCONNCTD
+      - pickuper_charlie:
+          - credentials:
+              <<: *charlie_cred
+          - wait: 5
+          - call: '*951001'
+          - waitfor: CONFIRMED
+          - waitfor: DISCONNCTD
+

--- a/tests/bbs/2300-test-conference.yaml
+++ b/tests/bbs/2300-test-conference.yaml
@@ -1,0 +1,21 @@
+# test-conference.yaml
+#
+# Simple scenario for testing route to pin protected conference room
+# Extension 500 must point to the conference room
+# Conference must have password 1234
+#
+# ----------------------------------------------------------------------------
+scenarios:
+  - name: call from alice to conference room
+    timeout: 30
+    sessions:
+      - voicemail_test_uac:
+          - credentials:
+              <<: *alice_cred
+          - call: 500
+          - waitfor: CONFIRMED
+          - wait: 5
+          - dtmf: 1234
+          - wait: 5
+          - hangup
+          - waitfor: DISCONNCTD

--- a/tests/bbs/3000-test-cfw-busy.yaml
+++ b/tests/bbs/3000-test-cfw-busy.yaml
@@ -1,0 +1,33 @@
+# test-cfw.yaml
+#
+# Simple scenario for testing user call forwards
+# Bob must have the extension 1001 assigned
+# And more things must happen
+#
+# ----------------------------------------------------------------------------
+scenarios:
+  - name: call from alice to bob busy forwarded to charlie
+    timeout: 20
+    sessions:
+      - caller_alice:
+          - credentials:
+              <<: *alice_cred
+          - call: 1001
+          - waitfor: CONFIRMED
+          - wait: 5
+          - hangup
+          - waitfor: DISCONNCTD
+      - callee_bob:
+          - register:
+              <<: *bob_cred
+          - waitfor: INCOMING
+          - busy
+          - waitfor: DISCONNCTD
+      - callee_charlie:
+          - register:
+              <<: *charlie_cred
+          - waitfor: INCOMING
+          - ringing
+          - wait
+          - answer
+          - waitfor: DISCONNCTD

--- a/tests/bbs/3100-test-cfw-noanswer.yaml
+++ b/tests/bbs/3100-test-cfw-noanswer.yaml
@@ -1,0 +1,33 @@
+# test-cfw.yaml
+#
+# Simple scenario for testing user call forwards
+# Bob must have the extension 1001 assigned
+# And more things must happen
+#
+# ----------------------------------------------------------------------------
+  - name: call from alice to charlie no-answer forwarded to bob
+    timeout: 20
+    sessions:
+      - caller_alice:
+          - credentials:
+              <<: *alice_cred
+          - call: 1002
+          - waitfor: CONFIRMED
+          - wait: 10
+          - hangup
+          - waitfor: DISCONNCTD
+      - callee_bob:
+          - register:
+              <<: *bob_cred
+          - waitfor: INCOMING
+          - ringing
+          - answer
+          - waitfor: DISCONNCTD
+      - callee_charlie:
+          - register:
+              <<: *charlie_cred
+          - waitfor: INCOMING
+          - ringing
+          - wait: 15
+          - waitfor: DISCONNCTD
+

--- a/tests/bbs/3200-test-cfw-unregistered.yaml
+++ b/tests/bbs/3200-test-cfw-unregistered.yaml
@@ -1,0 +1,27 @@
+# test-cfw.yaml
+#
+# Simple scenario for testing user call forwards
+# Bob must have the extension 1001 assigned
+# And more things must happen
+#
+# ----------------------------------------------------------------------------
+  - name: call from alice to eve no-registed forwarded to bob
+    timeout: 10
+    sessions:
+      - caller_alice:
+          - credentials:
+              <<: *alice_cred
+          - call: 1003
+          - waitfor: CONFIRMED
+          - wait: 5
+          - hangup
+          - waitfor: DISCONNCTD
+      - callee_bob:
+          - register:
+              <<: *bob_cred
+          - waitfor: INCOMING
+          - ringing
+          - answer
+          - waitfor: DISCONNCTD
+
+

--- a/tests/bbs/4000-test-attxfer.yaml
+++ b/tests/bbs/4000-test-attxfer.yaml
@@ -1,0 +1,53 @@
+# test-attxfer.yaml
+#
+# Simple scenario for testing attended transfer
+# Bob must have the extension 1001 assigned
+# Charlie must have the extension 1002 assigned
+#
+# ----------------------------------------------------------------------------
+
+scenarios:
+  - name: call from alice to bob transfered to charlie
+    timeout: 25
+    sessions:
+
+      # Alice: Call to Bob at 1001
+      - caller_alice:
+          - credentials:
+              <<: *alice_cred
+          - call: 1001
+          - waitfor: CONFIRMED
+          - waitfor: DISCONNCTD
+
+      # Bob: Receive the call from Alice and transfer to Charlie at 1002
+      - callee_bob:
+          - register:
+              <<: *bob_cred
+          - waitfor: INCOMING
+          - answer
+          - wait
+          - call:
+             name: TO_CHARLIE
+             number: 1002
+          - waitfor:
+             call: TO_CHARLIE
+             name: CONFIRMED
+          - attxfer: TO_CHARLIE
+          - waitfor: TRANSFER_ACCEPTED
+          - waitfor: TRANSFER_OK
+          - waitfor: { call: TO_CHARLIE, name: DISCONNCTD }
+          - hangup
+          - waitfor: DISCONNCTD
+          - unregister
+
+      # Charlie: Answer the call from Bob
+      - callee_charlie:
+          - register:
+              <<: *charlie_cred
+          - waitfor: INCOMING
+          - answer
+          - waitfor: CONFIRMED
+          - wait: 5
+          - hangup
+          - waitfor: DISCONNCTD
+          - unregister

--- a/tests/bbs/4100-test-blindxfer.yaml
+++ b/tests/bbs/4100-test-blindxfer.yaml
@@ -1,0 +1,41 @@
+# test-blindxfer.yaml
+#
+# Simple scenario for testing attended transfer
+# Bob must have the extension 1001 assigned
+# Charlie must have the extension 1002 assigned
+#
+# ----------------------------------------------------------------------------
+#
+scenarios:
+  - name: call from alice to bob blind transfered to charlie
+    timeout: 20
+    sessions:
+
+      - caller_alice:
+          - credentials:
+              <<: *alice_cred
+          - call: 1001
+          - waitfor: CONFIRMED
+          - waitfor: DISCONNCTD
+
+      - callee_bob:
+          - register:
+              <<: *bob_cred
+          - waitfor: INCOMING
+          - answer
+          - wait
+          - blindxfer: 1002
+          - waitfor: TRANSFER_ACCEPTED
+          - waitfor: TRANSFER_OK
+          - hangup
+          - waitfor: DISCONNCTD
+
+      - callee_charlie:
+          - register:
+              <<: *charlie_cred
+          - waitfor: INCOMING
+          - answer
+          - waitfor: CONFIRMED
+          - wait: 6
+          - hangup
+          - waitfor: DISCONNCTD

--- a/tests/bbs/4200-test-blondexfer.yaml
+++ b/tests/bbs/4200-test-blondexfer.yaml
@@ -1,0 +1,57 @@
+# test-attxfer.yaml
+#
+# Simple scenario for testing attended transfer
+# Alice must have extension 1000 assigned
+# Bob must have extension 1001 assigned
+# Charlie must have extension 1002 assigned
+#
+# ----------------------------------------------------------------------------
+
+scenarios:
+  - name: call from alice to charlie early transfered to bob
+    timeout: 25
+    sessions:
+
+      # Alice: Call from Alice to Charlie at 1002
+      - callee_alice:
+          - wait
+          - credentials:
+              <<: *alice_cred
+          - call: 1002
+          - waitfor: CONFIRMED
+          - waitfor: DISCONNCTD
+
+      # Charlie: Receive the call from Alice and transfer to Bob at 1001
+      - callee_charlie:
+          - register:
+              <<: *charlie_cred
+          - waitfor: INCOMING
+          - answer
+          - wait
+          - call:
+             name: TO_BOB
+             number: 1001
+          - waitfor:
+             call: TO_BOB
+             name: EARLY
+          - attxfer: TO_BOB
+          - waitfor: TRANSFER_ACCEPTED
+          - waitfor: { call: TO_BOB, name: DISCONNCTD }
+          - waitfor: TRANSFER_OK
+          - hangup
+          - waitfor: DISCONNCTD
+          - unregister
+
+      # Charlie: Answer the call from Bob
+      - callee_bob:
+          - register:
+              <<: *bob_cred
+          - waitfor: INCOMING
+          - ringing
+          - wait: 5
+          - answer
+          - waitfor: CONFIRMED
+          - wait
+          - hangup
+          - waitfor: DISCONNCTD
+

--- a/tests/bbs/README.md
+++ b/tests/bbs/README.md
@@ -1,0 +1,34 @@
+# BBS SIP Tests
+
+Files in this directory are used to test IvozProvider SIP behaviour by simulating
+calls between multiple users using [Black Box SIP](https://github.com/irontec/bbs)
+
+This tests are extremely superficial and they should be couple with
+traditional [SIPP](https://github.com/SIPp/sipp) tests.
+
+## Environment data
+
+In order to use the tests provided an extra file with environment data is required.
+
+This file is used to configure:
+
+ - Set user names and credentials
+ - Set SIP users server domain
+
+You can check _environment.yaml_ as example to create enviroment file. Tests assume that the required data used is already existing in the testing enviroment. You can pre-feed this data using rest tests if required.
+
+## Running tests
+
+Provided tests are generated to run with _bbs_ command line tool.
+Results can be exported in JUnit XML format for later analysis.
+
+```
+bbs -vvv -c 000-scenario.yaml -e environment.yaml -o results.xml
+```
+
+## Updating tests
+
+Test files are in YAML format and can contain multiples scenarios
+although it's recommended to split them for better results analysis.
+
+

--- a/tests/bbs/environment.yaml
+++ b/tests/bbs/environment.yaml
@@ -1,0 +1,15 @@
+users:
+  - alice: &alice_cred
+      username: alice
+      password: 4l1c3p4ssw0rd
+      domain: yoursip.domain.com
+
+  - bob: &bob_cred
+      username: bob
+      password: b0bp4ssw0rd
+      domain: yoursip.domain.com
+
+  - charlie: &charlie_cred
+      username: charlie
+      password: ch4rl13p4ssw0rd
+      domain: yoursip.domain.com


### PR DESCRIPTION
Files for simple SIP tests using BBS tool.

This tests are extremely superficial and they should be couple with
traditional [SIPP](https://github.com/SIPp/sipp) tests.