### PR TITLE
RingAll huntgroup: CANCEL with "Answered elsewhere" as an option

### DIFF
--- a/asterisk/agi/library/Agi/Action/HuntGroupAction.php
+++ b/asterisk/agi/library/Agi/Action/HuntGroupAction.php
@@ -55,6 +55,7 @@ class HuntGroupAction extends RouterAction
             return;
 
         $company = $this->_huntgroup->getCompany();
+        $huntgroup = $this->_huntgroup;
         $extension = $company->getExtension($firstExt);
         $user = $extension->getUser();
 
@@ -66,6 +67,7 @@ class HuntGroupAction extends RouterAction
             ->setDialContext('call-huntgroup')
             ->allowForwarding(false)
             ->setProcessDialStatus(false)
+            ->alwaysCancelWithAnsweredElsewhere($huntgroup->getPreventMissedCalls())
             ->call();
 
         //  If call has not been redirected to context, process next
@@ -173,8 +175,8 @@ class HuntGroupAction extends RouterAction
         }
 
         // Dial Options
-        // Cancelled calls are marked as 'answered elsewhere'
-        $options = "c";
+        // Cancelled calls may be marked as 'answered elsewhere'
+        $options = ($huntGroup->getPreventMissedCalls())? "c":"";
 
         // For record asterisk builtin feature code (FIXME Dont use both X's)
         if ($user->getCompany()->getOnDemandRecord() == 2) {

--- a/asterisk/agi/library/Agi/Action/UserCallAction.php
+++ b/asterisk/agi/library/Agi/Action/UserCallAction.php
@@ -14,6 +14,8 @@ class UserCallAction extends RouterAction
 
     protected $_allowForwarding = true;
 
+    protected $_alwaysCancelWithAnsweredElsewhere = false;
+
     protected $_processDialStatus = true;
 
 
@@ -38,6 +40,12 @@ class UserCallAction extends RouterAction
     public function allowForwarding($allow)
     {
         $this->_allowForwarding = $allow;
+        return $this;
+    }
+
+    public function alwaysCancelWithAnsweredElsewhere($cancel)
+    {
+        $this->_alwaysCancelWithAnsweredElsewhere= $cancel;
         return $this;
     }
 
@@ -157,6 +165,11 @@ class UserCallAction extends RouterAction
         if ($this->_processDialStatus) {
             // Process Dialstatus after calling this user (allows call forwards)
             $options .= "g";
+        }
+
+        if ($this->_alwaysCancelWithAnsweredElsewhere) {
+            // Cancel with Answered elsewhere
+            $options .= "c";
         }
 
         // Update Called name

--- a/library/IvozProvider/Mapper/Sql/DbTable/HuntGroups.php
+++ b/library/IvozProvider/Mapper/Sql/DbTable/HuntGroups.php
@@ -273,6 +273,23 @@ class HuntGroups extends TableAbstract
 	    'PRIMARY_POSITION' => NULL,
 	    'IDENTITY' => false,
 	  ),
+	  'preventMissedCalls' => 
+	  array (
+	    'SCHEMA_NAME' => NULL,
+	    'TABLE_NAME' => 'HuntGroups',
+	    'COLUMN_NAME' => 'preventMissedCalls',
+	    'COLUMN_POSITION' => 13,
+	    'DATA_TYPE' => 'int',
+	    'DEFAULT' => '1',
+	    'NULLABLE' => false,
+	    'LENGTH' => NULL,
+	    'SCALE' => NULL,
+	    'PRECISION' => NULL,
+	    'UNSIGNED' => true,
+	    'PRIMARY' => false,
+	    'PRIMARY_POSITION' => NULL,
+	    'IDENTITY' => false,
+	  ),
 	);
 
 

--- a/library/IvozProvider/Mapper/Sql/Raw/HuntGroups.php
+++ b/library/IvozProvider/Mapper/Sql/Raw/HuntGroups.php
@@ -60,6 +60,7 @@ class HuntGroups extends MapperAbstract
                 'noAnswerNumberValue' => $model->getNoAnswerNumberValue(),
                 'noAnswerExtensionId' => $model->getNoAnswerExtensionId(),
                 'noAnswerVoiceMailUserId' => $model->getNoAnswerVoiceMailUserId(),
