### PR TITLE
core: Update from_domain accordingly

### DIFF
--- a/library/CoreBundle/Resources/config/lifecycle/ivoz/domain.yml
+++ b/library/CoreBundle/Resources/config/lifecycle/ivoz/domain.yml
@@ -21,3 +21,10 @@ services:
     arguments:
       $usersDomainReload:
         '@XmlRpc\XmlRpcUsersRequest::DomainReload'
+
+  Ivoz\Ast\Domain\Service\PsEndpoint\UpdateByDomain:
+    tags:
+      - { name: provider.lifecycle.domain.post_persist, priority: 20}
+    arguments:
+      $entityPersister:
+        '@Ivoz\Core\Infrastructure\Domain\Service\DoctrineEntityPersister'

--- a/library/Ivoz/Ast/Domain/Service/PsEndpoint/UpdateByDomain.php
+++ b/library/Ivoz/Ast/Domain/Service/PsEndpoint/UpdateByDomain.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Ivoz\Ast\Domain\Service\PsEndpoint;
+
+use Ivoz\Core\Domain\Service\EntityPersisterInterface;
+use Ivoz\Ast\Domain\Model\PsEndpoint\PsEndpointDTO;
+use Ivoz\Ast\Domain\Model\PsEndpoint\PsEndpointInterface;
+use Ivoz\Provider\Domain\Model\Domain\DomainInterface;
+use Ivoz\Provider\Domain\Model\Friend\FriendInterface;
+use Ivoz\Provider\Domain\Model\Terminal\TerminalInterface;
+use Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface;
+use Ivoz\Provider\Domain\Service\Domain\DomainLifecycleEventHandlerInterface;
+
+class UpdateByDomain implements DomainLifecycleEventHandlerInterface
+{
+    /**
+     * @var EntityPersisterInterface
+     */
+    protected $entityPersister;
+
+    public function __construct(EntityPersisterInterface $entityPersister) {
+        $this->entityPersister = $entityPersister;
+    }
+
+    public function execute(DomainInterface $entity)
+    {
+        /** @var FriendInterface[] $friends */
+        $friends = $entity->getFriends();
+
+        foreach ($friends as $friend) {
+            if (!$friend->getFromDomain()) {
+                $this->updateEndpoint($friend->getAstPsEndpoint(), $entity->getDomain());
+            }
+        }
+
+        /** @var RetailAccountInterface[] $retailAccounts */
+        $retailAccounts= $entity->getRetailAccounts();
+
+        foreach ($retailAccounts as $retailAccount) {
+            if (!$retailAccount->getFromDomain()) {
+                $this->updateEndpoint($retailAccount->getAstPsEndpoint(), $entity->getDomain());            }
+        }
+
+        /** @var TerminalInterface[] $terminals */
+        $terminals = $entity->getTerminals();
+
+        foreach ($terminals as $terminal) {
+            $this->updateEndpoint($terminal->getAstPsEndpoint(), $entity->getDomain());
+        }
+
+        $this->entityPersister->dispatchQueued();
+    }
+
+    private function updateEndpoint(PsEndpointInterface $endpoint, $fromdomain)
+    {
+        /** @var PsEndpointDTO $endpointDTO */
+        $endpointDTO = $endpoint->toDTO();
+        $endpointDTO->setFromDomain($fromdomain);
+
+        $this->entityPersister->persistDto($endpointDTO, $endpoint);
+    }
+}

--- a/library/Ivoz/Ast/Domain/Service/PsEndpoint/UpdateByFriend.php
+++ b/library/Ivoz/Ast/Domain/Service/PsEndpoint/UpdateByFriend.php
@@ -53,12 +53,17 @@ class UpdateByFriend implements FriendLifecycleEventHandlerInterface
             $endPointDto = $endpoint->toDto();
         }
 
