### PR TITLE
Kamailio wholesale basics

### DIFF
--- a/debian/ivozprovider.postinst
+++ b/debian/ivozprovider.postinst
@@ -41,6 +41,7 @@ function setup_proxies()
 
     # Change ProxyTrunks ports if USERS_ADDRESS == TRUNKS_ADDRESS
     if [ -n "$USERS_ADDRESS" ] && [ "$USERS_ADDRESS" == "$TRUNKS_ADDRESS" ]; then
+        sed -i -e '/#!define TRUNKS_SIP_PORT/c\#!define TRUNKS_SIP_PORT 7060' /etc/kamailio/users/kamailio.cfg
         sed -i -e '/#!define SIP_PORT/c\#!define SIP_PORT 7060' /etc/kamailio/proxytrunks/kamailio.cfg
         sed -i -e '/#!define SIPS_PORT/c\#!define SIPS_PORT 7061' /etc/kamailio/proxytrunks/kamailio.cfg
         sed -i -e '/contact=sip:trunks.ivozprovider.local/c\contact=sip:trunks.ivozprovider.local:7060' /etc/asterisk/pjsip.conf

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -152,6 +152,7 @@ loadmodule    "diversion.so"
 loadmodule    "evapi.so"
 loadmodule    "json.so"
 loadmodule    "jsonrpcs.so"
+loadmodule    "ipops.so"
 
 #!ifdef WITH_ANTIFLOOD
 loadmodule    "pike.so"
@@ -319,8 +320,9 @@ modparam("dialplan", "attrs_pvar", "$avp(s:appliedrule)")
 # PERMISSIONS
 modparam("permissions", "db_url", DBURL)
 modparam("permissions", "address_table", "kam_trunks_address") # Not used
-modparam("permissions", "trusted_table", "kam_trusted") # IPs excluded from pike checking
+modparam("permissions", "trusted_table", "kam_trusted") # IPs excluded from pike checking and wholesale IPs
 modparam("permissions", "db_mode", 1)
+modparam("permissions", "peer_tag_avp", "$avp(trustedTag)")
 
 ####### Routing Logic ########
 
@@ -400,6 +402,8 @@ request_route {
         $dlg_var(bounced) = '1';
     }
 
+    # Is this a wholesale call?
+    route(DETECT_WHOLESALE);
 
     # Easy routing:
     # (a) From ASs ----> Choose GW (except bounced calls)
@@ -432,6 +436,20 @@ request_route {
             $dlg_var(peeringContractId) = $avp(peeringContractId);
             $dlg_var(bounced) = '1';
         }