+                'preventMissedCalls' => $model->getPreventMissedCalls(),
             );
         } else {
             $result = array();
@@ -638,7 +639,8 @@ class HuntGroups extends MapperAbstract
                   ->setNoAnswerTargetType($data['noAnswerTargetType'])
                   ->setNoAnswerNumberValue($data['noAnswerNumberValue'])
                   ->setNoAnswerExtensionId($data['noAnswerExtensionId'])
-                  ->setNoAnswerVoiceMailUserId($data['noAnswerVoiceMailUserId']);
+                  ->setNoAnswerVoiceMailUserId($data['noAnswerVoiceMailUserId'])
+                  ->setPreventMissedCalls($data['preventMissedCalls']);
         } else if ($data instanceof \Zend_Db_Table_Row_Abstract || $data instanceof \stdClass) {
             $entry->setId($data->{'id'})
                   ->setName($data->{'name'})
@@ -651,7 +653,8 @@ class HuntGroups extends MapperAbstract
                   ->setNoAnswerTargetType($data->{'noAnswerTargetType'})
                   ->setNoAnswerNumberValue($data->{'noAnswerNumberValue'})
                   ->setNoAnswerExtensionId($data->{'noAnswerExtensionId'})
-                  ->setNoAnswerVoiceMailUserId($data->{'noAnswerVoiceMailUserId'});
+                  ->setNoAnswerVoiceMailUserId($data->{'noAnswerVoiceMailUserId'})
+                  ->setPreventMissedCalls($data->{'preventMissedCalls'});
 
         } else if ($data instanceof \IvozProvider\Model\Raw\HuntGroups) {
             $entry->setId($data->getId())
@@ -665,7 +668,8 @@ class HuntGroups extends MapperAbstract
                   ->setNoAnswerTargetType($data->getNoAnswerTargetType())
                   ->setNoAnswerNumberValue($data->getNoAnswerNumberValue())
                   ->setNoAnswerExtensionId($data->getNoAnswerExtensionId())
-                  ->setNoAnswerVoiceMailUserId($data->getNoAnswerVoiceMailUserId());
+                  ->setNoAnswerVoiceMailUserId($data->getNoAnswerVoiceMailUserId())
+                  ->setPreventMissedCalls($data->getPreventMissedCalls());
 
         }
 

--- a/library/IvozProvider/Model/Raw/HuntGroups.php
+++ b/library/IvozProvider/Model/Raw/HuntGroups.php
@@ -120,6 +120,13 @@ class HuntGroups extends ModelAbstract
      */
     protected $_noAnswerVoiceMailUserId;
 
