### PR TITLE
Changed invoice pdf generation timeout to 10min

### DIFF
--- a/library/IvozProvider/Gearmand/Invoices/Generator.php
+++ b/library/IvozProvider/Gearmand/Invoices/Generator.php
@@ -114,6 +114,7 @@ class Generator
         $architecture = (php_uname("m") === 'x86_64') ? 'amd64' : 'i386';
 
         $snappy = new Pdf(APPLICATION_PATH . '/../../library/vendor/bin/wkhtmltopdf-' . $architecture);
+        $snappy->setTimeout(60 * 10);
         $snappy->setOption('header-html', $header);
         $snappy->setOption('header-spacing', 3);
         $snappy->setOption('footer-html', $footer);


### PR DESCRIPTION
It used to be 1 min. This value should be enough for everybody, tested rendering 2000 page invoice.