### PR TITLE
Add enable/disable toggle to user call forward settings

### DIFF
--- a/asterisk/agi/library/Agi/Action/UserCallAction.php
+++ b/asterisk/agi/library/Agi/Action/UserCallAction.php
@@ -90,7 +90,7 @@ class UserCallAction extends RouterAction
         // Check if user has call forwarding enabled
         if ($this->_allowForwarding) {
             // Process inconditional Call Forwards
-            $cfwSettings = $user->getCallForwardSettingsByUser("callForwardType='inconditional'");
+            $cfwSettings = $user->getEnabledCallForwardSettingsByUser("callForwardType='inconditional'");
             foreach ($cfwSettings as $cfwSetting) {
                 $cfwType = $cfwSetting->getCallTypeFilter();
                 if ($cfwType == "both" || $cfwType == $this->agi->getCallType()) {
@@ -126,7 +126,7 @@ class UserCallAction extends RouterAction
         // If there's no timeout
         if (empty($this->_timeout)) {
             // Get the timeout from the call forward
-            $cfwSettings = $user->getCallForwardSettingsByUser("callForwardType='noAnswer'");
+            $cfwSettings = $user->getEnabledCallForwardSettingsByUser("callForwardType='noAnswer'");
             foreach ($cfwSettings as $cfwSetting) {
                 $cfwType = $cfwSetting->getCallTypeFilter();
                 if ($cfwType == "both" || $cfwType == $this->agi->getCallType()) {
@@ -260,7 +260,7 @@ class UserCallAction extends RouterAction
     private function _processCallForward($user, $type)
     {
         // Process busy Call Forwards
-        $cfwSettings = $user->getCallForwardSettingsByUser("callForwardType='$type'");
+        $cfwSettings = $user->getEnabledCallForwardSettingsByUser("callForwardType='$type'");
         foreach ($cfwSettings as $cfwSetting) {
             $cfwType = $cfwSetting->getCallTypeFilter();
             if ($cfwType == "both" || $cfwType == $this->agi->getCallType()) {

--- a/library/IvozProvider/Mapper/Sql/CallForwardSettings.php
+++ b/library/IvozProvider/Mapper/Sql/CallForwardSettings.php
@@ -24,6 +24,10 @@ class CallForwardSettings extends Raw\CallForwardSettings
             $recursive = false, $useTransaction = true, $transactionTag = null, $forceInsert = false
     )
     {
+        if (!$model->isEnabled()) {
+            return parent::_save($model, $recursive, $useTransaction, $transactionTag, $forceInsert);
+        }
+
         $callTypeFilterConditions = array(
             $model->getCallTypeFilter()
         );
@@ -37,6 +41,7 @@ class CallForwardSettings extends Raw\CallForwardSettings
         $inconditionalCallForwardsConditions = array(
             "id != '".$model->getPrimaryKey()."'",
             "userId = '".$model->getUserId()."'",
+            "enabled = '1'",
             "callTypeFilter in ('".implode("','", $callTypeFilterConditions)."')",
             "callForwardType = 'inconditional'"
         );
@@ -51,6 +56,7 @@ class CallForwardSettings extends Raw\CallForwardSettings
             $callForwardsConditions = array(
                 "id != '".$model->getPrimaryKey()."'",
                 "userId = '".$model->getUserId()."'",
+                "enabled = '1'",
                 "callTypeFilter in ('".implode("','", $callTypeFilterConditions)."')",
             );
             $callForwards = $this->fetchList(implode(" AND ", $callForwardsConditions));
@@ -65,6 +71,7 @@ class CallForwardSettings extends Raw\CallForwardSettings
             $busyCallForwardsConditions = array(
                 "id != '".$model->getPrimaryKey()."'",
                 "userId = '".$model->getUserId()."'",
+                "enabled = '1'",
                 "callTypeFilter in ('".implode("','", $callTypeFilterConditions)."')",
                 "callForwardType = 'busy'"
             );
@@ -80,6 +87,7 @@ class CallForwardSettings extends Raw\CallForwardSettings
             $noAnswerCallForwardsConditions = array(
                 "id != '".$model->getPrimaryKey()."'",
                 "userId = '".$model->getUserId()."'",
+                "enabled = '1'",
                 "callTypeFilter in ('".implode("','", $callTypeFilterConditions)."')",
                 "callForwardType = 'noAnswer'",
             );
@@ -95,6 +103,7 @@ class CallForwardSettings extends Raw\CallForwardSettings
             $userNotRegisteredCallForwardsConditions = array(
                 "id != '".$model->getPrimaryKey()."'",
                 "userId = '".$model->getUserId()."'",
+                "enabled = '1'",
                 "callTypeFilter in ('".implode("','", $callTypeFilterConditions)."')",
                 "callForwardType = 'userNotRegistered'",
             );

--- a/library/IvozProvider/Mapper/Sql/DbTable/CallForwardSettings.php
+++ b/library/IvozProvider/Mapper/Sql/DbTable/CallForwardSettings.php
@@ -211,6 +211,23 @@ class CallForwardSettings extends TableAbstract
 	    'PRIMARY_POSITION' => NULL,
 	    'IDENTITY' => false,
 	  ),
+	  'enabled' => 
+	  array (
+	    'SCHEMA_NAME' => NULL,
+	    'TABLE_NAME' => 'CallForwardSettings',
+	    'COLUMN_NAME' => 'enabled',
+	    'COLUMN_POSITION' => 10,
+	    'DATA_TYPE' => 'tinyint',
+	    'DEFAULT' => '1',
+	    'NULLABLE' => false,
+	    'LENGTH' => NULL,
+	    'SCALE' => NULL,
+	    'PRECISION' => NULL,
+	    'UNSIGNED' => true,
+	    'PRIMARY' => false,
+	    'PRIMARY_POSITION' => NULL,
+	    'IDENTITY' => false,
+	  ),
 	);
 
 

--- a/library/IvozProvider/Mapper/Sql/Raw/CallForwardSettings.php
+++ b/library/IvozProvider/Mapper/Sql/Raw/CallForwardSettings.php
@@ -57,6 +57,7 @@ class CallForwardSettings extends MapperAbstract
                 'extensionId' => $model->getExtensionId(),
                 'voiceMailUserId' => $model->getVoiceMailUserId(),
                 'noAnswerTimeout' => $model->getNoAnswerTimeout(),
+                'enabled' => $model->getEnabled(),
             );
         } else {
             $result = array();
@@ -559,7 +560,8 @@ class CallForwardSettings extends MapperAbstract
                   ->setNumberValue($data['numberValue'])
                   ->setExtensionId($data['extensionId'])
                   ->setVoiceMailUserId($data['voiceMailUserId'])
-                  ->setNoAnswerTimeout($data['noAnswerTimeout']);
+                  ->setNoAnswerTimeout($data['noAnswerTimeout'])
+                  ->setEnabled($data['enabled']);
         } else if ($data instanceof \Zend_Db_Table_Row_Abstract || $data instanceof \stdClass) {
             $entry->setId($data->{'id'})
                   ->setUserId($data->{'userId'})
@@ -569,7 +571,8 @@ class CallForwardSettings extends MapperAbstract
                   ->setNumberValue($data->{'numberValue'})
                   ->setExtensionId($data->{'extensionId'})
                   ->setVoiceMailUserId($data->{'voiceMailUserId'})
-                  ->setNoAnswerTimeout($data->{'noAnswerTimeout'});
+                  ->setNoAnswerTimeout($data->{'noAnswerTimeout'})
+                  ->setEnabled($data->{'enabled'});
 
         } else if ($data instanceof \IvozProvider\Model\Raw\CallForwardSettings) {
             $entry->setId($data->getId())
@@ -580,7 +583,8 @@ class CallForwardSettings extends MapperAbstract
                   ->setNumberValue($data->getNumberValue())
                   ->setExtensionId($data->getExtensionId())
                   ->setVoiceMailUserId($data->getVoiceMailUserId())
-                  ->setNoAnswerTimeout($data->getNoAnswerTimeout());
+                  ->setNoAnswerTimeout($data->getNoAnswerTimeout())
+                  ->setEnabled($data->getEnabled());
 
         }
 

--- a/library/IvozProvider/Model/CallForwardSettings.php
+++ b/library/IvozProvider/Model/CallForwardSettings.php
@@ -39,6 +39,7 @@ class CallForwardSettings extends Raw\CallForwardSettings
         $numberValue = $this->getNumberValue();
         settype($numberValue, "integer");
 
+        $model['enabled'] = $this->getEnabled();
         $model['callTypeFilter'] = $this->getCallTypeFilter();
         $model['callForwardType'] = $this->getCallForwardType();
         $model['targetType'] = $this->getTargetType();
@@ -63,6 +64,16 @@ class CallForwardSettings extends Raw\CallForwardSettings
 
         return $model;
 
+    }
+
+    /**
+     * Return in current cfw status is enabled
+     *
+     * @return boolean
+     */
+    public function isEnabled()
+    {
+        return $this->getEnabled() == '1';
     }
 
 }

--- a/library/IvozProvider/Model/Raw/CallForwardSettings.php
+++ b/library/IvozProvider/Model/Raw/CallForwardSettings.php
@@ -105,6 +105,13 @@ class CallForwardSettings extends ModelAbstract
      */
     protected $_noAnswerTimeout;
 
+    /**
+     * Database var type tinyint
+     *
+     * @var int
+     */
+    protected $_enabled;
+
 
     /**
      * Parent relation CallForwardSettings_ibfk_1
@@ -138,6 +145,7 @@ class CallForwardSettings extends ModelAbstract
         'extensionId'=>'extensionId',
         'voiceMailUserId'=>'voiceMailUserId',
         'noAnswerTimeout'=>'noAnswerTimeout',
+        'enabled'=>'enabled',
     );
 
     /**
@@ -179,6 +187,7 @@ class CallForwardSettings extends ModelAbstract
 
         $this->_defaultValues = array(
             'noAnswerTimeout' => '10',
+            'enabled' => '1',
         );
 
         $this->_initFileObjects();
@@ -537,6 +546,40 @@ class CallForwardSettings extends ModelAbstract
     public function getNoAnswerTimeout()
     {
         return $this->_noAnswerTimeout;
+    }
+
+    /**
+     * Sets column Stored in ISO 8601 format.     *
+     * @param int $data
+     * @return \IvozProvider\Model\Raw\CallForwardSettings
+     */
+    public function setEnabled($data)
+    {
+
+        if ($this->_enabled != $data) {
+            $this->_logChange('enabled', $this->_enabled, $data);
+        }
+
+        if ($data instanceof \Zend_Db_Expr) {
+            $this->_enabled = $data;
+
+        } else if (!is_null($data)) {
+            $this->_enabled = (int) $data;
+
+        } else {
+            $this->_enabled = $data;
+        }
+        return $this;
+    }
+
+    /**
+     * Gets column enabled
+     *
+     * @return int
+     */
+    public function getEnabled()
+    {
+        return $this->_enabled;
     }
 
     /**

--- a/library/IvozProvider/Model/Users.php
+++ b/library/IvozProvider/Model/Users.php
@@ -348,4 +348,20 @@ class Users extends Raw\Users
         return $this->getCompany()->getAreaCodeValue();
     }
 
+    /**
+     * Gets enabled dependent CallForwardSettings_ibfk_1
+     *
+     * @param string or array $where
+     * @param string or array $orderBy
+     * @param boolean $avoidLoading skip data loading if it is not already
+     * @return array The array of \IvozProvider\Model\Raw\CallForwardSettings
+     */
+    public function getEnabledCallForwardSettingsByUser($where = null, $orderBy = null, $avoidLoading = false)
+    {
+        $conditions = [];
+        $conditions[] = "enabled = 1";
+        $conditions[] = $where;
+
+        return parent::getCallForwardSettingsByUser(implode(' AND ', $conditions), $orderBy, $avoidLoading);
+    }
 }

--- a/portals/application/configs/klear/CallForwardSettingsList.yaml
+++ b/portals/application/configs/klear/CallForwardSettingsList.yaml
@@ -14,7 +14,8 @@ production:
       class: ui-silk-telephone-go
       title: _("List of %s %2s", ngettext('Call forward setting', 'Call forward settings', 0), "[format| (%parent%)]")
       fields:
-        order:
+        order: &callForwardSettingsOrder_Link
+          enabled: true
           callTypeFilter: true
           callForwardType: true
           targetType: true
@@ -48,10 +49,13 @@ production:
       fields:
         blacklist:
           targetTypeValue: true
+        order:
+          <<: *callForwardSettingsOrder_Link
       fixedPositions: &callForwardSettingsFixedPositions_Link
         group0:
-          colsPerRow: 3
+          colsPerRow: 4
           fields:
+            enabled: 1
             callTypeFilter: 1
             callForwardType: 1
             noAnswerTimeout: 1
@@ -72,6 +76,8 @@ production:
         blacklist:
           extensionId: true
           targetTypeValue: true
+        order:
+          <<: *callForwardSettingsOrder_Link
       fixedPositions:
         <<: *callForwardSettingsFixedPositions_Link
 

--- a/portals/application/configs/klear/UsersList.yaml
+++ b/portals/application/configs/klear/UsersList.yaml
@@ -234,10 +234,6 @@ production:
     callForwardSettingsEdit_screen:
       <<: *callForwardSettingsEdit_screenLink
       filterField: userId
-      fields:
-        blacklist:
-          targetTypeValue: true
-
   dialogs: &users_dialogsLink
     usersDel_dialog: &usersDel_dialogLink
       <<: *Users

--- a/portals/application/configs/klear/model/CallForwardSettings.yaml
+++ b/portals/application/configs/klear/model/CallForwardSettings.yaml
@@ -15,6 +15,17 @@ production:
             template: '%name%'
           order: name
       default: true
+    enabled:
+      title: _('Enabled')
+      type: select
+      defaultValue: 1
+      source:
+        data: inline
+        values:
+          '0':
+            title: _("No")
+          '1':
+            title: _("Yes")
     callTypeFilter:
       title: _('Call type')
       type: select

--- a/portals/application/languages/en_US/en_US.po
+++ b/portals/application/languages/en_US/en_US.po
@@ -609,6 +609,9 @@ msgstr ""
 "number of outgoing calls to avoid toll-fraud. 'None' value makes outgoing "
 "calls unlimited as long as company IP policy is fulfilled."
 
+msgid "Enabled"
+msgstr "Enabled"
+
 msgid "End time"
 msgstr "End time"
 

--- a/portals/application/languages/es_ES/es_ES.po
+++ b/portals/application/languages/es_ES/es_ES.po
@@ -621,6 +621,9 @@ msgstr ""
 "número ilimitado de llamadas siempre y cuando se cumpla la política de "
 "restricción de IPs de la empresa."
 
+msgid "Enabled"
+msgstr "Activado"
+
 msgid "End time"
 msgstr "Fecha fin"
 

--- a/portals/application/modules/rest/controllers/CallForwardSettingsController.php
+++ b/portals/application/modules/rest/controllers/CallForwardSettingsController.php
@@ -40,7 +40,8 @@ class Rest_CallForwardSettingsController extends Iron_Controller_Rest_BaseContro
      *     'numberValue': '', 
      *     'extensionId': '', 
      *     'voiceMailUserId': '', 
-     *     'noAnswerTimeout': ''
+     *     'noAnswerTimeout': '', 
+     *     'enabled': ''
      * },{
      *     'id': '', 
      *     'userId': '', 
@@ -50,7 +51,8 @@ class Rest_CallForwardSettingsController extends Iron_Controller_Rest_BaseContro
      *     'numberValue': '', 
      *     'extensionId': '', 
      *     'voiceMailUserId': '', 
-     *     'noAnswerTimeout': ''
+     *     'noAnswerTimeout': '', 
+     *     'enabled': ''
      * }]")
      */
     public function indexAction()
