### PR TITLE
trunks: Forward 422 to AS to adapt minSE value

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -1239,6 +1239,9 @@ failure_route[MANAGE_FAILURE_GW] {
     } else if (t_check_status("486")) {
         if ($dlg_var(log)) xlog("L_INFO", "[b$dlg_var(brandId)][$dlg_var(cidhash)] MANAGE-FAILURE-GW: Destiny busy (reply code: $T_reply_code)\n");
         exit;
+    } else if (t_check_status("422")) {
+        if ($dlg_var(log)) xlog("L_INFO", "[b$dlg_var(brandId)][$dlg_var(cidhash)] MANAGE-FAILURE-GW: Session Interval Too Small, forward to AS (reply code: $T_reply_code)\n");
+        exit;
     } else {
         if ($dlg_var(log)) xlog("L_INFO", "[b$dlg_var(brandId)][$dlg_var(cidhash)] MANAGE-FAILURE-GW: Failure using gateway to place a call (reply code: $T_reply_code)\n");
         # FIXME: Which reply codes should inactivate current GW??


### PR DESCRIPTION
'422 Session Interval Too Small' is treated as a generic failure code, causing
GW failover and discarding that GW.

2 options here:

1) Make KamTrunks resend an INVITE request with the Session-Expires specified in
   422 response (adapting CSeqs onwards).

2) Forward 422 to AS and make him resend the INVITE.

As session-timers are negotiated between endpoints and CSeq adaptation is not
wanted, option 2 is implemented.