### PR TITLE
Retail account voicemail

### DIFF
--- a/asterisk/agi/library/Agi/Action/CallForwardRetailAction.php
+++ b/asterisk/agi/library/Agi/Action/CallForwardRetailAction.php
@@ -76,4 +76,13 @@ class CallForwardRetailAction extends RouterAction
             ->setDestination($this->_routeExternal)
             ->process();
     }
+
+    protected function _routeToVoiceMail()
+    {
+        // Handle voicemail route
+        $voicemailAction = new VoiceMailAction($this);
+        $voicemailAction
+            ->processRetailVoicemail();
+    }
+
 }

--- a/asterisk/agi/library/Agi/Action/VoiceMailAction.php
+++ b/asterisk/agi/library/Agi/Action/VoiceMailAction.php
@@ -2,6 +2,8 @@
 
 namespace Agi\Action;
 
+use IvozProvider\Model\RetailAccounts;
+
 class VoiceMailAction extends RouterAction
 {
     protected $_voicemail;
@@ -59,5 +61,19 @@ class VoiceMailAction extends RouterAction
             $this->agi->busy();
         }
     }
+
+    public function processRetailVoicemail()
+    {
+        /** @var RetailAccounts $retail */
+        $retail = $this->agi->getChannelCaller();
+
+        // Update CallerIdName to preferred format
+        $preferred = $retail->E164ToPreferred($this->agi->getOrigCallerIdNum());
+        $this->agi->setCallerIdNum($preferred);
+
+        // Run Voicemail Application
+        $this->agi->voicemail($retail->getVoiceMail(), "");
+    }
+
 
 }

--- a/library/IvozProvider/Mapper/Sql/Companies.php
+++ b/library/IvozProvider/Mapper/Sql/Companies.php
@@ -95,7 +95,8 @@ class Companies extends Raw\Companies
             $this->_updateDomains($model);
         }
 
-        if ($isNew) {
+        // Only Create Domain Attributes and Services for VPBX
+        if ($isNew && $model->getType() == $model::VPBX) {
             $this->_createDomainAttrs($model);
             $this->_propagateServices($model);
         }
@@ -112,11 +113,6 @@ class Companies extends Raw\Companies
 
     protected function _createDomainAttrs($model)
     {
-        // Only Create Domain Attributes if company has domain
-        if ($model->getType() !== $model::VPBX) {
-            return;
-        }
-
         $domainAttr = new \IvozProvider\Model\KamUsersDomainAttrs();
 
         $domainAttr->setDid($model->getDomainUsers())

--- a/library/IvozProvider/Mapper/Sql/DbTable/AstVoicemail.php
+++ b/library/IvozProvider/Mapper/Sql/DbTable/AstVoicemail.php
@@ -44,6 +44,11 @@ class AstVoicemail extends TableAbstract
             'columns' => 'userId',
             'refTableClass' => 'IvozProvider\\Mapper\\Sql\\DbTable\\Users',
             'refColumns' => 'id'
+        ),
+        'AstVoicemailIbfk2' => array(
+            'columns' => 'retailAccountId',
+            'refTableClass' => 'IvozProvider\\Mapper\\Sql\\DbTable\\RetailAccounts',
+            'refColumns' => 'id'
         )
     );
     
@@ -632,6 +637,23 @@ class AstVoicemail extends TableAbstract
 	    'TABLE_NAME' => 'ast_voicemail',
 	    'COLUMN_NAME' => 'userId',
 	    'COLUMN_POSITION' => 35,
