### PR TITLE
portals: avoid selecting linear strategy in already created queues

### DIFF
--- a/library/IvozProvider/Klear/Filter/QueueStrategies.php
+++ b/library/IvozProvider/Klear/Filter/QueueStrategies.php
@@ -1,0 +1,36 @@
+<?php
+
+use \IvozProvider\Mapper\Sql as Mapper;
+
+class IvozProvider_Klear_Filter_QueueStrategies implements KlearMatrix_Model_Field_Select_Filter_Interface
+{
+    private $_queue = null;
+
+    public function setRouteDispatcher(KlearMatrix_Model_RouteDispatcher $routeDispatcher)
+    {
+        $queueId = $routeDispatcher->getParam('pk', false);
+        if ($queueId) {
+            $queueMapper = new Mapper\Queues;
+            $this->_queue = $queueMapper->find($queueId);
+        }
+        return true;
+    }
+
+    /**
+     * Remove 'linear' from Strategy selectbox once Queue has been created.
+     * See: https://issues.asterisk.org/jira/browse/ASTERISK-17049
+     *
+     * @return array
+     */
+    public function getCondition()
+    {
+        $excludedStrategies = [];
+
+        if ($this->_queue && $this->_queue->getStrategy() != 'linear') {
+            $excludedStrategies[] = 'linear';
+        }
+
+        return $excludedStrategies;
+    }
+
+}

--- a/portals/application/configs/klear/model/Queues.yaml
+++ b/portals/application/configs/klear/model/Queues.yaml
@@ -259,6 +259,7 @@ production:
       defaultValue: 'rrmemory'
       source:
         data: inline
+        filterClass: IvozProvider_Klear_Filter_QueueStrategies
         values:
           'ringall': _('Ring all')
           'leastrecent': _('Least recent')


### PR DESCRIPTION
Linear strategy can only be used if queue has been already created with
that strategy or after an asterisk restart. At least until [1] has been
implemented.

This changes the edit screen strategy select box to disable 'linear'
strategy if queue has been already created with other strategy.

[1] https://issues.asterisk.org/jira/browse/ASTERISK-17049