### PR TITLE
trunks: Enable dialog cseq tracking mechanism

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -249,7 +249,7 @@ modparam("dialog", "profiles_with_value", "activeCalls; inboundCalls; outboundCa
 modparam("dialog", "send_bye", 1)
 modparam("dialog", "enable_stats", 1)
 modparam("dialog", "dlg_extra_hdrs", "Hint: inactivity timeout\r\n") # Added to requests generated locally by the module (e.g. BYE)
-modparam("dialog", "track_cseq_updates", 0) # FIXME Enable when 0066662 is solved
+modparam("dialog", "track_cseq_updates", 1)
 
 #!ifdef WITH_ANTIFLOOD
 # PIKE


### PR DESCRIPTION
Some time ago we disabled dialog track_cseq_updates modparam.
    
This setting aims to adapt cseq numbers one Kamailio's UAC uac_auth is done.
    
This mechanism had some errors with retransmissions and cancel events, so it was disabled as no carrier at the moment seems to be annoyed if two transactions use the same CSeq.

Even though any carrier at the moment seems to be annoyed if two transactions use the same CSeq for the unauth initial INVITE and the auth one, adapting these CSeqs is more RFC-compliant.

This PR enables it again.
