### PR TITLE
recordings: fix duration and date for created recordings

### DIFF
--- a/kamailio/recordings/application/bin/cli.php
+++ b/kamailio/recordings/application/bin/cli.php
@@ -17,6 +17,9 @@ set_include_path(implode(PATH_SEPARATOR, array(
     get_include_path(),
 )));
 
+// Include composer vendor libraries
+require_once realpath(APPLICATION_PATH . '/../../../library/vendor/autoload.php');
+
 require_once 'Zend/Loader/Autoloader.php';
 $loader = Zend_Loader_Autoloader::getInstance();
 

--- a/kamailio/recordings/application/controllers/RecordingsController.php
+++ b/kamailio/recordings/application/controllers/RecordingsController.php
@@ -117,11 +117,6 @@ class RecordingsController extends Zend_Controller_Action
                 continue;
             }
 
-            // Get when recording started and duration
-            $startTime = fileatime($this->_rawRecordingsDir . $filename);
-            $endTime = filemtime($this->_rawRecordingsDir . $filename);
-            $duration = $endTime - $startTime;
-
             // Convert files to .wav
             $extract_rtp = $this->_rawRecordingsDir . $file;
             $extract_wav = $this->_rawRecordingsDir . $callid . '.' . $recordcnt . '.wav';
@@ -146,6 +141,10 @@ class RecordingsController extends Zend_Controller_Action
                 continue;
             }
 
+            // Get created mp3 information
+            $mp3info = new \Zend_Media_Mpeg_Abs($convert_mp3);
+            $duration = $mp3info->getLengthEstimate();
+
             // Create an entry in Recordings table with the file
             $recording = new Model\Recordings;
 
@@ -162,7 +161,6 @@ class RecordingsController extends Zend_Controller_Action
             } else {
                 $type = 'ddi';
             }
-
 
             // Get company and brand for this recording
             $company = $kamAccCdr->getCompany();
@@ -183,7 +181,7 @@ class RecordingsController extends Zend_Controller_Action
             }
 
             $recording->setCompanyId($kamAccCdr->getCompanyId())
-                ->setCalldate(new Zend_Date($startTime, Zend_Date::TIMESTAMP))
+                ->setCalldate($kamAccCdr->getStartTimeUtc())
                 ->setType($type)
                 ->setCallid($kamAccCdr->getCallid())
                 ->setDuration($duration)

--- a/library/composer.json
+++ b/library/composer.json
@@ -6,6 +6,7 @@
         "h4cc/wkhtmltopdf-amd64": "0.12.3",
         "h4cc/wkhtmltopdf-i386": "0.12.3",
         "crada/php-apidoc":"@dev",
-        "xamin/handlebars.php": "^0.10.4"
+        "xamin/handlebars.php": "^0.10.4",
+        "debach/zend-mp3": "1.8.*"
     }
 }

--- a/library/composer.lock
+++ b/library/composer.lock
@@ -4,8 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "36fb20546f6bfc3ec792991ba3fd2e79",
-    "content-hash": "37a1c834302f7485e833957bdc47fb1c",
+    "content-hash": "86a84b3d377c4c534fd8887848f60c46",
     "packages": [
         {
             "name": "crada/php-apidoc",
@@ -65,6 +64,39 @@
             "time": "2016-10-24 15:05:56"
         },
         {
+            "name": "debach/zend-mp3",
+            "version": "1.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/debach/zend-mp3.git",
+                "reference": "17b523ad57f283ddf3a116bc0eff22cb9d1b4b27"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/debach/zend-mp3/zipball/17b523ad57f283ddf3a116bc0eff22cb9d1b4b27",
+                "reference": "17b523ad57f283ddf3a116bc0eff22cb9d1b4b27",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Zend_": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sven Vollbehr"
+                }
+            ],
+            "description": "The best PHP library for Object-Oriented media file information reading and writing.",
+            "homepage": "https://code.google.com/p/php-reader/",
+            "time": "2016-01-04T13:23:44+00:00"
+        },
+        {
             "name": "h4cc/wkhtmltopdf-amd64",
             "version": "0.12.3",
             "source": {
@@ -102,7 +134,7 @@
                 "thumbnail",
                 "wkhtmltopdf"
             ],
-            "time": "2016-02-02 19:38:55"
+            "time": "2016-02-02T19:38:55+00:00"
         },
         {
             "name": "h4cc/wkhtmltopdf-i386",
@@ -142,7 +174,7 @@
                 "thumbnail",
                 "wkhtmltopdf"
             ],
-            "time": "2016-02-02 19:38:57"
+            "time": "2016-02-02T19:38:57+00:00"
         },
         {
             "name": "knplabs/knp-snappy",
@@ -207,20 +239,20 @@
                 "thumbnail",
                 "wkhtmltopdf"
             ],
-            "time": "2015-11-17 13:16:27"
+            "time": "2015-11-17T13:16:27+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v3.3.2",
+            "version": "v3.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "8e30690c67aafb6c7992d6d8eb0d707807dd3eaf"
+                "reference": "5ab8949b682b1bf9d4511a228b5e045c96758c30"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/8e30690c67aafb6c7992d6d8eb0d707807dd3eaf",
-                "reference": "8e30690c67aafb6c7992d6d8eb0d707807dd3eaf",
+                "url": "https://api.github.com/repos/symfony/process/zipball/5ab8949b682b1bf9d4511a228b5e045c96758c30",
+                "reference": "5ab8949b682b1bf9d4511a228b5e045c96758c30",
                 "shasum": ""
             },
             "require": {
@@ -256,7 +288,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2017-05-22 12:32:03"
+            "time": "2017-07-03T08:12:02+00:00"
         },
         {
             "name": "xamin/handlebars.php",
@@ -298,7 +330,7 @@
             ],
             "description": "Handlebars processor for php",
             "homepage": "https://github.com/XaminProject/handlebars.php",
-            "time": "2016-12-12 13:51:02"
+            "time": "2016-12-12T13:51:02+00:00"
         }
     ],
     "packages-dev": [],


### PR DESCRIPTION
This commit changes the way recordings duration is
calculated. Insted of using the created and modified
dates of the file, we let zend-mp3[0] library to
do the task.

We have also changed the recording date to match
the call start-time instead of using the current
timestamp. Note that this will set all on-demand
recordings within the same call with the same
timestamp.

[0] https://github.com/debach/zend-mp3.git