@@ -77,6 +79,7 @@ class Rest_CallForwardSettingsController extends Iron_Controller_Rest_BaseContro
                 'extensionId',
                 'voiceMailUserId',
                 'noAnswerTimeout',
+                'enabled',
             );
         }
 
@@ -158,7 +161,8 @@ class Rest_CallForwardSettingsController extends Iron_Controller_Rest_BaseContro
      *     'numberValue': '', 
      *     'extensionId': '', 
      *     'voiceMailUserId': '', 
-     *     'noAnswerTimeout': ''
+     *     'noAnswerTimeout': '', 
+     *     'enabled': ''
      * }")
      */
     public function getAction()
@@ -184,6 +188,7 @@ class Rest_CallForwardSettingsController extends Iron_Controller_Rest_BaseContro
                 'extensionId',
                 'voiceMailUserId',
                 'noAnswerTimeout',
+                'enabled',
             );
         }
 
@@ -232,6 +237,7 @@ class Rest_CallForwardSettingsController extends Iron_Controller_Rest_BaseContro
      * @ApiParams(name="extensionId", nullable=true, type="int", sample="", description="")
      * @ApiParams(name="voiceMailUserId", nullable=true, type="int", sample="", description="")
      * @ApiParams(name="noAnswerTimeout", nullable=false, type="smallint", sample="", description="")