+	    'DATA_TYPE' => 'int',
+	    'DEFAULT' => NULL,
+	    'NULLABLE' => true,
+	    'LENGTH' => NULL,
+	    'SCALE' => NULL,
+	    'PRECISION' => NULL,
+	    'UNSIGNED' => true,
+	    'PRIMARY' => false,
+	    'PRIMARY_POSITION' => NULL,
+	    'IDENTITY' => false,
+	  ),
+	  'retailAccountId' => 
+	  array (
+	    'SCHEMA_NAME' => NULL,
+	    'TABLE_NAME' => 'ast_voicemail',
+	    'COLUMN_NAME' => 'retailAccountId',
+	    'COLUMN_POSITION' => 36,
 	    'DATA_TYPE' => 'int',
 	    'DEFAULT' => NULL,
 	    'NULLABLE' => true,

--- a/library/IvozProvider/Mapper/Sql/DbTable/RetailAccounts.php
+++ b/library/IvozProvider/Mapper/Sql/DbTable/RetailAccounts.php
@@ -69,7 +69,8 @@ class RetailAccounts extends TableAbstract
     protected $_dependentTables = array(
         'IvozProvider\\Mapper\\Sql\\DbTable\\CallForwardSettings',
         'IvozProvider\\Mapper\\Sql\\DbTable\\DDIs',
-        'IvozProvider\\Mapper\\Sql\\DbTable\\AstPsEndpoints'
+        'IvozProvider\\Mapper\\Sql\\DbTable\\AstPsEndpoints',
+        'IvozProvider\\Mapper\\Sql\\DbTable\\AstVoicemail'
     );
     protected $_metadata = array (
 	  'id' => 

--- a/library/IvozProvider/Mapper/Sql/Raw/AstVoicemail.php
+++ b/library/IvozProvider/Mapper/Sql/Raw/AstVoicemail.php
@@ -83,6 +83,7 @@ class AstVoicemail extends MapperAbstract
                 'imapflags' => $model->getImapflags(),
                 'stamp' => $model->getStamp(),
                 'userId' => $model->getUserId(),
+                'retailAccountId' => $model->getRetailAccountId(),
             );
         } else {
             $result = array();
@@ -611,7 +612,8 @@ class AstVoicemail extends MapperAbstract
                   ->setImapport($data['imapport'])
                   ->setImapflags($data['imapflags'])
                   ->setStamp($data['stamp'])
-                  ->setUserId($data['userId']);
+                  ->setUserId($data['userId'])
+                  ->setRetailAccountId($data['retailAccountId']);
         } else if ($data instanceof \Zend_Db_Table_Row_Abstract || $data instanceof \stdClass) {
             $entry->setUniqueid($data->{'uniqueid'})
                   ->setContext($data->{'context'})
@@ -647,7 +649,8 @@ class AstVoicemail extends MapperAbstract
                   ->setImapport($data->{'imapport'})
                   ->setImapflags($data->{'imapflags'})
                   ->setStamp($data->{'stamp'})
-                  ->setUserId($data->{'userId'});
+                  ->setUserId($data->{'userId'})
+                  ->setRetailAccountId($data->{'retailAccountId'});
 
         } else if ($data instanceof \IvozProvider\Model\Raw\AstVoicemail) {
             $entry->setUniqueid($data->getUniqueid())
@@ -684,7 +687,8 @@ class AstVoicemail extends MapperAbstract
                   ->setImapport($data->getImapport())
                   ->setImapflags($data->getImapflags())
                   ->setStamp($data->getStamp())
-                  ->setUserId($data->getUserId());
+                  ->setUserId($data->getUserId())
+                  ->setRetailAccountId($data->getRetailAccountId());
 
         }
 

--- a/library/IvozProvider/Mapper/Sql/Raw/RetailAccounts.php
+++ b/library/IvozProvider/Mapper/Sql/Raw/RetailAccounts.php
@@ -508,6 +508,20 @@ class RetailAccounts extends MapperAbstract
                     }
                 }
 
+                if ($model->getAstVoicemail(null, null, true) !== null) {
+                    $astVoicemail = $model->getAstVoicemail();
+
+                    if (!is_array($astVoicemail)) {
+
+                        $astVoicemail = array($astVoicemail);
+                    }
+
+                    foreach ($astVoicemail as $value) {
+                        $value->setRetailAccountId($primaryKey)
+                              ->saveRecursive(false, $transactionTag);
+                    }
+                }
+
             }
 
             if ($success === true) {

--- a/library/IvozProvider/Model/Brands.php
+++ b/library/IvozProvider/Model/Brands.php
@@ -126,4 +126,18 @@ class Brands extends Raw\Brands
 
         return $features;
     }
