### PR TITLE
Add enable/disable toggle to user call forward settings

### DIFF
--- a/asterisk/agi/src/Agi/Action/UserCallAction.php
+++ b/asterisk/agi/src/Agi/Action/UserCallAction.php
@@ -3,7 +3,6 @@
 namespace Agi\Action;
 
 use Agi\Wrapper;
-use Doctrine\Common\Collections\Criteria;
 use Ivoz\Core\Infrastructure\Persistence\Doctrine\Model\Helper\CriteriaHelper;
 use Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSettingInterface;
 use Ivoz\Provider\Domain\Model\User\UserInterface;
@@ -191,19 +190,16 @@ class UserCallAction
     {
         $timeout = null;
 
-        // Process inconditional Call Forwards
-        $criteria = new Criteria();
-        $criteria->where(
-            Criteria::expr()->eq(
-                'callForwardType',
-                'noAnswer'
-            )
-        );
+        // Get active NoAnswer call forwards
+        $criteria = [
+            array('callForwardType', 'eq', 'noAnswer'),
+            array('enabled', 'eq', '1'),
+        ];
 
         /**
          * @var CallForwardSettingInterface[] $cfwSettings
          */
-        $cfwSettings = $this->user->getCallForwardSettings($criteria);
+        $cfwSettings = $this->user->getCallForwardSettings(CriteriaHelper::fromArray($criteria));
 
         foreach ($cfwSettings as $cfwSetting) {
             $cfwType = $cfwSetting->getCallTypeFilter();
@@ -237,7 +233,7 @@ class UserCallAction
                 array('callTypeFilter', 'eq', 'both'),
                 array('callTypeFilter', 'eq', $callType),
             ),
-            // array('enabled', 'eq', '1'),     // TODO pending #400 migration to artemis
+            array('enabled', 'eq', '1')
         ];
 
         /** @var CallForwardSettingInterface[] $cfwSettings */

--- a/asterisk/agi/src/Agi/Action/UserStatusAction.php
+++ b/asterisk/agi/src/Agi/Action/UserStatusAction.php
@@ -3,7 +3,7 @@
 namespace Agi\Action;
 
 use Agi\Wrapper;
-use Doctrine\Common\Collections\Criteria;
+use Ivoz\Core\Infrastructure\Persistence\Doctrine\Model\Helper\CriteriaHelper;
 use Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSettingInterface;
 use Ivoz\Provider\Domain\Model\User\UserInterface;
 
@@ -114,19 +114,16 @@ class UserStatusAction
      */
     private function processCallForward($type)
     {
-        // Process inconditional Call Forwards
-        $criteria = new Criteria();
-        $criteria->where(
-            Criteria::expr()->eq(
-                'callForwardType',
-                $type
-            )
-        );
+        // Get active call forwards
+        $criteria = [
+            array('callForwardType', 'eq', $type),
+            array('enabled', 'eq', '1'),
+        ];
 
         /**
          * @var CallForwardSettingInterface[] $cfwSettings
          */
-        $cfwSettings = $this->user->getCallForwardSettings($criteria);
+        $cfwSettings = $this->user->getCallForwardSettings(CriteriaHelper::fromArray($criteria));
 
         // Process busy Call Forwards
         foreach ($cfwSettings as $cfwSetting) {

--- a/library/Ivoz/Provider/Domain/Model/CallForwardSetting/CallForwardSettingAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/CallForwardSetting/CallForwardSettingAbstract.php
@@ -42,6 +42,11 @@ abstract class CallForwardSettingAbstract
     protected $noAnswerTimeout = '10';
 
     /**
+     * @var boolean
+     */
+    protected $enabled = '1';
+
+    /**
      * @var \Ivoz\Provider\Domain\Model\User\UserInterface
      */
     protected $user;
@@ -71,12 +76,14 @@ abstract class CallForwardSettingAbstract
         $callTypeFilter,
         $callForwardType,
         $targetType,
-        $noAnswerTimeout
+        $noAnswerTimeout,
+        $enabled
     ) {
         $this->setCallTypeFilter($callTypeFilter);
         $this->setCallForwardType($callForwardType);
         $this->setTargetType($targetType);
         $this->setNoAnswerTimeout($noAnswerTimeout);
+        $this->setEnabled($enabled);
     }
 
     abstract public function getId();
@@ -146,7 +153,8 @@ abstract class CallForwardSettingAbstract
             $dto->getCallTypeFilter(),
             $dto->getCallForwardType(),
             $dto->getTargetType(),
-            $dto->getNoAnswerTimeout());
+            $dto->getNoAnswerTimeout(),
+            $dto->getEnabled());
 
         $self
             ->setNumberValue($dto->getNumberValue())
