### PR TITLE
agis: only check after call dial status when there are call forwards

### DIFF
--- a/library/Ivoz/Api/Core/Security/DataAccessControlParser.php
+++ b/library/Ivoz/Api/Core/Security/DataAccessControlParser.php
@@ -241,7 +241,7 @@ class DataAccessControlParser
                     $subCriteria[] = current($parsedValue);
                 }
 
-                $arrayCriteria[] =  [0, $key, $subCriteria];
+                $arrayCriteria[$key] =  $subCriteria;
                 continue;
             }
 

--- a/library/Ivoz/Core/Infrastructure/Persistence/Doctrine/Model/Helper/CriteriaHelper.php
+++ b/library/Ivoz/Core/Infrastructure/Persistence/Doctrine/Model/Helper/CriteriaHelper.php
@@ -51,25 +51,28 @@ class CriteriaHelper implements  CriteriaHelperInterface
     private static function arrayToExpressions(array $conditions)
     {
         $expressions = [];
-        foreach ($conditions as $comparison) {
-            list($field, $operator) = $comparison;
-            $value = $comparison[2] ?? null;
+        foreach ($conditions as $key => $comparison) {
 
-            switch ($operator) {
+            if (!in_array($key, ['or', 'and'], true)) {
+                list($field, $operator) = $comparison;
+                $value = $comparison[2] ?? null;
+
+                $expressions[] = self::createExpression($field, $operator, $value);
+                continue;
+            }
+
+            switch ($key) {
                 case 'or':
-                    $subExpressions = self::arrayToExpressions($value);
+                    $subExpressions = self::arrayToExpressions($comparison);
                     $expressions[] = Criteria::expr()->orX(
                         ...$subExpressions
                     );
                     break;
                 case 'and':
-                    $subExpressions = self::arrayToExpressions($value);
+                    $subExpressions = self::arrayToExpressions($comparison);
                     $expressions[] = Criteria::expr()->andX(
                         ...$subExpressions
                     );
-                    break;
-                default:
-                    $expressions[] = self::createExpression($field, $operator, $value);
                     break;
             }
         }


### PR DESCRIPTION
The `g` flag of dials that enables the UserStatus checking is only required if there are Call Forward settings that apply after the call. 

This logic can still improve by checking If found call forwards are enabled (when #400 is moved to artemis). I have left the code to check enabled status commented.