+
+        # Evaluate rating logic
+        if ($avp(externallyRated) == '1') {
+            xlog("L_INFO", "[b$dlg_var(brandId)][$dlg_var(cidhash)] Externally rating is enabled for this PeeringContract, proceed");
+            route(RELAY);
+        } else {
+            route(CGRATES_AUTH_REQUEST);
+        }
+    } else if ($dlg_var(wholesaleId) != $null) {
+        if ($dlg_var(log)) xlog("L_INFO", "[b$dlg_var(brandId)][$dlg_var(cidhash)] Wholesale call, route to corresponding GW\n");
+        $dlg_var(direction) = 'outbound';
+
+        # Evaluate routing logic
+        route(LOAD_GWS);
 
         # Evaluate rating logic
         if ($avp(externallyRated) == '1') {
@@ -644,6 +662,29 @@ route[PARSE_X_HEADERS] {
         if ($dlg_var(log)) xlog("L_INFO", "[b$dlg_var(brandId)][$dlg_var(cidhash)] PARSE-X-HEADERS: '$var(header)' header found, call will be recorded\n");
         $avp(recordCall) = 'yes';
     }
+}
+
+route[DETECT_WHOLESALE] {
+    $var(header) = 'X-Info-WholesaleId';
+    route(PARSE_OPTIONAL_X_HEADER);
+    $dlg_var(wholesaleId) = $var(header-value);
+
+    if ($dlg_var(wholesaleId) == $null) return;
+
+    # Wholesale call, extract headers
+    $dlg_var(companyId) = $dlg_var(wholesaleId);
+
+    # Extract brandId
+    $var(header) = 'X-Info-BrandId';
+    route(PARSE_MANDATORY_X_HEADER);
+    $dlg_var(brandId) = $var(header-value);
+
+    # Extract billingMethod
+    $var(header) = 'X-Info-BillingMethod';
+    route(PARSE_MANDATORY_X_HEADER);
+    $dlg_var(cgrReqType) = '*' + $var(header-value);
+
+    return;
 }
 
 route[MEDIARELAY_TYPE] {
@@ -993,10 +1034,10 @@ route[RELAY] {
 route[ANTIFLOOD] {
 #!ifdef WITH_ANTIFLOOD
     # AS or myself
-    if (src_ip==myself || ds_is_from_list("1")) return;
+    if (src_ip==myself || ds_is_from_list("1") || dns_sys_match_ip("users.ivozprovider.local", "$si")) return;
 
     # Trusted sources
-    if (allow_trusted($si, 'any')) {
+    if (allow_trusted($si, 'any') && $avp(trustedTag) == $null) {
         if ($dlg_var(log)) xlog("L_INFO", "[b$dlg_var(brandId)][$dlg_var(cidhash)] ANTIFLOOD: $si is not checked against antiflood (IP added in antiflood trusted IPs)\n");
         return;
     }
@@ -1410,6 +1451,7 @@ route[GENERIC_XMLRPC_COMMAND] {
 route[RTPRELAY] {
     if (!is_method("INVITE|UPDATE|ACK|BYE|CANCEL")) return;
     if (is_method("ACK") && !has_body("application/sdp")) return;
+    if ($dlg_var(wholesaleId) != $null) return;
 
     if ($dlg_var(mediaRelayType) == 'rtpproxy') {
         route(RTPPROXY);

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -9,6 +9,7 @@
 
 ####### Defines #########
 
+#!define TRUNKS_SIP_PORT 5060
 #!define SIP_PORT 5060
 #!define SIPS_PORT 5061
 #!define XMLRPC_PORT 8000
@@ -266,10 +267,11 @@ modparam("registrar", "max_contacts", 5)
 # PERMISSIONS
 modparam("permissions", "db_url", DBURL)
 modparam("permissions", "address_table", "kam_users_address") # Allowed networks per company
-modparam("permissions", "trusted_table", "kam_trusted") # IPs excluded from pike checking
+modparam("permissions", "trusted_table", "kam_trusted") # IPs excluded from pike checking and wholesale IPs
 modparam("permissions", "db_mode", 1)
 modparam("permissions", "grp_col", "companyId")
 modparam("permissions", "max_subnets", 4096)
+modparam("permissions", "peer_tag_avp", "$avp(trustedTag)")
 
 # ACC
 # -- transactions to syslog
@@ -398,6 +400,9 @@ request_route {
     # per request initial checks
     route(REQINIT);
 
+    # Is this a wholesale call?
+    route(DETECT_WHOLESALE);
+
     route(CONFIGURE_XLOG);
 
     if ($dlg_var(log)) xlog("L_NOTICE", "[b$dlg_var(brandId)][$dlg_var(cidhash)] Request: $rm '$ru' ($cs $rm) from '$fu' ($si:$sp) [$proto]\n");
@@ -498,6 +503,14 @@ request_route {
         route(FRIENDS);
         route(RETAILS);
         route(LOOKUP);
+    } else if ($dlg_var(wholesaleId) != $null) {
+        if ($dlg_var(log)) xlog("L_INFO", "[b$dlg_var(brandId)][$dlg_var(cidhash)] Wholesale call, send to trunks\n");
+        route(MEDIARELAY_TYPE);
+        route(CONTROL_MAXCALLS);
+        route(ADAPT_RURI);
+        route(ADAPT_PAI);
+        route(ADAPT_DIVERSION);
+        $du = "sip:trunks.ivozprovider.local:" + TRUNKS_SIP_PORT;
     } else {
         # (b) Subscriber calling
         if ($dlg_var(log)) xlog("L_INFO", "[b$dlg_var(brandId)][$dlg_var(cidhash)] Local subscriber calling to my domain, dispatch to AS\n");
@@ -701,6 +714,8 @@ route[REQINIT] {
 }
 
 route[GENERATE_PUBLISH] {
+    if ($dlg_var(wholesaleId) != $null) return; # Skip logic for wholesale clients
+
     if (ds_is_from_list("1")) {
         # No PUBLISH for calls to friends/retails
         if (is_present_hf("X-Info-Friend")) return;
@@ -882,6 +897,48 @@ route[RETAILS] {
     $avp(static_location) = 'yes';
 }
 
+route[DETECT_WHOLESALE]{
+    if(has_totag()) return;
+
+    if (allow_trusted($si, 'any') && $avp(trustedTag) != $null) {
+        # Wholesale detected
+        $dlg_var(wholesaleId) = $avp(trustedTag);
+
+        # Discard unsupported methods
+        if (!is_method("INVITE|CANCEL|ACK|PRACK|OPTIONS")) { # ACK/PRACK must have totag but just in case
+            xlog("L_ERR", "$rm not supported for wholesale client '$dlg_var(wholesaleId)'\n");
+            send_reply("501", "Not Implemented");
+            exit;
+        }
+
+        # Get needed information from wholesale client
+        route(GET_INFO_FROM_WHOLESALE);
+    }
+
+    return;
+}
+
+route[GET_INFO_FROM_WHOLESALE] {
+    sql_xquery("cb", "SELECT C.brandId, C.billingMethod, C.mediaRelaySetsId, C.maxCalls AS maxCallsCompany, B.maxCalls AS maxCallsBrand, CONCAT(C.transformationRuleSetId,0) AS caller_in, CONCAT(C.transformationRuleSetId,1) AS callee_in, CONCAT(C.transformationRuleSetId,2) AS caller_out, CONCAT(C.transformationRuleSetId,3) AS callee_out FROM Companies C JOIN Brands B ON B.id=C.brandId WHERE C.id='$dlg_var(wholesaleId)'", "ra");
+
+    $dlg_var(brandId) = $xavp(ra=>brandId);
+    $dlg_var(companyId) = $dlg_var(wholesaleId);
+    $dlg_var(billingMethod) = $xavp(ra=>billingMethod);
+    $dlg_var(mediaRelaySetsId) = $xavp(ra=>mediaRelaySetsId);
+    $dlg_var(maxCallsCompany) = $xavp(ra=>maxCallsCompany);
+    $dlg_var(maxCallsBrand) = $xavp(ra=>maxCallsBrand);
+
+    # Add X-Info-Headers for trunks
+    insert_hf("X-Info-BrandId: $dlg_var(brandId)\r\n");
+    insert_hf("X-Info-WholesaleId: $dlg_var(wholesaleId)\r\n");
+    insert_hf("X-Info-BillingMethod: $dlg_var(billingMethod)\r\n");
+
+    $dlg_var(caller_in) = $xavp(ra=>caller_in);
+    $dlg_var(callee_in) = $xavp(ra=>callee_in);
+    $dlg_var(caller_out) = $xavp(ra=>caller_out);
+    $dlg_var(callee_out) = $xavp(ra=>callee_out);
+}
+
 route[GET_INFO_FROM_CALLEE] {
     # Get needed information from To header
     sql_xquery("cb", "SELECT KU.type AS calleeType, KU.objectId, KU.caller_in, KU.callee_in, KU.caller_out, KU.callee_out FROM kam_users KU LEFT JOIN Companies C ON C.id=KU.companyId LEFT JOIN ApplicationServers AppS ON AppS.id=C.applicationServerId WHERE KU.name='$tU' AND KU.domain='$td'", "ra");
@@ -899,7 +956,6 @@ route[GET_INFO_FROM_CALLEE] {
     $dlg_var(caller_out) = $xavp(ra=>caller_out);
     $dlg_var(callee_out) = $xavp(ra=>callee_out);
 }
-
 
 route[GET_INFO_FROM_CALLER] {
     # Get needed information from terminal name
@@ -1078,6 +1134,8 @@ route[AUTH] {
         # No auth for AS requests
         return;
     }
+
+    if ($dlg_var(wholesaleId) != $null) return; # No AUTH for wholesale clients
 
     if (is_method("REGISTER") || from_uri==myself) {
         # authenticate requests
@@ -1295,11 +1353,14 @@ route[RELAY] {
 route[ANTIFLOOD] {
 #!ifdef WITH_ANTIFLOOD
     # AS or myself
-    if (src_ip==myself || ds_is_from_list("1")) return;
+    if (src_ip==myself || ds_is_from_list("1") || dns_sys_match_ip("trunks.ivozprovider.local", "$si")) return;
+
+    # Wholesale client
+    if ($dlg_var(wholesaleId) != $null) return;
 
     # Trusted sources
     if (allow_trusted($si, 'any')) {
-        if ($dlg_var(log)) xlog("L_INFO", "[b$dlg_var(brandId)][$dlg_var(cidhash)] ANTIFLOOD: $si is not checked against antiflood (IP added in antiflood trusted IPs)\n");
+        if ($dlg_var(log)) xlog("L_INFO", "[b$dlg_var(brandId)][$dlg_var(cidhash)] ANTIFLOOD: $si is not checked against antiflood (IP added in kam_trusted)\n");
         return;
     }
 
@@ -1373,6 +1434,11 @@ route[NATDETECT] {
     force_rport();
 
     if (nat_uac_test("18")) {
+        if ($dlg_var(wholesaleId) != $null) {
+           if ($dlg_var(log)) xlog("L_ERR", "[b$dlg_var(brandId)][$dlg_var(cidhash)] NATDETECT: Wholesale behind NAT not supported\n");
+           send_reply("400", "Wholesale behind NAT not supported");
+           exit;
+        }
         if ($dlg_var(log)) xlog("L_INFO", "[b$dlg_var(brandId)][$dlg_var(cidhash)] NATDETECT: NAT detected\n");
         setflag(FLT_NATS);
 
@@ -1394,6 +1460,11 @@ route[NATDETECT] {
 }
 
 route[WSFIX] {
+    if ($dlg_var(wholesaleId) != $null) {
+       if ($dlg_var(log)) xlog("L_ERR", "[b$dlg_var(brandId)][$dlg_var(cidhash)] WSFIX: Wholesale using WSS\n");
+       send_reply("400", "Invalid transport");
+       exit;
+    }
     if ($dlg_var(log)) xlog("L_INFO", "[b$dlg_var(brandId)][$dlg_var(cidhash)] WSFIX: Websockets detected, fix contact\n");
     # Do NAT traversal stuff for requests from a WebSocket
     # connection - even if it is not behind a NAT!
@@ -1482,24 +1553,26 @@ route[CONFIGURE_XLOG] {
 
     # Needed variables
     if ($dlg_var(cidhash) == $null) {
-        # Set brandId
-        if (ds_is_from_list("1")) {
-            $var(domain) = $rd; # AS talking
-        } else {
-            $var(domain) = $fd; # UAC talking
-        }
+        if ($dlg_var(wholesaleId) == $null) {
+            # Set brandId
+            if (ds_is_from_list("1")) {
+                $var(domain) = $rd; # AS talking
+            } else {
+                $var(domain) = $fd; # UAC talking
+            }
 
-        if (lookup_domain("$var(domain)")) {
-            if ($avp(brandId) == $null) {
-                if ($dlg_var(log)) xlog("L_ERR", "Brand couldn't be guessed from '$var(domain)', error\n");
-                send_reply("501", "Internal Server Error");
+            if (lookup_domain("$var(domain)")) {
+                if ($avp(brandId) == $null) {
+                    if ($dlg_var(log)) xlog("L_ERR", "Brand couldn't be guessed from '$var(domain)', error\n");
+                    send_reply("501", "Internal Server Error");
+                    exit;
+                }
+                $dlg_var(brandId) = $avp(brandId);
+            } else {
+                if ($dlg_var(log)) xlog("L_ERR", "'$var(domain)' not recognized as local domain, error\n");
+                send_reply("404", "Not Here");
                 exit;
             }
-            $dlg_var(brandId) = $avp(brandId);
-        } else {
-            if ($dlg_var(log)) xlog("L_ERR", "'$var(domain)' not recognized as local domain, error\n");
-            send_reply("404", "Not Here");
-            exit;
         }
 
         # Calculate callid hash


### PR DESCRIPTION
This PR contains needed changes in both kamailio configuration files to add support for basic wholesale clients:

- Wholesale clients just make outgoing calls.

- IP authentication only (no register, no SIP auth).

- Calls go directly from users to trunks, without any application server in the middle (unique SIP dialog).

- KamUsers calls to rtpproxy/rtpengine, trunks skips this logic.

**Known limitation**: bouncing calls (calls from wholesale clients to DDIs in IvozProvider) are not supported yet.