@@ -179,6 +187,7 @@ abstract class CallForwardSettingAbstract
             ->setTargetType($dto->getTargetType())
             ->setNumberValue($dto->getNumberValue())
             ->setNoAnswerTimeout($dto->getNoAnswerTimeout())
+            ->setEnabled($dto->getEnabled())
             ->setUser($dto->getUser())
             ->setExtension($dto->getExtension())
             ->setVoiceMailUser($dto->getVoiceMailUser())
@@ -202,6 +211,7 @@ abstract class CallForwardSettingAbstract
             ->setTargetType(self::getTargetType())
             ->setNumberValue(self::getNumberValue())
             ->setNoAnswerTimeout(self::getNoAnswerTimeout())
+            ->setEnabled(self::getEnabled())
             ->setUser(\Ivoz\Provider\Domain\Model\User\User::entityToDto(self::getUser(), $depth))
             ->setExtension(\Ivoz\Provider\Domain\Model\Extension\Extension::entityToDto(self::getExtension(), $depth))
             ->setVoiceMailUser(\Ivoz\Provider\Domain\Model\User\User::entityToDto(self::getVoiceMailUser(), $depth))
@@ -219,6 +229,7 @@ abstract class CallForwardSettingAbstract
             'targetType' => self::getTargetType(),
             'numberValue' => self::getNumberValue(),
             'noAnswerTimeout' => self::getNoAnswerTimeout(),
+            'enabled' => self::getEnabled(),
             'userId' => self::getUser() ? self::getUser()->getId() : null,
             'extensionId' => self::getExtension() ? self::getExtension()->getId() : null,
             'voiceMailUserId' => self::getVoiceMailUser() ? self::getVoiceMailUser()->getId() : null,
