### PR TITLE
portals: companies name constraint

### DIFF
--- a/portals/application/configs/klear/errors.yaml
+++ b/portals/application/configs/klear/errors.yaml
@@ -26,6 +26,7 @@ production:
   adminErrors:
     2001: _("SIP Domain can't be empty")
     2201: _("Email already in use")
+    2203: _("Name already in use")
   connectorErrors:
     9001: _("No Application Server available.")
 staging:


### PR DESCRIPTION
This aims to solve https://github.com/irontec/ivozprovider/issues/292 changing the constraint to allow same name for vpbx companies and retail companies and catching the exception on saving companies.