### PR TITLE
core: update Endpoint/Voicemail when Extension number changes

### DIFF
--- a/library/CoreBundle/Resources/config/lifecycle/ivoz/extension.yml
+++ b/library/CoreBundle/Resources/config/lifecycle/ivoz/extension.yml
@@ -23,3 +23,19 @@ services:
         '@Ivoz\Core\Infrastructure\Domain\Service\DoctrineEntityPersister'
       $userRepository:
         '@=service("doctrine.orm.entity_manager").getRepository("Ivoz\\Provider\\Domain\\Model\\User\\User")'
+
+  Ivoz\Ast\Domain\Service\PsEndpoint\UpdateByExtension:
+    tags:
+      - { name: provider.lifecycle.extension.post_persist, priority: 20}
+    arguments:
+      $entityPersister:
+        '@Ivoz\Core\Infrastructure\Domain\Service\DoctrineEntityPersister'
+
+  Ivoz\Ast\Domain\Service\Voicemail\UpdateByExtension:
+    tags:
+      - { name: provider.lifecycle.extension.post_persist, priority: 30 }
+    arguments:
+      $entityPersister:
+        '@Ivoz\Core\Infrastructure\Domain\Service\DoctrineEntityPersister'
+      $voicemailRepository:
+        '@=service("doctrine.orm.entity_manager").getRepository("Ivoz\\Ast\\Domain\\Model\\Voicemail\\Voicemail")'

--- a/library/Ivoz/Ast/Domain/Service/PsEndpoint/UpdateByExtension.php
+++ b/library/Ivoz/Ast/Domain/Service/PsEndpoint/UpdateByExtension.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Ivoz\Ast\Domain\Service\PsEndpoint;
+
+use Ivoz\Ast\Domain\Model\PsEndpoint\PsEndpointInterface;
+use Ivoz\Core\Domain\Service\EntityPersisterInterface;
+use Ivoz\Provider\Domain\Model\Extension\ExtensionInterface;
+use Ivoz\Provider\Domain\Service\Extension\ExtensionLifecycleEventHandlerInterface;
+
+/**
+ * Class UpdateByExtension
+ * @package Ivoz\Ast\Domain\Service\PsEndpoint
+ * @lifecycle pre_persist
+ */
+class UpdateByExtension implements ExtensionLifecycleEventHandlerInterface
+{
+    /**
+     * @var EntityPersisterInterface
+     */
+    protected $entityPersister;
+
+    public function __construct(
+        EntityPersisterInterface $entityPersister
+    ) {
+        $this->entityPersister = $entityPersister;
+    }
+
+    /**
+     * @param ExtensionInterface $entity
+     * @param $isNew
+     */
+    public function execute(ExtensionInterface $entity, $isNew)
+    {
+        // Ignore non-user extensions
+        $user = $entity->getUser();
+        if (!$user) {
+            return;
+        }
+
+        // Only apply to user's with extension
+        $extension = $user->getExtension();
+        if (!$extension) {
+            return;
+        }
+
+        // Only apply if the extension changed is user's screen extension
+        if ($entity->getId() != $extension->getId()) {
+            return;
+        }
+
+        // Ignore non-terminal users
+        $terminal = $user->getTerminal();
+        if (!$terminal) {
+            return;
+        }
+
+        // Update terminal endpoint
+        /** @var PsEndpointInterface $endpoint */
+        $endpoint = $terminal->getAstPsEndpoint();
+        if (!$endpoint) {
+            return;
+        }
+
+        $callerId = sprintf(
+            '%s <%s>',
+            $user->getFullName(),
+            $user->getExtensionNumber()
+        );
+
+        // Set new callerid with updated extension number
+        $endpoint->setCallerid($callerId);
+
+        // Update endpoint voicemail mailbox@context
+        if ($user->getVoicemailEnabled()) {
+            $endpoint->setMailboxes($user->getVoiceMail());
+        }
+
+        $this
+            ->entityPersister
+            ->persist($endpoint);
+    }
+}

--- a/library/Ivoz/Ast/Domain/Service/Voicemail/UpdateByExtension.php
+++ b/library/Ivoz/Ast/Domain/Service/Voicemail/UpdateByExtension.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Ivoz\Ast\Domain\Service\Voicemail;
+
+use Ivoz\Ast\Domain\Model\Voicemail\VoicemailDto;
+use Ivoz\Ast\Domain\Model\Voicemail\VoicemailInterface;
+use Ivoz\Ast\Domain\Model\Voicemail\VoicemailRepository;
+use Ivoz\Core\Domain\Service\EntityPersisterInterface;
+use Ivoz\Provider\Domain\Model\Extension\ExtensionInterface;
+use Ivoz\Provider\Domain\Service\Extension\ExtensionLifecycleEventHandlerInterface;
+
+/**
+ * Class UpdateByExtension
+ * @package Ivoz\Ast\Domain\Service\Voicemail
+ * @lifecycle pre_persist
+ */
+class UpdateByExtension implements ExtensionLifecycleEventHandlerInterface
+{
+    /**
+     * @var EntityPersisterInterface
+     */
+    protected $entityPersister;
+
+    /**
+     * @var VoicemailRepository
+     */
+    protected $voicemailRepository;
+
+    public function __construct(
+        EntityPersisterInterface $entityPersister,
+        VoicemailRepository $voicemailRepository
+    ) {
+        $this->entityPersister = $entityPersister;
+        $this->voicemailRepository = $voicemailRepository;
+    }
+
+    public function execute(ExtensionInterface $entity, $isNew)
+    {
+        // Ignore non-user extensions
+        $user = $entity->getUser();
+        if (!$user) {
+            return;
+        }
+
+        // Only apply to user's with extension
+        $extension = $user->getExtension();
+        if (!$extension) {
+            return;
+        }
+
+        // Only apply if the extension changed is user's screen extension
+        if ($entity->getId() != $extension->getId()) {
+            return;
+        }
+
+        // Only apply to users with voicemail enabled
+        /** @var VoicemailInterface $voicemail */
+        $voicemail = $this->voicemailRepository->findOneBy([
+            'user' => $user->getId()
+        ]);
+
+        if (!$voicemail) {
+            return;
+        }
+
+        /** @var VoicemailDto $voicemailDTO */
+        $voicemailDTO = $voicemail->toDto();
+        $voicemailDTO
+            ->setContext($user->getVoiceMailContext())
+            ->setMailbox($user->getVoiceMailUser());
+
+        $this->entityPersister->persistDto(
+            $voicemailDTO,
+            $voicemail
+        );
+    }
+}


### PR DESCRIPTION
Ast/PsEndpoint and Ast/Voicemail were only being updated when
the User changed the extension. This two tables contain the extension
number, so must be updated if the Extension itself changes, not only
its relation with the user.

This change only applies to those extension that are used as screen
extension for the user, not all the extension that route to user.