+
+    public function getVoicemailService()
+    {
+        /** @var BrandServices[] $brandServices */
+        $brandServices = $this->getBrandServices();
+
+        foreach ($brandServices as $brandService) {
+            if ($brandService->getService()->getIden() == 'Voicemail') {
+                return $brandService;
+            }
+        }
+
+        return null;
+    }
 }

--- a/library/IvozProvider/Model/Raw/AstVoicemail.php
+++ b/library/IvozProvider/Model/Raw/AstVoicemail.php
@@ -308,6 +308,13 @@ class AstVoicemail extends ModelAbstract
      */
     protected $_userId;
 
+    /**
+     * Database var type int
+     *
+     * @var int
+     */
+    protected $_retailAccountId;
+
 
     /**
      * Parent relation ast_voicemail_ibfk_1
@@ -315,6 +322,13 @@ class AstVoicemail extends ModelAbstract
      * @var \IvozProvider\Model\Raw\Users
      */
     protected $_User;
+
+    /**
+     * Parent relation ast_voicemail_ibfk_2
+     *
+     * @var \IvozProvider\Model\Raw\RetailAccounts
+     */
+    protected $_RetailAccount;
 
 
     protected $_columnsList = array(
@@ -353,6 +367,7 @@ class AstVoicemail extends ModelAbstract
         'imapflags'=>'imapflags',
         'stamp'=>'stamp',
         'userId'=>'userId',
+        'retailAccountId'=>'retailAccountId',
     );
 
     /**
@@ -372,6 +387,10 @@ class AstVoicemail extends ModelAbstract
             'AstVoicemailIbfk1'=> array(
                     'property' => 'User',
                     'table_name' => 'Users',
+                ),
+            'AstVoicemailIbfk2'=> array(
+                    'property' => 'RetailAccount',
+                    'table_name' => 'RetailAccounts',
                 ),
         ));
 
@@ -1664,6 +1683,40 @@ class AstVoicemail extends ModelAbstract
     }
 
     /**
+     * Sets column Stored in ISO 8601 format.     *
+     * @param int $data
+     * @return \IvozProvider\Model\Raw\AstVoicemail
+     */
+    public function setRetailAccountId($data)
+    {
+
+        if ($this->_retailAccountId != $data) {
+            $this->_logChange('retailAccountId', $this->_retailAccountId, $data);
+        }
+
+        if ($data instanceof \Zend_Db_Expr) {
+            $this->_retailAccountId = $data;
+
+        } else if (!is_null($data)) {
+            $this->_retailAccountId = (int) $data;
+
+        } else {
+            $this->_retailAccountId = $data;
+        }
+        return $this;
+    }
+
+    /**
+     * Gets column retailAccountId
+     *
+     * @return int
+     */
+    public function getRetailAccountId()
+    {
+        return $this->_retailAccountId;
+    }
+
+    /**
      * Sets parent relation User
      *
      * @param \IvozProvider\Model\Raw\Users $data
@@ -1712,6 +1765,57 @@ class AstVoicemail extends ModelAbstract
         }
 
         return $this->_User;
+    }
+
+    /**
+     * Sets parent relation RetailAccount
+     *
+     * @param \IvozProvider\Model\Raw\RetailAccounts $data
+     * @return \IvozProvider\Model\Raw\AstVoicemail
+     */
+    public function setRetailAccount(\IvozProvider\Model\Raw\RetailAccounts $data)
+    {
+        $this->_RetailAccount = $data;
+
+        $primaryKey = $data->getPrimaryKey();
+        if (is_array($primaryKey)) {
+            $primaryKey = $primaryKey['id'];
+        }
+
+        if (!is_null($primaryKey)) {
+            $this->setRetailAccountId($primaryKey);
+        }
+
+        $this->_setLoaded('AstVoicemailIbfk2');
+        return $this;
+    }
+
+    /**
+     * Gets parent RetailAccount
+     * TODO: Mejorar esto para los casos en que la relación no exista. Ahora mismo siempre se pediría el padre
+     * @return \IvozProvider\Model\Raw\RetailAccounts
+     */
+    public function getRetailAccount($where = null, $orderBy = null, $avoidLoading = false)
+    {
+        $fkName = 'AstVoicemailIbfk2';
+
+        $usingDefaultArguments = is_null($where) && is_null($orderBy);
+        if (!$usingDefaultArguments) {
+            $this->setNotLoaded($fkName);
+        }
+
+        $dontSkipLoading = !($avoidLoading);
+        $notLoadedYet = !($this->_isLoaded($fkName));
+
+        if ($dontSkipLoading && $notLoadedYet) {
+            $related = $this->getMapper()->loadRelated('parent', $fkName, $this, $where, $orderBy);
+            $this->_RetailAccount = array_shift($related);
+            if ($usingDefaultArguments) {
+                $this->_setLoaded($fkName);
+            }
+        }
+
+        return $this->_RetailAccount;
     }
 
     /**

--- a/library/IvozProvider/Model/Raw/RetailAccounts.php
+++ b/library/IvozProvider/Model/Raw/RetailAccounts.php
@@ -268,6 +268,14 @@ class RetailAccounts extends ModelAbstract
      */
     protected $_AstPsEndpoints;
 
