### PR TITLE
Hide Timings selector in RatingPlans list

### DIFF
--- a/library/Ivoz/Cgr/Domain/Model/TpRatingPlan/TpRatingPlanAbstract.php
+++ b/library/Ivoz/Cgr/Domain/Model/TpRatingPlan/TpRatingPlanAbstract.php
@@ -33,7 +33,7 @@ abstract class TpRatingPlanAbstract
      * column: timing_tag
      * @var string
      */
-    protected $timingTag;
+    protected $timingTag = '*any';
 
     /**
      * @var string
@@ -67,9 +67,10 @@ abstract class TpRatingPlanAbstract
     /**
      * Constructor
      */
-    protected function __construct($tpid, $weight, $createdAt)
+    protected function __construct($tpid, $timingTag, $weight, $createdAt)
     {
         $this->setTpid($tpid);
+        $this->setTimingTag($timingTag);
         $this->setWeight($weight);
         $this->setCreatedAt($createdAt);
     }
@@ -139,13 +140,13 @@ abstract class TpRatingPlanAbstract
 
         $self = new static(
             $dto->getTpid(),
+            $dto->getTimingTag(),
             $dto->getWeight(),
             $dto->getCreatedAt());
 
         $self
             ->setTag($dto->getTag())
             ->setDestratesTag($dto->getDestratesTag())
-            ->setTimingTag($dto->getTimingTag())
             ->setTiming($dto->getTiming())
             ->setRatingPlan($dto->getRatingPlan())
             ->setDestinationRate($dto->getDestinationRate())
@@ -314,11 +315,10 @@ abstract class TpRatingPlanAbstract
      *
      * @return self
      */