@@ -379,6 +390,33 @@ abstract class CallForwardSettingAbstract
     public function getNoAnswerTimeout()
     {
         return $this->noAnswerTimeout;
+    }
+
+    /**
+     * Set enabled
+     *
+     * @param boolean $enabled
+     *
+     * @return self
+     */
+    public function setEnabled($enabled)
+    {
+        Assertion::notNull($enabled, 'enabled value "%s" is null, but non null value was expected.');
+        Assertion::between(intval($enabled), 0, 1, 'enabled provided "%s" is not a valid boolean value.');
+
+        $this->enabled = $enabled;
+
+        return $this;
+    }
+
+    /**
+     * Get enabled
+     *
+     * @return boolean
+     */
+    public function getEnabled()
+    {
+        return $this->enabled;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/CallForwardSetting/CallForwardSettingDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/CallForwardSetting/CallForwardSettingDtoAbstract.php
@@ -38,6 +38,11 @@ abstract class CallForwardSettingDtoAbstract implements DataTransferObjectInterf
     private $noAnswerTimeout = '10';
 
     /**
+     * @var boolean
+     */
+    private $enabled = '1';
+
+    /**
      * @var integer
      */
     private $id;
@@ -85,6 +90,7 @@ abstract class CallForwardSettingDtoAbstract implements DataTransferObjectInterf
             'targetType' => 'targetType',
             'numberValue' => 'numberValue',
             'noAnswerTimeout' => 'noAnswerTimeout',
+            'enabled' => 'enabled',
             'id' => 'id',
             'userId' => 'user',
             'extensionId' => 'extension',
@@ -104,6 +110,7 @@ abstract class CallForwardSettingDtoAbstract implements DataTransferObjectInterf
             'targetType' => $this->getTargetType(),
             'numberValue' => $this->getNumberValue(),
             'noAnswerTimeout' => $this->getNoAnswerTimeout(),
+            'enabled' => $this->getEnabled(),
             'id' => $this->getId(),
             'user' => $this->getUser(),
             'extension' => $this->getExtension(),
@@ -229,6 +236,26 @@ abstract class CallForwardSettingDtoAbstract implements DataTransferObjectInterf
     public function getNoAnswerTimeout()
     {
         return $this->noAnswerTimeout;
+    }
+
+    /**
+     * @param boolean $enabled
+     *
+     * @return static
+     */
+    public function setEnabled($enabled = null)
+    {
+        $this->enabled = $enabled;
+
+        return $this;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getEnabled()
+    {
+        return $this->enabled;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/CallForwardSetting/CallForwardSettingInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/CallForwardSetting/CallForwardSettingInterface.php
@@ -105,6 +105,22 @@ interface CallForwardSettingInterface extends LoggableEntityInterface
     public function getNoAnswerTimeout();
 
     /**
+     * Set enabled
+     *
+     * @param boolean $enabled
+     *
+     * @return self
+     */
+    public function setEnabled($enabled);
+
+    /**
+     * Get enabled
+     *
+     * @return boolean
+     */
+    public function getEnabled();
+
+    /**
      * Set user
      *
      * @param \Ivoz\Provider\Domain\Model\User\UserInterface $user

--- a/library/Ivoz/Provider/Domain/Service/CallForwardSetting/CheckUniqueness.php
+++ b/library/Ivoz/Provider/Domain/Service/CallForwardSetting/CheckUniqueness.php
@@ -6,6 +6,7 @@ use Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSettingInterface;
 use Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSettingRepository;
 use Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSetting;
 use Doctrine\Common\Collections\Criteria;
+use Ivoz\Core\Infrastructure\Persistence\Doctrine\Model\Helper\CriteriaHelper;
 
 /**
  * Class CheckValidity
@@ -208,45 +209,20 @@ class CheckUniqueness implements CallForwardSettingLifecycleEventHandlerInterfac
      */
     protected function createConditions(CallForwardSetting $entity, $callTypeFilterConditions, $callForwardType = null)
     {
-        $criteria = Criteria::create();
-        $expressionBuilder = Criteria::expr();
 
-        $criteria
-            ->where(
-                $expressionBuilder->neq(
-                    'id',
-                    $entity->getId()
-                )
-            )
-            ->andWhere(
-                $expressionBuilder->eq(
-                    'user',
-                    $entity->getUser()
-                )
-            )
-            ->andWhere(
-                $expressionBuilder->in(
-                    'callTypeFilter',
-                    $callTypeFilterConditions
-                )
-            )
-            ->andWhere(
-                $expressionBuilder->eq(
-                    'enabled',
-                    1
-                )
-            );
+        $criteria = [
+            ['id', 'neq', $entity->getId()],
+            ['user', 'eq', $entity->getUser()],
+            ['callTypeFilter', 'in', $callTypeFilterConditions],
+            ['enabled', 'eq', 1]
+        ];
 
         if ($callForwardType) {
-            $criteria
-                ->andWhere(
-                    $expressionBuilder->eq(
-                        'callForwardType',
-                        $callForwardType
-                    )
-                );
+            $criteria[] = [
+                'callForwardType', 'eq', $callForwardType
+            ];
         }
 
-        return $criteria;
+        return CriteriaHelper::fromArray($criteria);
     }
 }

--- a/library/Ivoz/Provider/Domain/Service/CallForwardSetting/CheckUniqueness.php
+++ b/library/Ivoz/Provider/Domain/Service/CallForwardSetting/CheckUniqueness.php
@@ -35,6 +35,11 @@ class CheckUniqueness implements CallForwardSettingLifecycleEventHandlerInterfac
      */
     public function execute(CallForwardSettingInterface $entity, $isNew)
     {
+        // Skip checks for disabled call forward setting
+        if ($entity->getEnabled() == 0) {
+            return;
+        }
+
         $callTypeFilterConditions = array(
             $entity->getCallTypeFilter()
         );
@@ -223,6 +228,12 @@ class CheckUniqueness implements CallForwardSettingLifecycleEventHandlerInterfac
                 $expressionBuilder->in(
                     'callTypeFilter',
                     $callTypeFilterConditions
+                )
+            )
+            ->andWhere(
+                $expressionBuilder->eq(
+                    'enabled',
+                    1
                 )
             );
 

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/CallForwardSetting.CallForwardSettingAbstract.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/CallForwardSetting.CallForwardSettingAbstract.orm.yml
@@ -1,11 +1,5 @@
 Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSettingAbstract:
   type: mappedSuperclass
-  uniqueConstraints:
-    callFwTypeUser:
-      columns:
-        - callForwardType
-        - userId
-        - callTypeFilter
   fields:
     callTypeFilter:
       type: string
@@ -45,6 +39,12 @@ Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSettingAbstract:
         unsigned: false
         default: '10'
       column: noAnswerTimeout
+    enabled:
+      type: boolean
+      nullable: false
+      options:
+        default: '1'
+        unsigned: true
   manyToOne:
     user:
       targetEntity: \Ivoz\Provider\Domain\Model\User\UserInterface

--- a/library/spec/Ivoz/Provider/Domain/Service/CallForwardSetting/CheckUniquenessSpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Service/CallForwardSetting/CheckUniquenessSpec.php
@@ -48,31 +48,6 @@ class CheckUniquenessSpec extends ObjectBehavior
             ->willReturn($this->user);
     }
 
-    protected function getCallForwardTypeArgumentFilter($expectedCallForwardType)
-    {
-        return function ($criteria) use ($expectedCallForwardType) {
-            $whereConditions = $criteria
-                ->getWhereExpression()
-                ->getExpressionList();
-
-            $callForwardTypeCondition = end($whereConditions);
-            $type = $callForwardTypeCondition
-                ->getValue()
-                ->getValue();
-
-            return $type === $expectedCallForwardType;
-        };
-    }
-
-    protected function getCriteriaArgument($expectedCallForwardType)
-    {
-        return Argument::that(
-            $this->getCallForwardTypeArgumentFilter(
-                $expectedCallForwardType
-            )
-        );
-    }
-
     function it_is_initializable()
     {
         $this->shouldHaveType(CheckUniqueness::class);
@@ -88,11 +63,26 @@ class CheckUniquenessSpec extends ObjectBehavior
             ->willReturn(new ArrayCollection(['Something']));
 
         $message = "There is an inconditional call forward with that call type. You can't add call forwards";
-        $exception = new \Exception($message, 30000);
+        $exception = new \DomainException($message, 30000);
 
         $this
             ->shouldThrow($exception)
             ->during('execute', [$this->entity, false]);
+    }
+
+    function it_doesnt_run_checks_on_disabled_call_forward(CallForwardSetting $entity)
+    {
+        $entity
+            ->getEnabled()
+            ->willReturn(0);
+
+        $entity
+            ->getCallTypeFilter()
+            ->shouldNotBeCalled();
+
+        $this
+            ->shouldNotThrow(\DomainException::class)
+            ->during('execute', [$entity, false]);
     }
 
     function it_throws_exception_on_already_existing_busy_call_forward()
@@ -117,7 +107,7 @@ class CheckUniquenessSpec extends ObjectBehavior
             ->willReturn(new ArrayCollection(['Something']));
 
         $message = "There is already a busy call forward with that call type.";
-        $exception = new \Exception($message, 30002);
+        $exception = new \DomainException($message, 30002);
 
         $this
             ->shouldThrow($exception)
@@ -146,7 +136,7 @@ class CheckUniquenessSpec extends ObjectBehavior
             ->willReturn(new ArrayCollection(['Something']));
 
         $message = "There is already a noAnswer call forward with that call type.";
-        $exception = new \Exception($message, 30003);
+        $exception = new \DomainException($message, 30003);
 
         $this
             ->shouldThrow($exception)
@@ -182,10 +172,39 @@ class CheckUniquenessSpec extends ObjectBehavior
             ->willReturn(new ArrayCollection(['Something']));
 
         $message = "There is already a userNotRegistered call forward with that call type.";
-        $exception = new \Exception($message, 30004);
+        $exception = new \DomainException($message, 30004);
 
         $this
             ->shouldThrow($exception)
             ->during('execute', [$this->entity, false]);
+    }
+
+    ////////////////////////////////////////////////////////
+    ///
+    ////////////////////////////////////////////////////////
+
+    protected function getCallForwardTypeArgumentFilter($expectedCallForwardType)
+    {
+        return function ($criteria) use ($expectedCallForwardType) {
+            $whereConditions = $criteria
+                ->getWhereExpression()
+                ->getExpressionList();
+
+            $callForwardTypeCondition = end($whereConditions);
+            $type = $callForwardTypeCondition
+                ->getValue()
+                ->getValue();
+
+            return $type === $expectedCallForwardType;
+        };
+    }
+
+    protected function getCriteriaArgument($expectedCallForwardType)
+    {
+        return Argument::that(
+            $this->getCallForwardTypeArgumentFilter(
+                $expectedCallForwardType
+            )
+        );
     }
 }

