### PR TITLE
IVR: replace noAnswer with noInput handler

### DIFF
--- a/asterisk/agi/library/Agi/Action/IVRAction.php
+++ b/asterisk/agi/library/Agi/Action/IVRAction.php
@@ -15,7 +15,7 @@ class IVRAction extends RouterAction
     public function processTimeout()
     {
         $ivr = $this->_ivr;
-        $this->agi->verbose("Processing IVR timeout handler.");
+        $this->agi->verbose("Processing IVR no input handler.");
 
         // Play Timoeut Locution
         $this->agi->playback($ivr->getNoAnswerLocution());
@@ -42,20 +42,5 @@ class IVRAction extends RouterAction
         $this->_routeVoiceMail  = $ivr->getErrorVoiceMailUser();
         $this->_routeExternal   = $ivr->getErrorNumberValue();
         $this->route();
-    }
-
-    /**
-     * Overload routeToUser action to send the call to special context
-     */
-    protected function _routeToUser()
-    {
-        // Handle Call user route
-        $userAction = new UserCallAction($this);
-        $userAction
-            ->setDialContext('call-ivr')
-            ->setTimeout($this->_ivr->getNoAnswerTimeout())
-            ->setUser($this->_routeUser)
-            ->setProcessDialStatus(true)
-            ->call();
     }
 }

--- a/asterisk/agi/library/Agi/Action/IVRCommonAction.php
+++ b/asterisk/agi/library/Agi/Action/IVRCommonAction.php
@@ -34,7 +34,7 @@ class IVRCommonAction extends IVRAction
 
         // User hasn't pressed anything
         if (empty($userPressed))
-            return $this->processError();
+            return $this->processTimeout();
 
         // Not allowed numbers for this IVR
         $blackList = $ivr->getBlackListRegExp();

--- a/asterisk/agi/library/Agi/Action/IVRCustomAction.php
+++ b/asterisk/agi/library/Agi/Action/IVRCustomAction.php
@@ -36,7 +36,7 @@ class IVRCustomAction extends IVRAction
 
         // User hasn't pressed anything
         if (empty($userPressed)) {
-            return $this->processError();
+            return $this->processTimeout();
         }
 
         // Store current IVR data
@@ -54,30 +54,13 @@ class IVRCustomAction extends IVRAction
                 // Play entry success (if any)
                 $this->agi->playback($entry->getWelcomeLocution());
 
-                // For extension, use extension routing to apply timeout
-                if ($entry->getTargetType() == 'extension') {
-                    $extension = $entry->getTargetExtension();
-                    // FIXME Routing to extension should be the same as routing to
-                    // any other option...
-                    // !! Route this IVR using th extension parmaters !!
-                    $this->_routeType       = $extension->getRouteType();
-                    $this->_routeUser       = $extension->getUser();
-                    $this->_routeIVRCommon  = $extension->getIVRCommon();
-                    $this->_routeIVRCustom  = $extension->getIVRCustom();
-                    $this->_routeHuntGroup  = $extension->getHuntGroup();
-                    $this->_routeConference = $extension->getConferenceRoom();
-                    $this->_routeExternal   = $extension->getNumberValue();
-                    $this->_routeFriend     = $extension->getFriendValue();
-                    $this->_routeQueue      = $extension->getQueue();
-                    $this->_routeConditionalRoute = $extension->getConditionalRoute();
-                } else {
-                    // Route to destination
-                    $this->_routeType       = $entry->getTargetType();
-                    $this->_routeExtension  = $entry->getTargetExtension();
-                    $this->_routeVoiceMail  = $entry->getTargetVoiceMailUser();
-                    $this->_routeExternal   = $entry->getTargetNumberValue();
-                    $this->_routeConditionalRoute = $entry->getTargetConditionalRoute();
-                }
+                // Route to destination
+                $this->_routeType       = $entry->getTargetType();
+                $this->_routeExtension  = $entry->getTargetExtension();
+                $this->_routeVoiceMail  = $entry->getTargetVoiceMailUser();
+                $this->_routeExternal   = $entry->getTargetNumberValue();
+                $this->_routeConditionalRoute = $entry->getTargetConditionalRoute();
+
                 // Routed! :)
                 return $this->route();
             }

--- a/asterisk/config/dialplan/default.conf
+++ b/asterisk/config/dialplan/default.conf
@@ -68,12 +68,6 @@ exten => _X.,1,NoOp(Calling from ${CALLERID(all)} to ${DIAL_DST})
 exten => _X.,1,NoOp(Calling external number)
     same => n,Dial(${DIAL_DST},${DIAL_TIMEOUT},${DIAL_OPTS}b(add-headers^${EXTEN}^1))
 
