### PR TITLE
portals: fix domain length

### DIFF
--- a/portals/application/configs/klear/model/Brands.yaml
+++ b/portals/application/configs/klear/model/Brands.yaml
@@ -17,7 +17,7 @@ production:
       title: _('SIP domain')
       type: text
       trim: both
-      maxLength: 255
+      maxLength: 190
     defaultTimezoneId:
       title: _('Default timezone')
       type: select

--- a/portals/application/configs/klear/model/Terminals.yaml
+++ b/portals/application/configs/klear/model/Terminals.yaml
@@ -34,7 +34,7 @@ production:
     domain:
       title: _('Domain')
       type: text
-      maxLength: 255
+      maxLength: 190
     disallow:
       title: _('Disallowed audio codecs')
       type: text

--- a/scheme/deltas/072-domain-length-fix.sql
+++ b/scheme/deltas/072-domain-length-fix.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `Brands` MODIFY COLUMN `domain_users` varchar(190) DEFAULT NULL;
+ALTER TABLE 'Terminals' MODIFY COLUMN `domain` varchar(190) DEFAULT NULL;


### PR DESCRIPTION
Domain length must be 190. This aims to fix some places where it is set to 255.