### PR TITLE
core: remove Domains when their owners are removed

### DIFF
--- a/library/CoreBundle/Resources/config/lifecycle/ivoz/brand.yml
+++ b/library/CoreBundle/Resources/config/lifecycle/ivoz/brand.yml
@@ -29,3 +29,11 @@ services:
         '@=service("doctrine.orm.entity_manager").getRepository("Ivoz\\Provider\\Domain\\Model\\Country\\Country")'
       $routingPatternGroupByRoutingPatternAndCountry:
         '@Ivoz\Provider\Domain\Service\RoutingPatternGroup\UpdateByRoutingPatternAndCountry'
+
+  ##################################
+  ## post_remove
+  ##################################
+  Ivoz\Provider\Domain\Service\Domain\DeleteByBrand:
+    tags:
+      - { name: provider.lifecycle.brand.post_remove, priority: 10 }
+    arguments: ~

--- a/library/CoreBundle/Resources/config/lifecycle/ivoz/company.yml
+++ b/library/CoreBundle/Resources/config/lifecycle/ivoz/company.yml
@@ -48,3 +48,11 @@ services:
         '@Ivoz\Core\Infrastructure\Domain\Service\DoctrineEntityPersister'
       $brandServiceRepository:
         '@=service("doctrine.orm.entity_manager").getRepository("Ivoz\\Provider\\Domain\\Model\\BrandService\\BrandService")'
+
+  ##################################
+  ## post_remove
+  ##################################
+  Ivoz\Provider\Domain\Service\Domain\DeleteByCompany:
+    tags:
+      - { name: provider.lifecycle.company.post_remove, priority: 10 }
+    arguments: ~

--- a/library/Ivoz/Provider/Domain/Service/Domain/DeleteByBrand.php
+++ b/library/Ivoz/Provider/Domain/Service/Domain/DeleteByBrand.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Ivoz\Provider\Domain\Service\Domain;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Ivoz\Provider\Domain\Model\Brand\BrandInterface;
+use Ivoz\Provider\Domain\Service\Brand\BrandLifecycleEventHandlerInterface;
+
+/**
+ * Class DeleteByBrand
+ * @package Ivoz\Provider\Domain\Service\Domain
+ */
+class DeleteByBrand implements BrandLifecycleEventHandlerInterface
+{
+    /**
+     * @var EntityManagerInterface
+     */
+    protected $em;
+
+    /**
+     * DeleteByBrand constructor.
+     * @param EntityManagerInterface $em
+     */
+    public function __construct(
+        EntityManagerInterface $em
+    ) {
+        $this->em = $em;
+    }
+
+    public function execute(BrandInterface $entity, $isNew)
+    {
+        $domain = $entity->getDomain();
+
+        if ($domain) {
+            $this->em->remove($domain);
+        }
+    }
+}

--- a/library/Ivoz/Provider/Domain/Service/Domain/DeleteByCompany.php
+++ b/library/Ivoz/Provider/Domain/Service/Domain/DeleteByCompany.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Ivoz\Provider\Domain\Service\Domain;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Ivoz\Provider\Domain\Model\Company\CompanyInterface;
+use Ivoz\Provider\Domain\Service\Company\CompanyLifecycleEventHandlerInterface;
+
+/**
+ * Class DeleteByCompany
+ * @package Ivoz\Provider\Domain\Service\Domain
+ */
+class DeleteByCompany implements CompanyLifecycleEventHandlerInterface
+{
+    /**
+     * @var EntityManagerInterface
+     */
+    protected $em;
+
+    /**
+     * DeleteByCompany constructor.
+     * @param EntityManagerInterface $em
+     */
+    public function __construct(
+        EntityManagerInterface $em
+    ) {
+        $this->em = $em;
+    }
+
+    public function execute(CompanyInterface $entity, $isNew)
+    {
+        $domain = $entity->getDomain();
+
+        if ($domain) {
+            $this->em->remove($domain);
+        }
+    }
+}


### PR DESCRIPTION
Both Brands and Companies have a relation with Domains, but not the other way around, so this can not be done with database ON DELETE constraints.

Implemented two post_remove services to delete the related domain of Brands and Companies.

This fixes #362 