+    /**
+     * Dependent relation ast_voicemail_ibfk_2
+     * Type: One-to-Many relationship
+     *
+     * @var \IvozProvider\Model\Raw\AstVoicemail[]
+     */
+    protected $_AstVoicemail;
+
     protected $_columnsList = array(
         'id'=>'id',
         'brandId'=>'brandId',
@@ -346,6 +354,10 @@ class RetailAccounts extends ModelAbstract
             'AstPsEndpointsIbfk3' => array(
                     'property' => 'AstPsEndpoints',
                     'table_name' => 'ast_ps_endpoints',
+                ),
+            'AstVoicemailIbfk2' => array(
+                    'property' => 'AstVoicemail',
+                    'table_name' => 'ast_voicemail',
                 ),
         ));
 
@@ -1701,6 +1713,96 @@ class RetailAccounts extends ModelAbstract
         }
 
         return $this->_AstPsEndpoints;
+    }
+
+    /**
+     * Sets dependent relations ast_voicemail_ibfk_2
+     *
+     * @param array $data An array of \IvozProvider\Model\Raw\AstVoicemail
+     * @return \IvozProvider\Model\Raw\RetailAccounts
+     */
+    public function setAstVoicemail(array $data, $deleteOrphans = false)
+    {
+        if ($deleteOrphans === true) {
+
+            if ($this->_AstVoicemail === null) {
+
+                $this->getAstVoicemail();
+            }
+
+            $oldRelations = $this->_AstVoicemail;
+
+            if (is_array($oldRelations)) {
+
+                $dataPKs = array();
+
+                foreach ($data as $newItem) {
+
+                    $pk = $newItem->getPrimaryKey();
+                    if (!empty($pk)) {
+                        $dataPKs[] = $pk;
+                    }
+                }
+
+                foreach ($oldRelations as $oldItem) {
+
+                    if (!in_array($oldItem->getPrimaryKey(), $dataPKs)) {
+
+                        $this->_orphans[] = $oldItem;
+                    }
+                }
+            }
+        }
+
+        $this->_AstVoicemail = array();
+
+        foreach ($data as $object) {
+            $this->addAstVoicemail($object);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Sets dependent relations ast_voicemail_ibfk_2
+     *
+     * @param \IvozProvider\Model\Raw\AstVoicemail $data
+     * @return \IvozProvider\Model\Raw\RetailAccounts
+     */
+    public function addAstVoicemail(\IvozProvider\Model\Raw\AstVoicemail $data)
+    {
+        $this->_AstVoicemail[] = $data;
+        $this->_setLoaded('AstVoicemailIbfk2');
+        return $this;
+    }
+
+    /**
+     * Gets dependent ast_voicemail_ibfk_2
+     *
+     * @param string or array $where
+     * @param string or array $orderBy
+     * @param boolean $avoidLoading skip data loading if it is not already
+     * @return array The array of \IvozProvider\Model\Raw\AstVoicemail
+     */
+    public function getAstVoicemail($where = null, $orderBy = null, $avoidLoading = false)
+    {
+        $fkName = 'AstVoicemailIbfk2';
+
+        $usingDefaultArguments = is_null($where) && is_null($orderBy);
+        if (!$usingDefaultArguments) {
+            $this->setNotLoaded($fkName);
+        }
+
+        $dontSkipLoading = !($avoidLoading);
+        $notLoadedYet = !($this->_isLoaded($fkName));
+
+        if ($dontSkipLoading && $notLoadedYet) {
+            $related = $this->getMapper()->loadRelated('dependent', $fkName, $this, $where, $orderBy);
+            $this->_AstVoicemail = $related;
+            $this->_setLoaded($fkName);
+        }
+
+        return $this->_AstVoicemail;
     }
 
     /**

--- a/library/IvozProvider/Model/RetailAccounts.php
+++ b/library/IvozProvider/Model/RetailAccounts.php
@@ -189,4 +189,29 @@ class RetailAccounts extends Raw\RetailAccounts
 
         return parent::getCallForwardSettings(implode(' AND ', $conditions), $orderBy, $avoidLoading);
     }
+
+    /**
+     * @return string with the voicemail
+     */
+    public function getVoiceMail()
+    {
+        return $this->getVoiceMailUser() . '@' . $this->getVoiceMailContext();
+    }
+
+    /**
+     * @return string with the voicemail retail
+     */
+    public function getVoiceMailUser()
+    {
+        return "retail" . $this->getId();
+    }
+
+    /**
+     * @return string with the voicemail context
+     */
+    public function getVoiceMailContext()
+    {
+        return 'company' . $this->getCompany()->getId();
+    }
+
 }

--- a/portals/application/configs/klear/CallForwardSettingsList.yaml
+++ b/portals/application/configs/klear/CallForwardSettingsList.yaml
@@ -53,6 +53,7 @@ production:
           targetTypeValue: true
           userId: true
           retailAccountId: true
+          voiceMailUserId: ${auth.companyRetail}
         order:
           <<: *callForwardSettingsOrder_Link
       fixedPositions: &callForwardSettingsFixedPositions_Link
@@ -82,6 +83,7 @@ production:
           targetTypeValue: true
           userId: true
           retailAccountId: true
+          voiceMailUserId: ${auth.companyRetail}
         order:
           <<: *callForwardSettingsOrder_Link
       fixedPositions:

--- a/portals/application/modules/rest/controllers/AstVoicemailController.php
+++ b/portals/application/modules/rest/controllers/AstVoicemailController.php
@@ -66,7 +66,8 @@ class Rest_AstVoicemailController extends Iron_Controller_Rest_BaseController
      *     'imapport': '', 
      *     'imapflags': '', 
      *     'stamp': '', 
-     *     'userId': ''
+     *     'userId': '', 
+     *     'retailAccountId': ''
      * },{
      *     'uniqueid': '', 
      *     'context': '', 
@@ -102,7 +103,8 @@ class Rest_AstVoicemailController extends Iron_Controller_Rest_BaseController
      *     'imapport': '', 
      *     'imapflags': '', 
      *     'stamp': '', 
-     *     'userId': ''
+     *     'userId': '', 
+     *     'retailAccountId': ''
      * }]")
      */
     public function indexAction()
