### PR TITLE
portals: change default field for OutgoingRouting

### DIFF
--- a/portals/application/configs/klear/model/OutgoingRouting.yaml
+++ b/portals/application/configs/klear/model/OutgoingRouting.yaml
@@ -22,7 +22,6 @@ production:
             title: _('Fax')
             visualFilter:
               hide: ["routingPatternId","routingPatternGroupId"]
-      default: true
     routingPatternId:
       title: _('Select destination pattern')
       type: select
@@ -97,6 +96,7 @@ production:
             template: '%name%'
           order: name
         'null': _("Apply to all companies")
+      default: true
     target:
       title: _('Destination')
       type: ghost


### PR DESCRIPTION
OutgoingRouting model has type field as its default field so on the popup confirmation when you try to delete one of those routes you have not much information about which one you are actually going to delete.

Changing the default field to companyId gives better information.