--- a/library/spec/Ivoz/Provider/Domain/Service/CallForwardSetting/CheckUniquenessSpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Service/CallForwardSetting/CheckUniquenessSpec.php
@@ -39,6 +39,11 @@ class CheckUniquenessSpec extends ObjectBehavior
 
         $this
             ->entity
+            ->getEnabled()
+            ->willReturn(1);
+
+        $this
+            ->entity
             ->getUser()
             ->willReturn($this->user);
     }

--- a/scheme/app/DoctrineMigrations/Version20180328102026.php
+++ b/scheme/app/DoctrineMigrations/Version20180328102026.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20180328102026 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP INDEX callFwTypeUser ON CallForwardSettings');
+        $this->addSql('ALTER TABLE CallForwardSettings ADD enabled TINYINT(1) unsigned DEFAULT \'1\' NOT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE CallForwardSettings DROP enabled');
+        $this->addSql('CREATE UNIQUE INDEX callFwTypeUser ON CallForwardSettings (callForwardType, userId, callTypeFilter)');
+    }
+}

--- a/web/admin/application/configs/klear/CallForwardSettingsList.yaml
+++ b/web/admin/application/configs/klear/CallForwardSettingsList.yaml
@@ -15,6 +15,7 @@ production:
       title: _("List of %s %2s", ngettext('Call forward setting', 'Call forward settings', 0), "[format| (%parent%)]")
       fields:
         order:
