### PR TITLE
scheme: Drop incorrect unique in InvoiceTemplates

### DIFF
--- a/scheme/deltas/063-incorrect-unique-invoicetemplates.sql
+++ b/scheme/deltas/063-incorrect-unique-invoicetemplates.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `InvoiceTemplates` DROP KEY `name`;


### PR DESCRIPTION
The collision domain must be brand,name (it already has a unique key).