+     * @ApiParams(name="enabled", nullable=false, type="tinyint", sample="", description="")
      * @ApiReturnHeaders(sample="HTTP 201")
      * @ApiReturnHeaders(sample="Location: /rest/callforwardsettings/{id}")
      * @ApiReturn(type="object", sample="{}")
@@ -275,6 +281,7 @@ class Rest_CallForwardSettingsController extends Iron_Controller_Rest_BaseContro
      * @ApiParams(name="extensionId", nullable=true, type="int", sample="", description="")
      * @ApiParams(name="voiceMailUserId", nullable=true, type="int", sample="", description="")
      * @ApiParams(name="noAnswerTimeout", nullable=false, type="smallint", sample="", description="")
+     * @ApiParams(name="enabled", nullable=false, type="tinyint", sample="", description="")
      * @ApiReturnHeaders(sample="HTTP 200")
      * @ApiReturn(type="object", sample="{}")
      */
@@ -409,6 +416,11 @@ class Rest_CallForwardSettingsController extends Iron_Controller_Rest_BaseContro
                     'required' => true,
                     'comment' => '',
                 ),
+                'enabled' => array(
+                    'type' => "tinyint",
+                    'required' => true,
+                    'comment' => '',
+                ),
             )
         );
 
@@ -457,6 +469,11 @@ class Rest_CallForwardSettingsController extends Iron_Controller_Rest_BaseContro
                 ),
                 'noAnswerTimeout' => array(
                     'type' => "smallint",
+                    'required' => true,
+                    'comment' => '',
+                ),
+                'enabled' => array(
+                    'type' => "tinyint",
                     'required' => true,
                     'comment' => '',
                 ),