+    /**
+     * Database var type int
+     *
+     * @var int
+     */
+    protected $_preventMissedCalls;
+
 
     /**
      * Parent relation HuntGroups_ibfk_1
@@ -203,6 +210,7 @@ class HuntGroups extends ModelAbstract
         'noAnswerNumberValue'=>'noAnswerNumberValue',
         'noAnswerExtensionId'=>'noAnswerExtensionId',
         'noAnswerVoiceMailUserId'=>'noAnswerVoiceMailUserId',
+        'preventMissedCalls'=>'preventMissedCalls',
     );
 
     /**
@@ -274,6 +282,7 @@ class HuntGroups extends ModelAbstract
         $this->_defaultValues = array(
             'name' => '',
             'description' => '',
+            'preventMissedCalls' => '1',
         );
 
         $this->_initFileObjects();
@@ -728,6 +737,40 @@ class HuntGroups extends ModelAbstract
     public function getNoAnswerVoiceMailUserId()
     {
         return $this->_noAnswerVoiceMailUserId;
+    }
+
+    /**
+     * Sets column Stored in ISO 8601 format.     *
+     * @param int $data
+     * @return \IvozProvider\Model\Raw\HuntGroups
+     */
+    public function setPreventMissedCalls($data)
+    {
+
+        if ($this->_preventMissedCalls != $data) {
+            $this->_logChange('preventMissedCalls', $this->_preventMissedCalls, $data);
+        }
+
+        if ($data instanceof \Zend_Db_Expr) {
+            $this->_preventMissedCalls = $data;
+
+        } else if (!is_null($data)) {
+            $this->_preventMissedCalls = (int) $data;
+
+        } else {
+            $this->_preventMissedCalls = $data;
+        }
+        return $this;
+    }
+
+    /**
+     * Gets column preventMissedCalls
+     *
+     * @return int
+     */
+    public function getPreventMissedCalls()
+    {
+        return $this->_preventMissedCalls;
     }
 
     /**

--- a/portals/application/configs/klear/HuntGroupsList.yaml
+++ b/portals/application/configs/klear/HuntGroupsList.yaml
@@ -35,6 +35,7 @@ production:
           noAnswerNumberValue: true
           noAnswerExtensionId: true
           noAnswerVoiceMailUserId: true
+          preventMissedCalls: true
       options:
         title: _("Options")
         screens:
@@ -57,12 +58,13 @@ production:
       fixedPositions: &huntGroupsFixedPositions_Link
         group0:
           label: _("Basic Configuration")
-          colsPerRow: 2
+          colsPerRow: 12
           fields:
-            name: 1
-            description: 1
-            strategy: 1
-            ringAllTimeOut: 1
+            name: 6
+            description: 6
+            strategy: 4
+            ringAllTimeOut: 4
+            preventMissedCalls: 4
         group1:
           label: _("Target data")
           colsPerRow: 3

--- a/portals/application/configs/klear/model/HuntGroups.yaml
+++ b/portals/application/configs/klear/model/HuntGroups.yaml
@@ -57,6 +57,23 @@ production:
         icon: help
         label: _("Need help?")
         text: _("Determines the order users will be called")
+    preventMissedCalls:
+      title: _('Prevent missed calls')
+      type: select
+      defaultValue: 1
+      source:
+        data: inline
+        values:
+          '0':
+            title: _("No")
+          '1':
+            title: _("Yes")
+      info:
+        type: box
+        position: left
+        icon: help
+        label: _("Need help?")
+        text: _("When 'Yes', calls will never generate a missed call. When 'No', missed calls will be prevented only for RingAll huntgroups if someone answers.")
     ringAllTimeout:
       title: _('Ring all timeout')
       type: number

--- a/portals/application/languages/en_US/en_US.po
+++ b/portals/application/languages/en_US/en_US.po
@@ -1688,6 +1688,9 @@ msgstr "Prepend this field to callee"
 msgid "Presented CID"
 msgstr "Presented CID"
 
+msgid "Prevent missed calls"
+msgstr "Prevent missed calls"
+
 msgid "Price"
 msgid_plural "Prices"
 msgstr[0] "Price"
@@ -2425,6 +2428,13 @@ msgstr "Weight"
 
 msgid "Welcome locution"
 msgstr "Welcome locution"
+
+msgid ""
+"When 'Yes', calls will never generate a missed call. When 'No', missed calls "
+"will be prevented only for RingAll huntgroups if someone answers."
+msgstr ""
+"When 'Yes', calls will never generate a missed call. When 'No', missed calls "
+"will be prevented only for RingAll huntgroups if someone answers."
 
 msgid "When Outbound Proxy is used, SIP Proxy must not include a port."
 msgstr "When Outbound Proxy is used, SIP Proxy must not include a port."

--- a/portals/application/languages/es_ES/es_ES.po
+++ b/portals/application/languages/es_ES/es_ES.po
@@ -1711,6 +1711,9 @@ msgstr "Añadir este campo como prefijo del número destino"
 msgid "Presented CID"
 msgstr "CID presentado"
 
+msgid "Prevent missed calls"
+msgstr "Evitar llamadas perdidas"
+
 msgid "Price"
 msgid_plural "Prices"
 msgstr[0] "Precio"
@@ -2452,6 +2455,13 @@ msgstr "Peso"
 
 msgid "Welcome locution"
 msgstr "Locución Bienvenida"
+
+msgid ""
+"When 'Yes', calls will never generate a missed call. When 'No', missed calls "
+"will be prevented only for RingAll huntgroups if someone answers."
+msgstr ""
+"'Sí' evita de forma incondicional la generación de llamadas perdidas. 'No' "
+"evita las llamadas perdidas solo para grupos de salto RingAll si alguien contesta."
 
 msgid "When Outbound Proxy is used, SIP Proxy must not include a port."
 msgstr "Cuando se emplea Proxy de salida, el Proxy SIP no debe incluir puerto."

--- a/portals/application/modules/rest/controllers/HuntGroupsController.php
+++ b/portals/application/modules/rest/controllers/HuntGroupsController.php
@@ -43,7 +43,8 @@ class Rest_HuntGroupsController extends Iron_Controller_Rest_BaseController
      *     'noAnswerTargetType': '', 
      *     'noAnswerNumberValue': '', 
      *     'noAnswerExtensionId': '', 
-     *     'noAnswerVoiceMailUserId': ''
+     *     'noAnswerVoiceMailUserId': '', 
+     *     'preventMissedCalls': ''
      * },{
      *     'id': '', 
      *     'name': '', 
@@ -56,7 +57,8 @@ class Rest_HuntGroupsController extends Iron_Controller_Rest_BaseController
      *     'noAnswerTargetType': '', 
      *     'noAnswerNumberValue': '', 
      *     'noAnswerExtensionId': '', 
-     *     'noAnswerVoiceMailUserId': ''
+     *     'noAnswerVoiceMailUserId': '', 
+     *     'preventMissedCalls': ''
      * }]")
      */
     public function indexAction()
