### PR TITLE
portals: change default field for Friends

### DIFF
--- a/portals/application/configs/klear/model/Friends.yaml
+++ b/portals/application/configs/klear/model/Friends.yaml
@@ -17,7 +17,6 @@ production:
               - name
             template: '%name%'
           order: name
-      default: true
     name:
       title: _('Name')
       type: text
@@ -31,6 +30,7 @@ production:
         icon: help
         text: _("Allowed characters: a-z, A-Z, 0-9, underscore and '*'")
         label: _("Need help?")
+      default: true
     description:
       title: _('Description')
       type: text


### PR DESCRIPTION
Current default fields for Friends is companyId so when you are going to delete a friend that is what is shown in the popup confirmation. The name is a better default field in my opinion.