--- a/portals/application/modules/userweb/controllers/CallForwardSettingsController.php
+++ b/portals/application/modules/userweb/controllers/CallForwardSettingsController.php
@@ -185,6 +185,7 @@ class Userweb_CallForwardSettingsController extends Iron_Controller_Rest_BaseCon
         $model->setCallTypeFilter($params['callTypeFilter']);
         $model->setCallForwardType($params['callForwardType']);
         $model->setTargetType($params['targetType']);
+        $model->setEnabled($params['enabled']);
 
         return $model;
 

--- a/scheme/deltas/079-disable-cfw.sql
+++ b/scheme/deltas/079-disable-cfw.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `CallForwardSettings` ADD `enabled` tinyint(1) unsigned NOT NULL DEFAULT '1';
+ALTER TABLE `CallForwardSettings` DROP KEY `callFwTypeUser`;

--- a/userweb/app/languages/locale-es.json
+++ b/userweb/app/languages/locale-es.json
@@ -57,6 +57,7 @@
     "exportToCsv": "Exportar a .CSV",
     "clear": "Limpiar",
     "search": "Buscar",
+    "enabled": "Habilitado",
     "NuevoDesvio": "Nuevo Desvio",
     "inconditional": "Incondicional",
     "noAnswer": "Sin Respuesta",

