### PR TITLE
portals: Enable company security by default

### DIFF
--- a/library/IvozProvider/Mapper/Sql/Companies.php
+++ b/library/IvozProvider/Mapper/Sql/Companies.php
@@ -49,7 +49,6 @@ class Companies extends Raw\Companies
             if (!$model->hasChange('languageId')) $model->setLanguageId($model->getBrand()->getLanguageId());
             if (!$model->hasChange('outbound_prefix')) $model->setOutboundPrefix('');
             if (!$model->hasChange('mediaRelaySetsId')) $model->setMediaRelaySetsId(0);
-            if (!$model->hasChange('ipFilter')) $model->setIpFilter(0);
             if (!$model->hasChange('onDemandRecord')) $model->setOnDemandRecord(0);
             if (!$model->hasChange('onDemandRecordCode')) $model->setOnDemandRecordCode('');
             if (!$model->hasChange('areaCode')) $model->setAreaCode('');

--- a/portals/application/configs/klear/CompaniesList.yaml
+++ b/portals/application/configs/klear/CompaniesList.yaml
@@ -102,11 +102,9 @@ production:
           country: true
           onDemandRecord: true
           onDemandRecordCode: true
-          ipFilter: true
           mediaRelaySetsId: true
           outbound_prefix: true
           applicationServerId: true
-          externalMaxCalls: true
           countryId: true
           areaCode: true
           outgoingDDIId: true
@@ -117,6 +115,29 @@ production:
           recordingsLimitMB: true
           recordingsLimitEmail: true
           recordingsDiskUsage: true
+        order: &companiesOrder_Link
+          id: true
+          name: true
+          externalMaxCalls: true
+          defaultTimezoneId: true
+          outbound_prefix: true
+          postalAddress: true
+          recordingsLimitMB: true
+          externallyExtraOpts: true
+      fixedPositions:
+        group0:
+          colsPerRow: 12
+          label: _("Basic data")
+          fields:
+            name: 4
+            domain_users: 5
+            FeaturesRelCompanies: 2
+        group1:
+          colsPerRow: 2
+          label: _("Security")
+          fields:
+            externalMaxCalls: 1
+            ipFilter: 1
       class: ui-silk-add
       label: true
       multiInstance: true
@@ -146,6 +167,8 @@ production:
           country: ${auth.brand.invoices.disabled}
         whitelist:
           id: ${auth.isMainOperator}
+        order:
+          <<: *companiesOrder_Link
       class: ui-silk-pencil
       label: false
       title: _("Edit %s %2s", ngettext('Company', 'Companies', 1), "[format| (%item%)]")
@@ -153,33 +176,38 @@ production:
         <<: *forcedBrand
       fixedPositions: &companiesFixedPositions_Link
         group0:
-          colsPerRow: 2
+          colsPerRow: 12
           label: _("Basic data")
           fields:
-            name: 1
-            nif: 1
-            FeaturesRelCompanies: 1
+            name: 4
+            nif: 4
+            domain_users: 5
+            FeaturesRelCompanies: 2
         group1:
+          colsPerRow: 2
+          label: _("Security")
+          fields:
+            externalMaxCalls: 1
+            ipFilter: 1
+        group2:
           colsPerRow: 2
           label: _("Locales")
           fields:
             defaultTimezoneId: 1
             languageId: 1
-        group2:
+        group3:
           colsPerRow: 12
           label: _("Server data")
           fields:
             outgoingDDIId: 6
             outgoingDDIRuleId: 6
             outbound_prefix: 4
-            externalMaxCalls: 6
             domain_users: 9
             countryId: 6
             areaCode: 6
             mediaRelaySetsId: 6
             applicationServerId: 6
-            ipFilter: 6
-        group3:
+        group4:
           colsPerRow: 2
           label: _("Invoice data")
           fields:
@@ -189,7 +217,7 @@ production:
             province: 1
             country: 1
             registryData: 2
-        group4:
+        group5:
           colsPerRow: 12
           label: _("Recordings")
           collapsed: true
@@ -200,7 +228,7 @@ production:
             __empty1: 6
             onDemandRecord: 6
             onDemandRecordCode: 6
-        group5:
+        group6:
           colsPerRow: 1
           collapsed: true
           label: _("Externally rated options")

--- a/portals/application/configs/klear/RetailClientsList.yaml
+++ b/portals/application/configs/klear/RetailClientsList.yaml
@@ -102,11 +102,11 @@ production:
           country: true
           onDemandRecord: true
           onDemandRecordCode: true
-          ipFilter: true
+          ipFilter: false
           mediaRelaySetsId: true
           outbound_prefix: true
           applicationServerId: true
