### PR TITLE
as: enable DTMF on-demand recording with * prefix

### DIFF
--- a/asterisk/agi/application/controllers/CallsController.php
+++ b/asterisk/agi/application/controllers/CallsController.php
@@ -65,7 +65,7 @@ class CallsController extends BaseController
 
         // Check company On demand record code
         if ($company->getOnDemandRecord()) {
-            $this->agi->setVariable("FEATUREMAP(automixmon)", $company->getOnDemandRecordCode());
+            $this->agi->setVariable("FEATUREMAP(automixmon)", $company->getOnDemandRecordDTMFs());
         }
 
         // Set DDI as the caller
@@ -638,7 +638,7 @@ class CallsController extends BaseController
             // Set on-demand recording header (only for proxyusers)
             if ($company->getOnDemandRecord()) {
                 $this->agi->setSIPHeader("X-Info-RecordCode", $company->getOnDemandRecordCode());
-                $this->agi->setVariable("FEATUREMAP(automixmon)", $company->getOnDemandRecordCode());
+                $this->agi->setVariable("FEATUREMAP(automixmon)", $company->getOnDemandRecordDTMFs());
             }
 
         } else {

--- a/library/IvozProvider/Model/Companies.php
+++ b/library/IvozProvider/Model/Companies.php
@@ -328,6 +328,14 @@ class Companies extends Raw\Companies
         return false;
     }
 
+    /**
+     * Get On demand recording code DTMFs
+     */
+    public function getOnDemandRecordDTMFs()
+    {
+        return '*' . $this->getOnDemandRecordCode();
+    }
+
     public function getFeatures()
     {
         $features = array();


### PR DESCRIPTION
This bug only affects companies with on demand recordings enabled by DTMFs.

The code being detected as start/stop recording was not considering the '*' prefix, so any captured DTMFs that matched the code was not being sent to the other end and ativated the recording process.