--- a/userweb/app/modules/detours/detoursCtrl.js
+++ b/userweb/app/modules/detours/detoursCtrl.js
@@ -36,7 +36,7 @@ angular
         } else {
             resutl = '';
         }
-        
+
         return resutl;
     };
     

--- a/userweb/app/modules/detours/detoursEditCtrl.js
+++ b/userweb/app/modules/detours/detoursEditCtrl.js
@@ -30,6 +30,9 @@ angular
             $scope.extensions = extensions.data;
             Restangular.all('call-forward-settings').get(detourId).then(function(detour) {
                 $scope.detour = detour.data;
+
+                detour.data.enabled = '' + detour.data.enabled;
+
                 $scope.formDisabled = false;
                 $scope.loading = false;
                 ngProgress.complete();

--- a/userweb/app/views/detours/edit.html
+++ b/userweb/app/views/detours/edit.html
@@ -41,6 +41,28 @@
                     <div class="form-group col-md-12">
 
                         <label
+                                for="enabled"
+                                class="col-sm-4 control-label"
+                                translate="enabled"
+                        ></label>
+
+                        <div class="col-sm-8">
+                            <select
+                                    class="form-control"
+                                    id="enabled"
+                                    name="enabled"
+                                    ng-model="detour.enabled"
+                                    required="required"
+                            >
+                                <option value="0" translate="no"></option>
+                                <option value="1" translate="yes"></option>
+                            </select>
+                        </div>
+
+                    </div>
+                    <div class="form-group col-md-12">
+
+                        <label
                                 for="callTypeFilter"
                                 class="col-sm-4 control-label"
                                 translate="callTypeFilter"

--- a/userweb/app/views/detours/new.html
+++ b/userweb/app/views/detours/new.html
@@ -39,27 +39,53 @@
 
                     <div class="form-group col-md-12">
 
-                        <label
-                                for="callTypeFilter"
-                                class="col-sm-4 control-label"
-                                translate="callTypeFilter"
-                        ></label>
 
-                        <div class="col-sm-8">
-                            <select
-                                    class="form-control"
-                                    id="callTypeFilter"
-                                    name="callTypeFilter"
-                                    ng-model="detour.callTypeFilter"
-                                    required="required"
-                            >
-                                <option value="internal" translate="internal"></option>
-                                <option value="external" translate="external"></option>
-                                <option value="both" translate="both"></option>
-                            </select>
+                        <div class="form-group col-md-12">
+
+                            <label
+                                    for="enabled"
+                                    class="col-sm-4 control-label"
+                                    translate="enabled"
+                            ></label>
+
+                            <div class="col-sm-8">
+                                <select
+                                        class="form-control"
+                                        id="enabled"
+                                        name="enabled"
+                                        ng-model="detour.enabled"
+                                        required="required"
+                                >
+                                    <option value="0" translate="no"></option>
+                                    <option value="1" translate="yes"></option>
+                                </select>
+                            </div>
+
                         </div>
 
-                    </div>
+                        <div class="form-group col-md-12">
+
+                            <label
+                                    for="callTypeFilter"
+                                    class="col-sm-4 control-label"
+                                    translate="callTypeFilter"
+                            ></label>
+
+                            <div class="col-sm-8">
+                                <select
+                                        class="form-control"
+                                        id="callTypeFilter"
+                                        name="callTypeFilter"
+                                        ng-model="detour.callTypeFilter"
+                                        required="required"
+                                >
+                                    <option value="internal" translate="internal"></option>
+                                    <option value="external" translate="external"></option>
+                                    <option value="both" translate="both"></option>
+                                </select>
+                            </div>
+
+                        </div>
 
                     <div class="form-group col-md-12">
 

--- a/userweb/app/views/detours/table-detours.html
+++ b/userweb/app/views/detours/table-detours.html
@@ -1,6 +1,7 @@
 <table class="table table-striped table-calls">
     <thead>
         <tr>
+           <th translate="enabled"></th>
            <th translate="callTypeFilter"></th>
            <th translate="callForwardType"></th>
            <th translate="targetType"></th>
@@ -12,6 +13,11 @@
     <tbody>
         <tr ng-repeat="detour in callsFS">
         
+          <td data-th="{{'enabled' | translate}}">
+              <span ng-show="detour.enabled">{{'yes' | translate}}</span>
+              <span ng-show="!detour.enabled">{{'no' | translate}}</span>
+
+          </td>
           <td data-th="{{'callTypeFilter' | translate}}">{{detour.callTypeFilter | translate}}</td>
           <td data-th="{{'callForwardType' | translate}}">{{detour.callForwardType | translate}}</td>
           <td data-th="{{'targetType' | translate}}">{{detour.targetType | translate}}</td>


### PR DESCRIPTION
- User call forward can now be enabled/disabled from both admin portal and user portal.
- Disabled call forward settings are ignored.
- You can have multiple colliding call forwards but only one of them can be enabled at a time.

This PR fixes #378.