### PR TITLE
web/user: Fix terminal registration info

### DIFF
--- a/web/rest/src/Controller/My/StatusAction.php
+++ b/web/rest/src/Controller/My/StatusAction.php
@@ -49,7 +49,8 @@ class StatusAction
         $userLocation = null;
         if ($terminal) {
             $userLocation  = $this->usersLocationRepository->findOneBy([
-                'username' => $terminal->getName()
+                'username' => $terminal->getName(),
+                'domain' => $company->getDomain()->getName()
             ]);
         }
         $extension = $user->getExtension();


### PR DESCRIPTION
The logic used to obtain the terminal registration information of the user must use company domain to avoid mixing things up.