### PR TITLE
kam+agis: Fix misleading maxcalls implementation

### DIFF
--- a/asterisk/agi/application/controllers/CallsController.php
+++ b/asterisk/agi/application/controllers/CallsController.php
@@ -593,10 +593,6 @@ class CallsController extends BaseController
             }
         }
 
-        // Add MaxCalls X-Info headers
-        $this->agi->setSIPHeader("X-Info-CompanyMaxCalls", $company->getMaxCalls());
-        $this->agi->setSIPHeader("X-Info-BrandMaxCalls", $company->getBrand()->getMaxCalls());
-
         // Set Special header for Forwarding
         if ($this->agi->getRedirecting('from-tag')) {
             $this->agi->setSIPHeader("X-Info-ForwardExt", $this->agi->getRedirecting('from-tag'));

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -408,7 +408,6 @@ request_route {
 
         # AS provides needed info in X-INFO header
         route(PARSE_X_HEADERS);
-        route(CONTROL_MAXCALLS);
         route(PROFILE_OUTBOUND_CALL);
 
         #!ifdef DELAY_MEDIALIBERATION
@@ -619,16 +618,6 @@ route[PARSE_X_HEADERS] {
     $var(header) = 'X-Info-MediaRelaySet';
     route(PARSE_OPTIONAL_X_HEADER);
     if ($var(header-value) != '') $dlg_var(mediaRelaySetsId) = $var(header-value);
-
-    # Extract MaxCallsCompany
-    $var(header) = 'X-Info-CompanyMaxCalls';
-    route(PARSE_MANDATORY_X_HEADER);
-    $dlg_var(maxCallsCompany) = $var(header-value);
-
-    # Extract MaxCallsBrand
-    $var(header) = 'X-Info-BrandMaxCalls';
-    route(PARSE_MANDATORY_X_HEADER);
-    $dlg_var(maxCallsBrand) = $var(header-value);
 
     # Extract Record header
     $var(header) = 'X-Info-Record';

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -508,7 +508,6 @@ request_route {
             if ($dlg_var(log)) xlog("L_INFO", "[b$dlg_var(brandId)][$dlg_var(cidhash)] AS calling to local subscriber, relay to subcriber\n");
             route(PARSE_X_HEADERS);
             route(MAXCALLS_USER);
-            route(CONTROL_MAXCALLS);
             route(RELATE_LEGS);
             route(FRIENDS);
             route(RETAILS);
@@ -820,16 +819,6 @@ route[PARSE_X_HEADERS] {
     $var(header) = 'X-Info-UserMaxCalls';
     route(PARSE_MANDATORY_X_HEADER);
     $dlg_var(maxcallsUser) = $var(header-value);
-
-    # Extract company maxcalls
-    $var(header) = 'X-Info-CompanyMaxCalls';
-    route(PARSE_MANDATORY_X_HEADER);
-    $dlg_var(maxcallsCompany) = $var(header-value);
-
-    # Extract brand maxcalls
-    $var(header) = 'X-Info-BrandMaxCalls';
-    route(PARSE_MANDATORY_X_HEADER);
-    $dlg_var(maxcallsBrand) = $var(header-value);
 
     # Extract brandId
     $var(header) = 'X-Info-BrandId';

--- a/portals/application/configs/klear/model/Brands.yaml
+++ b/portals/application/configs/klear/model/Brands.yaml
@@ -29,7 +29,7 @@ production:
         type: box
         position: left
         icon: help
-        text: _("Limits both internal and external calls (0 for unlimited).")
+        text: _("Limits both user generated and external received calls to this value (0 for unlimited).")
         label: _("Need help?")
     defaultTimezoneId:
       title: _('Default timezone')

--- a/portals/application/configs/klear/model/Companies.yaml
+++ b/portals/application/configs/klear/model/Companies.yaml
@@ -97,7 +97,7 @@ production:
         type: box
         position: left
         icon: help
-        text: _("Limits both internal and external calls (0 for unlimited).")
+        text: _("Limits both user generated and external received calls to this value (0 for unlimited).")
         label: _("Need help?")
     postalAddress:
       title: _('Postal address')

--- a/portals/application/languages/en_US/en_US.po
+++ b/portals/application/languages/en_US/en_US.po
@@ -1116,6 +1116,13 @@ msgid "Limits both internal and external calls (0 for unlimited)."
 msgstr "Limits both internal and external calls (0 for unlimited)."
 
 msgid ""
+"Limits both user generated and external received calls to this value (0 for "
+"unlimited)."
+msgstr ""
+"Limits both user generated and external received calls to this value (0 for "
+"unlimited)."
+
+msgid ""
 "Limits the number of received calls if the user is handling simultaneously "
 "(inbound and outbound) more than the number set. Set 0 for unlimited calls."
 msgstr ""

--- a/portals/application/languages/es_ES/es_ES.po
+++ b/portals/application/languages/es_ES/es_ES.po
@@ -1131,6 +1131,13 @@ msgstr ""
 "Limita llamadas externas tanto entrantes como salientes (0 para ilimitado)."
 
 msgid ""
+"Limits both user generated and external received calls to this value (0 for "
+"unlimited)."
+msgstr ""
+"Limita tanto las llamadas generadas por los usuarios como las llamadas recibidas "
+"desde el exterior a este valor (0 para ilimitado)."
+
+msgid ""
 "Limits the number of received calls if the user is handling simultaneously "
 "(inbound and outbound) more than the number set. Set 0 for unlimited calls."
 msgstr ""


### PR DESCRIPTION
This commit fixes the misleading implementation made in #398 for maxcalls.

Before this commit:

- KamUsers had an independent counter that counted dialogs in both directions:
  - UAC -> KamUsers -> AS
  - AS -> KamUsers -> UAC

- KamTrunks had an independent counter that counted dialogs in both directions:
  - Carrier -> KamTrunks -> AS
  - AS -> KamTrunks -> Carrier

This made difficult to answer the question "how many calls can I handle with this
setting set to 10":

- 10 external outgoing calls made by users.

or

- 10 external incoming calls received by users.

or

- 10 external incoming calls forwarded outside again + 10 internal calls.

After this commit:

- KamUsers has an independent counter but only counts (and limits) UAC->AS calls.
- KamTrunks has an independent counter but only counts (and limits) Carrier->AS calls.

This way the previous question can be answered easily:

- 10 calls generated by users + 10 calls received from the outside world.

Until a counter is shared between Kamusers and KamTrunks, this implementation seems
less ambiguous.