### PR TITLE
Fix voicemail-user-extension logic

### DIFF
--- a/asterisk/agi/src/Agi/Action/VoiceMailAction.php
+++ b/asterisk/agi/src/Agi/Action/VoiceMailAction.php
@@ -74,8 +74,6 @@ class VoiceMailAction
                     $this->agi->verbose("Playing custom user Voicemail Locution.");
                     $this->agi->playback($voicemail->getVoiceMailLocution());
                     $vmopts .= "s";     // Skip welcome message
-                } else {
-                    $vmopts .= "u";     // Play unavailable message
                 }
             } else {
                 $vmopts .= "s";         // Skip welcome message

--- a/library/Ivoz/Provider/Domain/Model/User/User.php
+++ b/library/Ivoz/Provider/Domain/Model/User/User.php
@@ -176,15 +176,7 @@ class User extends UserAbstract implements UserInterface, AdvancedUserInterface,
      */
     public function getVoiceMail()
     {
-        if (!is_null($this->getVoiceMailUser())) {
-
-            return sprintf("%s@%s",
-                $this->getVoiceMailUser(),
-                $this->getVoiceMailContext()
-            );
-        }
-
-        return '';
+        return $this->getVoiceMailUser() . '@' . $this->getVoiceMailContext();
     }
 
     /**
@@ -192,7 +184,7 @@ class User extends UserAbstract implements UserInterface, AdvancedUserInterface,
      */
     public function getVoiceMailUser()
     {
-        return $this->getExtensionNumber();
+        return "user" . $this->getId();
     }
 
     /**


### PR DESCRIPTION
Voicemail are now related to users, not to user's extension.

This is equivalent to #407 done in Oasis.

It assumes that you come from 1.7 (where existing voicemails are already fixed) or you have no voicemail yet. Otherwise you must apply 50396bf2fffef30c0059398702895975633f8c71 and 9662c7deb4ba43a5abadc709e56dfaeebe0a9e4c manually (read [1.7 upgrade guide](https://github.com/irontec/ivozprovider/blob/oasis/doc/UPGRADE-1.7.md) for further information).