@@ -86,6 +88,7 @@ class Rest_HuntGroupsController extends Iron_Controller_Rest_BaseController
                 'noAnswerNumberValue',
                 'noAnswerExtensionId',
                 'noAnswerVoiceMailUserId',
+                'preventMissedCalls',
             );
         }
 
@@ -170,7 +173,8 @@ class Rest_HuntGroupsController extends Iron_Controller_Rest_BaseController
      *     'noAnswerTargetType': '', 
      *     'noAnswerNumberValue': '', 
      *     'noAnswerExtensionId': '', 
-     *     'noAnswerVoiceMailUserId': ''
+     *     'noAnswerVoiceMailUserId': '', 
+     *     'preventMissedCalls': ''
      * }")
      */
     public function getAction()
@@ -199,6 +203,7 @@ class Rest_HuntGroupsController extends Iron_Controller_Rest_BaseController
                 'noAnswerNumberValue',
                 'noAnswerExtensionId',
                 'noAnswerVoiceMailUserId',
+                'preventMissedCalls',
             );
         }
 
@@ -250,6 +255,7 @@ class Rest_HuntGroupsController extends Iron_Controller_Rest_BaseController
      * @ApiParams(name="noAnswerNumberValue", nullable=true, type="varchar", sample="", description="")
      * @ApiParams(name="noAnswerExtensionId", nullable=true, type="int", sample="", description="")
      * @ApiParams(name="noAnswerVoiceMailUserId", nullable=true, type="int", sample="", description="")
+     * @ApiParams(name="preventMissedCalls", nullable=false, type="int", sample="", description="")
      * @ApiReturnHeaders(sample="HTTP 201")
      * @ApiReturnHeaders(sample="Location: /rest/huntgroups/{id}")
      * @ApiReturn(type="object", sample="{}")
@@ -296,6 +302,7 @@ class Rest_HuntGroupsController extends Iron_Controller_Rest_BaseController
      * @ApiParams(name="noAnswerNumberValue", nullable=true, type="varchar", sample="", description="")
      * @ApiParams(name="noAnswerExtensionId", nullable=true, type="int", sample="", description="")
      * @ApiParams(name="noAnswerVoiceMailUserId", nullable=true, type="int", sample="", description="")
+     * @ApiParams(name="preventMissedCalls", nullable=false, type="int", sample="", description="")
      * @ApiReturnHeaders(sample="HTTP 200")
      * @ApiReturn(type="object", sample="{}")
      */
@@ -445,6 +452,11 @@ class Rest_HuntGroupsController extends Iron_Controller_Rest_BaseController
                     'required' => false,
                     'comment' => '',
                 ),
+                'preventMissedCalls' => array(
+                    'type' => "int",
+                    'required' => true,
+                    'comment' => '',
+                ),
             )
         );
 
@@ -509,6 +521,11 @@ class Rest_HuntGroupsController extends Iron_Controller_Rest_BaseController
                 'noAnswerVoiceMailUserId' => array(
                     'type' => "int",
                     'required' => false,
+                    'comment' => '',
+                ),
+                'preventMissedCalls' => array(
+                    'type' => "int",
+                    'required' => true,
                     'comment' => '',
                 ),
             )

--- a/scheme/deltas/080-ringall-missed-calls.sql
+++ b/scheme/deltas/080-ringall-missed-calls.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `HuntGroups` ADD `preventMissedCalls` int(10) unsigned NOT NULL DEFAULT '1';
+UPDATE `HuntGroups` SET preventMissedCalls = 0 WHERE strategy != 'ringAll';


### PR DESCRIPTION
**RingAll huntgroups:** Add a selector to avoid generating missed calls for ringall huntgroups (current behaviour) or to generate them only when no member answers (new behaviour).

**Remaining huntgroups:** Add selector to avoid generating missed calls (new behaviour).

This PR fixes #393 