### PR TITLE
provision: customizable specific provision routes

### DIFF
--- a/doc/dev/en/storage.md
+++ b/doc/dev/en/storage.md
@@ -80,3 +80,4 @@ The rest of the folders are exclusively used by portals and there is no backgrou
 
     drwxrwxrwx www-data www-data ivozprovider_model_brands.logo
     drwxrwxrwx www-data www-data ivozprovider_model_brandurls.logo
+    drwxrwxrwx www-data www-data Provision_template

--- a/library/IvozProvider/Mapper/Sql/TerminalModels.php
+++ b/library/IvozProvider/Mapper/Sql/TerminalModels.php
@@ -20,7 +20,8 @@
 namespace IvozProvider\Mapper\Sql;
 class TerminalModels extends Raw\TerminalModels
 {
-    public function save(\IvozProvider\Model\Raw\TerminalModels $model, $forceInsert = false){
+    public function save(\IvozProvider\Model\Raw\TerminalModels $model, $forceInsert = false)
+    {
         $genericMustChange = $model->hasChange("genericTemplate");
         $specificMustChange = $model->hasChange("specificTemplate");
 
@@ -34,28 +35,23 @@ class TerminalModels extends Raw\TerminalModels
         $path = $conf->Iron['fso']['localStoragePath'];
         $route = $path . DIRECTORY_SEPARATOR . "Provision_template" . DIRECTORY_SEPARATOR . $pk;
 
-        if( $genericMustChange ){
-            try{
+        if ($genericMustChange) {
+            try {
                 $template = $model->getGenericTemplate();
                 $this->createFolder($route);
                 $file = "generic.phtml";
                 $this->saveFiles($file, $route, $template);
-            }
-            catch (\Exception $e){
+
+            } catch (\Exception $e) {
                 throw $e;
             }
         }
 
-        if( $specificMustChange ){
-            try{
-                $template = $model->getSpecificTemplate();
-                $this->createFolder($route);
-                $file = "specific.phtml";
-                $this->saveFiles($file, $route, $template);
-            }
-            catch (\Exception $e){
-                throw $e;
-            }
+        if ($specificMustChange){
+            $template = $model->getSpecificTemplate();
+            $this->createFolder($route);
+            $file = "specific.phtml";
+            $this->saveFiles($file, $route, $template);
         }
 
         return $pk;

--- a/portals/application/configs/klear/model/TerminalModels.yaml
+++ b/portals/application/configs/klear/model/TerminalModels.yaml
@@ -71,7 +71,6 @@ production:
     specificUrlPattern:
       title: _('Specific URL Pattern')
       type: text
-      readonly: true
       trim: both
       prefix: 'https://{PROVISIONING_URL}:{PORT_IN_GENERIC_FILE}/provision/{OPTIONAL_SUBPATHS}/'
       info:

--- a/scheme/deltas/063-Specific-provision-route-fix.sql
+++ b/scheme/deltas/063-Specific-provision-route-fix.sql
@@ -1,0 +1,1 @@
+UPDATE `TerminalModels` SET `specificUrlPattern` = '{mac}' where `specificUrlPattern` != '{mac}.cfg';


### PR DESCRIPTION
Make speficic provision file name editable as requested in https://github.com/irontec/ivozprovider/issues/200

This is the proposed flow:

1 - Extract any posible mac from the url
2 - Search thoose values into Terminals table
3 - Double check against specificUrlPattern in TerminalModels table

This PR aims to close https://github.com/irontec/ivozprovider/issues/200

Apart from custom file formats, the following mac formats should work from now on:
- https://test/provision/xxXXxxXXxxXX.cfg
- https://test/provision/xx:xx:xx:xx:xx:xx.cfg
- https://test/provision/xx-xx-xx-xx-xx-xx.cfg
