### PR TITLE
kamusers: Remove redis and redis modules

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -96,7 +96,6 @@ Depends: ivozprovider-profile-common,
     supervisor,
     libav-tools,
     sox,
-    redis-server,
     libsox-fmt-mp3
 Homepage: http://www.irontec.com
 Description: IVOZ Provider - Portal System Profile
@@ -117,7 +116,6 @@ Depends: ivozprovider-profile-common,
         ivozprovider-kamailio-tls-modules,
         ivozprovider-kamailio-xml-modules,
         ivozprovider-kamailio-websocket-modules,
-        ivozprovider-kamailio-redis-modules,
         ivozprovider-kamailio-presence-modules,
         ivozprovider-kamailio-trunks,
         ivozprovider-kamailio-users

--- a/extra/simple-cdd/package.list
+++ b/extra/simple-cdd/package.list
@@ -8,7 +8,6 @@ ivozprovider-doc
 ivozprovider-kamailio:#ARCH#
 ivozprovider-kamailio-json-modules:#ARCH#
 ivozprovider-kamailio-mysql-modules:#ARCH#
-ivozprovider-kamailio-redis-modules:#ARCH#
 ivozprovider-kamailio-tls-modules:#ARCH#
 ivozprovider-kamailio-trunks
 ivozprovider-kamailio-users

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -59,9 +59,6 @@
 #!define WITH_STATSPERCALL
 # Note: if enabled, one additional sql query is made per call
 
-##!define WITH_REDIS
-# Note: if enabled, call stats are saved to REDIS
-
 #!define DBURL "mysql://kamailio:ironsecret@data/ivozprovider"
 
 #!define REGISTER_TIMEOUT 300
@@ -200,10 +197,6 @@ loadmodule    "presence_xml.so"
 loadmodule    "presence_dialoginfo.so"
 loadmodule    "ipops.so"
 
-#!ifdef WITH_REDIS
-loadmodule    "ndb_redis.so"
-#!endif
-
 #!ifdef WITH_ANTIFLOOD
 loadmodule    "pike.so"
 #!endif
@@ -216,12 +209,6 @@ modparam("rtpproxy", "db_url", DBURL)
 modparam("rtpproxy", "table_name", "kam_rtpproxy")
 modparam("rtpproxy", "rtp_inst_pvar", "$var(RTP_INSTANCE)")
 modparam("rtpproxy", "nortpproxy_str", "a=sdpmangled:yes\r\n")
-
-#!ifdef WITH_REDIS
-# REDIS
-modparam("ndb_redis", "server", "name=redis;addr=jobs.ivozprovider.local;port=6379")
-modparam("ndb_redis", "init_without_redis", 1)
-#!endif
 
 # DEBUGGER
 modparam("debugger", "mod_hash_size", 5)
@@ -522,13 +509,6 @@ request_route {
             route(RETAILS);
             if ($avp(static) != 'yes') route(LOOKUP);
             route(PROFILE_AS_CALL);
-
-            #!ifdef WITH_REDIS
-            # Redis data
-            $dlg_var(AoR) = $tU + '@' + $td;
-            $dlg_var(interlocutor) = $(ai{uri.user});
-            $dlg_var(redisset) = 'call::b' + $dlg_var(brandId) + 'c' + $dlg_var(companyId) + 'e' + $dlg_var(callee) + '::' + $ci;
-            #!endif
         } else {
             # ACC CDR insert will fail, but that's OK
             if ($dlg_var(log)) xlog("L_INFO", "[b$dlg_var(brandId)][$dlg_var(cidhash)] AS calling to conference room, proceed\n");
@@ -547,13 +527,6 @@ request_route {
             if ($dlg_var(log)) xlog("L_INFO", "[b$dlg_var(brandId)][$dlg_var(cidhash)] Calling to non-feature-like $rU, dispatch to any AS\n");
             route(PROFILE_UAC_CALL);
         }
-
-        #!ifdef WITH_REDIS
-        # Redis data
-        $dlg_var(AoR) = $fU + '@' + $fd;
-        $dlg_var(interlocutor) = $rU;
-        $dlg_var(redisset) = 'call::b' + $dlg_var(brandId) + 'c' + $dlg_var(companyId) + 'e' + $dlg_var(caller) + '::' + $ci;
-        #!endif
 
         route(DISPATCH);
     }
