### PR TITLE
as: replace default pickup builtin feature code

### DIFF
--- a/asterisk/config/features.conf
+++ b/asterisk/config/features.conf
@@ -9,7 +9,7 @@
                                 ; (default is 3 seconds)
 ;xfersound = beep               ; to indicate an attended transfer is complete
 ;xferfailsound = beeperr        ; to indicate a failed transfer
-;pickupexten = *8               ; Configure the pickup extension. (default is *8)
+pickupexten = ###               ; Configure the pickup extension. (default is *8)
 ;pickupsound = beep             ; to indicate a successful pickup (default: no sound)
 ;pickupfailsound = beeperr      ; to indicate that the pickup failed (default: no sound)
 ;featuredigittimeout = 1000     ; Max time (ms) between digits for


### PR DESCRIPTION
Default Asterisk builtin feature code for pickup is *8

This can clash with configured Service feature codes, and not knowing how to disable this feature,
we'll change it to something that won't be dialed (easily).

This allow dialplan execution for *8 services codes.

This PR fixes #163 