### PR TITLE
Changed invoice date format to dd-mm-yyyy

### DIFF
--- a/library/IvozProvider/Gearmand/Invoices/Generator.php
+++ b/library/IvozProvider/Gearmand/Invoices/Generator.php
@@ -6,6 +6,10 @@ use Handlebars\Handlebars;
 
 class Generator
 {
+    const DATE_FORMAT = 'dd-MM-yyyy';
+    const DATE_TIME_FORMAT = 'dd-MM-yyyy HH:mm:ss';
+    const MYSQL_DATETIME_FORMAT = 'yyyy-MM-dd HH:mm:ss';
+
     protected $_invoiceId = null;
     protected $_logger = null;
     protected $_fixedCostTotal = 0;
@@ -65,8 +69,6 @@ class Generator
             $brandLogoPath = "images/palmera90.png";
         }
 
-        $dateFormat = \Zend_Locale_Format::getDateFormat($invoice->getCompany()->getLanguageCode());
-
         $invoiceTz = $company->getDefaultTimezone()->getTz();
         $invoiceDate = new \Zend_Date();
         $invoiceDate->setTimezone($invoiceTz);
@@ -78,9 +80,9 @@ class Generator
         $outDate->addDay(1)->subSecond(1);
 
         $invoiceArray = $invoice->toArray();
-        $invoiceArray["invoiceDate"] = $invoiceDate->toString($dateFormat);
-        $invoiceArray["inDate"] = $inDate->toString($dateFormat);
-        $invoiceArray["outDate"] = $outDate->toString($dateFormat);
+        $invoiceArray["invoiceDate"] = $invoiceDate->toString(self::DATE_FORMAT);
+        $invoiceArray["inDate"] = $inDate->toString(self::DATE_FORMAT);
+        $invoiceArray["outDate"] = $outDate->toString(self::DATE_FORMAT);
         $brandArray = $brand->toArray();
         $brandArray["logoPath"] = $brandLogoPath;
 
@@ -169,8 +171,8 @@ class Generator
             "metered = 1 ",
             "peeringContractId IS NOT NULL",
             "peeringContractId != ''",
-            "start_time_utc >= '".$inDate->toString('yyyy-MM-dd HH:mm:ss')."'",
-            "start_time_utc <= '".$outDate->toString('yyyy-MM-dd HH:mm:ss')."'"
+            "start_time_utc >= '".$inDate->toString(self::MYSQL_DATETIME_FORMAT)."'",
+            "start_time_utc <= '".$outDate->toString(self::MYSQL_DATETIME_FORMAT)."'"
         );
 
         $where = implode(" AND ", $wheres);
