### PR TITLE
as: Allow using + instead of international prefix

### DIFF
--- a/asterisk/config/dialplan/default.conf
+++ b/asterisk/config/dialplan/default.conf
@@ -15,7 +15,7 @@ include => replacer
 ;; Context for user calls (from proxyUsers)
 ;; ${EXTEN} may match a Company Extension, Company Service or External number
 [users]
-exten => _[*0-9].,1,NoOp(Outgoing call from user ${CALLERID(all)} to ${EXTEN})
+exten => _[+*0-9].,1,NoOp(Outgoing call from user ${CALLERID(all)} to ${EXTEN})
     same => n,AGI(agi://127.0.0.1:4573/cli.php?model=default/calls/users)
 ; External Attended transfer support
 include => replacer
@@ -24,7 +24,7 @@ include => sounds
 
 ;; Context for friends calls (aka friendly trunks)
 [friends]
-exten => _[*0-9].,1,NoOp(Outgoing call from friend ${CALLERID(all)} to ${EXTEN})
+exten => _[+*0-9].,1,NoOp(Outgoing call from friend ${CALLERID(all)} to ${EXTEN})
     same => n,AGI(agi://127.0.0.1:4573/cli.php?model=default/calls/friends)
 ; Playback specific sounds and leave
 include => sounds
@@ -35,7 +35,7 @@ include => replacer
 
 ;; Context for retail accounts
 [retail]
-exten => _[*0-9].,1,NoOp(Outgoing call from retail account ${CALLERID(all)} to ${EXTEN})
+exten => _[+*0-9].,1,NoOp(Outgoing call from retail account ${CALLERID(all)} to ${EXTEN})
     same => n,AGI(agi://127.0.0.1:4573/cli.php?model=default/calls/retail)
 ; Playback specific sounds and leave
 include => sounds


### PR DESCRIPTION
Current users/friends/retails pattern does not allow using + instead of
international prefix (e.g. +34944048182 instead of 0034944048182).

Underlying logic (see Countries.e164Pattern) is already adapted, changing
dialplan pattern should be enough.