### PR TITLE
users: Improve websockets detection logic

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -1687,7 +1687,7 @@ route[TRANSPORT_DETECT] {
     if (!is_method("INVITE")) return;
 
     if (is_request() && !has_totag()) {
-        if ($rP == 'ws' || $rP == 'wss' || $proto == 'ws' || $proto == 'wss') {
+        if ($rP == 'ws' || $rP == 'wss' || $proto == 'ws' || $proto == 'wss' || $xavp(ulattrs=>transport) == 'ws' || $xavp(ulattrs=>transport) == 'wss') {
             xlog("L_WARN", "[b$dlg_var(brandId)][$dlg_var(cidhash)] TRANSPORT-DETECT: Websockets, set FLB_WEBSOCKETS\n");
             setbflag(FLB_WEBSOCKETS);
         }


### PR DESCRIPTION
DETECT_TRANSPORT route tries to detect if WS(S) is involved in current session and
rtpengine should be used instead of rtpproxy.

This decision was made using:

- $proto: Protocol of received message

- $rP: Assuming that UACs registered with WSS would use ;transport=wss R-URI param.

Improve this last escenario using xavp(ulattrs=>transport) saved on register for
R-URI without transport param that use WSS.