@@ -200,7 +202,7 @@ class Generator
             foreach ($calls as $call) {
 
                 $callData = $call->toArray();
-                $callData["calldate"] = $call->getStartTimeUtc(true)->setTimezone($invoiceTz)->toString();
+                $callData["calldate"] = $call->getStartTimeUtc(true)->setTimezone($invoiceTz)->toString(self::DATE_TIME_FORMAT);
                 $callData["dst"] = $call->getCallee();
                 $callData["price"] = number_format(ceil($callData["price"]*10000)/10000, 4);
                 $callData["dst_duration_formatted"] = $this->_timeFormat($callData["duration"]);

--- a/portals/application/controllers/KlearCustomInvoiceTemplateTesterController.php
+++ b/portals/application/controllers/KlearCustomInvoiceTemplateTesterController.php
@@ -134,12 +134,12 @@ class KlearCustomInvoiceTemplateTesterController extends Zend_Controller_Action
             'invoice' =>
             array (
                 'number' => '667',
-                'inDate' => '1/5/2017',
-                'outDate' => '16/5/2017',
+                'inDate' => '01/05/2017',
+                'outDate' => '16/05/2017',
                 'total' => 5.5700000000000003,
                 'taxRate' => 20,
                 'totalWithTax' => 6.6900000000000004,
-                'invoiceDate' => '24/6/2017',
+                'invoiceDate' => '24/06/2017',
             ),
             'company' =>
             array (
@@ -186,7 +186,7 @@ class KlearCustomInvoiceTemplateTesterController extends Zend_Controller_Action
                                 0 =>
                                 array (
                                     'id' => 2418,
-                                    'calldate' => '7/5/2017 18:28:21',
+                                    'calldate' => '07/05/2017 18:28:21',
                                     'dst' => '944048182',
                                     'price' => '0.05',
                                     'durationFormatted' => '00:00:03',
@@ -210,7 +210,7 @@ class KlearCustomInvoiceTemplateTesterController extends Zend_Controller_Action
                                 1 =>
                                 array (
                                     'id' => 2442,
-                                    'calldate' => '8/5/2017 8:21:20',
+                                    'calldate' => '08/05/2017 8:21:20',
                                     'dst' => '944048182',
                                     'price' => '1.05',
                                     'durationFormatted' => '00:01:34',
@@ -227,7 +227,7 @@ class KlearCustomInvoiceTemplateTesterController extends Zend_Controller_Action
                                 2 =>
                                 array (
                                     'id' => 2467,
-                                    'calldate' => '11/5/2017 9:34:05',
+                                    'calldate' => '11/05/2017 9:34:05',
                                     'dst' => '944048182',
                                     'price' => '0.09',
                                     'durationFormatted' => '00:00:06',
@@ -243,7 +243,7 @@ class KlearCustomInvoiceTemplateTesterController extends Zend_Controller_Action
                                 3 =>
                                 array (
                                     'id' => 2475,
-                                    'calldate' => '11/5/2017 9:37:15',
+                                    'calldate' => '11/05/2017 9:37:15',
                                     'dst' => '944048182',
                                     'price' => '0.50',
                                     'durationFormatted' => '00:00:44',
@@ -259,7 +259,7 @@ class KlearCustomInvoiceTemplateTesterController extends Zend_Controller_Action
                                 4 =>
                                 array (
                                     'id' => 2482,
-                                    'calldate' => '11/5/2017 9:39:58',
+                                    'calldate' => '11/05/2017 9:39:58',
                                     'dst' => '944048182',
                                     'price' => '0.29',
                                     'durationFormatted' => '00:00:25',
@@ -275,7 +275,7 @@ class KlearCustomInvoiceTemplateTesterController extends Zend_Controller_Action
                                 5 =>
                                 array (
                                     'id' => 2484,
-                                    'calldate' => '11/5/2017 9:40:26',
+                                    'calldate' => '11/05/2017 9:40:26',
                                     'dst' => '944048182',
                                     'price' => '0.36',
                                     'durationFormatted' => '00:00:31',
@@ -295,7 +295,7 @@ class KlearCustomInvoiceTemplateTesterController extends Zend_Controller_Action
                                 0 =>
                                 array (
                                     'id' => 2464,
-                                    'calldate' => '11/5/2017 9:33:29',
+                                    'calldate' => '11/05/2017 9:33:29',
                                     'dst' => '44676105642',
                                     'price' => '0.29',
                                     'durationFormatted' => '00:00:08',
@@ -311,7 +311,7 @@ class KlearCustomInvoiceTemplateTesterController extends Zend_Controller_Action
                                 1 =>
                                 array (
                                     'id' => 2468,
-                                    'calldate' => '11/5/2017 9:34:41',
+                                    'calldate' => '11/05/2017 9:34:41',
                                     'dst' => '44620114553',
                                     'price' => '0.08',
                                     'durationFormatted' => '00:00:02',
@@ -327,7 +327,7 @@ class KlearCustomInvoiceTemplateTesterController extends Zend_Controller_Action
                                 2 =>
                                 array (
                                     'id' => 2474,
-                                    'calldate' => '11/5/2017 9:36:24',
+                                    'calldate' => '11/05/2017 9:36:24',
                                     'dst' => '44620114553',
                                     'price' => '0.74',
                                     'durationFormatted' => '00:00:21',
@@ -343,7 +343,7 @@ class KlearCustomInvoiceTemplateTesterController extends Zend_Controller_Action
                                 3 =>
                                 array (
                                     'id' => 2476,
-                                    'calldate' => '11/5/2017 9:37:57',
+                                    'calldate' => '11/05/2017 9:37:57',
                                     'dst' => '44620114553',
                                     'price' => '0.18',
                                     'durationFormatted' => '00:00:05',
@@ -359,7 +359,7 @@ class KlearCustomInvoiceTemplateTesterController extends Zend_Controller_Action
                                 4 =>
                                 array (
                                     'id' => 2479,
-                                    'calldate' => '11/5/2017 9:39:13',
+                                    'calldate' => '11/05/2017 9:39:13',
                                     'dst' => '44620114553',
                                     'price' => '0.08',
                                     'durationFormatted' => '00:00:02',
@@ -376,7 +376,7 @@ class KlearCustomInvoiceTemplateTesterController extends Zend_Controller_Action
                                 5 =>
                                 array (
                                     'id' => 2483,
-                                    'calldate' => '11/5/2017 9:39:44',
+                                    'calldate' => '11/05/2017 9:39:44',
                                     'dst' => '44676105642',
                                     'price' => '0.15',
                                     'durationFormatted' => '00:00:04',
@@ -411,7 +411,7 @@ class KlearCustomInvoiceTemplateTesterController extends Zend_Controller_Action
                         ),
                         'calls' => array (
                             0 => array (
-                                'calldate' => '11/5/2017 9:33:29',
+                                'calldate' => '11/05/2017 9:33:29',
                                 'caller' => '49302540070',
                                 'dst' => '1008',
                                 'price' => '0.29',

--- a/portals/templates/basic.txt
+++ b/portals/templates/basic.txt
@@ -236,7 +236,7 @@
                     {{#each fixedCosts}}
                         <div class="tr">
                             <div class="td">
-                                {{name}} *
+                                {{name}}
                                 {{#if description}}
                                     <br />
                                     {{description}}

--- a/portals/templates/detailed.txt
+++ b/portals/templates/detailed.txt
@@ -236,7 +236,7 @@
                     {{#each fixedCosts}}
                         <div class="tr">
                             <div class="td">
-                                {{name}} *
+                                {{name}}
                                 {{#if description}}
                                     <br />
                                     {{description}}


### PR DESCRIPTION
Zend_Locale wasn't providing us a proper date format for invoices: newither in spanish nor english. 
It has been replaced by dd-mm-yyyy so that it fits spanish, and [aparently](https://en.wikipedia.org/wiki/Date_format_by_country), UK format as well