### PR TITLE
portals: added hint text for recording extension field

### DIFF
--- a/portals/application/configs/klear/model/Locutions.yaml
+++ b/portals/application/configs/klear/model/Locutions.yaml
@@ -1,34 +1,34 @@
-production: 
+production:
   class: \IvozProvider\Model\Locutions
-  fields: 
-    companyId: 
+  fields:
+    companyId:
       title: _('Company')
       type: select
       required: true
-      source: 
+      source:
         data: mapper
-        config: 
+        config:
           mapperName: \IvozProvider\Mapper\Sql\Companies
-          fieldName: 
-            fields: 
+          fieldName:
+            fields:
               - name
             template: '%name%'
           order: name
-    originalFile: 
+    originalFile:
       title: ngettext('Uploaded file', 'Uploaded files', 1)
       type: file
-      source: 
+      source:
         data: fso
         size_limit: 20M
-        options: 
-          download: 
+        options:
+          download:
             external: true
             type: command
             target: locutionsOriginalFileDownload_command
             icon: ui-silk-bullet-disk
             title: _("Download file")
             onNull: hide
-          upload: 
+          upload:
             type: command
             target: locutionsOriginalFileUpload_command
             title: _("Upload file")
@@ -40,14 +40,14 @@ production:
             class: jmedia
             onNull: hide
             target: locutionsEncodedFileDownload_command
-    encodedFile: 
+    encodedFile:
       title: ngettext('File for play', 'Files for play', 1)
       type: file
-      source: 
+      source:
         data: fso
         size_limit: 20M
-        options: 
-          download: 
+        options:
+          download:
             external: true
             type: command
             target: locutionsEncodedFileDownload_command
@@ -60,7 +60,7 @@ production:
             class: jmedia
             onNull: hide
             target: locutionsEncodedFileDownload_command
-    name: 
+    name:
       title: ngettext('Name', 'Names', 1)
       type: text
       trim: both
@@ -72,11 +72,17 @@ production:
       source:
         class: IvozProvider_Klear_Ghost_RecordLocution
         method: getRecordingExtension
-staging: 
+      info:
+        type: box
+        position: left
+        icon: help
+        text: _("You can call this extension from any company terminal to record this locution")
+        label: _("Need help?")
+staging:
   _extends: production
-testing: 
+testing:
   _extends: production
-development: 
+development:
   _extends: production
-localdev: 
+localdev:
   _extends: production

--- a/portals/application/languages/en_US/en_US.po
+++ b/portals/application/languages/en_US/en_US.po
@@ -3106,6 +3106,11 @@ msgstr[1] "Files for play"
 msgid "Recording extension"
 msgstr "Recordings"
 
+msgid ""
+"You can call this extension from any company terminal to record this locution"
+msgstr ""
+"You can call this extension from any company terminal to record this locution"
+
 msgid "Regular Expression"
 msgstr "Regular Expression"
 

--- a/portals/application/languages/es_ES/es_ES.po
+++ b/portals/application/languages/es_ES/es_ES.po
@@ -3137,6 +3137,12 @@ msgstr[1] "Ficheros convertidos"
 msgid "Recording extension"
 msgstr ""
 
+msgid ""
+"You can call this extension from any company terminal to record this locution"
+msgstr ""
+"Puede llamar a esta extensión para grabar está locución desde cualquier "
+"terminal de la compañía"
+
 msgid "Regular Expression"
 msgstr "Expresión regular"
 


### PR DESCRIPTION
Added a text next to the field to specify what the extension is for:

_You can call this extension from any company terminal to record this locution_

[Current documentation](https://god.oasis-kai.irontec.com/doc/en/pbx_features/sounds.html#locutions) for this section is:

_Locutions can be recorded from any terminal by dialing the Recording extension displayed in their edit screen._


This PR aims to fix #199 