-    public function setTimingTag($timingTag = null)
+    public function setTimingTag($timingTag)
     {
-        if (!is_null($timingTag)) {
-            Assertion::maxLength($timingTag, 64, 'timingTag value "%s" is too long, it should have no more than %d characters, but has %d characters.');
-        }
+        Assertion::notNull($timingTag, 'timingTag value "%s" is null, but non null value was expected.');
+        Assertion::maxLength($timingTag, 64, 'timingTag value "%s" is too long, it should have no more than %d characters, but has %d characters.');
 
         $this->timingTag = $timingTag;
 
@@ -399,7 +399,7 @@ abstract class TpRatingPlanAbstract
      *
      * @return self
      */
-    public function setTiming(\Ivoz\Cgr\Domain\Model\TpTiming\TpTimingInterface $timing)
+    public function setTiming(\Ivoz\Cgr\Domain\Model\TpTiming\TpTimingInterface $timing = null)
     {
         $this->timing = $timing;
 

--- a/library/Ivoz/Cgr/Domain/Model/TpRatingPlan/TpRatingPlanDtoAbstract.php
+++ b/library/Ivoz/Cgr/Domain/Model/TpRatingPlan/TpRatingPlanDtoAbstract.php
@@ -30,7 +30,7 @@ abstract class TpRatingPlanDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $timingTag;
+    private $timingTag = '*any';
 
     /**
      * @var string

--- a/library/Ivoz/Cgr/Domain/Model/TpRatingPlan/TpRatingPlanInterface.php
+++ b/library/Ivoz/Cgr/Domain/Model/TpRatingPlan/TpRatingPlanInterface.php
@@ -61,7 +61,7 @@ interface TpRatingPlanInterface extends EntityInterface
      *
      * @return self
      */
-    public function setTimingTag($timingTag = null);
+    public function setTimingTag($timingTag);
 
     /**
      * Get timingTag
@@ -109,7 +109,7 @@ interface TpRatingPlanInterface extends EntityInterface
      *
      * @return self
      */
-    public function setTiming(\Ivoz\Cgr\Domain\Model\TpTiming\TpTimingInterface $timing);
+    public function setTiming(\Ivoz\Cgr\Domain\Model\TpTiming\TpTimingInterface $timing = null);
 
     /**
      * Get timing

--- a/library/Ivoz/Cgr/Domain/Service/TpRatingPlan/InheritRatingPlanTag.php
+++ b/library/Ivoz/Cgr/Domain/Service/TpRatingPlan/InheritRatingPlanTag.php
@@ -17,9 +17,12 @@ class InheritRatingPlanTag implements TpRatingPlanLifecycleEventHandlerInterface
             $entity->getDestinationRate()->getTag()
         );
 
-        $entity->setTimingTag(
-            $entity->getTiming()->getTag()
-        );
+        $timing = $entity->getTiming();
+        if (!is_null($timing)) {
+            $entity->setTimingTag(
+                $entity->getTiming()->getTag()
+            );
+        }
     }
 
 }

--- a/library/Ivoz/Cgr/Infrastructure/Persistence/Doctrine/Mapping/TpRatingPlan.TpRatingPlanAbstract.orm.yml
+++ b/library/Ivoz/Cgr/Infrastructure/Persistence/Doctrine/Mapping/TpRatingPlan.TpRatingPlanAbstract.orm.yml
@@ -38,10 +38,11 @@ Ivoz\Cgr\Domain\Model\TpRatingPlan\TpRatingPlanAbstract:
       column: destrates_tag
     timingTag:
       type: string
-      nullable: true
+      nullable: false
       length: 64
       options:
         fixed: false
+        default: '*any'
       column: timing_tag
     weight:
       type: decimal
@@ -90,7 +91,7 @@ Ivoz\Cgr\Domain\Model\TpRatingPlan\TpRatingPlanAbstract:
       inversedBy: null
       joinColumns:
         timingId:
-          nullable: false
+          nullable: true
           referencedColumnName: id
-          onDelete: cascade
+          onDelete: set null
       orphanRemoval: false

--- a/scheme/app/DoctrineMigrations/Version20180405103050.php
+++ b/scheme/app/DoctrineMigrations/Version20180405103050.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20180405103050 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE tp_rating_plans DROP FOREIGN KEY FK_4CC2BCAB8E5B4C15');
+        $this->addSql('ALTER TABLE tp_rating_plans CHANGE timing_tag timing_tag VARCHAR(64) DEFAULT \'*any\' NOT NULL, CHANGE timingId timingId INT UNSIGNED DEFAULT NULL');
+        $this->addSql('ALTER TABLE tp_rating_plans ADD CONSTRAINT FK_4CC2BCAB8E5B4C15 FOREIGN KEY (timingId) REFERENCES tp_timings (id) ON DELETE SET NULL');
+
+        // Set all timing_tags to '*any'
+        $this->addSql('UPDATE tp_rating_plans SET timingId=NULL,timing_tag=\'*any\'');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        // Set all timing_tags to 'ALWAYS'
+        $this->addSql('UPDATE tp_rating_plans SET timingId=1,timing_tag=\'ALWAYS\'');
+
+        $this->addSql('ALTER TABLE tp_rating_plans DROP FOREIGN KEY FK_4CC2BCAB8E5B4C15');
+        $this->addSql('ALTER TABLE tp_rating_plans CHANGE timing_tag timing_tag VARCHAR(64) DEFAULT NULL COLLATE utf8_general_ci, CHANGE timingId timingId INT UNSIGNED NOT NULL');
+        $this->addSql('ALTER TABLE tp_rating_plans ADD CONSTRAINT FK_4CC2BCAB8E5B4C15 FOREIGN KEY (timingId) REFERENCES tp_timings (id) ON DELETE CASCADE');
+    }
+}

--- a/web/admin/application/configs/klear/TpRatingPlansList.yaml
+++ b/web/admin/application/configs/klear/TpRatingPlansList.yaml
@@ -18,7 +18,7 @@ production:
           tag: true
           name: true
           description: true
-        blacklist:
+        blacklist: &tpRatingPlans_blacklistLink
           timingId: true
         options:
           title: _("Options")
@@ -42,13 +42,15 @@ production:
       multiInstance: true
       title: _("Add %s", ngettext('Rating plan', 'Rating plans', 1), "[format| (%parent%)]")
       shortcutOption: N
-      fixedPositions:
+      fields:
+        blacklist:
+          <<: *tpRatingPlans_blacklistLink
+      fixedPositions: &tpRatingPlans_fixedPositionsLink
         group1:
-          colsPerRow: 9
+          colsPerRow: 4
           fields:
             destinationRateId: 3
-            weight: 3
-            timingId: 3
+            weight: 1
 
     tpRatingPlansEdit_screen: &tpRatingPlansEdit_screenLink
       <<: *TpRatingPlans
@@ -56,13 +58,11 @@ production:
       class: ui-silk-pencil
       label: false
       title: _("Edit %s %2s", ngettext('Rating plan', 'Rating plans', 1), "[format| (%item%)]")
+      fields:
+        blacklist:
+          <<: *tpRatingPlans_blacklistLink
       fixedPositions:
-        group1:
-          colsPerRow: 9
-          fields:
-            destinationRateId: 3
-            weight: 3
-            timingId: 3
+        <<: *tpRatingPlans_fixedPositionsLink
 
   dialogs: &tpRatingPlans_dialogsLink
     tpRatingPlansDel_dialog: &tpRatingPlansDel_dialogLink


### PR DESCRIPTION
Timings selector is currently useless as it is not possible to add new timings.

This PR just hides it and makes '*any' default timing_tag for all rating plans (*any keyword behaves equal to 'ALWAYS' timing we used prior to this PR).