### PR TITLE
ivr: fix IVRCustom handlers for timeout and error

### DIFF
--- a/asterisk/agi/application/controllers/CallsController.php
+++ b/asterisk/agi/application/controllers/CallsController.php
@@ -473,16 +473,16 @@ class CallsController extends BaseController
         // Noone picked up
         if ($dialStatus == "NOANSWER") {
             $ivrId = $this->agi->getVariable("IVRID");
+            $ivrType = $this->agi->getVariable("IVRTYPE");
 
-            // Get IVRCommon..
-            $ivrCommonMapper = new Mapper\IVRCommon();
-            $ivr = $ivrCommonMapper->find($ivrId);
-
-            // Or IVRcustom...
-            if (empty($ivr)) {
-                $ivrCustomMapper = new Mapper\IVRCustom();
-                $ivr = $ivrCustomMapper->find($ivrId);
+            if ($ivrType == 'COMMON') {
+                $ivrMapper = new Mapper\IVRCommon();
+            } else {
+                $ivrMapper = new Mapper\IVRCustom();
             }
+
+            // Get IVR data
+            $ivr = $ivrMapper->find($ivrId);
 
             // Process NoAnswer handler
             $ivrAction = new IVRAction($this);

--- a/asterisk/agi/library/Agi/Action/IVRAction.php
+++ b/asterisk/agi/library/Agi/Action/IVRAction.php
@@ -49,9 +49,6 @@ class IVRAction extends RouterAction
      */
     protected function _routeToUser()
     {
-        // Set id variable for postprocessing
-        $this->agi->setVariable("IVRID", $this->_ivr->getId());
-
         // Handle Call user route
         $userAction = new UserCallAction($this);
         $userAction

--- a/asterisk/agi/library/Agi/Action/IVRCommonAction.php
+++ b/asterisk/agi/library/Agi/Action/IVRCommonAction.php
@@ -52,6 +52,10 @@ class IVRCommonAction extends IVRAction
             return $this->processError();
         }
 
+        // Store current IVR data
+        $this->agi->setVariable("IVRID", $ivr->getId());
+        $this->agi->setVariable("IVRTYPE", 'COMMON');
+
         // Success!! Place call to given extension
         $this->agi->playback($ivr->getSuccessLocution());
 

--- a/asterisk/agi/library/Agi/Action/IVRCustomAction.php
+++ b/asterisk/agi/library/Agi/Action/IVRCustomAction.php
@@ -39,6 +39,10 @@ class IVRCustomAction extends IVRAction
             return $this->processError();
         }
 
+        // Store current IVR data
+        $this->agi->setVariable("IVRID", $ivr->getId());
+        $this->agi->setVariable("IVRTYPE", 'CUSTOM');
+
         // Check if the pressed input matches one of the configured extensions
         $entries = $ivr->getIVRCustomEntries();
         foreach ($entries as $entry) {


### PR DESCRIPTION
Fixed a bug where the IVRCustom handlers were not properly processed.

The logic stored the IVR id but not the IVR type. While processing the handlers
for a IVRCustom, if a IVRCommon with the same id was found they were processed
instead of the original IVRCustom handlers.

This commit includes an extra channel variable IVRTYPE to determine if the
IVR handlers being processed belong to a IVRCustom or a IVRCommon.