@@ -155,6 +157,7 @@ class Rest_AstVoicemailController extends Iron_Controller_Rest_BaseController
                 'imapflags',
                 'stamp',
                 'userId',
+                'retailAccountId',
             );
         }
 
@@ -262,7 +265,8 @@ class Rest_AstVoicemailController extends Iron_Controller_Rest_BaseController
      *     'imapport': '', 
      *     'imapflags': '', 
      *     'stamp': '', 
-     *     'userId': ''
+     *     'userId': '', 
+     *     'retailAccountId': ''
      * }")
      */
     public function getAction()
@@ -314,6 +318,7 @@ class Rest_AstVoicemailController extends Iron_Controller_Rest_BaseController
                 'imapflags',
                 'stamp',
                 'userId',
+                'retailAccountId',
             );
         }
 
@@ -388,6 +393,7 @@ class Rest_AstVoicemailController extends Iron_Controller_Rest_BaseController
      * @ApiParams(name="imapflags", nullable=true, type="varchar", sample="", description="")
      * @ApiParams(name="stamp", nullable=true, type="datetime", sample="", description="")
      * @ApiParams(name="userId", nullable=true, type="int", sample="", description="")
+     * @ApiParams(name="retailAccountId", nullable=true, type="int", sample="", description="")
      * @ApiReturnHeaders(sample="HTTP 201")
      * @ApiReturnHeaders(sample="Location: /rest/astvoicemail/{uniqueid}")
      * @ApiReturn(type="object", sample="{}")
