### PR TITLE
portals: allow IP networks with lower masks

### DIFF
--- a/library/IvozProvider/Mapper/Sql/KamUsersAddress.php
+++ b/library/IvozProvider/Mapper/Sql/KamUsersAddress.php
@@ -44,11 +44,6 @@ class KamUsersAddress extends Raw\KamUsersAddress
             }
         }
 
-        // Avoid too big ranges
-        if ($mask < 24) {
-                throw new \Exception("Wrong mask, it should be at least /24", 70002);
-        }
-
         // Save validated values
         $model->setIpAddr($ip);
         $model->setMask($mask);


### PR DESCRIPTION
Simply remove the /24 limitation for network mask in allowed company IPs

Mapper stills validate the netmask is between 0 and 32

This PR aims to fix #179 