-;; Context for Calling a user from an IVR (and handle IVR Noanswer call forwards)
-[call-ivr]
-exten => _X.,1,NoOp(Calling from IVR to ${DIAL_DST})
-    same => n,Dial(${DIAL_DST},${DIAL_TIMEOUT},gb(add-headers^${EXTEN}^1))
-    same => n,AGI(agi://127.0.0.1:4573/cli.php?model=default/calls/ivrstatus)
-
 ;; Context for Calling a user from a HuntGroup (and handle HuntGroup post-process or continues)
 [call-huntgroup]
 exten => _X.,1,NoOp(Calling huntgroup)

--- a/doc/sphinx/locale/es/LC_MESSAGES/pbx_features.po
+++ b/doc/sphinx/locale/es/LC_MESSAGES/pbx_features.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: IvozProvider 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-09-06 17:37+0200\n"
+"POT-Creation-Date: 2017-09-18 19:15+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -816,7 +816,8 @@ msgstr "Ninguno, uno o más listas de horarios (pre-creadas, ver :ref:`Horarios`
 #: ../../pbx_features/conditional_routes.rst:66
 msgid "None, one or more calendar (pre-created, see :ref:`calendars`)"
 msgstr ""
-"Ninguno, uno o más listas de calendarios (pre-creadas, ver :ref:`Calendarios`)"
+"Ninguno, uno o más listas de calendarios (pre-creadas, ver "
+":ref:`Calendarios`)"
 
 #: ../../pbx_features/conditional_routes.rst:68
 msgid "These 3 criteria are combined (applying an AND logic)."
@@ -833,8 +834,8 @@ msgid ""
 "with DDIs need an additional explanation."
 msgstr ""
 "El comportamiento cuando la opción de un IVR o una extensión se enruta a "
-"una ruta condicional es fácil de entender, pero su utilización con "
-"DDIs merece una explicación adicional."
+"una ruta condicional es fácil de entender, pero su utilización con DDIs "
+"merece una explicación adicional."
 
 #: ../../pbx_features/conditional_routes.rst:77
 msgid "Imagine this scenario:"
@@ -1968,19 +1969,18 @@ msgstr ""
 "locución (típicamente dirá algo así como \"Contactando...\")."
 
 #: ../../pbx_features/ivrs.rst:35
-msgid "No answer process"
-msgstr "Configuración No contesta"
+msgid "No input process"
+msgstr "Configuración sin entrada"
 
 #: ../../pbx_features/ivrs.rst:37
 msgid ""
-"If the dialed extension points to a user and does not answer in X "
-"seconds, the no answer process will trigger, playing the configured "
-"locution and redirecting the call to another number, extension or "
-"voicemail."
+"If the caller does not input any digit in the timeout value, the no input"
+" process will trigger, playing the configured locution and redirecting "
+"the call to another number, extension or voicemail."
 msgstr ""
-"En caso de que la extensión destino apunte a un usuario y no conteste en el"
-" tiempo indicado, se reproduce la locución indicada y se desvía al número"
-" externo, extensión interna o buzón seleccionado."
+"Si el llamante no introduce ningún digito, se reproduce la locución "
+"indicada y se desvía la llamada al número externo, extensión interna o "
+"buzón seleccionado."
 
 #: ../../pbx_features/ivrs.rst:40
 msgid "Error process"
@@ -1988,29 +1988,19 @@ msgstr "Configuración Error"
 
 #: ../../pbx_features/ivrs.rst:42
 msgid ""
-"If the dialed extension is invalid (o nothing has been dialed), the error"
-" process will trigger, playing the configured locution and redirecting "
-"the call to another number, extension or voicemail."
+"If the dialed extension is invalid, the error process will trigger, "
+"playing the configured locution and redirecting the call to another "
+"number, extension or voicemail."
 msgstr ""
-"Si lo que ha marcado el llamante no es válido (o no ha marcado nada), se"
-" reproduce la locución indicada y se desvía la llamada al número externo,"
-" extensión interna o buzón seleccionado."
+"Si lo que ha marcado el llamante no es válido, se reproduce la locución "
+"indicada y se desvía la llamada al número externo, extensión interna o "
+"buzón seleccionado."
 
-#: ../../pbx_features/ivrs.rst:46
-msgid ""
-"No answer processing only applies for extensions pointing to users. "
-"Extensions that point to other entities (such as external number, "
-"huntgroup, etc.) won't use this logic."
-msgstr ""
-"El procesamiento en caso de no contesta solo aplica para las extensiones "
-"que apuntan a usuarios. Las extensiones que apuntan a otras entidades "
-"(números externos, grupos de salto, etc.) no utilizarán esta lógica."
-
-#: ../../pbx_features/ivrs.rst:54
+#: ../../pbx_features/ivrs.rst:50
 msgid "Custom IVRs"
 msgstr "IVRs a medida"
 
-#: ../../pbx_features/ivrs.rst:56
+#: ../../pbx_features/ivrs.rst:52
 msgid ""
 "Contrary to the generic IVRs where the caller can only dial internal "
 "extensions, the custom IVRS can configure options that can be routed in "
@@ -2020,7 +2010,7 @@ msgstr ""
 " extensiones internas, los IVRs a medida permiten marcar dígitos que "
 "luego se pueden convertir a lo que el administrador de empresa desee."
 
-#: ../../pbx_features/ivrs.rst:60
+#: ../../pbx_features/ivrs.rst:56
 msgid ""
 "The most common usage for this IVR is combining them with a welcome "
 "locution that says something like 'Press 1 to contact XXX, Press 2 to "
@@ -2029,11 +2019,11 @@ msgstr ""
 "El caso más típico es el IVR que dice algo así como \"Marque 1 si quiere "
 "hablar con administración, marque 2 si quiere hablar con informática...\""
 
-#: ../../pbx_features/ivrs.rst:64
+#: ../../pbx_features/ivrs.rst:60
 msgid "Most of the configurable fields are the same that generic IVR uses:"
 msgstr "Los campos que se presentan son prácticamente idénticos al IVR genérico:"
 
-#: ../../pbx_features/ivrs.rst:66
+#: ../../pbx_features/ivrs.rst:62
 msgid ""
 "The process of each entry of the IVR can be defined in the following "
 "button:"
@@ -2041,7 +2031,7 @@ msgstr ""
 "Pulsando el botón de la siguiente imagen se pueden definir las "
 "equivalencias deseadas:"
 
-#: ../../pbx_features/ivrs.rst:70
+#: ../../pbx_features/ivrs.rst:66
 msgid ""
 "In this example, the caller can dial 1, 2 or 3 (the rest will be "
 "considered as an error and will trigger the **Error process**):"
@@ -2049,7 +2039,7 @@ msgstr ""
 "En este caso se puede marcar 1, 2 y 3 (todo lo demás será considerado "
 "inválido y activará la **Configuración de Error**):"
 
-#: ../../pbx_features/ivrs.rst:75
+#: ../../pbx_features/ivrs.rst:71
 msgid ""
 "1: Call to the internal extension 200, created in :ref:`previous section "
 "<huntgroups>` that routes to hunt group *Reception*."
@@ -2057,15 +2047,15 @@ msgstr ""
 "1: Llamada a la extensión interna 200, creada :ref:`en la sección "
 "anterior <huntgroups>` y que apunta al grupo de salto *Recepción*."
 
-#: ../../pbx_features/ivrs.rst:77
+#: ../../pbx_features/ivrs.rst:73
 msgid "2: Call to the internal extension 101."
 msgstr "2: Llama a la extensión interna 101."
 
-#: ../../pbx_features/ivrs.rst:78
+#: ../../pbx_features/ivrs.rst:74
 msgid "3: Route this call to the external number 676 676 676."
 msgstr "3: Desvía la llamada al número externo 676 676 676."
 
-#: ../../pbx_features/ivrs.rst:80
+#: ../../pbx_features/ivrs.rst:76
 msgid ""
 "Each of the Custom IVR entries supports a locution that, if set, will be "
 "played instead of the IVR **success locution**. This way, you can "
@@ -2078,23 +2068,11 @@ msgstr ""
 "podríamos tener otra que dijera \"Contactando con Administración, espere "
 "por favor\"."
 
-#: ../../pbx_features/ivrs.rst:85
-msgid ""
-"No answer processing only applies for options that point to extensions "
-"that point to users. Options that point to extensions that point to other"
-" entities (such as external number, huntgroup, etc.) won't use this "
-"logic."
-msgstr ""
-"El procesamiento en caso de no contesta solo aplica para las opciones que "
-"apuntan a extensiones que a su vez apuntan a usuarios. Las opciones que "
-"apuntan a extensiones que apuntan a otras entidades (números externos, grupos "
-"de salto, etc.) no utilizarán esta lógica."
-
-#: ../../pbx_features/ivrs.rst:91
+#: ../../pbx_features/ivrs.rst:82
 msgid "Entries are regular expressions"
 msgstr "Las opciones son expresiones regulares"
 
-#: ../../pbx_features/ivrs.rst:92
+#: ../../pbx_features/ivrs.rst:83
 msgid ""
 "Although on the most typical usage of this IVRs options will be digits "
 "from 1 to 9, **entries are interpreted as regular expressions**. This "
@@ -2102,21 +2080,21 @@ msgid ""
 "of all numbers from 200 to 299. With this usage, **Max digits** parameter"
 " is important too."
 msgstr ""
-"Aunque en el uso más habitual las opciones del IVR sean de un único dígito "
-"del 0 al 10, **las opciones se interpretan internamente como expresiones "
-"regulares**. De este modo, se podría añadir una opción \"^2[0-9]{2}$\" para "
-"agrupar el comportamiento de los números del 200 al 299. Es importante ajustar "
-"el valor del parámetro **Max digits**".
+"Aunque en el uso más habitual las opciones del IVR sean de un único "
+"dígito del 0 al 10, **las opciones se interpretan internamente como "
+"expresiones regulares**. De este modo, se podría añadir una opción "
+"\"^2[0-9]{2}$\" para agrupar el comportamiento de los números del 200 al "
+"299. Es importante ajustar el valor del parámetro **Max digits**\""
 
-#: ../../pbx_features/ivrs.rst:97
+#: ../../pbx_features/ivrs.rst:88
 msgid ""
 "To avoid undesired behaviour, **if you use options out of 0-9, use "
 "regular expression notation** ('^1$' instead of '1', '^10$' instead of "
 "'10' and so on)."
 msgstr ""
-"Para evitar comportamientos no deseados, **en caso de utilizar opciones de más "
-"de un dígito, utilice la notación de expresiones regulares** ('^1$' en lugar "
-"de '1', '^10$' en lugar de '10', etc.)."
+"Para evitar comportamientos no deseados, **en caso de utilizar opciones "
+"de más de un dígito, utilice la notación de expresiones regulares** "
+"('^1$' en lugar de '1', '^10$' en lugar de '10', etc.)."
 
 #: ../../pbx_features/match_lists.rst:5
 msgid "Match Lists"
@@ -2257,8 +2235,8 @@ msgid ""
 "IvozProvider supports most of the common audio formats and *encodes* them"
 " to the optimal format for the platform."
 msgstr ""
-"IvozProvider reconoce archivos de audio en los formatos más comunes y "
-"los *encodea* a los formatos óptimos para la plataforma."
+"IvozProvider reconoce archivos de audio en los formatos más comunes y los"
+" *encodea* a los formatos óptimos para la plataforma."
 
 #: ../../pbx_features/music_on_hold.rst:35
 msgid ""
@@ -2697,9 +2675,9 @@ msgid ""
 "dialing an special code. Voice instructions will be provided in the "
 "user's language."
 msgstr ""
-"Este servicio permite grabar la locución llamando desde cualquier terminal "
-"de cualquier usuario a un código especial. Las instrucciones se mostrarán "
-"en el idioma del usuario."
+"Este servicio permite grabar la locución llamando desde cualquier "
+"terminal de cualquier usuario a un código especial. Las instrucciones se "
+"mostrarán en el idioma del usuario."
 
 #: ../../pbx_features/services.rst:52
 msgid ""
@@ -2932,8 +2910,8 @@ msgid ""
 msgstr ""
 "Campo necesario para modelos que utilizan el sistema de :ref:`provisión "
 "de terminales <provisioning>` de IvozProvider. Recoge la `dirección "
-"física <https://es.wikipedia.org/wiki/Direcci%C3%B3n_MAC>`_ del "
-"adaptador de red del dispositivo SIP."
+"física <https://es.wikipedia.org/wiki/Direcci%C3%B3n_MAC>`_ del adaptador"
+" de red del dispositivo SIP."
 
 #: ../../pbx_features/terminals.rst:55
 msgid ""

--- a/doc/sphinx/pbx_features/ivrs.rst
+++ b/doc/sphinx/pbx_features/ivrs.rst
@@ -2,7 +2,7 @@
 Interactive Voice Response (IVR)
 ################################
 
-IVRs are the most common way to make **audio menus** where the caller must 
+IVRs are the most common way to make **audio menus** where the caller must
 choose the destination of the call by **pressing codes** based on the locutions
 instructions that will be played.
 
@@ -14,7 +14,7 @@ Generic IVRs
 
 In this type of IVRs, the caller will directly press the extension that must
 previously know (or the welcome locution suggests) and the system will
-automatically connect with that extension: 
+automatically connect with that extension:
 
 Generic IVRs have the following fields:
 
@@ -24,7 +24,7 @@ Generic IVRs have the following fields:
         Descriptive name of the IVR that will be used in other sections.
 
     Timeout
-        Time that caller has to enter the digits of the target extension. 
+        Time that caller has to enter the digits of the target extension.
 
     Welcome locution
         This locution will be played as soon as the caller enters the IVR.
@@ -33,19 +33,15 @@ Generic IVRs have the following fields:
         In case the dialed extension exists in the company, this locution will
         be played (usually something like 'Connecting, please wait...').
 
-    No answer process
-        If the dialed extension points to a user and does not answer in X seconds,
-        the no answer process will trigger, playing the configured locution and 
+    No input process
+        If the caller does not input any digit in the timeout value, the
+        no input process will trigger, playing the configured locution and
         redirecting the call to another number, extension or voicemail.
 
     Error process
-        If the dialed extension is invalid (o nothing has been dialed), the 
-        error process will trigger, playing the configured locution and
-        redirecting the call to another number, extension or voicemail. 
-
-.. warning:: No answer processing only applies for extensions pointing to 
-               users. Extensions that point to other entities (such as external
-               number, huntgroup, etc.) won't use this logic.
+        If the dialed extension is invalid, the error process will trigger,
+        playing the configured locution and redirecting the call to another
+        number, extension or voicemail.
 
 .. _custom_ivrs:
 
@@ -53,12 +49,12 @@ Generic IVRs have the following fields:
 Custom IVRs
 ***********
 
-Contrary to the generic IVRs where the caller can only dial internal 
+Contrary to the generic IVRs where the caller can only dial internal
 extensions, the custom IVRS can configure options that can be routed
 in different ways.
 
 .. hint:: The most common usage for this IVR is combining them with a welcome
-   locution that says something like 'Press 1 to contact XXX, Press 2 to 
+   locution that says something like 'Press 1 to contact XXX, Press 2 to
    contact YYY, ..."
 
 Most of the configurable fields are the same that generic IVR uses:
@@ -68,24 +64,19 @@ The process of each entry of the IVR can be defined in the following button:
 .. image:: img/ivr_custom2.png
 
 In this example, the caller can dial 1, 2 or 3 (the rest will be considered as
-an error and will trigger the **Error process**): 
+an error and will trigger the **Error process**):
 
 .. image:: img/ivr_custom3.png
 
-- 1: Call to the internal extension 200, created in :ref:`previous section 
+- 1: Call to the internal extension 200, created in :ref:`previous section
   <huntgroups>` that routes to hunt group *Reception*.
 - 2: Call to the internal extension 101.
 - 3: Route this call to the external number 676 676 676.
 
-.. note:: Each of the Custom IVR entries supports a locution that, if set, 
-   will be played instead of the IVR **success locution**. This way, you can 
+.. note:: Each of the Custom IVR entries supports a locution that, if set,
+   will be played instead of the IVR **success locution**. This way, you can
    configure a generic locution (like 'Connecting....') or a custom one for
    a given entry (like 'Connecting reception department, please wait...').
-
-.. warning:: No answer processing only applies for options that point to extensions
-               that point to users. Options that point to extensions that point
-               to other entities (such as external number, huntgroup, etc.)
-               won't use this logic.
 
 .. rubric:: Entries are regular expressions
 
@@ -97,4 +88,3 @@ to 299. With this usage, **Max digits** parameter is important too.
 .. error:: To avoid undesired behaviour, **if you use options out of 0-9, use
            regular expression notation** ('^1$' instead of '1', '^10$' instead
            of '10' and so on).
-

--- a/portals/application/configs/klear/IVRCommonList.yaml
+++ b/portals/application/configs/klear/IVRCommonList.yaml
@@ -28,6 +28,7 @@ production:
           maxDigits: true
           welcomeLocutionId: true
           noAnswerLocutionId: true
+          noAnswerTimeout: true
           errorLocutionId: true
           successLocutionId: true
           timeoutNumberValue: true
@@ -64,6 +65,7 @@ production:
         blacklist:
           timeoutTarget: true
           errorTarget: true
+          noAnswerTimeout: true
       fixedPositions: &IVRCommonFixedPositions_link
         group0:
           label: _("Basic Configuration")
@@ -76,11 +78,11 @@ production:
             successLocutionId: 6
             blackListRegExp: 8
         group1:
-          label: _("No answer configuration")
+          label: _("No input configuration")
           colsPerRow: 3
           fields:
             noAnswerLocutionId: 2
-            noAnswerTimeout: 1
+            __empty1: 1
             timeoutTargetType: 1
             timeoutNumberValue: 1
             timeoutExtensionId: 1
@@ -106,6 +108,7 @@ production:
         blacklist:
           timeoutTarget: true
           errorTarget: true
+          noAnswerTimeout: true
       fixedPositions:
         <<: *IVRCommonFixedPositions_link
   dialogs:

--- a/portals/application/configs/klear/IVRCustomList.yaml
+++ b/portals/application/configs/klear/IVRCustomList.yaml
@@ -28,6 +28,7 @@ production:
           maxDigits: true
           welcomeLocutionId: true
           noAnswerLocutionId: true
+          noAnswerTimeout: true
           errorLocutionId: true
           successLocutionId: true
           timeoutNumberValue: true
@@ -63,6 +64,7 @@ production:
       fields:
         blacklist:
           noAnswerTarget: true
+          noAnswerTimeout: true
           errorTarget: true
           timeoutTarget : true
       fixedPositions: &IVRCustomFixedPositions_link
@@ -76,11 +78,11 @@ production:
             welcomeLocutionId: 6
             successLocutionId: 6
         group1:
-          label: _("No answer configuration")
+          label: _("No input configuration")
           colsPerRow: 3
           fields:
             noAnswerLocutionId: 2
-            noAnswerTimeout: 1
+            __empty1: 1
             timeoutTargetType: 1
             timeoutNumberValue: 1
             timeoutExtensionId: 1
@@ -107,6 +109,7 @@ production:
       fields:
         blacklist:
           noAnswerTarget: true
+          noAnswerTimeout: true
           errorTarget: true
           timeoutTarget: true
       fixedPositions:

--- a/portals/application/configs/klear/model/IVRCommon.yaml
+++ b/portals/application/configs/klear/model/IVRCommon.yaml
@@ -30,6 +30,7 @@ production:
       required: true
       source:
         data: mapper
+
         config:
           mapperName: \IvozProvider\Mapper\Sql\Locutions
           filterClass: IvozProvider_Klear_Filter_Company
@@ -39,7 +40,7 @@ production:
             template: '%name%'
           order: name
     noAnswerLocutionId:
-      title: _('No answer locution')
+      title: _('No input locution')
       type: select
       source:
         data: mapper
@@ -116,7 +117,7 @@ production:
       source:
         control: Spinner
     timeoutTargetType:
-      title: _('Timeout target type')
+      title: _('No input target type')
       type: select
       source:
         data: inline
@@ -238,7 +239,7 @@ production:
           order: name
         'null': _("Unassigned")
     timeoutTarget:
-      title: _('Timeout target')
+      title: _('No input target')
       type: ghost
       source:
         class: IvozProvider_Klear_Ghost_IVRCommonTarget

--- a/portals/application/configs/klear/model/IVRCustom.yaml
+++ b/portals/application/configs/klear/model/IVRCustom.yaml
@@ -112,7 +112,7 @@ production:
       source:
         control: Spinner
     timeoutTargetType:
-      title: _('Timeout target type')
+      title: _('No input target type')
       type: select
       source:
         data: inline
@@ -234,7 +234,7 @@ production:
           order: name
         'null': _("Unassigned")
     timeoutTarget:
-      title: _('Timeout target')
+      title: _('No input target')
       type: ghost
       source:
         class: IvozProvider_Klear_Ghost_IVRCustomTarget

--- a/portals/application/languages/en_US/en_US.po
+++ b/portals/application/languages/en_US/en_US.po
@@ -1375,6 +1375,18 @@ msgstr "No answer locution"
 msgid "No answer timeout"
 msgstr "No answer timeout"
 
+msgid "No input configuration"
+msgstr "No input configuration"
+
+msgid "No input locution"
+msgstr "No input locution"
+
+msgid "No input target"
+msgstr "No input target"
+
+msgid "No input target type"
+msgstr "No input target"
+
 msgid "No matching condition handler"
 msgstr "No matching condition handler"
 
@@ -2189,9 +2201,6 @@ msgstr "Timeout configuration"
 msgid "Timeout route"
 msgstr "Timeout route"
 
-msgid "Timeout target"
-msgstr "Timeout target"
-
 msgid "Timeout target type"
 msgstr "Timeout target"
 
@@ -2412,6 +2421,7 @@ msgid ""
 msgstr ""
 "You can call this extension from any company terminal to record this locution"
 
+#, python-brace-format
 msgid ""
 "You can optionally prepend the terminal model or any other subpath to the "
 "url before the MAC address for verbosity/debugging purposes. If a extension "

--- a/portals/application/languages/es_ES/es_ES.po
+++ b/portals/application/languages/es_ES/es_ES.po
@@ -1393,6 +1393,18 @@ msgstr "Loc. No contesta"
 msgid "No answer timeout"
 msgstr "Timeout no contesta"
 
+msgid "No input configuration"
+msgstr "Configuración sin entrada"
+
+msgid "No input locution"
+msgstr "Loc. sin entrada"
+
+msgid "No input target"
+msgstr "Destino sin entrada"
+
+msgid "No input target type"
+msgstr "Enrutado sin entrada"
+
 msgid "No matching condition handler"
 msgstr "Tratamiento sin coincidencia"
 
@@ -2212,9 +2224,6 @@ msgstr "Configuración no contesta"
 msgid "Timeout route"
 msgstr "Enrutar no contesta"
 
-msgid "Timeout target"
-msgstr "Destino si timeout"
-
 msgid "Timeout target type"
 msgstr "Enrutado timeout"
 
@@ -2436,6 +2445,7 @@ msgstr ""
 "Puede llamar a esta extensión para grabar está locución desde cualquier "
 "terminal de la compañía"
 
+#, python-brace-format
 msgid ""
 "You can optionally prepend the terminal model or any other subpath to the "
 "url before the MAC address for verbosity/debugging purposes. If a extension "

--- a/tests/bbs/2002-test-ivr-common-noinput-extension.yaml
+++ b/tests/bbs/2002-test-ivr-common-noinput-extension.yaml
@@ -1,0 +1,22 @@
+# ----------------------------------------------------------------------------
+scenarios:
+  - name: call to IVR common not input routed to extension
+    type: simple
+    timeout: 30
+    sessions:
+      - alice:
+          - call:
+              dest: 600             # IVR common extension
+              credentials:
+                <<: *alice_cred
+          - waitfor: CONFIRMED
+          - waitfor: DISCONNCTD
+      - dave:
+          - register:
+              <<: *dave_cred
+          - waitfor: INCOMING
+          - wait
+          - answer
+          - wait: 5
+          - hangup
+          - waitfor: DISCONNCTD

--- a/tests/bbs/2003-test-ivr-common-usercfw-noanswer.yaml
+++ b/tests/bbs/2003-test-ivr-common-usercfw-noanswer.yaml
@@ -1,0 +1,30 @@
+# ----------------------------------------------------------------------------
+scenarios:
+  - name: call to IVR common to eve not answering redirected to bob
+    type: simple
+    timeout: 30
+    sessions:
+      - alice:
+          - call:
+              dest: 600             # IVR common extension
+              credentials:
+                <<: *alice_cred
+          - waitfor: CONFIRMED
+          - dtmf: 1005
+          - waitfor: DISCONNCTD
+      - eve:
+          - register:
+              <<: *eve_cred
+          - waitfor: INCOMING
+          - ringing
+          - waitfor: DISCONNCTD
+      - bob:
+          - register:
+              <<: *bob_cred
+          - waitfor: INCOMING
+          - ringing
+          - wait
+          - answer
+          - wait: 5
+          - hangup
+          - waitfor: DISCONNCTD

--- a/tests/bbs/2004-test-ivr-common-usercfw-busy.yaml
+++ b/tests/bbs/2004-test-ivr-common-usercfw-busy.yaml
@@ -1,6 +1,6 @@
 # ----------------------------------------------------------------------------
 scenarios:
-  - name: call to IVR common not answered routed to extension
+  - name: call to IVR common to eve busy redirected to bob
     type: simple
     timeout: 30
     sessions:
@@ -10,19 +10,24 @@ scenarios:
               credentials:
                 <<: *alice_cred
           - waitfor: CONFIRMED
-          - dtmf: 1003            # Press Charlie Extension
+          - dtmf: 1005
+          - waitfor: DISCONNCTD
+      - eve:
+          - register:
+              <<: *eve_cred
+          - waitfor: INCOMING
+          - ringing
+          - wait
+          - busy
           - waitfor: DISCONNCTD
       - charlie:
           - register:
               <<: *charlie_cred
           - waitfor: INCOMING
           - ringing
-          - waitfor: DISCONNCTD  # Wait until call is cancelled
-      - dave:
-          - register:
-              <<: *dave_cred
-          - waitfor: INCOMING
+          - wait
           - answer
           - wait: 5
           - hangup
           - waitfor: DISCONNCTD
+

--- a/tests/bbs/2012-test-ivr-custom-noinput-extension.yaml
+++ b/tests/bbs/2012-test-ivr-custom-noinput-extension.yaml
@@ -1,0 +1,22 @@
+# ----------------------------------------------------------------------------
+scenarios:
+  - name: call to IVR custom not input routed to extension
+    type: simple
+    timeout: 30
+    sessions:
+      - alice:
+          - call:
+              dest: 601             # IVR custom extension
+              credentials:
+                <<: *alice_cred
+          - waitfor: CONFIRMED
+          - waitfor: DISCONNCTD
+      - dave:
+          - register:
+              <<: *dave_cred
+          - waitfor: INCOMING
+          - wait
+          - answer
+          - wait: 5
+          - hangup
+          - waitfor: DISCONNCTD

--- a/tests/bbs/2013-test-ivr-custom-usercfw-noanswer.yaml
+++ b/tests/bbs/2013-test-ivr-custom-usercfw-noanswer.yaml
@@ -1,0 +1,30 @@
+# ----------------------------------------------------------------------------
+scenarios:
+  - name: call to IVR custom to eve not answering redirected to bob
+    type: simple
+    timeout: 30
+    sessions:
+      - alice:
+          - call:
+              dest: 601             # IVR custom extension
+              credentials:
+                <<: *alice_cred
+          - waitfor: CONFIRMED
+          - dtmf: 5
+          - waitfor: DISCONNCTD
+      - eve:
+          - register:
+              <<: *eve_cred
+          - waitfor: INCOMING
+          - ringing
+          - waitfor: DISCONNCTD
+      - bob:
+          - register:
+              <<: *bob_cred
+          - waitfor: INCOMING
+          - ringing
+          - wait
+          - answer
+          - wait: 5
+          - hangup
+          - waitfor: DISCONNCTD

--- a/tests/bbs/2014-test-ivr-custom-usercfw-busy.yaml
+++ b/tests/bbs/2014-test-ivr-custom-usercfw-busy.yaml
@@ -1,0 +1,33 @@
+# ----------------------------------------------------------------------------
+scenarios:
+  - name: call to IVR custom to eve busy redirected to bob
+    type: simple
+    timeout: 30
+    sessions:
+      - alice:
+          - call:
+              dest: 601             # IVR custom extension
+              credentials:
+                <<: *alice_cred
+          - waitfor: CONFIRMED
+          - dtmf: 5
+          - waitfor: DISCONNCTD
+      - eve:
+          - register:
+              <<: *eve_cred
+          - waitfor: INCOMING
+          - ringing
+          - wait
+          - busy
+          - waitfor: DISCONNCTD
+      - charlie:
+          - register:
+              <<: *charlie_cred
+          - waitfor: INCOMING
+          - ringing
+          - wait
+          - answer
+          - wait: 5
+          - hangup
+          - waitfor: DISCONNCTD
+

--- a/tests/bbs/dataset.json
+++ b/tests/bbs/dataset.json
@@ -2,7 +2,7 @@
 	"variables": [],
 	"info": {
 		"name": "IvozProvider - BBS Dataset",
-		"_postman_id": "3cdf5f7b-5497-0dfb-a895-18718b253652",
+		"_postman_id": "7ab9ba82-ab4f-069c-9ae9-d83dbad7cad1",
 		"description": "",
 		"schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json"
 	},
@@ -41,73 +41,73 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
 							"mode": "formdata",
 							"formdata": [
 								{
+									"description": "",
 									"key": "name",
-									"value": "ZZZ - BBS - Brand for Black Box SIP tests",
 									"type": "text",
-									"description": ""
+									"value": "ZZZ - BBS - Brand for Black Box SIP tests"
 								},
 								{
+									"description": "",
 									"key": "nif",
-									"value": "01234567890AF",
 									"type": "text",
-									"description": ""
+									"value": "01234567890AF"
 								},
 								{
+									"description": "",
 									"key": "defaultTimezoneId",
-									"value": "70",
 									"type": "text",
-									"description": ""
+									"value": "70"
 								},
 								{
+									"description": "",
 									"key": "postalAddress",
-									"value": "Postal address created from REST API",
 									"type": "text",
-									"description": ""
+									"value": "Postal address created from REST API"
 								},
 								{
+									"description": "",
 									"key": "postalCode",
-									"value": "48901",
 									"type": "text",
-									"description": ""
+									"value": "48901"
 								},
 								{
+									"description": "",
 									"key": "town",
-									"value": "Rest API town",
 									"type": "text",
-									"description": ""
+									"value": "Rest API town"
 								},
 								{
+									"description": "",
 									"key": "province",
-									"value": "Rest API province",
 									"type": "text",
-									"description": ""
+									"value": "Rest API province"
 								},
 								{
+									"description": "",
 									"key": "country",
-									"value": "Rest API country",
 									"type": "text",
-									"description": ""
+									"value": "Rest API country"
 								},
 								{
+									"description": "",
 									"key": "registryData",
-									"value": "Brand Invoice Footer data",
 									"type": "text",
-									"description": ""
+									"value": "Brand Invoice Footer data"
 								},
 								{
+									"description": "",
 									"key": "domain_users",
-									"value": "retail-bbs.ivozprovider.local",
 									"type": "text",
-									"description": ""
+									"value": "retail-bbs.ivozprovider.local"
 								}
 							]
 						},
@@ -137,9 +137,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -185,9 +185,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -233,9 +233,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -281,9 +281,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -329,9 +329,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -377,9 +377,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -425,9 +425,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -473,9 +473,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -521,9 +521,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -577,9 +577,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -604,22 +604,22 @@
 									"value": "1"
 								},
 								{
+									"description": "",
 									"key": "internationalCode",
-									"value": "00",
-									"description": "",
-									"type": "text"
+									"type": "text",
+									"value": "00"
 								},
 								{
+									"description": "",
 									"key": "nationalNumLength",
-									"value": "9",
-									"description": "",
-									"type": "text"
+									"type": "text",
+									"value": "9"
 								},
 								{
-									"key": "countryId",
-									"value": "70",
 									"description": "",
-									"type": "text"
+									"key": "countryId",
+									"type": "text",
+									"value": "70"
 								}
 							]
 						},
@@ -657,9 +657,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -678,16 +678,16 @@
 									"value": "BBS Peering Contract"
 								},
 								{
-									"key": "externallyRated",
-									"value": "0",
 									"description": "",
-									"type": "text"
+									"key": "externallyRated",
+									"type": "text",
+									"value": "0"
 								},
 								{
-									"key": "transformationRulesetGroupsTrunksId",
-									"value": "{{transformationRulesetId}}",
 									"description": "",
-									"type": "text"
+									"key": "transformationRulesetGroupsTrunksId",
+									"type": "text",
+									"value": "{{transformationRulesetId}}"
 								}
 							]
 						},
@@ -725,9 +725,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -746,10 +746,10 @@
 									"value": "{{peeringContractId}}"
 								},
 								{
-									"key": "sip_proxy",
-									"value": "127.0.0.1",
 									"description": "",
-									"type": "text"
+									"key": "sip_proxy",
+									"type": "text",
+									"value": "127.0.0.1"
 								}
 							]
 						},
@@ -787,9 +787,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -855,9 +855,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -997,9 +997,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -1071,9 +1071,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -1098,16 +1098,16 @@
 									"value": "BBS - Spain"
 								},
 								{
-									"key": "description_es",
-									"value": "BBS - España",
 									"description": "",
-									"type": "text"
+									"key": "description_es",
+									"type": "text",
+									"value": "BBS - España"
 								},
 								{
-									"key": "description_en",
-									"value": "BBS - Spain",
 									"description": "",
-									"type": "text"
+									"key": "description_en",
+									"type": "text",
+									"value": "BBS - Spain"
 								},
 								{
 									"description": "",
@@ -1151,9 +1151,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -1178,16 +1178,16 @@
 									"value": "BBS - USA"
 								},
 								{
-									"key": "description_es",
-									"value": "BBS - EEUU",
 									"description": "",
-									"type": "text"
+									"key": "description_es",
+									"type": "text",
+									"value": "BBS - EEUU"
 								},
 								{
-									"key": "description_en",
-									"value": "BBS - USA",
 									"description": "",
-									"type": "text"
+									"key": "description_en",
+									"type": "text",
+									"value": "BBS - USA"
 								},
 								{
 									"description": "",
@@ -1231,9 +1231,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -1258,16 +1258,16 @@
 									"value": "BBS - Tests"
 								},
 								{
-									"key": "description_es",
-									"value": "BBS - Pruebas",
 									"description": "",
-									"type": "text"
+									"key": "description_es",
+									"type": "text",
+									"value": "BBS - Pruebas"
 								},
 								{
-									"key": "description_en",
-									"value": "BBS - Tests",
 									"description": "",
-									"type": "text"
+									"key": "description_en",
+									"type": "text",
+									"value": "BBS - Tests"
 								}
 							]
 						},
@@ -1302,9 +1302,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -1329,22 +1329,22 @@
 									"value": "{{targetPatternESId}}"
 								},
 								{
+									"description": "",
 									"key": "connectionCharge",
-									"value": "0.15",
-									"description": "",
-									"type": "text"
+									"type": "text",
+									"value": "0.15"
 								},
 								{
+									"description": "",
 									"key": "periodTime",
-									"value": "1",
-									"description": "",
-									"type": "text"
+									"type": "text",
+									"value": "1"
 								},
 								{
-									"key": "perPeriodCharge",
-									"value": "0.20",
 									"description": "",
-									"type": "text"
+									"key": "perPeriodCharge",
+									"type": "text",
+									"value": "0.20"
 								}
 							]
 						},
@@ -1379,9 +1379,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -1406,22 +1406,22 @@
 									"value": "{{targetPatternUSId}}"
 								},
 								{
+									"description": "",
 									"key": "connectionCharge",
-									"value": "0.20",
-									"description": "",
-									"type": "text"
+									"type": "text",
+									"value": "0.20"
 								},
 								{
+									"description": "",
 									"key": "periodTime",
-									"value": "1",
-									"description": "",
-									"type": "text"
+									"type": "text",
+									"value": "1"
 								},
 								{
-									"key": "perPeriodCharge",
-									"value": "0.25",
 									"description": "",
-									"type": "text"
+									"key": "perPeriodCharge",
+									"type": "text",
+									"value": "0.25"
 								}
 							]
 						},
@@ -1465,9 +1465,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -1475,64 +1475,64 @@
 							"formdata": [
 								{
 									"key": "brandId",
-									"value": "{{brandId}}",
-									"type": "text"
+									"type": "text",
+									"value": "{{brandId}}"
 								},
 								{
 									"key": "name",
-									"value": "BBS - Company for Black Box SIP tests",
-									"type": "text"
+									"type": "text",
+									"value": "BBS - Company for Black Box SIP tests"
 								},
 								{
 									"key": "nif",
-									"value": "09876543210ART",
-									"type": "text"
+									"type": "text",
+									"value": "09876543210ART"
 								},
 								{
 									"key": "defaultTimezoneId",
-									"value": "1",
-									"type": "text"
+									"type": "text",
+									"value": "1"
 								},
 								{
 									"key": "postalAddress",
-									"value": "Company postal address",
-									"type": "text"
+									"type": "text",
+									"value": "Company postal address"
 								},
 								{
 									"key": "postalCode",
-									"value": "Company postal code",
-									"type": "text"
+									"type": "text",
+									"value": "Company postal code"
 								},
 								{
 									"key": "town",
-									"value": "Company town",
-									"type": "text"
+									"type": "text",
+									"value": "Company town"
 								},
 								{
 									"key": "province",
-									"value": "Company province",
-									"type": "text"
+									"type": "text",
+									"value": "Company province"
 								},
 								{
 									"key": "country",
-									"value": "Company country",
-									"type": "text"
+									"type": "text",
+									"value": "Company country"
 								},
 								{
 									"key": "domain_users",
-									"value": "bbs.ivozprovider.local",
-									"type": "text"
+									"type": "text",
+									"value": "bbs.ivozprovider.local"
 								},
 								{
 									"key": "type",
-									"value": "vpbx",
-									"type": "text"
+									"type": "text",
+									"value": "vpbx"
 								},
 								{
-									"key": "externalMaxCalls",
-									"value": "2",
 									"description": "",
-									"type": "text"
+									"key": "externalMaxCalls",
+									"type": "text",
+									"value": "2"
 								}
 							]
 						},
@@ -1567,9 +1567,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -1594,22 +1594,22 @@
 									"value": "{{companyId}}"
 								},
 								{
+									"description": "",
 									"key": "validFrom",
-									"value": "2000-01-01",
-									"description": "",
-									"type": "text"
+									"type": "text",
+									"value": "2000-01-01"
 								},
 								{
+									"description": "",
 									"key": "validTo",
-									"value": "2099-12-31",
-									"description": "",
-									"type": "text"
+									"type": "text",
+									"value": "2099-12-31"
 								},
 								{
-									"key": "metric",
-									"value": "1",
 									"description": "",
-									"type": "text"
+									"key": "metric",
+									"type": "text",
+									"value": "1"
 								}
 							]
 						},
@@ -1639,9 +1639,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -1687,9 +1687,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -1735,9 +1735,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -1783,9 +1783,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -1831,9 +1831,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -1879,9 +1879,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -1931,9 +1931,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -1941,28 +1941,28 @@
 							"formdata": [
 								{
 									"key": "companyId",
-									"value": "{{companyId}}",
-									"type": "text"
+									"type": "text",
+									"value": "{{companyId}}"
 								},
 								{
 									"key": "terminalModelId",
-									"value": "5",
-									"type": "text"
+									"type": "text",
+									"value": "5"
 								},
 								{
 									"key": "name",
-									"value": "alice",
-									"type": "text"
+									"type": "text",
+									"value": "alice"
 								},
 								{
 									"key": "password",
-									"value": "4l1c3p4ssw0rd",
-									"type": "text"
+									"type": "text",
+									"value": "4l1c3p4ssw0rd"
 								},
 								{
 									"key": "direct_media_method",
-									"value": "invite",
-									"type": "text"
+									"type": "text",
+									"value": "invite"
 								}
 							]
 						},
@@ -1996,9 +1996,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -2006,53 +2006,53 @@
 							"formdata": [
 								{
 									"key": "companyId",
-									"value": "{{companyId}}",
-									"type": "text"
+									"type": "text",
+									"value": "{{companyId}}"
 								},
 								{
 									"key": "name",
-									"value": "Alice",
-									"type": "text"
+									"type": "text",
+									"value": "Alice"
 								},
 								{
 									"key": "lastname",
-									"value": "Allison",
-									"type": "text"
+									"type": "text",
+									"value": "Allison"
 								},
 								{
 									"key": "email",
-									"value": "alice@bbs.ivozprovider.local",
-									"type": "text"
+									"type": "text",
+									"value": "alice@bbs.ivozprovider.local"
 								},
 								{
 									"key": "username",
-									"value": "alice",
-									"type": "text"
+									"type": "text",
+									"value": "alice"
 								},
 								{
 									"key": "pass",
-									"value": "4l1c3p4ssw0rd",
-									"type": "text"
+									"type": "text",
+									"value": "4l1c3p4ssw0rd"
 								},
 								{
 									"key": "timezoneId",
-									"value": "1",
-									"type": "text"
+									"type": "text",
+									"value": "1"
 								},
 								{
 									"key": "terminalId",
-									"value": "{{aliceTerminalId}}",
-									"type": "text"
+									"type": "text",
+									"value": "{{aliceTerminalId}}"
 								},
 								{
 									"key": "countryId",
-									"value": "70",
-									"type": "text"
+									"type": "text",
+									"value": "70"
 								},
 								{
 									"key": "",
-									"value": "",
-									"type": "text"
+									"type": "text",
+									"value": ""
 								}
 							]
 						},
@@ -2086,9 +2086,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -2096,23 +2096,23 @@
 							"formdata": [
 								{
 									"key": "companyId",
-									"value": "{{companyId}}",
-									"type": "text"
+									"type": "text",
+									"value": "{{companyId}}"
 								},
 								{
 									"key": "routeType",
-									"value": "user",
-									"type": "text"
+									"type": "text",
+									"value": "user"
 								},
 								{
 									"key": "number",
-									"value": "1001",
-									"type": "text"
+									"type": "text",
+									"value": "1001"
 								},
 								{
 									"key": "userId",
-									"value": "{{aliceUserId}}",
-									"type": "text"
+									"type": "text",
+									"value": "{{aliceUserId}}"
 								}
 							]
 						},
@@ -2150,9 +2150,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -2189,10 +2189,10 @@
 									"value": "{{aliceUserId}}"
 								},
 								{
-									"key": "peeringContractId",
-									"value": "{{peeringContractId}}",
 									"description": "",
-									"type": "text"
+									"key": "peeringContractId",
+									"type": "text",
+									"value": "{{peeringContractId}}"
 								}
 							]
 						},
@@ -2226,9 +2226,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -2236,28 +2236,28 @@
 							"formdata": [
 								{
 									"key": "companyId",
-									"value": "{{companyId}}",
-									"type": "text"
+									"type": "text",
+									"value": "{{companyId}}"
 								},
 								{
 									"key": "terminalModelId",
-									"value": "5",
-									"type": "text"
+									"type": "text",
+									"value": "5"
 								},
 								{
 									"key": "name",
-									"value": "bob",
-									"type": "text"
+									"type": "text",
+									"value": "bob"
 								},
 								{
 									"key": "password",
-									"value": "b0bp4ssw0rd",
-									"type": "text"
+									"type": "text",
+									"value": "b0bp4ssw0rd"
 								},
 								{
 									"key": "direct_media_method",
-									"value": "invite",
-									"type": "text"
+									"type": "text",
+									"value": "invite"
 								}
 							]
 						},
@@ -2291,9 +2291,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -2301,48 +2301,48 @@
 							"formdata": [
 								{
 									"key": "companyId",
-									"value": "{{companyId}}",
-									"type": "text"
+									"type": "text",
+									"value": "{{companyId}}"
 								},
 								{
 									"key": "name",
-									"value": "Bob",
-									"type": "text"
+									"type": "text",
+									"value": "Bob"
 								},
 								{
 									"key": "lastname",
-									"value": "Bobson",
-									"type": "text"
+									"type": "text",
+									"value": "Bobson"
 								},
 								{
 									"key": "email",
-									"value": "bob@bbs.ivozprovider.local",
-									"type": "text"
+									"type": "text",
+									"value": "bob@bbs.ivozprovider.local"
 								},
 								{
 									"key": "username",
-									"value": "bob",
-									"type": "text"
+									"type": "text",
+									"value": "bob"
 								},
 								{
 									"key": "pass",
-									"value": "b0bp4ssw0rd",
-									"type": "text"
+									"type": "text",
+									"value": "b0bp4ssw0rd"
 								},
 								{
 									"key": "timezoneId",
-									"value": "1",
-									"type": "text"
+									"type": "text",
+									"value": "1"
 								},
 								{
 									"key": "terminalId",
-									"value": "{{bobTerminalId}}",
-									"type": "text"
+									"type": "text",
+									"value": "{{bobTerminalId}}"
 								},
 								{
 									"key": "countryId",
-									"value": "70",
-									"type": "text"
+									"type": "text",
+									"value": "70"
 								}
 							]
 						},
@@ -2376,9 +2376,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -2386,23 +2386,23 @@
 							"formdata": [
 								{
 									"key": "companyId",
-									"value": "{{companyId}}",
-									"type": "text"
+									"type": "text",
+									"value": "{{companyId}}"
 								},
 								{
 									"key": "routeType",
-									"value": "user",
-									"type": "text"
+									"type": "text",
+									"value": "user"
 								},
 								{
 									"key": "number",
-									"value": "1002",
-									"type": "text"
+									"type": "text",
+									"value": "1002"
 								},
 								{
 									"key": "userId",
-									"value": "{{bobUserId}}",
-									"type": "text"
+									"type": "text",
+									"value": "{{bobUserId}}"
 								}
 							]
 						},
@@ -2440,9 +2440,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -2479,10 +2479,10 @@
 									"value": "{{bobUserId}}"
 								},
 								{
-									"key": "peeringContractId",
-									"value": "{{peeringContractId}}",
 									"description": "",
-									"type": "text"
+									"key": "peeringContractId",
+									"type": "text",
+									"value": "{{peeringContractId}}"
 								}
 							]
 						},
@@ -2516,9 +2516,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -2526,28 +2526,28 @@
 							"formdata": [
 								{
 									"key": "companyId",
-									"value": "{{companyId}}",
-									"type": "text"
+									"type": "text",
+									"value": "{{companyId}}"
 								},
 								{
 									"key": "terminalModelId",
-									"value": "5",
-									"type": "text"
+									"type": "text",
+									"value": "5"
 								},
 								{
 									"key": "name",
-									"value": "charlie",
-									"type": "text"
+									"type": "text",
+									"value": "charlie"
 								},
 								{
 									"key": "password",
-									"value": "ch4rl13p4ssw0rd",
-									"type": "text"
+									"type": "text",
+									"value": "ch4rl13p4ssw0rd"
 								},
 								{
 									"key": "direct_media_method",
-									"value": "invite",
-									"type": "text"
+									"type": "text",
+									"value": "invite"
 								}
 							]
 						},
@@ -2581,9 +2581,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -2591,48 +2591,48 @@
 							"formdata": [
 								{
 									"key": "companyId",
-									"value": "{{companyId}}",
-									"type": "text"
+									"type": "text",
+									"value": "{{companyId}}"
 								},
 								{
 									"key": "name",
-									"value": "Charlie",
-									"type": "text"
+									"type": "text",
+									"value": "Charlie"
 								},
 								{
 									"key": "lastname",
-									"value": "Charlison",
-									"type": "text"
+									"type": "text",
+									"value": "Charlison"
 								},
 								{
 									"key": "email",
-									"value": "charly@bbs.ivozprovider.local",
-									"type": "text"
+									"type": "text",
+									"value": "charly@bbs.ivozprovider.local"
 								},
 								{
 									"key": "username",
-									"value": "charlie",
-									"type": "text"
+									"type": "text",
+									"value": "charlie"
 								},
 								{
 									"key": "pass",
-									"value": "ch4rl13p4ssw0rd",
-									"type": "text"
+									"type": "text",
+									"value": "ch4rl13p4ssw0rd"
 								},
 								{
 									"key": "timezoneId",
-									"value": "1",
-									"type": "text"
+									"type": "text",
+									"value": "1"
 								},
 								{
 									"key": "terminalId",
-									"value": "{{charlieTerminalId}}",
-									"type": "text"
+									"type": "text",
+									"value": "{{charlieTerminalId}}"
 								},
 								{
 									"key": "countryId",
-									"value": "70",
-									"type": "text"
+									"type": "text",
+									"value": "70"
 								}
 							]
 						},
@@ -2666,9 +2666,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -2676,28 +2676,28 @@
 							"formdata": [
 								{
 									"key": "companyId",
-									"value": "{{companyId}}",
-									"type": "text"
+									"type": "text",
+									"value": "{{companyId}}"
 								},
 								{
 									"key": "routeType",
-									"value": "user",
-									"type": "text"
+									"type": "text",
+									"value": "user"
 								},
 								{
 									"key": "number",
-									"value": "1003",
-									"type": "text"
+									"type": "text",
+									"value": "1003"
 								},
 								{
 									"key": "userId",
-									"value": "{{charlieUserId}}",
-									"type": "text"
+									"type": "text",
+									"value": "{{charlieUserId}}"
 								},
 								{
 									"key": "",
-									"value": "",
 									"type": "text",
+									"value": "",
 									"disabled": true
 								}
 							]
@@ -2736,9 +2736,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -2775,10 +2775,10 @@
 									"value": "{{charlieUserId}}"
 								},
 								{
-									"key": "peeringContractId",
-									"value": "{{peeringContractId}}",
 									"description": "",
-									"type": "text"
+									"key": "peeringContractId",
+									"type": "text",
+									"value": "{{peeringContractId}}"
 								}
 							]
 						},
@@ -2812,9 +2812,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -2822,28 +2822,28 @@
 							"formdata": [
 								{
 									"key": "companyId",
-									"value": "{{companyId}}",
-									"type": "text"
+									"type": "text",
+									"value": "{{companyId}}"
 								},
 								{
 									"key": "terminalModelId",
-									"value": "5",
-									"type": "text"
+									"type": "text",
+									"value": "5"
 								},
 								{
 									"key": "name",
-									"value": "dave",
-									"type": "text"
+									"type": "text",
+									"value": "dave"
 								},
 								{
 									"key": "password",
-									"value": "d4v3p4ssw0rd",
-									"type": "text"
+									"type": "text",
+									"value": "d4v3p4ssw0rd"
 								},
 								{
 									"key": "direct_media_method",
-									"value": "invite",
-									"type": "text"
+									"type": "text",
+									"value": "invite"
 								}
 							]
 						},
@@ -2877,9 +2877,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -2887,53 +2887,53 @@
 							"formdata": [
 								{
 									"key": "companyId",
-									"value": "{{companyId}}",
-									"type": "text"
+									"type": "text",
+									"value": "{{companyId}}"
 								},
 								{
 									"key": "name",
-									"value": "Dave",
-									"type": "text"
+									"type": "text",
+									"value": "Dave"
 								},
 								{
 									"key": "lastname",
-									"value": "Daveson",
-									"type": "text"
+									"type": "text",
+									"value": "Daveson"
 								},
 								{
 									"key": "email",
-									"value": "dave@bbs.ivozprovider.local",
-									"type": "text"
+									"type": "text",
+									"value": "dave@bbs.ivozprovider.local"
 								},
 								{
 									"key": "username",
-									"value": "dave",
-									"type": "text"
+									"type": "text",
+									"value": "dave"
 								},
 								{
 									"key": "pass",
-									"value": "d4v3p4ssw0rd",
-									"type": "text"
+									"type": "text",
+									"value": "d4v3p4ssw0rd"
 								},
 								{
 									"key": "timezoneId",
-									"value": "1",
-									"type": "text"
+									"type": "text",
+									"value": "1"
 								},
 								{
 									"key": "terminalId",
-									"value": "{{daveTerminalId}}",
-									"type": "text"
+									"type": "text",
+									"value": "{{daveTerminalId}}"
 								},
 								{
 									"key": "countryId",
-									"value": "235",
-									"type": "text"
+									"type": "text",
+									"value": "235"
 								},
 								{
 									"key": "area_code",
-									"value": "999",
-									"type": "text"
+									"type": "text",
+									"value": "999"
 								}
 							]
 						},
@@ -2967,9 +2967,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -2977,23 +2977,23 @@
 							"formdata": [
 								{
 									"key": "companyId",
-									"value": "{{companyId}}",
-									"type": "text"
+									"type": "text",
+									"value": "{{companyId}}"
 								},
 								{
 									"key": "routeType",
-									"value": "user",
-									"type": "text"
+									"type": "text",
+									"value": "user"
 								},
 								{
 									"key": "number",
-									"value": "1004",
-									"type": "text"
+									"type": "text",
+									"value": "1004"
 								},
 								{
 									"key": "userId",
-									"value": "{{daveUserId}}",
-									"type": "text"
+									"type": "text",
+									"value": "{{daveUserId}}"
 								}
 							]
 						},
@@ -3031,9 +3031,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -3070,10 +3070,10 @@
 									"value": "{{daveUserId}}"
 								},
 								{
-									"key": "peeringContractId",
-									"value": "{{peeringContractId}}",
 									"description": "",
-									"type": "text"
+									"key": "peeringContractId",
+									"type": "text",
+									"value": "{{peeringContractId}}"
 								}
 							]
 						},
@@ -3107,9 +3107,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -3117,28 +3117,28 @@
 							"formdata": [
 								{
 									"key": "companyId",
-									"value": "{{companyId}}",
-									"type": "text"
+									"type": "text",
+									"value": "{{companyId}}"
 								},
 								{
 									"key": "terminalModelId",
-									"value": "5",
-									"type": "text"
+									"type": "text",
+									"value": "5"
 								},
 								{
 									"key": "name",
-									"value": "eve",
-									"type": "text"
+									"type": "text",
+									"value": "eve"
 								},
 								{
 									"key": "password",
-									"value": "3v3p4ssw0rd",
-									"type": "text"
+									"type": "text",
+									"value": "3v3p4ssw0rd"
 								},
 								{
 									"key": "direct_media_method",
-									"value": "invite",
-									"type": "text"
+									"type": "text",
+									"value": "invite"
 								}
 							]
 						},
@@ -3172,9 +3172,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -3182,53 +3182,53 @@
 							"formdata": [
 								{
 									"key": "companyId",
-									"value": "{{companyId}}",
-									"type": "text"
+									"type": "text",
+									"value": "{{companyId}}"
 								},
 								{
 									"key": "name",
-									"value": "Eve",
-									"type": "text"
+									"type": "text",
+									"value": "Eve"
 								},
 								{
 									"key": "lastname",
-									"value": "Eveson",
-									"type": "text"
+									"type": "text",
+									"value": "Eveson"
 								},
 								{
 									"key": "email",
-									"value": "eve@bbs.ivozprovider.local",
-									"type": "text"
+									"type": "text",
+									"value": "eve@bbs.ivozprovider.local"
 								},
 								{
 									"key": "username",
-									"value": "eve",
-									"type": "text"
+									"type": "text",
+									"value": "eve"
 								},
 								{
 									"key": "pass",
-									"value": "3v3p4ssw0rd",
-									"type": "text"
+									"type": "text",
+									"value": "3v3p4ssw0rd"
 								},
 								{
 									"key": "timezoneId",
-									"value": "1",
-									"type": "text"
+									"type": "text",
+									"value": "1"
 								},
 								{
 									"key": "terminalId",
-									"value": "{{eveTerminalId}}",
-									"type": "text"
+									"type": "text",
+									"value": "{{eveTerminalId}}"
 								},
 								{
 									"key": "countryId",
-									"value": "235",
-									"type": "text"
+									"type": "text",
+									"value": "235"
 								},
 								{
 									"key": "area_code",
-									"value": "999",
-									"type": "text"
+									"type": "text",
+									"value": "999"
 								}
 							]
 						},
@@ -3262,9 +3262,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -3272,23 +3272,23 @@
 							"formdata": [
 								{
 									"key": "companyId",
-									"value": "{{companyId}}",
-									"type": "text"
+									"type": "text",
+									"value": "{{companyId}}"
 								},
 								{
 									"key": "routeType",
-									"value": "user",
-									"type": "text"
+									"type": "text",
+									"value": "user"
 								},
 								{
 									"key": "number",
-									"value": "1005",
-									"type": "text"
+									"type": "text",
+									"value": "1005"
 								},
 								{
 									"key": "userId",
-									"value": "{{eveUserId}}",
-									"type": "text"
+									"type": "text",
+									"value": "{{eveUserId}}"
 								}
 							]
 						},
@@ -3326,9 +3326,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -3365,10 +3365,10 @@
 									"value": "{{eveUserId}}"
 								},
 								{
-									"key": "peeringContractId",
-									"value": "{{peeringContractId}}",
 									"description": "",
-									"type": "text"
+									"key": "peeringContractId",
+									"type": "text",
+									"value": "{{peeringContractId}}"
 								}
 							]
 						},
@@ -3395,9 +3395,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -3405,8 +3405,8 @@
 							"formdata": [
 								{
 									"key": "outgoingDDIId",
-									"value": "{{aliceDDIId}}",
-									"type": "text"
+									"type": "text",
+									"value": "{{aliceDDIId}}"
 								}
 							]
 						},
@@ -3440,9 +3440,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -3520,9 +3520,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -3575,9 +3575,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -3644,9 +3644,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -3654,53 +3654,53 @@
 							"formdata": [
 								{
 									"key": "brandId",
-									"value": "{{brandId}}",
-									"type": "text"
+									"type": "text",
+									"value": "{{brandId}}"
 								},
 								{
 									"key": "name",
-									"value": "BBS - Retail for Black Box SIP tests",
-									"type": "text"
+									"type": "text",
+									"value": "BBS - Retail for Black Box SIP tests"
 								},
 								{
 									"key": "nif",
-									"value": "09876543210ART",
-									"type": "text"
+									"type": "text",
+									"value": "09876543210ART"
 								},
 								{
 									"key": "defaultTimezoneId",
-									"value": "1",
-									"type": "text"
+									"type": "text",
+									"value": "1"
 								},
 								{
 									"key": "postalAddress",
-									"value": "Retail postal address",
-									"type": "text"
+									"type": "text",
+									"value": "Retail postal address"
 								},
 								{
 									"key": "postalCode",
-									"value": "Retail postal code",
-									"type": "text"
+									"type": "text",
+									"value": "Retail postal code"
 								},
 								{
 									"key": "town",
-									"value": "Retail town",
-									"type": "text"
+									"type": "text",
+									"value": "Retail town"
 								},
 								{
 									"key": "province",
-									"value": "Retail province",
-									"type": "text"
+									"type": "text",
+									"value": "Retail province"
 								},
 								{
 									"key": "country",
-									"value": "Retail country",
-									"type": "text"
+									"type": "text",
+									"value": "Retail country"
 								},
 								{
 									"key": "type",
-									"value": "retail",
-									"type": "text"
+									"type": "text",
+									"value": "retail"
 								}
 							]
 						},
@@ -3735,9 +3735,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -3762,22 +3762,22 @@
 									"value": "{{retailId}}"
 								},
 								{
+									"description": "",
 									"key": "validFrom",
-									"value": "2000-01-01",
-									"description": "",
-									"type": "text"
+									"type": "text",
+									"value": "2000-01-01"
 								},
 								{
+									"description": "",
 									"key": "validTo",
-									"value": "2099-12-31",
-									"description": "",
-									"type": "text"
+									"type": "text",
+									"value": "2099-12-31"
 								},
 								{
-									"key": "metric",
-									"value": "1",
 									"description": "",
-									"type": "text"
+									"key": "metric",
+									"type": "text",
+									"value": "1"
 								}
 							]
 						},
@@ -3807,9 +3807,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -3855,9 +3855,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -3903,9 +3903,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -3959,9 +3959,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -4039,9 +4039,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -4102,9 +4102,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -4112,8 +4112,8 @@
 							"formdata": [
 								{
 									"key": "outgoingDDIId",
-									"value": "{{retailDDIId}}",
-									"type": "text"
+									"type": "text",
+									"value": "{{retailDDIId}}"
 								}
 							]
 						},
@@ -4181,12 +4181,6 @@
 									"value": "5"
 								},
 								{
-									"description": "",
-									"key": "noAnswerTimeout",
-									"type": "text",
-									"value": "5"
-								},
-								{
 									"key": "maxDigits",
 									"type": "text",
 									"value": "4"
@@ -4247,9 +4241,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -4345,21 +4339,15 @@
 								},
 								{
 									"description": "",
-									"key": "noAnswerTimeout",
-									"type": "text",
-									"value": "5"
-								},
-								{
-									"description": "",
 									"key": "timeoutTargetType",
 									"type": "text",
-									"value": "voicemail"
+									"value": "extension"
 								},
 								{
 									"description": "",
 									"key": "timeoutExtensionId",
 									"type": "text",
-									"value": "{{daveUserId}}"
+									"value": "{{daveExtensionId}}"
 								},
 								{
 									"description": "",
@@ -4369,9 +4357,9 @@
 								},
 								{
 									"description": "",
-									"key": "errorNumberValue",
+									"key": "errorExtensionId",
 									"type": "text",
-									"value": "{{daveExtensionId}}"
+									"value": "{{eveExtensionId}}"
 								}
 							]
 						},
@@ -4394,7 +4382,7 @@
 									"",
 									"var id = Location.substr(Location.lastIndexOf('/') + 1);",
 									"tests[\"Object id is valid\"] = id !== 0;",
-									"postman.setGlobalVariable(\"ivrCommonExtensionId\", id);",
+									"postman.setGlobalVariable(\"ivrCustomExtensionId\", id);",
 									""
 								]
 							}
@@ -4415,23 +4403,23 @@
 							"formdata": [
 								{
 									"key": "companyId",
-									"value": "{{companyId}}",
-									"type": "text"
+									"type": "text",
+									"value": "{{companyId}}"
 								},
 								{
 									"key": "routeType",
-									"value": "IVRCustom",
-									"type": "text"
+									"type": "text",
+									"value": "IVRCustom"
 								},
 								{
 									"key": "number",
-									"value": "601",
-									"type": "text"
+									"type": "text",
+									"value": "601"
 								},
 								{
 									"key": "IVRCustomId",
-									"value": "{{ivrCustomId}}",
-									"type": "text"
+									"type": "text",
+									"value": "{{ivrCustomId}}"
 								}
 							]
 						},
@@ -4454,7 +4442,6 @@
 									"",
 									"var id = Location.substr(Location.lastIndexOf('/') + 1);",
 									"tests[\"Object id is valid\"] = id !== 0;",
-									"postman.setGlobalVariable(\"ivrCommonExtensionId\", id);",
 									""
 								]
 							}
@@ -4475,28 +4462,82 @@
 							"formdata": [
 								{
 									"key": "IVRCustomId",
-									"value": "{{ivrCustomId}}",
-									"type": "text"
+									"type": "text",
+									"value": "{{ivrCustomId}}"
 								},
 								{
 									"key": "entry",
-									"value": "1",
-									"type": "text"
-								},
-								{
-									"key": "number",
-									"value": "601",
-									"type": "text"
+									"type": "text",
+									"value": "1"
 								},
 								{
 									"key": "targetType",
-									"value": "extension",
-									"type": "text"
+									"type": "text",
+									"value": "extension"
 								},
 								{
 									"key": "targetExtensionId",
-									"value": "{{aliceExtensionId}}",
-									"type": "text"
+									"type": "text",
+									"value": "{{aliceExtensionId}}"
+								}
+							]
+						},
+						"description": ""
+					},
+					"response": []
+				},
+				{
+					"name": "Create IVR Custom Entry 5",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"tests[\"Status code is 201 Created\"] = responseCode.code === 201;",
+									"",
+									"var Location = postman.getResponseHeader(\"Location\");",
+									"tests[\"Location header is present\"] = Location !== null;",
+									"",
+									"var id = Location.substr(Location.lastIndexOf('/') + 1);",
+									"tests[\"Object id is valid\"] = id !== 0;",
+									""
+								]
+							}
+						}
+					],
+					"request": {
+						"url": "{{api_url}}//i-v-r-custom-entries",
+						"method": "POST",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "{{api_auth}}",
+								"description": ""
+							}
+						],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "IVRCustomId",
+									"type": "text",
+									"value": "{{ivrCustomId}}"
+								},
+								{
+									"key": "entry",
+									"type": "text",
+									"value": "5"
+								},
+								{
+									"key": "targetType",
+									"type": "text",
+									"value": "extension"
+								},
+								{
+									"key": "targetExtensionId",
+									"type": "text",
+									"value": "{{eveExtensionId}}"
 								}
 							]
 						},
@@ -4540,9 +4581,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -4550,24 +4591,24 @@
 							"urlencoded": [
 								{
 									"key": "companyId",
-									"value": "{{companyId}}",
-									"type": "text"
+									"type": "text",
+									"value": "{{companyId}}"
 								},
 								{
 									"key": "name",
-									"value": "BBS Pickup Group",
-									"type": "text"
+									"type": "text",
+									"value": "BBS Pickup Group"
 								},
 								{
 									"key": "",
-									"value": "",
 									"type": "text",
+									"value": "",
 									"disabled": true
 								},
 								{
 									"key": "",
-									"value": "",
 									"type": "text",
+									"value": "",
 									"disabled": true
 								}
 							]
@@ -4603,9 +4644,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -4613,24 +4654,24 @@
 							"urlencoded": [
 								{
 									"key": "pickUpGroupId",
-									"value": "{{pickupGroupId}}",
-									"type": "text"
+									"type": "text",
+									"value": "{{pickupGroupId}}"
 								},
 								{
 									"key": "userId",
-									"value": "{{aliceUserId}}",
-									"type": "text"
+									"type": "text",
+									"value": "{{aliceUserId}}"
 								},
 								{
 									"key": "",
-									"value": "",
 									"type": "text",
+									"value": "",
 									"disabled": true
 								},
 								{
 									"key": "",
-									"value": "",
 									"type": "text",
+									"value": "",
 									"disabled": true
 								}
 							]
@@ -4666,9 +4707,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -4676,24 +4717,24 @@
 							"urlencoded": [
 								{
 									"key": "pickUpGroupId",
-									"value": "{{pickupGroupId}}",
-									"type": "text"
+									"type": "text",
+									"value": "{{pickupGroupId}}"
 								},
 								{
 									"key": "userId",
-									"value": "{{bobUserId}}",
-									"type": "text"
+									"type": "text",
+									"value": "{{bobUserId}}"
 								},
 								{
 									"key": "",
-									"value": "",
 									"type": "text",
+									"value": "",
 									"disabled": true
 								},
 								{
 									"key": "",
-									"value": "",
 									"type": "text",
+									"value": "",
 									"disabled": true
 								}
 							]
@@ -4729,9 +4770,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -4739,24 +4780,24 @@
 							"urlencoded": [
 								{
 									"key": "pickUpGroupId",
-									"value": "{{pickupGroupId}}",
-									"type": "text"
+									"type": "text",
+									"value": "{{pickupGroupId}}"
 								},
 								{
 									"key": "userId",
-									"value": "{{charlieUserId}}",
-									"type": "text"
+									"type": "text",
+									"value": "{{charlieUserId}}"
 								},
 								{
 									"key": "",
-									"value": "",
 									"type": "text",
+									"value": "",
 									"disabled": true
 								},
 								{
 									"key": "",
-									"value": "",
 									"type": "text",
+									"value": "",
 									"disabled": true
 								}
 							]
@@ -4801,9 +4842,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -4811,28 +4852,28 @@
 							"urlencoded": [
 								{
 									"key": "companyId",
-									"value": "{{companyId}}",
-									"type": "text"
+									"type": "text",
+									"value": "{{companyId}}"
 								},
 								{
 									"key": "name",
-									"value": "BBS Conference Room",
-									"type": "text"
+									"type": "text",
+									"value": "BBS Conference Room"
 								},
 								{
 									"key": "pinProtected",
-									"value": "1",
-									"type": "text"
+									"type": "text",
+									"value": "1"
 								},
 								{
 									"key": "pinCode",
-									"value": "1234",
-									"type": "text"
+									"type": "text",
+									"value": "1234"
 								},
 								{
 									"key": "maxMembers",
-									"value": "2",
-									"type": "text"
+									"type": "text",
+									"value": "2"
 								}
 							]
 						},
@@ -4866,9 +4907,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -4876,23 +4917,23 @@
 							"formdata": [
 								{
 									"key": "companyId",
-									"value": "{{companyId}}",
-									"type": "text"
+									"type": "text",
+									"value": "{{companyId}}"
 								},
 								{
 									"key": "number",
-									"value": "500",
-									"type": "text"
+									"type": "text",
+									"value": "500"
 								},
 								{
 									"key": "routeType",
-									"value": "conferenceRoom",
-									"type": "text"
+									"type": "text",
+									"value": "conferenceRoom"
 								},
 								{
 									"key": "conferenceRoomId",
-									"value": "{{conferenceRoomId}}",
-									"type": "text"
+									"type": "text",
+									"value": "{{conferenceRoomId}}"
 								}
 							]
 						},
@@ -4936,9 +4977,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -5007,9 +5048,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -5063,9 +5104,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -5109,9 +5150,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -5155,9 +5196,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -5209,9 +5250,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -5245,10 +5286,10 @@
 									"value": "{{eveExtensionId}}"
 								},
 								{
-									"key": "ringAllTimeout",
-									"value": "0",
 									"description": "",
-									"type": "text"
+									"key": "ringAllTimeout",
+									"type": "text",
+									"value": "0"
 								}
 							]
 						},
@@ -5282,9 +5323,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -5338,9 +5379,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -5357,16 +5398,16 @@
 									"value": "{{bobUserId}}"
 								},
 								{
-									"key": "timeoutTime",
-									"value": "3",
 									"description": "",
-									"type": "text"
+									"key": "timeoutTime",
+									"type": "text",
+									"value": "3"
 								},
 								{
-									"key": "priority",
-									"value": "1",
 									"description": "",
-									"type": "text"
+									"key": "priority",
+									"type": "text",
+									"value": "1"
 								}
 							]
 						},
@@ -5396,9 +5437,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -5454,9 +5495,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -5523,9 +5564,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -5589,9 +5630,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {
@@ -5624,8 +5665,8 @@
 								},
 								{
 									"key": "noAnswerTimeout",
-									"value": "5",
-									"type": "text"
+									"type": "text",
+									"value": "5"
 								}
 							]
 						},
@@ -5660,9 +5701,9 @@
 						"method": "POST",
 						"header": [
 							{
+								"description": "",
 								"key": "Authorization",
-								"value": "{{api_auth}}",
-								"description": ""
+								"value": "{{api_auth}}"
 							}
 						],
 						"body": {


### PR DESCRIPTION
This PR replaces existing noAnswer handler of IVRs with noInput

The noAnswer handler was triggering when IVRs dial an extension pointing to a user, by checking the dial result was NOANSWER. This was preventing the triggering of users call forwards setting as IVR handlers was being processed instead.

We should avoid having "mid logic" handlers: only the last element of the call should have handlers.

This implements #182 and clarifies #275 

