### PR TITLE
portals: change default field for Retail Accounts

### DIFF
--- a/portals/application/configs/klear/model/RetailAccounts.yaml
+++ b/portals/application/configs/klear/model/RetailAccounts.yaml
@@ -17,7 +17,6 @@ production:
               - name
             template: '%name%'
           order: name
-      default: true
     name:
       title: _('Name')
       type: text
@@ -31,6 +30,7 @@ production:
         icon: help
         text: _("Allowed characters: a-z, A-Z, 0-9, underscore and '*'")
         label: _("Need help?")
+      default: true
     description:
       title: _('Description')
       type: text


### PR DESCRIPTION
Actual default field for Retails Accounts is companyId. Name is a better default field.