-          externalMaxCalls: true
+          externalMaxCalls: false
           countryId: true
           areaCode: true
           outgoingDDIId: true
@@ -116,6 +116,28 @@ production:
           recordingsLimitMB: true
           recordingsLimitEmail: true
           recordingsDiskUsage: true
+        order: &retailClientsOrder_Link
+          id: true
+          name: true
+          externalMaxCalls: true
+          defaultTimezoneId: true
+          outbound_prefix: true
+          invoiceLanguageId: true
+          recordingsLimitMB: true
+          externallyExtraOpts: true
+      fixedPositions: &retailClientsFixedPositions_Link
+        group0:
+          colsPerRow: 6
+          label: _("Basic data")
+          fields:
+            name: 3
+            FeaturesRelCompanies: 3
+        group1:
+          colsPerRow: 2
+          label: _("Security")
+          fields:
+            externalMaxCalls: 1
+            ipFilter: 1
       class: ui-silk-add
       label: true
       multiInstance: true
@@ -146,12 +168,9 @@ production:
           country: ${auth.brand.invoices.disabled}
         whitelist:
           id: ${auth.isMainOperator}
-      class: ui-silk-pencil
-      label: false
-      title: _("Edit %s %2s", ngettext('Retail Client', 'Retail Clients', 1), "[format| (%item%)]")
-      forcedValues:
-        <<: *forcedBrand
-      fixedPositions: &retailClientsFixedPositions_Link
+        order:
+          <<: *retailClientsOrder_Link
+      fixedPositions:
         group0:
           colsPerRow: 6
           label: _("Basic data")
@@ -161,23 +180,27 @@ production:
             FeaturesRelCompanies: 6
         group1:
           colsPerRow: 2
+          label: _("Security")
+          fields:
+            externalMaxCalls: 1
+            ipFilter: 1
+        group2:
+          colsPerRow: 2
           label: _("Locales")
           fields:
             defaultTimezoneId: 1
             languageId: 1
-        group2:
+        group3:
           colsPerRow: 2
           label: _("Server data")
           fields:
             outbound_prefix: 1
             outgoingDDIId: 1
-            externalMaxCalls: 1
             countryId: 1
             areaCode: 1
             mediaRelaySetsId: 1
             applicationServerId: 1
-            ipFilter: 1
-        group3:
+        group4:
           colsPerRow: 2
           label: _("Invoice data")
           fields:
@@ -188,7 +211,7 @@ production:
             province: 1
             country: 1
             registryData: 2
-        group4:
+        group5:
           colsPerRow: 12
           label: _("Recordings")
           collapsed: true
@@ -199,12 +222,17 @@ production:
             __empty1: 6
             onDemandRecord: 6
             onDemandRecordCode: 6
-        group5:
+        group6:
           colsPerRow: 1
           collapsed: true
           label: _("Externally rated options")
           fields:
             externallyExtraOpts: 1
+      class: ui-silk-pencil
+      label: false
+      title: _("Edit %s %2s", ngettext('Retail Client', 'Retail Clients', 1), "[format| (%item%)]")
+      forcedValues:
+        <<: *forcedBrand
     #companyAdmins:
     companyAdminsList_screen:
       <<: *companyAdminsList_screenLink

--- a/portals/application/configs/klear/model/Companies.yaml
+++ b/portals/application/configs/klear/model/Companies.yaml
@@ -81,9 +81,15 @@ production:
     externalMaxCalls:
       title: _('External max call')
       type: number
-      defaultValue: 0
+      defaultValue: 10
       source:
         control: Spinner
+      info:
+        type: box
+        position: left
+        icon: help
+        text: _("Limits both incoming and outgoing external calls.")
+        label: _("Need help?")
     postalAddress:
       title: _('Postal address')
       type: text
@@ -206,7 +212,7 @@ production:
     ipFilter:
       title: _('Filter by IP address')
       type: select
-      defaultValue: 1
+      defaultValue: 0
       source:
         data: inline
         values:

--- a/portals/application/configs/klear/model/RetailClients.yaml
+++ b/portals/application/configs/klear/model/RetailClients.yaml
@@ -75,7 +75,7 @@ production:
     externalMaxCalls:
       title: _('External max call')
       type: number
-      defaultValue: 0
+      defaultValue: 2
       source:
         control: Spinner
     postalAddress:
@@ -200,7 +200,7 @@ production:
     ipFilter:
       title: _('Filter by IP address')
       type: select
-      defaultValue: 1
+      defaultValue: 0
       source:
         data: inline
         values:


### PR DESCRIPTION
Show both mechanisms on creation:

* Limit external calls (default value 2 in retail, 10 in vPBX)
* IP filter (disabled by default)

This way, on fast company creation, at least external calls will be limited.