@@ -457,6 +463,7 @@ class Rest_AstVoicemailController extends Iron_Controller_Rest_BaseController
      * @ApiParams(name="imapflags", nullable=true, type="varchar", sample="", description="")
      * @ApiParams(name="stamp", nullable=true, type="datetime", sample="", description="")
      * @ApiParams(name="userId", nullable=true, type="int", sample="", description="")
+     * @ApiParams(name="retailAccountId", nullable=true, type="int", sample="", description="")
      * @ApiReturnHeaders(sample="HTTP 200")
      * @ApiReturn(type="object", sample="{}")
      */
@@ -721,6 +728,11 @@ class Rest_AstVoicemailController extends Iron_Controller_Rest_BaseController
                     'required' => false,
                     'comment' => '',
                 ),
+                'retailAccountId' => array(
+                    'type' => "int",
+                    'required' => false,
+                    'comment' => '',
+                ),
             )
         );
 
@@ -898,6 +910,11 @@ class Rest_AstVoicemailController extends Iron_Controller_Rest_BaseController
                     'comment' => '',
                 ),
                 'userId' => array(
+                    'type' => "int",
+                    'required' => false,
+                    'comment' => '',
+                ),
+                'retailAccountId' => array(
                     'type' => "int",
                     'required' => false,
                     'comment' => '',

--- a/scheme/deltas/082-retailaccount-voicemail.sql
+++ b/scheme/deltas/082-retailaccount-voicemail.sql
@@ -1,0 +1,11 @@
+-- Delete Company services for Retail
+DELETE FROM CompanyServices WHERE companyId IN (SELECT id FROM Companies WHERE type = 'retail');
+
+-- Add retail to voicemail table
+ALTER TABLE `ast_voicemail` ADD `retailAccountId` int(10) unsigned DEFAULT NULL AFTER `userId`;
+ALTER TABLE `ast_voicemail` ADD FOREIGN KEY (`retailAccountId`) REFERENCES `RetailAccounts` (`id`) ON DELETE CASCADE;
+
+-- Create voicemail for existing Retail Accounts
+INSERT INTO ast_voicemail (context, mailbox, tz, retailAccountId) SELECT CONCAT('company', R.companyId), CONCAT('retail', R.id), T.tz, R.id FROM RetailAccounts AS R INNER JOIN Companies AS C ON R.companyId = C.id INNER JOIN Timezones AS T ON T.id = C.defaultTimezoneId;
+
+


### PR DESCRIPTION
Add support for Call Forward Settings route to Voicemail.
All retail accounts will have a voicemail by default that can checked using the Voicemail brand's service code.

This PR fixes #395
