### PR TITLE
portals: change retail accounts domain length

### DIFF
--- a/scheme/deltas/072-retailaccounts-domain-length.sql
+++ b/scheme/deltas/072-retailaccounts-domain-length.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `RetailAccounts` MODIFY COLUMN `domain` varchar(255) DEFAULT NULL;


### PR DESCRIPTION
Brand SIP domain is a 255 length varchar so retail accounts domain must be too.