### PR TITLE
pkg: remove unnecessary tmp dir in storage

### DIFF
--- a/debian/ivozprovider-asterisk-agi.postinst
+++ b/debian/ivozprovider-asterisk-agi.postinst
@@ -10,6 +10,11 @@ export SYMFONY_ENV=prod
 
 # Create project cache
 cd /opt/irontec/ivozprovider/asterisk/agi
+
+# Set proper var permissions
+setfacl -dR -m u:www-data:rwX -m u:root:rwX var
+setfacl  -R -m u:www-data:rwX -m u:root:rwX var
+
 bin/console cache:clear --no-warmup -q -n
 
 :

--- a/debian/ivozprovider-profile-common.dirs
+++ b/debian/ivozprovider-profile-common.dirs
@@ -1,1 +1,1 @@
-/opt/irontec/ivozprovider/storage/tmp
+/opt/irontec/ivozprovider/storage

--- a/debian/ivozprovider-recordings.postinst
+++ b/debian/ivozprovider-recordings.postinst
@@ -10,6 +10,11 @@ export SYMFONY_ENV=prod
 
 # Create project cache
 cd /opt/irontec/ivozprovider/microservices/recordings
+
+# Set proper var permissions
+setfacl -dR -m u:www-data:rwX -m u:root:rwX var
+setfacl  -R -m u:www-data:rwX -m u:root:rwX var
+
 bin/console cache:clear --no-warmup -q -n
 
 :


### PR DESCRIPTION
The tmp dir was being used for uploading files from administration portal without using FSO.
Right now there is no upload without FSO, so this is no longer required

This is a dummy change, but I want to use this PR to test CI tests :-)