+        // Use company domain if retail from-domain not set
+        $fromDomain = $entity->getFromDomain()
+            ? $entity->getFromDomain()
+            : $entity->getDomain()->getDomain();
+
         // Update/Insert endpoint data
         $domainUsers = $entity->getCompany()->getDomainUsers();
         $endPointDto
             ->setFriendId($entity->getId())
             ->setSorceryId($entity->getSorcery())
-            ->setFromDomain($domainUsers)
+            ->setFromDomain($fromDomain)
             ->setAors($entity->getSorcery())
             ->setDisallow($entity->getDisallow())
             ->setAllow($entity->getAllow())

--- a/library/Ivoz/Ast/Domain/Service/PsEndpoint/UpdateByRetailAccount.php
+++ b/library/Ivoz/Ast/Domain/Service/PsEndpoint/UpdateByRetailAccount.php
@@ -53,11 +53,16 @@ class UpdateByRetailAccount implements RetailAccountLifecycleEventHandlerInterfa
             $endpointDTO  = $endpoint->toDTO();
         }
 
+        // Use company domain if retail from-domain not set
+        $fromDomain = $entity->getFromDomain()
+            ? $entity->getFromDomain()
+            : $entity->getDomain()->getDomain();
+
         // Update/Insert endpoint data
         $endpointDTO
             ->setRetailAccountId($entity->getId())
             ->setSorceryId($entity->getSorcery())
-            ->setFromDomain($entity->getFromDomain())
+            ->setFromDomain($fromDomain)
             ->setAors($entity->getSorcery())
             ->setDisallow($entity->getDisallow())
             ->setAllow($entity->getAllow())

--- a/library/Ivoz/Provider/Domain/Model/Domain/DomainDTO.php
+++ b/library/Ivoz/Provider/Domain/Model/Domain/DomainDTO.php
@@ -32,6 +32,21 @@ class DomainDTO implements DataTransferObjectInterface
     private $id;
 
     /**
+     * @var array|null
+     */
+    private $friends = null;
+
+    /**
+     * @var array|null
+     */
+    private $retailAccounts = null;
+
+    /**
+     * @var array|null
+     */
+    private $terminals = null;
+
+    /**
      * @return array
      */
     public function __toArray()
@@ -40,7 +55,10 @@ class DomainDTO implements DataTransferObjectInterface
             'domain' => $this->getDomain(),
             'pointsTo' => $this->getPointsTo(),
             'description' => $this->getDescription(),
-            'id' => $this->getId()
+            'id' => $this->getId(),
+            'friends' => $this->getFriends(),
+            'retailAccounts' => $this->getRetailAccounts(),
+            'terminals' => $this->getTerminals()
         ];
     }
 
@@ -49,6 +67,38 @@ class DomainDTO implements DataTransferObjectInterface
      */
     public function transformForeignKeys(ForeignKeyTransformerInterface $transformer)
     {
+        if (!is_null($this->friends)) {
+            $items = $this->getFriends();
+            $this->friends = [];
+            foreach ($items as $item) {
+                $this->friends[] = $transformer->transform(
+                    'Ivoz\\Provider\\Domain\\Model\\Friend\\Friend',
+                    $item->getId() ?? $item
+                );
+            }
+        }
+
+        if (!is_null($this->retailAccounts)) {
+            $items = $this->getRetailAccounts();
+            $this->retailAccounts = [];
+            foreach ($items as $item) {
+                $this->retailAccounts[] = $transformer->transform(
+                    'Ivoz\\Provider\\Domain\\Model\\RetailAccount\\RetailAccount',
+                    $item->getId() ?? $item
+                );
+            }
+        }
+
+        if (!is_null($this->terminals)) {
+            $items = $this->getTerminals();
+            $this->terminals = [];
+            foreach ($items as $item) {
+                $this->terminals[] = $transformer->transform(
+                    'Ivoz\\Provider\\Domain\\Model\\Terminal\\Terminal',
+                    $item->getId() ?? $item
+                );
+            }
+        }
 
     }
 
