### PR TITLE
webadmin: fix available terminals listbox

### DIFF
--- a/library/Ivoz/Provider/Domain/Model/User/UserRepository.php
+++ b/library/Ivoz/Provider/Domain/Model/User/UserRepository.php
@@ -7,6 +7,5 @@ use Doctrine\Common\Collections\Selectable;
 
 interface UserRepository extends ObjectRepository, Selectable
 {
-    public function getAssignedTerminalIds(array $userIdsToExclude);
 }
 

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/UserDoctrineRepository.php
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/UserDoctrineRepository.php
@@ -13,38 +13,5 @@ use Ivoz\Provider\Domain\Model\User\UserRepository;
  */
 class UserDoctrineRepository extends EntityRepository implements UserRepository
 {
-    const ENTITY_ALIAS = 'user';
-
-    public function getAssignedTerminalIds(array $userIdsToExclude)
-    {
-        $qb = $this->createQueryBuilder(self::ENTITY_ALIAS);
-        $where = $qb->expr()->isNotNull(self::ENTITY_ALIAS . '.terminal');
-        $qb
-           ->select('IDENTITY(user.terminal)')
-           ->where(
-               $where
-           );
-
-        foreach ($userIdsToExclude as $id) {
-            $qb->andWhere(
-                $qb->expr()->neq(
-                    self::ENTITY_ALIAS . '.id',
-                    $id
-                )
-            );
-        }
-
-        $results = $qb
-            ->getQuery()
-            ->getScalarResult();
-
-        $response = [];
-        foreach ($results as $result) {
-            $response[] = array_shift($result);
-        }
-
-        return $response;
-
-    }
 
 }

--- a/web/admin/application/configs/klear/model/Users.yaml
+++ b/web/admin/application/configs/klear/model/Users.yaml
@@ -97,7 +97,7 @@ production:
         data: mapper
         config:
           entity: \Ivoz\Provider\Domain\Model\Terminal\Terminal
-#          filterClass: IvozProvider_Klear_Filter_Terminals
+          filterClass: IvozProvider_Klear_Filter_Terminals
           fieldName:
             fields:
               - name


### PR DESCRIPTION
When creating a new user or editing an existing one
the listbox must only display available terminals and the
one already assigned to the user.

This commit removes the function from repository and
implements it in the filter as its code is not expected
to be reused in the near future.