### PR TITLE
qa: Adjusted timeouts

### DIFF
--- a/portals/e2e/features/brand_features/outgoingRouting.feature
+++ b/portals/e2e/features/brand_features/outgoingRouting.feature
@@ -20,7 +20,7 @@ Scenario: I can save outgoing routing
   Given I can see at least one row
   And I click on "OutgoingRouting" first elements edit button
   And I click on save button
-  Then I can see confirmation dialog
+  Then I can see confirmation dialog within "40" seconds or lower
   And I click on close dialog button
   Then I am on "OutgoingRouting" list
 

--- a/portals/e2e/features/pages/edit.js
+++ b/portals/e2e/features/pages/edit.js
@@ -22,9 +22,15 @@ function edit () {
       );
   }
 
-  function assertConfirmationDialog() {
+  function assertConfirmationDialog(timeoutSeconds) {
+
+    var timeoutMilliseconds;
+    if (timeoutSeconds) {
+        timeoutMilliseconds = timeoutSeconds * 1000;
+    }
+
     return this
-      .waitForElementVisible('@dialog');
+      .waitForElementVisible('@dialog', timeoutMilliseconds);
   }
 
   function closeDialog() {

--- a/portals/e2e/features/step_definitions/edit.js
+++ b/portals/e2e/features/step_definitions/edit.js
@@ -11,6 +11,10 @@ defineSupportCode(({Given, Then, When}) => {
     return edit.assertConfirmationDialog();
   });
 
+  Then(/^I can see confirmation dialog within "([^"]*)" seconds or lower$/, (timeoutSeconds) => {
+    return edit.assertConfirmationDialog(timeoutSeconds);
+  });
+
   Then(/^I click on close dialog button$/, () => {
     return edit.closeDialog();
   });

--- a/portals/e2e/nightwatch.conf.js
+++ b/portals/e2e/nightwatch.conf.js
@@ -16,8 +16,8 @@ module.exports = {
   "custom_commands_path" : "commands",
 	"custom_assertions_path" : "",
   "selenium" : {
-    "start_process" : false,
-    "server_path" : "",
+    "start_process" : true,
+    "server_path" : "/opt/selenium/selenium-server-standalone-2.53.1.jar",
     "log_path" : "",
     "port" : 4444,
     "cli_args" : {
@@ -30,8 +30,8 @@ module.exports = {
       "globals" : {
         'user': 'admin',
         'password': 'changeme',
-        'waitForConditionTimeout': 10000,
-        'retryAssertionTimeout': 10000
+        'waitForConditionTimeout': 20000,
+        'retryAssertionTimeout': 20000
       },
       "selenium_port"  : 9515,
       "selenium_host"  : "localhost",


### PR DESCRIPTION
outgoing routing e2e tests were failing because of timeouts.