+          enabled: true
           callTypeFilter: true
           callForwardType: true
           targetType: true
@@ -52,10 +53,14 @@ production:
       fields:
         blacklist:
           targetTypeValue: true
+        order: &callForwardSettingsOrder_Link
+          enabled: true
+          targetType: true
       fixedPositions: &callForwardSettingsFixedPositions_Link
         group0:
-          colsPerRow: 3
+          colsPerRow: 4
           fields:
+            enabled: 1
             callTypeFilter: 1
             callForwardType: 1
             noAnswerTimeout: 1
@@ -75,8 +80,9 @@ production:
       title: _("Edit %s %2s", ngettext('Call forward setting', 'Call forward settings', 1), "[format| (%item%)]")
       fields:
         blacklist:
-          extensionId: true
           targetTypeValue: true
+        order:
+          <<: *callForwardSettingsOrder_Link
       fixedPositions:
         <<: *callForwardSettingsFixedPositions_Link
 

--- a/web/admin/application/configs/klear/UsersList.yaml
+++ b/web/admin/application/configs/klear/UsersList.yaml
@@ -233,9 +233,6 @@ production:
     callForwardSettingsEdit_screen:
       <<: *callForwardSettingsEdit_screenLink
       filterField: User
-      fields:
-        blacklist:
-          targetTypeValue: true
 
   dialogs: &users_dialogsLink
     usersDel_dialog: &usersDel_dialogLink

