### PR TITLE
users+trunks: Inactivate even last AS

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -1255,12 +1255,8 @@ failure_route[MANAGE_FAILURE_AS] {
     if (t_check_status("404") or (t_branch_timeout() and !t_branch_replied())) {
         # Invalidate AS only if no response received
         if (t_branch_timeout() and !t_branch_replied()) {
-            if ($cnt($avp(AVP_DST)) > 1) {
-                if ($dlg_var(log)) xlog("L_ERR", "[b$dlg_var(brandId)][$dlg_var(cidhash)] MANAGE-FAILURE-AS: Mark AS '$avp(AVP_DST)' as inactive\n");
-                ds_mark_dst("ip");
-            } else {
-                if ($dlg_var(log)) xlog("L_WARN", "[b$dlg_var(brandId)][$dlg_var(cidhash)] MANAGE-FAILURE-AS: Skip marking last AS '$avp(AVP_DST)' as inactive\n");
-            }
+            if ($dlg_var(log)) xlog("L_ERR", "[b$dlg_var(brandId)][$dlg_var(cidhash)] MANAGE-FAILURE-AS: Mark AS '$avp(AVP_DST)' as inactive\n");
+            ds_mark_dst("ip");
         }
 
         if(ds_next_dst()) {

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -1579,12 +1579,8 @@ failure_route[MANAGE_FAILURE_AS] {
     if (t_check_status("404") or (t_branch_timeout() and !t_branch_replied())) {
         # Invalidate AS only if no response received
         if (t_branch_timeout() and !t_branch_replied()) {
-            if ($cnt($avp(AVP_DST)) > 1) {
-                if ($dlg_var(log)) xlog("L_ERR", "[b$dlg_var(brandId)][$dlg_var(cidhash)] MANAGE-FAILURE-AS: Mark AS '$avp(AVP_DST)' as inactive\n");
-                ds_mark_dst("ip");
-            } else {
-                if ($dlg_var(log)) xlog("L_WARN", "[b$dlg_var(brandId)][$dlg_var(cidhash)] MANAGE-FAILURE-AS: Skip marking last AS '$avp(AVP_DST)' as inactive\n");
-            }
+            if ($dlg_var(log)) xlog("L_ERR", "[b$dlg_var(brandId)][$dlg_var(cidhash)] MANAGE-FAILURE-AS: Mark AS '$avp(AVP_DST)' as inactive\n");
+            ds_mark_dst("ip");
         }
 
         if(ds_next_dst()) {


### PR DESCRIPTION
Skip discarding last AS was a mistake, even in standalone installations. This
decision masks a problem and prevents potential self-healing logics
(e.g. trigger some event when a AS is discarded so that it gets back asap).

With current configuration, when dispatcher module marks a GW as inactive,
it starts sending OPTIONS every 5 seconds. Retransmissions of those OPTIONS
mean that inactive GWs are monitored at least once every 1,5 seconds.

This commit reverts this decision made in #64.