### PR TITLE
include branch name in doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,20 +34,20 @@ From its beginning, IvozProvider was designed to be installed distributed betwee
    - Provides database and shared storage for the rest of machines
    - Powered by [MySQL 5.5 Server](http://www.mysql.com/)
 
-And [many others](https://irontec.github.io/ivozprovider/en/intro/what_is_inside.html) open source projects.
+And [many others](https://irontec.github.io/ivozprovider/en/artemis/basics/intro/what_is_inside.html) open source projects.
 
 Bear in mind that, while at least one of each profile must be installed for the platform to work, there can be multiple machines of each profile and all of them can also be installed in the same machine (a.k.a. standalone installation).
 
 ![scaling](web/admin/public/images/horizontalscaling.png)
 
 #### Cloud Service
-IvozProvider is designed to work directly from the Internet. Although it can be used in local environments, being exposed to the public network [has it's advantages](https://irontec.github.io/ivozprovider/en/intro/what_is_ivozprovider.html#exposed-to-the-public-network)
+IvozProvider is designed to work directly from the Internet. Although it can be used in local environments, being exposed to the public network [has it's advantages](https://irontec.github.io/ivozprovider/en/artemis/basics/intro/what_is_ivozprovider.html#exposed-to-the-public-network)
 
 ## Installation
 
-There are [several ways](https://irontec.github.io/ivozprovider/en/installation) to install IvozProvider.
+There are [several ways](https://irontec.github.io/ivozprovider/en/artemis/basics/installation) to install IvozProvider.
 
-If you want to test an [standalone](https://irontec.github.io/ivozprovider/en/installation/install_types.html#instalacion-standalone) installation, we recommend using one of auto-install CDs based on Debian Jessie 9.4 amd64.
+If you want to test an [standalone](https://irontec.github.io/ivozprovider/en/artemis/basics/installation/install_types.html#standalone-install) installation, we recommend using one of auto-install CDs based on Debian Jessie 9.4 amd64.
 
 
 | Version  | 64 bits  | 32 bits |
@@ -63,8 +63,8 @@ You can browse online documentation in different formats:
 
 | Language | HTML | LaTeX | PDF | EPUB |
 |----------|:----:|:-----:|:---:|:----:|
-| Spanish  | [![badge html](web/admin/public/images/doc-html-green.png)](https://irontec.github.io/ivozprovider/es) [![badge singlehtml](web/admin/public/images/doc-singlehtml-green.png)](https://irontec.github.io/ivozprovider/essingle) | [![badge latex](web/admin/public/images/doc-latex-ff69b4.png)](https://irontec.github.io/ivozprovider/eslatex/artemis/IvozProvider.tex) | [![badge pdf](web/admin/public/images/doc-pdf-blue.png)](https://irontec.github.io/ivozprovider/eslatex/artemis/IvozProvider.pdf) | [![badge epub](web/admin/public/images/doc-epub-orange.png)](https://irontec.github.io/ivozprovider/esepub/artemis/IvozProvider.epub) |
-| English  | [![badge html](web/admin/public/images/doc-html-green.png)](https://irontec.github.io/ivozprovider/en) [![badge singlehtml](web/admin/public/images/doc-singlehtml-green.png)](https://irontec.github.io/ivozprovider/ensingle) | [![badge latex](web/admin/public/images/doc-latex-ff69b4.png)](https://irontec.github.io/ivozprovider/enlatex/artemis/IvozProvider.tex) | [![badge pdf](web/admin/public/images/doc-pdf-blue.png)](https://irontec.github.io/ivozprovider/enlatex/artemis/IvozProvider.pdf) | [![badge epub](web/admin/public/images/doc-epub-orange.png)](https://irontec.github.io/ivozprovider/enepub/artemis/IvozProvider.epub) |
+| Spanish  | [![badge html](web/admin/public/images/doc-html-green.png)](https://irontec.github.io/ivozprovider/es/artemis) [![badge singlehtml](web/admin/public/images/doc-singlehtml-green.png)](https://irontec.github.io/ivozprovider/essingle/artemis) | [![badge latex](web/admin/public/images/doc-latex-ff69b4.png)](https://irontec.github.io/ivozprovider/eslatex/artemis/IvozProvider.tex) | [![badge pdf](web/admin/public/images/doc-pdf-blue.png)](https://irontec.github.io/ivozprovider/eslatex/artemis/IvozProvider.pdf) | [![badge epub](web/admin/public/images/doc-epub-orange.png)](https://irontec.github.io/ivozprovider/esepub/artemis/IvozProvider.epub) |
+| English  | [![badge html](web/admin/public/images/doc-html-green.png)](https://irontec.github.io/ivozprovider/en/artemis) [![badge singlehtml](web/admin/public/images/doc-singlehtml-green.png)](https://irontec.github.io/ivozprovider/ensingle/artemis) | [![badge latex](web/admin/public/images/doc-latex-ff69b4.png)](https://irontec.github.io/ivozprovider/enlatex/artemis/IvozProvider.tex) | [![badge pdf](web/admin/public/images/doc-pdf-blue.png)](https://irontec.github.io/ivozprovider/enlatex/artemis/IvozProvider.pdf) | [![badge epub](web/admin/public/images/doc-epub-orange.png)](https://irontec.github.io/ivozprovider/enepub/artemis/IvozProvider.epub) |
 
 
 ## Feedback & Questions


### PR DESCRIPTION
To partially fix #476 

There are no latex, pdf, epub for bleeding. The artemis version is used on those links and I didn't change them.