### PR TITLE
portals: logo size limited by height

### DIFF
--- a/portals/application/assets/css/global.css
+++ b/portals/application/assets/css/global.css
@@ -1,5 +1,5 @@
 #applicationLogo img {
-    max-width: 250px;
+    max-height: 80px;
     margin-top: 10px;
 }
 


### PR DESCRIPTION
There is nothing that prevents the logo from being wider. There is a lot of white space to the right.

Wouldn't it be better to limit the logo size by height?

I decided to set it to 96px which is your actual logo height.