@@ -57,7 +107,18 @@ class DomainDTO implements DataTransferObjectInterface
      */
     public function transformCollections(CollectionTransformerInterface $transformer)
     {
-
+        $this->friends = $transformer->transform(
+            'Ivoz\\Provider\\Domain\\Model\\Friend\\Friend',
+            $this->friends
+        );
+        $this->retailAccounts = $transformer->transform(
+            'Ivoz\\Provider\\Domain\\Model\\RetailAccount\\RetailAccount',
+            $this->retailAccounts
+        );
+        $this->terminals = $transformer->transform(
+            'Ivoz\\Provider\\Domain\\Model\\Terminal\\Terminal',
+            $this->terminals
+        );
     }
 
     /**
@@ -138,6 +199,66 @@ class DomainDTO implements DataTransferObjectInterface
     public function getId()
     {
         return $this->id;
+    }
+
+    /**
+     * @param array $friends
+     *
+     * @return DomainDTO
+     */
+    public function setFriends($friends)
+    {
+        $this->friends = $friends;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getFriends()
+    {
+        return $this->friends;
+    }
+
+    /**
+     * @param array $retailAccounts
+     *
+     * @return DomainDTO
+     */
+    public function setRetailAccounts($retailAccounts)
+    {
+        $this->retailAccounts = $retailAccounts;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getRetailAccounts()
+    {
+        return $this->retailAccounts;
+    }
+
+    /**
+     * @param array $terminals
+     *
+     * @return DomainDTO
+     */
+    public function setTerminals($terminals)
+    {
+        $this->terminals = $terminals;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getTerminals()
+    {
+        return $this->terminals;
     }
 }
 

--- a/library/Ivoz/Provider/Domain/Model/Domain/DomainInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/Domain/DomainInterface.php
@@ -3,6 +3,7 @@
 namespace Ivoz\Provider\Domain\Model\Domain;
 
 use Ivoz\Core\Domain\Model\LoggableEntityInterface;
+use Doctrine\Common\Collections\Collection;
 
 interface DomainInterface extends LoggableEntityInterface
 {
@@ -55,6 +56,99 @@ interface DomainInterface extends LoggableEntityInterface
      * @return string
      */
     public function getDescription();
+
+    /**
+     * Add friend
+     *
+     * @param \Ivoz\Provider\Domain\Model\Friend\FriendInterface $friend
+     *
+     * @return DomainTrait
+     */
+    public function addFriend(\Ivoz\Provider\Domain\Model\Friend\FriendInterface $friend);
+
+    /**
+     * Remove friend
+     *
+     * @param \Ivoz\Provider\Domain\Model\Friend\FriendInterface $friend
+     */
+    public function removeFriend(\Ivoz\Provider\Domain\Model\Friend\FriendInterface $friend);
+
+    /**
+     * Replace friends
+     *
+     * @param \Ivoz\Provider\Domain\Model\Friend\FriendInterface[] $friends
+     * @return self
+     */
+    public function replaceFriends(Collection $friends);
+
+    /**
+     * Get friends
+     *
+     * @return array
+     */
+    public function getFriends(\Doctrine\Common\Collections\Criteria $criteria = null);
+
+    /**
+     * Add retailAccount
+     *
+     * @param \Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface $retailAccount
+     *
+     * @return DomainTrait
+     */
+    public function addRetailAccount(\Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface $retailAccount);
+
+    /**
+     * Remove retailAccount
+     *
+     * @param \Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface $retailAccount
+     */
+    public function removeRetailAccount(\Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface $retailAccount);
+
+    /**
+     * Replace retailAccounts
+     *
+     * @param \Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface[] $retailAccounts
+     * @return self
+     */
+    public function replaceRetailAccounts(Collection $retailAccounts);
+
+    /**
+     * Get retailAccounts
+     *
+     * @return array
+     */
+    public function getRetailAccounts(\Doctrine\Common\Collections\Criteria $criteria = null);
+
+    /**
+     * Add terminal
+     *
+     * @param \Ivoz\Provider\Domain\Model\Terminal\TerminalInterface $terminal
+     *
+     * @return DomainTrait
+     */
+    public function addTerminal(\Ivoz\Provider\Domain\Model\Terminal\TerminalInterface $terminal);
+
+    /**
+     * Remove terminal
+     *
+     * @param \Ivoz\Provider\Domain\Model\Terminal\TerminalInterface $terminal
+     */
+    public function removeTerminal(\Ivoz\Provider\Domain\Model\Terminal\TerminalInterface $terminal);
+
+    /**
+     * Replace terminals
+     *
+     * @param \Ivoz\Provider\Domain\Model\Terminal\TerminalInterface[] $terminals
+     * @return self
+     */
+    public function replaceTerminals(Collection $terminals);
+
+    /**
+     * Get terminals
+     *
+     * @return array
+     */
+    public function getTerminals(\Doctrine\Common\Collections\Criteria $criteria = null);
 
 }
 

--- a/library/Ivoz/Provider/Domain/Model/Domain/DomainTrait.php
+++ b/library/Ivoz/Provider/Domain/Model/Domain/DomainTrait.php
@@ -3,6 +3,9 @@
 namespace Ivoz\Provider\Domain\Model\Domain;
 
 use Ivoz\Core\Application\DataTransferObjectInterface;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Collections\Criteria;
 
 /**
  * DomainTrait
@@ -15,6 +18,21 @@ trait DomainTrait
      */
     protected $id;
 
+    /**
+     * @var Collection
+     */
+    protected $friends;
+
+    /**
+     * @var Collection
+     */
+    protected $retailAccounts;
+
+    /**
+     * @var Collection
+     */
+    protected $terminals;
+
 
     /**
      * Constructor
@@ -22,7 +40,9 @@ trait DomainTrait
     public function __construct()
     {
         parent::__construct(...func_get_args());
-
+        $this->friends = new ArrayCollection();
+        $this->retailAccounts = new ArrayCollection();
+        $this->terminals = new ArrayCollection();
     }
 
     /**
@@ -44,7 +64,17 @@ trait DomainTrait
          * @var $dto DomainDTO
          */
         $self = parent::fromDTO($dto);
+        if ($dto->getFriends()) {
+            $self->replaceFriends($dto->getFriends());
+        }
 
+        if ($dto->getRetailAccounts()) {
+            $self->replaceRetailAccounts($dto->getRetailAccounts());
+        }
+
+        if ($dto->getTerminals()) {
+            $self->replaceTerminals($dto->getTerminals());
+        }
         if ($dto->getId()) {
             $self->id = $dto->getId();
             $self->initChangelog();
@@ -63,7 +93,15 @@ trait DomainTrait
          * @var $dto DomainDTO
          */
         parent::updateFromDTO($dto);
-
+        if ($dto->getFriends()) {
+            $this->replaceFriends($dto->getFriends());
+        }
+        if ($dto->getRetailAccounts()) {
+            $this->replaceRetailAccounts($dto->getRetailAccounts());
+        }
+        if ($dto->getTerminals()) {
+            $this->replaceTerminals($dto->getTerminals());
+        }
         return $this;
     }
 
@@ -85,6 +123,223 @@ trait DomainTrait
         return parent::__toArray() + [
             'id' => self::getId()
         ];
+    }
+
+
+    /**
+     * Add friend
+     *
+     * @param \Ivoz\Provider\Domain\Model\Friend\FriendInterface $friend
+     *
+     * @return DomainTrait
+     */
+    public function addFriend(\Ivoz\Provider\Domain\Model\Friend\FriendInterface $friend)
+    {
+        $this->friends->add($friend);
+
+        return $this;
+    }
+
+    /**
+     * Remove friend
+     *
+     * @param \Ivoz\Provider\Domain\Model\Friend\FriendInterface $friend
+     */
+    public function removeFriend(\Ivoz\Provider\Domain\Model\Friend\FriendInterface $friend)
+    {
+        $this->friends->removeElement($friend);
+    }
+
+    /**
+     * Replace friends
+     *
+     * @param \Ivoz\Provider\Domain\Model\Friend\FriendInterface[] $friends
+     * @return self
+     */
+    public function replaceFriends(Collection $friends)
+    {
+        $updatedEntities = [];
+        $fallBackId = -1;
+        foreach ($friends as $entity) {
+            $index = $entity->getId() ? $entity->getId() : $fallBackId--;
+            $updatedEntities[$index] = $entity;
+            $entity->setDomain($this);
+        }
+        $updatedEntityKeys = array_keys($updatedEntities);
+
+        foreach ($this->friends as $key => $entity) {
+            $identity = $entity->getId();
+            if (in_array($identity, $updatedEntityKeys)) {
+                $this->friends->set($key, $updatedEntities[$identity]);
+            } else {
+                $this->friends->remove($key);
+            }
+            unset($updatedEntities[$identity]);
+        }
+
+        foreach ($updatedEntities as $entity) {
+            $this->addFriend($entity);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get friends
+     *
+     * @return array
+     */
+    public function getFriends(Criteria $criteria = null)
+    {
+        if (!is_null($criteria)) {
+            return $this->friends->matching($criteria)->toArray();
+        }
+
+        return $this->friends->toArray();
+    }
+
+    /**
+     * Add retailAccount
+     *
+     * @param \Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface $retailAccount
+     *
+     * @return DomainTrait
+     */
+    public function addRetailAccount(\Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface $retailAccount)
+    {
+        $this->retailAccounts->add($retailAccount);
+
+        return $this;
+    }
+
+    /**
+     * Remove retailAccount
+     *
+     * @param \Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface $retailAccount
+     */
+    public function removeRetailAccount(\Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface $retailAccount)
+    {
+        $this->retailAccounts->removeElement($retailAccount);
+    }
+
+    /**
+     * Replace retailAccounts
+     *
+     * @param \Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface[] $retailAccounts
+     * @return self
+     */
+    public function replaceRetailAccounts(Collection $retailAccounts)
+    {
+        $updatedEntities = [];
+        $fallBackId = -1;
+        foreach ($retailAccounts as $entity) {
+            $index = $entity->getId() ? $entity->getId() : $fallBackId--;
+            $updatedEntities[$index] = $entity;
+            $entity->setDomain($this);
+        }
+        $updatedEntityKeys = array_keys($updatedEntities);
+
+        foreach ($this->retailAccounts as $key => $entity) {
+            $identity = $entity->getId();
+            if (in_array($identity, $updatedEntityKeys)) {
+                $this->retailAccounts->set($key, $updatedEntities[$identity]);
+            } else {
+                $this->retailAccounts->remove($key);
+            }
+            unset($updatedEntities[$identity]);
+        }
+
+        foreach ($updatedEntities as $entity) {
+            $this->addRetailAccount($entity);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get retailAccounts
+     *
+     * @return array
+     */
+    public function getRetailAccounts(Criteria $criteria = null)
+    {
+        if (!is_null($criteria)) {
+            return $this->retailAccounts->matching($criteria)->toArray();
+        }
+
+        return $this->retailAccounts->toArray();
+    }
+
+    /**
+     * Add terminal
+     *
+     * @param \Ivoz\Provider\Domain\Model\Terminal\TerminalInterface $terminal
+     *
+     * @return DomainTrait
+     */
+    public function addTerminal(\Ivoz\Provider\Domain\Model\Terminal\TerminalInterface $terminal)
+    {
+        $this->terminals->add($terminal);
+
+        return $this;
+    }
+
+    /**
+     * Remove terminal
+     *
+     * @param \Ivoz\Provider\Domain\Model\Terminal\TerminalInterface $terminal
+     */
+    public function removeTerminal(\Ivoz\Provider\Domain\Model\Terminal\TerminalInterface $terminal)
+    {
+        $this->terminals->removeElement($terminal);
+    }
+
+    /**
+     * Replace terminals
+     *
+     * @param \Ivoz\Provider\Domain\Model\Terminal\TerminalInterface[] $terminals
+     * @return self
+     */
+    public function replaceTerminals(Collection $terminals)
+    {
+        $updatedEntities = [];
+        $fallBackId = -1;
+        foreach ($terminals as $entity) {
+            $index = $entity->getId() ? $entity->getId() : $fallBackId--;
+            $updatedEntities[$index] = $entity;
+            $entity->setDomain($this);
+        }
+        $updatedEntityKeys = array_keys($updatedEntities);
+
+        foreach ($this->terminals as $key => $entity) {
+            $identity = $entity->getId();
+            if (in_array($identity, $updatedEntityKeys)) {
+                $this->terminals->set($key, $updatedEntities[$identity]);
+            } else {
+                $this->terminals->remove($key);
+            }
+            unset($updatedEntities[$identity]);
+        }
+
+        foreach ($updatedEntities as $entity) {
+            $this->addTerminal($entity);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get terminals
+     *
+     * @return array
+     */
+    public function getTerminals(Criteria $criteria = null)
+    {
+        if (!is_null($criteria)) {
+            return $this->terminals->matching($criteria)->toArray();
+        }
+
+        return $this->terminals->toArray();
     }
 
 

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/Domain.Domain.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/Domain.Domain.orm.yml
@@ -11,6 +11,17 @@ Ivoz\Provider\Domain\Model\Domain\Domain:
       id: true
       generator:
         strategy: IDENTITY
+  oneToMany:
+    friends:
+      targetEntity: Ivoz\Provider\Domain\Model\Friend\Friend
+      mappedBy: domain
+    retailAccounts:
+      targetEntity: Ivoz\Provider\Domain\Model\RetailAccount\RetailAccount
+      mappedBy: domain
+    terminals:
+      targetEntity: Ivoz\Provider\Domain\Model\Terminal\Terminal
+      mappedBy: domain
+
   lifecycleCallbacks:
     postLoad:
       - initChangelog

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/Friend.FriendAbstract.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/Friend.FriendAbstract.orm.yml
@@ -158,7 +158,7 @@ Ivoz\Provider\Domain\Model\Friend\FriendAbstract:
       cascade: {  }
       fetch: LAZY
       mappedBy: null
-      inversedBy: null
+      inversedBy: friends
       joinColumns:
         domainId:
           domainId: id

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/RetailAccount.RetailAccountAbstract.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/RetailAccount.RetailAccountAbstract.orm.yml
@@ -139,7 +139,7 @@ Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountAbstract:
       cascade: {  }
       fetch: LAZY
       mappedBy: null
-      inversedBy: null
+      inversedBy: retailAccounts
       joinColumns:
         domainId:
           domainId: id

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/Terminal.TerminalAbstract.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/Terminal.TerminalAbstract.orm.yml
@@ -90,7 +90,7 @@ Ivoz\Provider\Domain\Model\Terminal\TerminalAbstract:
       cascade: {  }
       fetch: LAZY
       mappedBy: null
-      inversedBy: null
+      inversedBy: terminals
       joinColumns:
         domainId:
           domainId: id


### PR DESCRIPTION
ast_ps_endpoints.from_domain determines the domain used by Asterisk in From header
for outgoing calls.

It has this value:

- For terminals: always company domain.

- For friends: company domain, unless "From domain" is set in Friends section.

- For retail accounts: brand domain, unless "From domain" is set in Retail accounts section.

This commit aims to keep this value updated accordingly.