### PR TITLE
agis: Make mail template configurable by brand

### DIFF
--- a/asterisk/agi/application/controllers/VoicemailController.php
+++ b/asterisk/agi/application/controllers/VoicemailController.php
@@ -97,9 +97,13 @@ class VoicemailController extends Zend_Controller_Action
                 '${VM_DATE}'        => $vmdata[self::VM_DATE],
             );
 
-            $templateDir = APPLICATION_PATH . "/../templates/voicemail/$template/" . $user->getLanguageCode() . "/";
-            $body = file_get_contents($templateDir . "body");
-            $subject = file_get_contents($templateDir . "subject");
+            $templateDir = APPLICATION_PATH . "/../templates/voicemail/brand" . $brand->getId() . "/" . $user->getLanguageCode();
+            if (!is_dir($templateDir)) {
+                $templateDir = APPLICATION_PATH . "/../templates/voicemail/$template/" . $user->getLanguageCode();
+            }
+
+            $body = file_get_contents($templateDir . "/body");
+            $subject = file_get_contents($templateDir . "/subject");
 
             foreach ($substitution as $search => $replace) {
                 $body = str_replace($search, $replace, $body);

--- a/asterisk/agi/library/Agi/Action/FaxCallAction.php
+++ b/asterisk/agi/library/Agi/Action/FaxCallAction.php
@@ -161,10 +161,13 @@ class FaxCallAction extends RouterAction
                     '${FAX_PAGES}'      => $faxIn->getPages(),
             );
 
-            $templateDir = APPLICATION_PATH . "/../templates/faxmail/$template/" . $company->getLanguageCode() . "/";
+            $templateDir = APPLICATION_PATH . "/../templates/faxmail/brand" . $company->getBrandId() . "/" . $company->getLanguageCode();
+            if (!is_dir($templateDir)) {
+                $templateDir = APPLICATION_PATH . "/../templates/faxmail/$template/" . $company->getLanguageCode();
+            }
 
-            $body = file_get_contents($templateDir . "body");
-            $subject = file_get_contents($templateDir . "subject");
+            $body = file_get_contents($templateDir . "/body");
+            $subject = file_get_contents($templateDir . "/subject");
 
             foreach ($substitution as $search => $replace) {
                 $body = str_replace($search, $replace, $body);


### PR DESCRIPTION
No UI changes, but if directory 'brandX' exists, those templates will be used
instead of default ones.

Valid for faxes and voicemail mails.