--- a/web/admin/application/configs/klear/model/CallForwardSettings.yaml
+++ b/web/admin/application/configs/klear/model/CallForwardSettings.yaml
@@ -138,6 +138,17 @@ production:
       source:
         class: IvozProvider_Klear_Ghost_RouteTarget
         method: getTarget
+    enabled:
+      title: _('Enabled')
+      type: select
+      defaultValue: 1
+      source:
+        data: inline
+        values:
+          '0':
+            title: _("No")
+          '1':
+            title: _("Yes")
 
 staging:
   _extends: production

--- a/web/admin/application/languages/en_US/en_US.po
+++ b/web/admin/application/languages/en_US/en_US.po
@@ -626,6 +626,9 @@ msgstr ""
 "number of outgoing calls to avoid toll-fraud. 'None' value makes outgoing "
 "calls unlimited as long as company IP policy is fulfilled."
 
+msgid "Enabled"
+msgstr "Enabled"
+
 msgid "End time"
 msgstr "End time"
 

--- a/web/admin/application/languages/es_ES/es_ES.po
+++ b/web/admin/application/languages/es_ES/es_ES.po
@@ -638,6 +638,9 @@ msgstr ""
 "número ilimitado de llamadas siempre y cuando se cumpla la política de "
 "restricción de IPs de la empresa."
 
+msgid "Enabled"
+msgstr "Activado"
+
 msgid "End time"
 msgstr "Fecha fin"
 

--- a/web/rest/features/provider/callForwardSetting/getCallForwardSetting.feature
+++ b/web/rest/features/provider/callForwardSetting/getCallForwardSetting.feature
@@ -56,6 +56,7 @@ Feature: Retrieve callForwardSetting
           "targetType": "number",
           "numberValue": "946002053",
           "noAnswerTimeout": 10,
