### PR TITLE
Implement basic wholesale client interfaces

### DIFF
--- a/library/Ivoz/Kam/Domain/Model/Trusted/Trusted.php
+++ b/library/Ivoz/Kam/Domain/Model/Trusted/Trusted.php
@@ -27,5 +27,20 @@ class Trusted extends TrustedAbstract implements TrustedInterface
     {
         return $this->id;
     }
+
+
+    /**
+     * @return void
+     * @throws \Exception
+     */
+    protected function sanitizeValues()
+    {
+        // Set tag with companyId value
+        $company = $this->getCompany();
+        if ($company) {
+            $this->setTag((string) $company->getId());
+        }
+    }
+
 }
 

--- a/library/Ivoz/Provider/Domain/Model/Company/Company.php
+++ b/library/Ivoz/Provider/Domain/Model/Company/Company.php
@@ -21,6 +21,8 @@ class Company extends CompanyAbstract implements CompanyInterface
 
     const RETAIL    = "retail";
 
+    const WHOLESALE = "wholesale";
+
     use CompanyTrait;
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/Company/CompanyAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Company/CompanyAbstract.php
@@ -14,7 +14,7 @@ use Ivoz\Core\Domain\Model\EntityInterface;
 abstract class CompanyAbstract
 {
     /**
-     * comment: enum:vpbx|retail
+     * comment: enum:vpbx|retail|wholesale
      * @var string
      */
     protected $type = 'vpbx';
@@ -457,6 +457,7 @@ abstract class CompanyAbstract
         Assertion::choice($type, array (
           0 => 'vpbx',
           1 => 'retail',
+          2 => 'wholesale',
         ), 'typevalue "%s" is not an element of the valid values: %s');
 
         $this->type = $type;

--- a/library/Ivoz/Provider/Domain/Model/Feature/Feature.php
+++ b/library/Ivoz/Provider/Domain/Model/Feature/Feature.php
@@ -13,7 +13,6 @@ class Feature extends FeatureAbstract implements FeatureInterface
      * Available features Ids
      */
     const QUEUES            = 1;
-
     const RECORDINGS        = 2;
     const FAXES             = 3;
     const FRIENDS           = 4;
@@ -22,6 +21,7 @@ class Feature extends FeatureAbstract implements FeatureInterface
     const INVOICES          = 7;
     const PROGRESS          = 8;
     const RETAIL            = 9;
+    const WHOLESALE         = 10;
 
     /**
      * @codeCoverageIgnore

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/Company.CompanyAbstract.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/Company.CompanyAbstract.orm.yml
@@ -15,7 +15,7 @@ Ivoz\Provider\Domain\Model\Company\CompanyAbstract:
       length: 25
       options:
         fixed: false
-        comment: '[enum:vpbx|retail]'
+        comment: '[enum:vpbx|retail|wholesale]'
         default: vpbx
     name:
       type: string

--- a/scheme/app/DoctrineMigrations/Version20180418161848.php
+++ b/scheme/app/DoctrineMigrations/Version20180418161848.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20180418161848 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE Companies CHANGE type type VARCHAR(25) DEFAULT \'vpbx\' NOT NULL COMMENT \'[enum:vpbx|retail|wholesale]\'');
+        $this->addSql('INSERT INTO Features (id, iden, name_en, name_es) VALUES (10, \'wholesale\', \'Wholesale Clients\', \'Clientes Wholesale\')');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DELETE FROM Features WHERE id = 10');
+        $this->addSql('ALTER TABLE Companies CHANGE type type VARCHAR(25) DEFAULT \'vpbx\' NOT NULL COLLATE utf8_general_ci COMMENT \'[enum:vpbx|retail]\'');
+    }
+}

--- a/web/admin/application/assets/js/customMenu.js
+++ b/web/admin/application/assets/js/customMenu.js
@@ -227,8 +227,10 @@
                 entity = 'Empresa';
                 if (config.getSubType() == 'vpbx') {
                     icon = 'building';
-                } else {
+                } else if (config.getSubType() == 'retail') {
                     icon = 'basket';
+                } else if (config.getSubType() == 'wholesale') {
+                    icon = 'cart';
                 }
             } else if (config.getType() == 'brand') {
                icon = 'world';

--- a/web/admin/application/configs/klear/CompaniesList.yaml
+++ b/web/admin/application/configs/klear/CompaniesList.yaml
@@ -18,7 +18,7 @@ production:
         items: 25
       <<: *Companies
       class: ui-silk-building
-      title: _("List of %s %2s", ngettext('Company', 'Companies', 0), "[format| (%parent%)]")
+      title: _("List of %s %2s", ngettext('Virtual PBX', 'Virtual PBXs', 0), "[format| (%parent%)]")
       info:
         <<: *documentationLink
         href: "/doc/${lang}/brand/companies.html"
@@ -155,7 +155,7 @@ production:
       class: ui-silk-add
       label: true
       multiInstance: true
-      title: _("Add %s", ngettext('Company', 'Companies', 1))
+      title: _("Add %s", ngettext('Virtual PBX', 'Virtual PBXs', 1))
       shortcutOption: N
       forcedValues:
         type: "vpbx"
@@ -198,7 +198,7 @@ production:
           <<: *companiesOrder_Link
       class: ui-silk-pencil
       label: false
-      title: _("Edit %s %2s", ngettext('Company', 'Companies', 1), "[format| (%item%)]")
+      title: _("Edit %s %2s", ngettext('Virtual PBX', 'Virtual PBXs', 1), "[format| (%item%)]")
       forcedValues:
         <<: *forcedBrand
       fixedPositions: &companiesFixedPositions_Link
@@ -336,9 +336,9 @@ production:
       class: ui-silk-bin
       secureDelete: true
       labelOption: false
-      title: _("Delete %s", ngettext('Company', 'Companies', 1))
-      description: _("Do you want to delete this %s?", ngettext('Company', 'Companies', 1))
-      message: _("%s successfully deleted.", ngettext('Company', 'Companies', 1))
+      title: _("Delete %s", ngettext('Virtual PBX', 'Virtual PBXs', 1))
+      description: _("Do you want to delete this %s?", ngettext('Virtual PBX', 'Virtual PBXs', 1))
+      message: _("%s successfully deleted.", ngettext('Virtual PBX', 'Virtual PBXs', 1))
       multiItem: 1
       labelOnList: 1
 
@@ -359,7 +359,7 @@ production:
     importCompanies_dialog:
       <<: *Companies
       module: default
-      title: _("Import %s", ngettext('Company', 'Companies', 0))
+      title: _("Import %s", ngettext('Virtual PBX', 'Virtual PBXs', 0))
       label: false
       labelOnEdit: true
       labelOnList: true

--- a/web/admin/application/configs/klear/KamTrunksCdrsWholesaleList.yaml
+++ b/web/admin/application/configs/klear/KamTrunksCdrsWholesaleList.yaml
@@ -1,0 +1,89 @@
+#include conf.d/mapperList.yaml
+#include conf.d/actions.yaml
+#include conf.d/documentationLink.yaml
+
+production:
+  main:
+    module: klearMatrix
+    defaultScreen: kamTrunksCdrsList_screen
+
+  screens: &kamTrunksCdrs_screensLink
+    kamTrunksCdrsList_screen: &kamTrunksCdrsList_screenLink
+      controller: list
+      csv: true
+      order:
+        field:
+          - TrunksCdr.startTime
+          - TrunksCdr.brand
+          - TrunksCdr.company
+        type: desc
+      rawCondition: "TrunksCdr.direction='outbound'"
+      pagination:
+        items: 25
+      <<: *KamTrunksCdrs
+      class: ui-silk-application-view-list
+      title: _("List of %s %2s", ngettext('Call registry', 'Call registries', 1), "[format| (%parent%)]")
+      forcedValues:
+        <<: *forcedBrand
+        <<: *forcedCompany
+      info:
+        <<: *documentationLink
+        href: "/doc/${lang}/brand/billing/billable_calls.html"
+      fields: &kamTrunksCdrs_fieldsLink
+        options:
+          title: _("Options")
+          screens:
+            kamTrunksCdrsView_screen: true
+          default: kamTrunksCdrsView_screen
+        blacklist:
+          brand: true
+          company: true
+          peeringContract: true
+          invoice: true
+        order:
+          startTime: true
+          callee: true
+          duration: true
+          price: true
+    kamTrunksCdrsView_screen: &kamTrunksCdrsView_screenLink
+      <<: *KamTrunksCdrs
+      controller: edit
+      class: ui-silk-eye
+      label: false
+      disableSave: true
+      labelOnPostAction: _("View %s %2s", ngettext('Call registry', 'Call registries', 1), "[format| (%item%)]")
+      title: _("View %s %2s", ngettext('Call registry', 'Call registries', 1), "[format| (%item%)]")
+      fields:
+        blacklist:
+          brand: true
+          company: true
+          peeringContract: true
+          invoice: true
+        order:
+          startTime: true
+          callee: true
+          duration: true
+          price: true
+      fixedPositions:
+        group0:
+          label: _("Basic Information")
+          colsPerRow: 12
+          fields:
+            callee: 6
+            startTime: 6
+            duration: 6
+        group1:
+          label: _("Billing Information")
+          colsPerRow: 12
+          fields:
+            price: 6
+            direction: 6
+
+staging:
+  _extends: production
+testing:
+  _extends: production
+development:
+  _extends: production
+localdev:
+  _extends: production

--- a/web/admin/application/configs/klear/KamTrustedList.yaml
+++ b/web/admin/application/configs/klear/KamTrustedList.yaml
@@ -13,7 +13,8 @@ production:
         items: 25
       <<: *Trusted
       class: ui-silk-text-list-bullets
-      title: _("List of %s %2s", ngettext('Trusted IP address', 'Trusted IP address(es)', 0), "[format| (%parent%)]")
+      title: _("List of %s %2s", ngettext('Trusted IP address', 'Trusted IP addresses', 0), "[format| (%parent%)]")
+      rawCondition: "Trusted.company IS NULL"
       info:
         <<: *documentationLink
         href: "/doc/${lang}/platform/antiflood.html"
@@ -42,7 +43,7 @@ production:
       class: ui-silk-add
       label: true
       multiInstance: true
-      title: _("Add %s", ngettext('Trusted IP address', 'Trusted IP address(es)', 1), "[format| (%parent%)]")
+      title: _("Add %s", ngettext('Trusted IP address', 'Trusted IP addresses', 1), "[format| (%parent%)]")
       shortcutOption: N
       fields:
         blacklist:
@@ -61,17 +62,17 @@ production:
           ruriPattern: true
           priority: true
       label: false
-      labelOnPostAction: _("Edit %s %2s", ngettext('Trusted IP address', 'Trusted IP address(es)', 1), "[format| (%item%)]")
-      title: _("Edit %s %2s", ngettext('Trusted IP address', 'Trusted IP address(es)', 1), "[format| (%item%)]")
+      labelOnPostAction: _("Edit %s %2s", ngettext('Trusted IP address', 'Trusted IP addresses', 1), "[format| (%item%)]")
+      title: _("Edit %s %2s", ngettext('Trusted IP address', 'Trusted IP addresses', 1), "[format| (%item%)]")
   dialogs: &kamTrusted_dialogsLink
     kamTrustedDel_dialog: &kamTrustedDel_dialogLink 
       <<: *Trusted
       controller: delete
       class: ui-silk-bin
       labelOption: false
-      title: _("Delete %s", ngettext('Trusted IP address', 'Trusted IP address(es)', 1))
-      description: _("Do you want to delete this %s?", ngettext('Trusted IP address', 'Trusted IP address(es)', 1))
-      message: _("%s successfully deleted.", ngettext('Trusted IP address', 'Trusted IP address(es)', 1))
+      title: _("Delete %s", ngettext('Trusted IP address', 'Trusted IP addresses', 1))
+      description: _("Do you want to delete this %s?", ngettext('Trusted IP address', 'Trusted IP addresses', 1))
+      message: _("%s successfully deleted.", ngettext('Trusted IP address', 'Trusted IP addresses', 1))
       multiItem: 1
       labelOnList: 1
 staging:

--- a/web/admin/application/configs/klear/KamUsersCdrsRetailList.yaml
+++ b/web/admin/application/configs/klear/KamUsersCdrsRetailList.yaml
@@ -1,0 +1,3 @@
+#include conf.d/mapperList.yaml
+#include conf.d/actions.yaml
+#include KamUsersCdrsList.yaml

--- a/web/admin/application/configs/klear/RetailDDIsList.yaml
+++ b/web/admin/application/configs/klear/RetailDDIsList.yaml
@@ -1,0 +1,3 @@
+#include conf.d/mapperList.yaml
+#include conf.d/actions.yaml
+#include DDIsList.yaml

--- a/web/admin/application/configs/klear/WholesaleClientsList.yaml
+++ b/web/admin/application/configs/klear/WholesaleClientsList.yaml
@@ -1,0 +1,320 @@
+#include conf.d/mapperList.yaml
+#include conf.d/actions.yaml
+#include TpRatingProfilesList.yaml
+#include AdministratorsList.yaml
+#include KamTrustedList.yaml
+
+production:
+  main:
+    module: klearMatrix
+    defaultScreen: wholesaleClientsList_screen
+  screens: &wholesaleClients_screensLink
+    wholesaleClientsList_screen: &wholesaleClientsList_screenLink
+      controller: list
+      pagination:
+        items: 25
+      <<: *WholesaleClients
+      class: ui-silk-cart
+      title: _("List of %s %2s", ngettext('Wholesale Client', 'Wholesale Clients', 0), "[format| (%parent%)]")
+      forcedValues:
+        type: 'wholesale'
+        <<: *forcedBrand
+      fields:
+        options:
+          title: _("Options")
+          screens:
+            wholesaleClientsEdit_screen: true
+            kamTrustedList_screen: true
+            administratorsList_screen: true
+            tpRatingProfilesList_screen: true
+          dialogs:
+            wholesaleClientsDel_dialog: false
+            emulateCompany_dialog: true
+          default: wholesaleClientsEdit_screen
+        blacklist:
+          typeIcon: true
+          transformationRuleSet: true
+          postalAddress: true
+          postalCode: true
+          town: true
+          province: true
+          countryName: true
+          registryData: true
+          defaultTimezone: true
+          mediaRelaySets: true
+          language: true
+        order:
+          name: true
+          nif: true
+          billingMethod: true
+          balance: true
+          maxCalls: true
+          language: true
+          transformationRuleSet: true
+          domainUsers: true
+          recordingsDiskUsage: true
+      options:
+        title: _("Options")
+        screens:
+          wholesaleClientsNew_screen: true
+        dialogs:
+          wholesaleClientsDel_dialog: true
+      csv:
+        active: false
+        filename: "WholesaleClients"
+        headers: true
+        enclosure: '"'
+        separator: ";"
+        nameklear: false
+        rawValues: true
+        ignoreBlackList: true
+        newLine: "\r\n"
+        encoding: "utf-8"
+        executionSeconds: ""
+
+    wholesaleClientsNew_screen: &wholesaleClientsNew_screenLink
+      <<: *WholesaleClients
+      controller: new
+      fields:
+        blacklist:
+          nif: true
+          type: true
+          typeIcon: true
+          postalAddress: true
+          postalCode: true
+          town: true
+          province: true
+          countryName: true
+          mediaRelaySets: true
+          maxCalls: false
+        order: &wholesaleClientsOrder_Link
+          id: true
+          name: true
+          language: true
+          maxCalls: true
+          defaultTimezone: true
+      fixedPositions: &wholesaleClientsFixedPositions_Link
+        group0:
+          colsPerRow: 6
+          label: _("Basic Configuration")
+          fields:
+            name: 3
+            billingMethod: 3
+        group1:
+          colsPerRow: 12
+          label: _("Geographic Configuration")
+          fields:
+            language: 4
+            country: 4
+            defaultTimezone: 4
+        group2:
+          colsPerRow: 2
+          label: _("Security")
+          fields:
+            maxCalls: 1
+      class: ui-silk-add
+      label: true
+      multiInstance: true
+      title: _("Add %s", ngettext('Wholesale Client', 'Wholesale Clients', 1))
+      shortcutOption: N
+      forcedValues:
+        type: "wholesale"
+        <<: *forcedBrand
+        nif: '12345678-Z'
+        postalAddress: 'Postal address'
+        postalCode: 'PC'
+        town: 'Town'
+        countryName: 'Country'
+        province: 'Province'
+
+    wholesaleClientsEdit_screen: &wholesaleClientsEdit_screenLink
+      <<: *WholesaleClients
+      controller: edit
+      fields:
+        blacklist:
+          type: true
+          typeIcon: true
+          mediaRelaySets: ${auth.isNotMainOperator}
+          nif: ${auth.brand.invoices.disabled}
+          postalAddress: ${auth.brand.invoices.disabled}
+          postalCode: ${auth.brand.invoices.disabled}
+          town: ${auth.brand.invoices.disabled}
+          province: ${auth.brand.invoices.disabled}
+          countryName: ${auth.brand.invoices.disabled}
+        whitelist:
+          id: ${auth.isMainOperator}
+        order:
+          <<: *wholesaleClientsOrder_Link
+      fixedPositions:
+        group0:
+          colsPerRow: 6
+          label: _("Basic Configuration")
+          fields:
+            name: 4
+            nif: 2
+            billingMethod: 3
+        group1:
+          colsPerRow: 12
+          label: _("Geographic Configuration")
+          fields:
+            language: 4
+            country: 4
+            defaultTimezone: 4
+            transformationRuleSet: 8
+        group2:
+          colsPerRow: 2
+          label: _("Security")
+          fields:
+            maxCalls: 1
+            ipFilter: 1
+        group3:
+          colsPerRow: 12
+          label: _("Server data")
+          fields:
+            mediaRelaySets: 4
+        group4:
+          colsPerRow: 2
+          label: _("Invoice data")
+          fields:
+            invoiceLanguage: 1
+            postalAddress: 2
+            postalCode: 1
+            town: 1
+            province: 1
+            countryName: 1
+            registryData: 2
+        group5:
+          colsPerRow: 12
+          label: ngettext('Recording', 'Recordings', 0)
+          collapsed: true
+          fields:
+            recordingsLimitMB: 6
+            recordingsDiskUsage: 6
+            recordingsLimitEmail: 6
+            onDemandRecord: 6
+            onDemandRecordCode: 6
+        group6:
+          colsPerRow: 1
+          collapsed: true
+          label: _("Externally rated options")
+          fields:
+            externallyExtraOpts: 1
+        group7:
+          colsPerRow: 2
+          collapsed: true
+          label: _("Notification options")
+          fields:
+            voicemailNotificationTemplate: 1
+            faxNotificationTemplate: 1
+      class: ui-silk-pencil
+      label: false
+      title: _("Edit %s %2s", ngettext('Wholesale Client', 'Wholesale Clients', 1), "[format| (%item%)]")
+      forcedValues:
+        <<: *forcedBrand
+
+    # Administrators screens
+    <<: *administrators_screensLink
+    administratorsList_screen:
+      <<: *administratorsList_screenLink
+      class: ui-silk-user-gray
+      title: _("List of %s %2s", ngettext('Company admin', 'Company admins', 0), "[format| (%parent%)]")
+      filterField: Company
+      parentOptionCustomizer:
+        - recordCount
+    administratorsNew_screen:
+      <<: *administratorsNew_screenLink
+      title: _("Add %s", ngettext('Company admin', 'Company admins', 1), "[format| (%parent%)]")
+      filterField: Company
+    administratorsEdit_screen:
+      <<: *administratorsEdit_screenLink
+      title: _("Edit %s %2s", ngettext('Company admin', 'Company admins', 1), "[format| (%item%)]")
+      filterField: Company
+
+    # KamTrusted Address screens
+    <<: *kamTrusted_screensLink
+    kamTrustedList_screen:
+      <<: *kamTrustedList_screenLink
+      class: ui-silk-door-in
+      title: _("List of %s %2s", ngettext('Wholesale Address', 'Wholesale Addresses', 0), "[format| (%parent%)]")
+      info:         # Disable info box @TODO
+      rawCondition: # Disable raw condtion filtering @TODO
+      filterField: Company
+      parentOptionCustomizer:
+        - recordCount
+    kamTrustedNew_screen:
+      <<: *kamTrustedNew_screenLink
+      title: _("Add %s", ngettext('Wholesale Address', 'Wholesale Addresses', 1), "[format| (%parent%)]")
+      filterField: Company
+    kamTrustedEdit_screen:
+      <<: *kamTrustedEdit_screenLink
+      title: _("Edit %s %2s", ngettext('Wholesale Address', 'Wholesale Addresses', 1), "[format| (%item%)]")
+      filterField: Company
+
+    # tpRatingPlan:
+    <<: *tpRatingProfiles_screensLink
+    tpRatingProfilesList_screen:
+      <<: *tpRatingProfilesList_screenLink
+      filterField: company
+      parentOptionCustomizer:
+        - recordCount
+    tpRatingProfilesNew_screen:
+      <<: *tpRatingProfilesNew_screenLink
+      filterField: company
+    tpRatingProfilesEdit_screen:
+      <<: *tpRatingProfilesEdit_screenLink
+      filterField: company
+
+  dialogs: &wholesaleClients_dialogsLink
+    wholesaleClientsDel_dialog: &wholesaleClientsDel_dialogLink
+      <<: *WholesaleClients
+      controller: delete
+      secureDelete: true
+      class: ui-silk-bin
+      labelOption: false
+      title: _("Delete %s", ngettext('Wholesale Client', 'Wholesale Clients', 1))
+      description: _("Do you want to delete this %s?", ngettext('Wholesale Client', 'Wholesale Clients', 1))
+      message: _("%s successfully deleted.", ngettext('Wholesale Client', 'Wholesale Clients', 1))
+      multiItem: 1
+      labelOnList: 1
+
+    emulateCompany_dialog:
+      title: _("Emulate Wholesale Client %s", "[format| (%item%)]")
+      module: default
+      controller: klear-custom-extra-auth
+      action: emulate
+      class: ui-silk-cart-add
+      label: false
+      labelOnEdit: false
+      labelOnList: false
+      labelOnEntityPostSave: false
+      multiItem: false
+      parentOptionCustomizer:
+        - IvozProvider_Klear_Options_OptionsCustomizer
+
+    # Administrators dialogs
+    <<: *administrators_dialogsLink
+    administratorsDel_dialog:
+      <<: *administratorsDel_dialogLink
+      title: _("Delete %s", ngettext('Wholesale admin', 'Wholesale admins', 1))
+      description: _("Do you want to delete this %s?", ngettext('Wholesale admin', 'Wholesale admins', 1))
+      message: _("%s successfully deleted.", ngettext('Wholesale admin', 'Wholesale admins', 1))
+
+    # KamTrusted dialogs
+    <<: *kamTrusted_dialogsLink
+    kamTrustedDel_dialog:
+      <<: *kamTrustedDel_dialogLink
+      title: _("Delete %s", ngettext('Wholesale admin', 'Wholesale admins', 1))
+      description: _("Do you want to delete this %s?", ngettext('Wholesale admin', 'Wholesale admins', 1))
+      message: _("%s successfully deleted.", ngettext('Wholesale admin', 'Wholesale admins', 1))
+
+    # tpRatingProfiles:
+    <<: *tpRatingProfiles_dialogsLink
+
+staging:
+  _extends: production
+testing:
+  _extends: production
+development:
+  _extends: production
+localdev:
+  _extends: production

--- a/web/admin/application/configs/klear/conf.d/mapperList.yaml
+++ b/web/admin/application/configs/klear/conf.d/mapperList.yaml
@@ -303,6 +303,10 @@ mappers:
         modelFile: Users,
         entity: 'Ivoz\\Provider\\Domain\\Model\\User\\User'
     }
+  - &WholesaleClients {
+        modelFile: WholesaleClients,
+        entity: 'Ivoz\\Provider\\Domain\\Model\\Company\\Company'
+    }
   - &KamTrunksCdrs {
         modelFile: KamTrunksCdrs,
         entity: 'Ivoz\\Kam\\Domain\\Model\\TrunksCdr\\TrunksCdr'

--- a/web/admin/application/configs/klear/klear.yaml
+++ b/web/admin/application/configs/klear/klear.yaml
@@ -100,18 +100,23 @@ production:
       showOnlyIf: ${auth.canSeeBrand}
       submenus:
         CompaniesList:
-          title: ngettext('Company', 'Companies', 0)
+          title: ngettext('Virtual PBX', 'Virtual PBXs', 0)
           class: ui-silk-building
-          description: _("List of %s", ngettext('Company', 'Companies', 0))
+          description: _("List of %s", ngettext('Virtual PBX', 'Virtual PBXs', 0))
         RetailClientsList:
-          title: ngettext('Retail Client', 'Retail Clients', 0)
+          title: ngettext('Retail', 'Retail', 0)
           class: ui-silk-basket
-          description: _("List of %s", ngettext('Retail Client', 'Retail Clients', 0))
+          description: _("List of %s", ngettext('Retail', 'Retail', 0))
+          showOnlyIf: ${auth.brand.retail.enabled}
+        WholesaleClientsList:
+          title: ngettext('Wholesale', 'Wholesale', 0)
+          class: ui-silk-cart
+          description: _("List of %s", ngettext('Wholesale', 'Wholesale', 0))
+          showOnlyIf: ${auth.brand.wholesale.enabled}
         CompanyBalancesList:
           title: ngettext('Prepaid Balance', 'Prepaid Balances', 0)
           class: ui-silk-money-yen
           description: _("List of %s", ngettext('Company', 'Companies', 0))
-          showOnlyIf: ${auth.brand.retail.enabled}
         CompanyBalancesList:
           title: ngettext('Prepaid Balance', 'Prepaid Balances', 0)
           class: ui-silk-money-yen
@@ -230,6 +235,12 @@ production:
           title: ngettext('DDI', 'DDIs', 0)
           class: ui-silk-lightning-go
           description: _("List of %s", ngettext('DDI', 'DDIs', 0))
+          showOnlyIf: ${auth.companyVPBX}
+        RetailDDIsList:
+          title: ngettext('DDI', 'DDIs', 0)
+          class: ui-silk-lightning-go
+          description: _("List of %s", ngettext('DDI', 'DDIs', 0))
+          showOnlyIf: ${auth.companyRetail}
         OutgoingDDIRulesList:
           title: ngettext('Outgoing DDI Rule', 'Outgoing DDI Rules', 0)
           class: ui-silk-script-lightning
@@ -330,6 +341,17 @@ production:
           title: ngettext('Call registry', 'Call registries', 1)
           class: ui-silk-application-view-list
           description: _("List of %s", ngettext('Call', 'Calls', 0))
+          showOnlyIf: ${auth.companyVPBX}
+        KamUsersCdrsRetailList:
+          title: ngettext('Call registry', 'Call registries', 1)
+          class: ui-silk-application-view-list
+          description: _("List of %s", ngettext('Call', 'Calls', 0))
+          showOnlyIf: ${auth.companyRetail}
+        KamTrunksCdrsWholesaleList:
+          title: ngettext('Call registry', 'Call registries', 1)
+          class: ui-silk-application-view-list
+          description: _("List of %s", ngettext('Call registry', 'Call registries', 1))
+          showOnlyIf: ${auth.companyWholesale}
   footerMenu:
     footer:
       title: ''

--- a/web/admin/application/configs/klear/model/WholesaleClients.yaml
+++ b/web/admin/application/configs/klear/model/WholesaleClients.yaml
@@ -1,0 +1,154 @@
+production:
+  entity: Ivoz\Provider\Domain\Model\Company\Company
+  fields:
+    id:
+      title: ngettext('Id', 'Ids', 1)
+      required: false
+      readonly: true
+    brand:
+      title: ngettext('Brand', 'Brands', 1)
+      type: select
+      required: true
+      source:
+        data: mapper
+        config:
+          entity: \Ivoz\Provider\Domain\Model\Brand\Brand
+          fieldName:
+            fields:
+              - name
+            template: '%name%'
+          order:
+            Brand.name: asc
+    name:
+      title: _('Name')
+      type: text
+      trim: both
+      required: true
+      default: true
+    nif:
+      title: _('Nif')
+      type: text
+      trim: both
+      required: true
+    defaultTimezone:
+      title: _('Default timezone')
+      type: select
+      defaultValue: 145
+      required: true
+      source:
+        data: mapper
+        config:
+          entity: \Ivoz\Provider\Domain\Model\Timezone\Timezone
+          fieldName:
+            fields:
+              - tz
+            template: '%tz%'
+          order:
+            Timezone.tz: asc
+    maxCalls:
+      title: _('Max calls')
+      type: number
+      defaultValue: 2
+      source:
+        control: Spinner
+      info:
+        type: box
+        position: left
+        icon: help
+        text: _("Limits both user generated and external received calls to this value (0 for unlimited).")
+        label: _("Need help?")
+    postalAddress:
+      title: _('Postal address')
+      type: text
+      trim: both
+      required: true
+      maxLength: 255
+    postalCode:
+      title: ngettext('Postal code', 'Postal codes', 1)
+      type: text
+      trim: both
+      required: true
+      maxLength: 10
+    town:
+      title: _('Town')
+      type: text
+      trim: both
+      required: true
+      maxLength: 255
+    province:
+      title: ngettext('Province', 'Provinces', 1)
+      type: text
+      trim: both
+      required: true
+      maxLength: 255
+    countryName:
+      title: ngettext('Country', 'Countries', 1)
+      type: text
+      trim: both
+      required: true
+      maxLength: 255
+    language:
+      title: _('Language')
+      type: select
+      defaultValue: 1
+      required: true
+      source:
+        data: mapper
+        config:
+          entity: \Ivoz\Provider\Domain\Model\Language\Language
+          fieldName:
+            fields:
+              - name${lang}
+            template: '%name${lang}%'
+          order:
+            Language.name.${lang}: asc
+    mediaRelaySets:
+      title: _('Media relay Set')
+      type: select
+      source:
+        data: mapper
+        config:
+          entity: \Ivoz\Provider\Domain\Model\MediaRelaySet\MediaRelaySet
+          fieldName:
+            fields:
+              - name
+            template: '%name%'
+          order:
+            MediaRelaySet.name: asc
+    billingMethod:
+      title: _('Billing method')
+      type: select
+      defaultValue: postpaid
+      source:
+        data: inline
+        values:
+          'postpaid':
+            title: _("Postpaid")
+          'prepaid':
+            title: _("Prepaid")
+          'pseudoprepaid':
+            title: _("Pseudo-prepaid")
+    transformationRuleSet:
+      title: ngettext('Numeric transformation', 'Numeric transformations', 1)
+      type: select
+      required: true
+      defaultValue: 70
+      source:
+        data: mapper
+        config:
+          entity: \Ivoz\Provider\Domain\Model\TransformationRuleSet\TransformationRuleSet
+          filterClass: IvozProvider_Klear_Filter_TransformationRuleSets
+          fieldName:
+            fields:
+              - name${lang}
+            template: '%name${lang}%'
+          order:
+            TransformationRuleSet.name.${lang}: asc
+staging:
+  _extends: production
+testing:
+  _extends: production
+development:
+  _extends: production
+localdev:
+  _extends: production

--- a/web/admin/application/controllers/KlearCustomExtraAuthController.php
+++ b/web/admin/application/controllers/KlearCustomExtraAuthController.php
@@ -98,10 +98,10 @@ class KlearCustomExtraAuthController extends Zend_Controller_Action
                 if ($type == 'brand') {
                     $html .= '<option value="'.$option->getId().'" '.$selected.'>'.$option->getName().'</option>';
                 } else if ($type == 'company') {
-                    if ($option->getType() == 'vpbx') {
-                        $icon = "building";
-                    } else {
-                        $icon = "basket";
+                    switch($option->getType()) {
+                        case 'vpbx': $icon = "building"; break;
+                        case 'retail': $icon = "basket"; break;
+                        case 'wholesale': $icon = "cart"; break;
                     }
                     $html .= '<option data-subtype="'.$option->getType()
                     .'" data-icon="ui-silk inline ui-silk-'.$icon
@@ -211,6 +211,7 @@ class KlearCustomExtraAuthController extends Zend_Controller_Action
                 break;
             case "RetailClientsList":
             case "CompaniesList":
+            case "WholesaleClientsList":
                 $type = "company";
                 $entity = Company::class;
                 break;

--- a/web/admin/application/languages/en_US/en_US.po
+++ b/web/admin/application/languages/en_US/en_US.po
@@ -621,6 +621,10 @@ msgstr "Emulate Company %s"
 msgid "Emulate Retail Client %s"
 msgstr "Emulate Retail Client %s"
 
+#, python-format
+msgid "Emulate Wholesale Client %s"
+msgstr "Emulate Wholesale Client %s"
+
 msgid ""
 "Enable calling from non-granted IP addresses for this user. It limits the "
 "number of outgoing calls to avoid toll-fraud. 'None' value makes outgoing "
@@ -1824,6 +1828,11 @@ msgstr "Restore last backup"
 msgid "Results"
 msgstr "Results"
 
+msgid "Retail"
+msgid_plural "Retail"
+msgstr[0] "Retail Client"
+msgstr[1] "Retail Clients"
+
 msgid "Retail Account"
 msgid_plural "Retail Accounts"
 msgstr[0] "Retail Account"
@@ -2333,6 +2342,11 @@ msgstr "View Incoming %s %s"
 msgid "View Outgoing %s %s"
 msgstr "View Outgoing %s %s"
 
+msgid "Virtual PBX"
+msgid_plural "Virtual PBXs"
+msgstr[0] ""
+msgstr[1] ""
+
 msgid "Voicemail"
 msgid_plural "Voicemails"
 msgstr[0] "Voicemail"
@@ -2386,6 +2400,26 @@ msgstr ""
 
 msgid "White Lists"
 msgstr "White Lists"
+
+msgid "Wholesale"
+msgid_plural "Wholesale"
+msgstr[0] "Wholesale"
+msgstr[1] "Wholesale"
+
+msgid "Wholesale Address"
+msgid_plural "Wholesale Addresses"
+msgstr[0] "Wholesale Address"
+msgstr[1] "Wholesale Addresses"
+
+msgid "Wholesale Client"
+msgid_plural "Wholesale Clients"
+msgstr[0] "Wholesale Client"
+msgstr[1] "Wholesale Clients"
+
+msgid "Wholesale admin"
+msgid_plural "Wholesale admins"
+msgstr[0] "Wholesale admin"
+msgstr[1] "Wholesale admins"
 
 msgid "Will be shown on page footer"
 msgstr "Will be shown on page footer"

--- a/web/admin/application/languages/es_ES/es_ES.po
+++ b/web/admin/application/languages/es_ES/es_ES.po
@@ -632,6 +632,10 @@ msgstr "Emular Compañía %s"
 msgid "Emulate Retail Client %s"
 msgstr "Emular Cliente Retail %s"
 
+#, python-format
+msgid "Emulate Wholesale Client %s"
+msgstr "Emular Cliente Wholesale %s"
+
 msgid ""
 "Enable calling from non-granted IP addresses for this user. It limits the "
 "number of outgoing calls to avoid toll-fraud. 'None' value makes outgoing "
@@ -1845,6 +1849,11 @@ msgstr "Restaurar último backup"
 msgid "Results"
 msgstr "Resultados"
 
+msgid "Retail"
+msgid_plural "Retail"
+msgstr[0] "Cliente Retail"
+msgstr[1] "Clientes Retail"
+
 msgid "Retail Account"
 msgid_plural "Retail Accounts"
 msgstr[0] "Cuenta Retail"
@@ -2359,6 +2368,11 @@ msgstr "Ver entrantes %s %s"
 msgid "View Outgoing %s %s"
 msgstr "Ver salientes %s %s"
 
+msgid "Virtual PBX"
+msgid_plural "Virtual PBXs"
+msgstr[0] "PBX Virtual"
+msgstr[1] "PBXs Virtuales"
+
 msgid "Voicemail"
 msgid_plural "Voicemails"
 msgstr[0] "Buzón de voz"
@@ -2413,6 +2427,26 @@ msgstr ""
 
 msgid "White Lists"
 msgstr "Listas blancas"
+
+msgid "Wholesale"
+msgid_plural "Wholesale"
+msgstr[0] "Wholesale"
+msgstr[1] "Wholesale"
+
+msgid "Wholesale Address"
+msgid_plural "Wholesale Addresses"
+msgstr[0] "Dirección IP wholesale"
+msgstr[1] "Direcciones IP wholesale"
+
+msgid "Wholesale Client"
+msgid_plural "Wholesale Clients"
+msgstr[0] "Cliente Wholesale"
+msgstr[1] "Clientes Wholesale"
+
+msgid "Wholesale admin"
+msgid_plural "Wholesale admins"
+msgstr[0] "Administrador Wholesale"
+msgstr[1] "Administradores Wholesale"
 
 msgid "Will be shown on page footer"
 msgstr "Se mostrará en el pie de página"
@@ -2519,4 +2553,3 @@ msgstr "compartido"
 
 msgid "unlimited"
 msgstr "ilimitado"
-

--- a/web/admin/application/library/IvozProvider/Klear/Auth/User.php
+++ b/web/admin/application/library/IvozProvider/Klear/Auth/User.php
@@ -75,6 +75,7 @@ class User extends \Klear_Model_UserAdvanced
         $this->companyType = $company->getType();
         $this->companyVPBX = $company->getType() === Company::VPBX;
         $this->companyRetail = $company->getType() === Company::RETAIL;
+        $this->companyWholesale = $company->getType() === Company::WHOLESALE;
     }
 
     public function getCompany()

--- a/web/admin/application/library/IvozProvider/Klear/Filter/Features.php
+++ b/web/admin/application/library/IvozProvider/Klear/Filter/Features.php
@@ -37,6 +37,7 @@ class IvozProvider_Klear_Filter_Features implements KlearMatrix_Model_Field_Sele
             if ($featureId == Feature::BILLING) continue;
             if ($featureId == Feature::INVOICES) continue;
             if ($featureId == Feature::RETAIL) continue;
+            if ($featureId == Feature::WHOLESALE) continue;
             $featureIds[] = $featureId;
         }
 

--- a/web/admin/application/library/IvozProvider/Klear/Filter/RetailFeatures.php
+++ b/web/admin/application/library/IvozProvider/Klear/Filter/RetailFeatures.php
@@ -40,6 +40,7 @@ class IvozProvider_Klear_Filter_RetailFeatures implements KlearMatrix_Model_Fiel
             Feature::BILLING,
             Feature::INVOICES,
             Feature::RETAIL,
+            Feature::WHOLESALE,
         );
 
         $featureIds = [];

--- a/web/admin/application/library/IvozProvider/Klear/Ghost/Companies.php
+++ b/web/admin/application/library/IvozProvider/Klear/Ghost/Companies.php
@@ -20,6 +20,8 @@ class IvozProvider_Klear_Ghost_Companies extends KlearMatrix_Model_Field_Ghost_A
                 return '<span class="ui-silk inline ui-silk-building" title="Company"></span>';
             case Company::RETAIL:
                 return '<span class="ui-silk inline ui-silk-basket" title="Retail"></span>';
+            case Company::WHOLESALE:
+                return '<span class="ui-silk inline ui-silk-cart" title="Wholesale"></span>';
             default:
                 return $model->getType();
         }


### PR DESCRIPTION
This PR adds a new Brand feature to enable Wholesale clients creation on brands, allowing access to its configuration sections in the portal.

This does not include any logic related to those screens, so the entered data won't be used until proxies logics are updated.