@@ -1033,14 +1006,6 @@ route[AUTH] {
 route[WITHINDLG] {
     if (!$dlg_var(confirmed) && is_method("UPDATE|INVITE")) drop;
 
-    #!ifdef WITH_REDIS
-    # Update interlocutor
-    if (is_present_hf("P-Asserted-Identity") && $(ai{uri.user})) {
-        if ($dlg_var(log)) xlog("L_INFO", "[b$dlg_var(brandId)][$dlg_var(cidhash)] WITHINDLG: Update redis interlocutor to $(ai{uri.user})\n");
-        redis_cmd("redis", "HMSET $dlg_var(redisset) interlocutor $(ai{uri.user})", "r");
-    }
-    #!endif
-
     # sequential request withing a dialog should
     # take the path determined by record-routing
     if (loose_route()) {
@@ -1514,18 +1479,6 @@ onreply_route[MANAGE_REPLY] {
         setflag(FLT_ACCMISSED);
     }
 
-    #!ifdef WITH_REDIS
-    # Create Redis object
-    if (is_method("INVITE") && $rs =~ "[12][0-9][0-9]") {
-        if ($dlg_var(log)) xlog("L_INFO", "[b$dlg_var(brandId)][$dlg_var(cidhash)] MANAGE_REPLY: Create/Update $dlg_var(redisset) redis object\n");
-        redis_cmd("redis", "HSETNX $dlg_var(redisset) create-time $TS", "r");
-        redis_cmd("redis", "HSET $dlg_var(redisset) status $rr", "r");
-        redis_cmd("redis", "HSETNX $dlg_var(redisset) AoR $dlg_var(AoR)", "r");
-        redis_cmd("redis", "HSETNX $dlg_var(redisset) interlocutor $dlg_var(interlocutor)", "r");
-        redis_cmd("redis", "HSETNX $dlg_var(redisset) applicationserver $sht(dialogs=>$ci::applicationserver)", "r");
-    }
-    #!endif
-
     # Manage NAT
     if ($rs =~ "[12][0-9][0-9]") {
         if ($dlg_var(log)) xlog("L_INFO", "[b$dlg_var(brandId)][$dlg_var(cidhash)] MANAGE_REPLY: Non-error reply $rs, call NATMANAGE\n");
@@ -1600,21 +1553,8 @@ branch_route[MANAGE_BRANCH] {
     route(NATMANAGE);
 }
 
-# Executed when dialog fails with +3XX response code
-#!ifdef WITH_REDIS
-event_route[dialog:failed] {
-    if ($dlg_var(log)) xlog("L_INFO", "[b$dlg_var(brandId)][$dlg_var(cidhash)] dialog-failed: Delete $dlg_var(redisset) redis object\n");
-    redis_cmd("redis", "DEL $dlg_var(redisset)", "r");
-}
-#!endif
-
 # Executed when dialog is confirmed with 2XX response code
 event_route[dialog:start] {
-#!ifdef WITH_REDIS
-    if ($dlg_var(log)) xlog("L_INFO", "[b$dlg_var(brandId)][$dlg_var(cidhash)] dialog-start: Update $dlg_var(redisset) redis object status to established\n");
-    redis_cmd("redis", "HMSET $dlg_var(redisset) status established establish-time $TS", "r");
-#!endif
-
     if(isbflagset(FLB_WEBSOCKETS)) {
         if ($dlg_var(log)) xlog("L_WARN", "[b$dlg_var(brandId)][$dlg_var(cidhash)] Answered dialog involves websockets\n");
         $dlg_var(ws) = 'yes';
@@ -1628,11 +1568,6 @@ event_route[dialog:start] {
 
 # Executed when dialog is ended with BYE or timeout
 event_route[dialog:end] {
-#!ifdef WITH_REDIS
-    if ($dlg_var(log)) xlog("L_INFO", "[b$dlg_var(brandId)][$dlg_var(cidhash)] dialog-end: Delete $dlg_var(redisset) redis object\n");
-    redis_cmd("redis", "DEL $dlg_var(redisset)", "r");
-#!endif
-
     if ($dlg_var(log)) xlog("L_INFO", "[b$dlg_var(brandId)][$dlg_var(cidhash)] Dialog ended, delete keys from dialogs htable starting with $ci\n");
     sht_rm_name_re("dialogs=>$ci::.*");
 


### PR DESCRIPTION
Redis was included as an experimental approach to have some realtime
statistics (total calls, calls per company, etc.).

This approach has been discarded and this commits tries to erase all
references to it.