+          "enabled": true,
           "id": 1,
           "user": {
               "name": "Alice",

--- a/web/rest/features/provider/callForwardSetting/postCallForwardSetting.feature
+++ b/web/rest/features/provider/callForwardSetting/postCallForwardSetting.feature
@@ -50,6 +50,7 @@ Feature: Create application servers
           "targetType": "number",
           "numberValue": "946002020",
           "noAnswerTimeout": 0,
+          "enabled": true,
           "id": 5,
           "user": {
               "name": "Bob",

--- a/web/rest/features/provider/callForwardSetting/putCallForwardSetting.feature
+++ b/web/rest/features/provider/callForwardSetting/putCallForwardSetting.feature
@@ -16,6 +16,7 @@ Feature: Update application servers
         "targetType": "number",
         "numberValue": "946002021",
         "noAnswerTimeout": 0,
+        "enabled": true,
         "user": 1,
         "extension": null,
         "voiceMailUser": null,
@@ -33,6 +34,7 @@ Feature: Update application servers
           "targetType": "number",
           "numberValue": "946002021",
           "noAnswerTimeout": 0,
+          "enabled": true,
           "id": 1,
           "user": {
               "name": "Alice",

--- a/web/user/app/languages/locale-es.json
+++ b/web/user/app/languages/locale-es.json
@@ -57,6 +57,7 @@
     "exportToCsv": "Exportar a .CSV",
     "clear": "Limpiar",
     "search": "Buscar",
+    "enabled": "Habilitado",
     "NuevoDesvio": "Nuevo Desvio",
     "inconditional": "Incondicional",
     "noAnswer": "Sin Respuesta",

--- a/web/user/app/modules/detours/detoursEditCtrl.js
+++ b/web/user/app/modules/detours/detoursEditCtrl.js
@@ -45,6 +45,7 @@ angular
                 {headers: {accept: 'application/json'}}
             ).then(function(detour) {
                 $scope.detour = detour.data;
+                detour.data.enabled = '' + detour.data.enabled;
                 $scope.formDisabled = false;
                 $scope.loading = false;
                 ngProgress.complete();

--- a/web/user/app/views/detours/edit.html
+++ b/web/user/app/views/detours/edit.html
@@ -37,7 +37,28 @@
             <div class="col-md-12" style="margin-bottom: 20px; margin-top: 20px;">
 
                 <div class="col-md-12">
+                    <div class="form-group col-md-12">
 
+                        <label
+                                for="enabled"
+                                class="col-sm-4 control-label"
+                                translate="enabled"
+                        ></label>
+
+                        <div class="col-sm-8">
+                            <select
+                                    class="form-control"
+                                    id="enabled"
+                                    name="enabled"
+                                    ng-model="detour.enabled"
+                                    required="required"
+                            >
+                                <option value="0" translate="no"></option>
+                                <option value="1" translate="yes"></option>
+                            </select>
+                        </div>
+
+                    </div>
                     <div class="form-group col-md-12">
 
                         <label

--- a/web/user/app/views/detours/new.html
+++ b/web/user/app/views/detours/new.html
@@ -64,6 +64,27 @@
                     <div class="form-group col-md-12">
 
                         <label
+                                for="enabled"
+                                class="col-sm-4 control-label"
+                                translate="enabled"
+                        ></label>
+
+                        <div class="col-sm-8">
+                            <select
+                                    class="form-control"
+                                    id="enabled"
+                                    name="enabled"
+                                    ng-model="detour.enabled"
+                                    required="required"
+                            >
+                                <option value="0" translate="no"></option>
+                                <option value="1" translate="yes"></option>
+                            </select>
+                        </div>
+                    </div>
+
+                    <div class="form-group col-md-12">
+                        <label
                                 for="callForwardType"
                                 class="col-sm-4 control-label"
                                 translate="callForwardType"

--- a/web/user/app/views/detours/table-detours.html
+++ b/web/user/app/views/detours/table-detours.html
@@ -1,6 +1,7 @@
 <table class="table table-striped table-calls">
     <thead>
         <tr>
+           <th translate="enabled"></th>
            <th translate="callTypeFilter"></th>
            <th translate="callForwardType"></th>
            <th translate="targetType"></th>
@@ -12,6 +13,11 @@
     <tbody>
         <tr ng-repeat="detour in callsFS">
         
+          <td data-th="{{'enabled' | translate}}">
+              <span ng-show="detour.enabled">{{'yes' | translate}}</span>
+              <span ng-show="!detour.enabled">{{'no' | translate}}</span>
+
+          </td>
           <td data-th="{{'callTypeFilter' | translate}}">{{detour.callTypeFilter | translate}}</td>
           <td data-th="{{'callForwardType' | translate}}">{{detour.callForwardType | translate}}</td>
           <td data-th="{{'targetType' | translate}}">{{detour.targetType | translate}}</td>


### PR DESCRIPTION
Add to both user portal and company portal a toggle to enable/disable defined user call forward.

This way, instead of creating/deleting a call forward that you use a lot, you can simply disable/enable it.