### PR TITLE
Remove route by regexp

### DIFF
--- a/library/DataFixtures/ORM/ProviderRoutingPattern.php
+++ b/library/DataFixtures/ORM/ProviderRoutingPattern.php
@@ -23,7 +23,7 @@ class ProviderRoutingPattern extends Fixture implements DependentFixtureInterfac
         $manager->getClassMetadata(RoutingPattern::class)->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_NONE);
 
         $item1 = $this->createEntityInstanceWithPublicMethods(RoutingPattern::class);
-        $item1->setRegExp("+34");
+        $item1->setPrefix("+34");
         $item1->setName(new Name('en', 'es'));
         $item1->setDescription(new Description('en', 'es'));
         $item1->setBrand($this->getReference('_reference_ProviderBrand1'));
@@ -33,7 +33,7 @@ class ProviderRoutingPattern extends Fixture implements DependentFixtureInterfac
 
 
         $item2 = $this->createEntityInstanceWithPublicMethods(RoutingPattern::class);
-        $item2->setRegExp("+35");
+        $item2->setPrefix("+35");
         $item2->setName(new Name('en', 'es'));
         $item2->setDescription(new Description('en', 'es'));
         $item2->setBrand($this->getReference('_reference_ProviderBrand1'));

--- a/library/Ivoz/Provider/Domain/Model/LcrRule/LcrRule.php
+++ b/library/Ivoz/Provider/Domain/Model/LcrRule/LcrRule.php
@@ -29,40 +29,4 @@ class LcrRule extends LcrRuleAbstract implements LcrRuleInterface
     {
         return $this->id;
     }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function setRequestUri($requestUri = null)
-    {
-        if (!empty($requestUri)) {
-            Assertion::regex($requestUri, '/^:.+@$/');
-        }
-        return parent::setRequestUri($requestUri);
-    }
-
-    public function setCondition($regexp)
-    {
-        if (is_numeric($regexp) || $regexp == 'fax') {
-            $this->setPrefix($regexp);
-            $this->setRequestUri(null);
-
-            return $this;
-        }
-
-        $ruriRegexp = $regexp;
-        if(substr($ruriRegexp, 0, 1) == '^') {
-            $ruriRegexp = ':' . substr($ruriRegexp,1);
-        }
-
-        if(substr($ruriRegexp, -1) == '$') {
-            $ruriRegexp = substr($ruriRegexp, 0, -1) . '@';
-        }
-
-        $this->setRequestUri($ruriRegexp);
-        $this->setPrefix(null);
-
-        return $this;
-    }
 }
-

--- a/library/Ivoz/Provider/Domain/Model/LcrRule/LcrRuleInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/LcrRule/LcrRuleInterface.php
@@ -13,13 +13,6 @@ interface LcrRuleInterface extends LoggableEntityInterface
     public function getChangeSet();
 
     /**
-     * {@inheritDoc}
-     */
-    public function setRequestUri($requestUri = null);
-
-    public function setCondition($regexp);
-
-    /**
      * Set lcrId
      *
      * @param integer $lcrId
@@ -66,6 +59,15 @@ interface LcrRuleInterface extends LoggableEntityInterface
      * @return string
      */
     public function getFromUri();
+
+    /**
+     * Set requestUri
+     *
+     * @param string $requestUri
+     *
+     * @return self
+     */
+    public function setRequestUri($requestUri = null);
 
     /**
      * Get requestUri

--- a/library/Ivoz/Provider/Domain/Model/RoutingPattern/RoutingPattern.php
+++ b/library/Ivoz/Provider/Domain/Model/RoutingPattern/RoutingPattern.php
@@ -2,6 +2,8 @@
 
 namespace Ivoz\Provider\Domain\Model\RoutingPattern;
 
+use Assert\Assertion;
+
 /**
  * RoutingPattern
  */
@@ -17,6 +19,17 @@ class RoutingPattern extends RoutingPatternAbstract implements RoutingPatternInt
     public function getId()
     {
         return $this->id;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setPrefix($prefix = null)
+    {
+        if (!empty($prefix)) {
+            Assertion::regex($prefix, '/^\+[0-9]*/');
+        }
+        return parent::setPrefix($prefix);
     }
 }
 

--- a/library/Ivoz/Provider/Domain/Model/RoutingPattern/RoutingPatternAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/RoutingPattern/RoutingPatternAbstract.php
@@ -16,7 +16,7 @@ abstract class RoutingPatternAbstract
     /**
      * @var string
      */
-    protected $regExp;
+    protected $prefix;
 
     /**
      * @var Name
@@ -40,11 +40,11 @@ abstract class RoutingPatternAbstract
      * Constructor
      */
     protected function __construct(
-        $regExp,
+        $prefix,
         Name $name,
         Description $description
     ) {
-        $this->setRegExp($regExp);
+        $this->setPrefix($prefix);
         $this->setName($name);
         $this->setDescription($description);
     }
@@ -123,7 +123,7 @@ abstract class RoutingPatternAbstract
         );
 
         $self = new static(
-            $dto->getRegExp(),
+            $dto->getPrefix(),
             $name,
             $description
         );
@@ -160,7 +160,7 @@ abstract class RoutingPatternAbstract
         );
 
         $this
-            ->setRegExp($dto->getRegExp())
+            ->setPrefix($dto->getPrefix())
             ->setName($name)
             ->setDescription($description)
             ->setBrand($dto->getBrand());
@@ -178,7 +178,7 @@ abstract class RoutingPatternAbstract
     public function toDto($depth = 0)
     {
         return self::createDto()
-            ->setRegExp(self::getRegExp())
+            ->setPrefix(self::getPrefix())
             ->setNameEn(self::getName()->getEn())
             ->setNameEs(self::getName()->getEs())
             ->setDescriptionEn(self::getDescription()->getEn())
@@ -192,7 +192,7 @@ abstract class RoutingPatternAbstract
     protected function __toArray()
     {
         return [
-            'regExp' => self::getRegExp(),
+            'prefix' => self::getPrefix(),
             'nameEn' => self::getName()->getEn(),
             'nameEs' => self::getName()->getEs(),
             'descriptionEn' => self::getDescription()->getEn(),
@@ -205,30 +205,30 @@ abstract class RoutingPatternAbstract
     // @codeCoverageIgnoreStart
 
     /**
-     * Set regExp
+     * Set prefix
      *
-     * @param string $regExp
+     * @param string $prefix
      *
      * @return self
      */
-    public function setRegExp($regExp)
+    public function setPrefix($prefix)
     {
-        Assertion::notNull($regExp, 'regExp value "%s" is null, but non null value was expected.');
-        Assertion::maxLength($regExp, 80, 'regExp value "%s" is too long, it should have no more than %d characters, but has %d characters.');
+        Assertion::notNull($prefix, 'prefix value "%s" is null, but non null value was expected.');
+        Assertion::maxLength($prefix, 80, 'prefix value "%s" is too long, it should have no more than %d characters, but has %d characters.');
 
-        $this->regExp = $regExp;
+        $this->prefix = $prefix;
 
         return $this;
     }
 
     /**
-     * Get regExp
+     * Get prefix
      *
      * @return string
      */
-    public function getRegExp()
+    public function getPrefix()
     {
-        return $this->regExp;
+        return $this->prefix;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/RoutingPattern/RoutingPatternDto.php
+++ b/library/Ivoz/Provider/Domain/Model/RoutingPattern/RoutingPatternDto.php
@@ -13,7 +13,7 @@ class RoutingPatternDto extends RoutingPatternDtoAbstract
         if ($context === self::CONTEXT_COLLECTION) {
             return [
                 'id' => 'id',
-                'regExp' => 'regExp',
+                'prefix' => 'prefix',
                 'name' => ['en','es']
             ];
         }

--- a/library/Ivoz/Provider/Domain/Model/RoutingPattern/RoutingPatternDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/RoutingPattern/RoutingPatternDtoAbstract.php
@@ -15,7 +15,7 @@ abstract class RoutingPatternDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $regExp;
+    private $prefix;
 
     /**
      * @var integer
@@ -70,7 +70,7 @@ abstract class RoutingPatternDtoAbstract implements DataTransferObjectInterface
         }
 
         return [
-            'regExp' => 'regExp',
+            'prefix' => 'prefix',
             'id' => 'id',
             'name' => ['en','es'],
             'description' => ['en','es'],
@@ -84,7 +84,7 @@ abstract class RoutingPatternDtoAbstract implements DataTransferObjectInterface
     public function toArray($hideSensitiveData = false)
     {
         return [
-            'regExp' => $this->getRegExp(),
+            'prefix' => $this->getPrefix(),
             'id' => $this->getId(),
             'name' => [
                 'en' => $this->getNameEn(),
@@ -130,13 +130,13 @@ abstract class RoutingPatternDtoAbstract implements DataTransferObjectInterface
     }
 
     /**
-     * @param string $regExp
+     * @param string $prefix
      *
      * @return static
      */
-    public function setRegExp($regExp = null)
+    public function setPrefix($prefix = null)
     {
-        $this->regExp = $regExp;
+        $this->prefix = $prefix;
 
         return $this;
     }
@@ -144,9 +144,9 @@ abstract class RoutingPatternDtoAbstract implements DataTransferObjectInterface
     /**
      * @return string
      */
-    public function getRegExp()
+    public function getPrefix()
     {
-        return $this->regExp;
+        return $this->prefix;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/RoutingPattern/RoutingPatternInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/RoutingPattern/RoutingPatternInterface.php
@@ -8,20 +8,16 @@ use Doctrine\Common\Collections\Collection;
 interface RoutingPatternInterface extends EntityInterface
 {
     /**
-     * Set regExp
-     *
-     * @param string $regExp
-     *
-     * @return self
+     * {@inheritDoc}
      */
-    public function setRegExp($regExp);
+    public function setPrefix($prefix = null);
 
     /**
-     * Get regExp
+     * Get prefix
      *
      * @return string
      */
-    public function getRegExp();
+    public function getPrefix();
 
     /**
      * Set brand

--- a/library/Ivoz/Provider/Domain/Service/LcrRule/CreateByOutgoingRoutingAndRoutingPattern.php
+++ b/library/Ivoz/Provider/Domain/Service/LcrRule/CreateByOutgoingRoutingAndRoutingPattern.php
@@ -39,11 +39,11 @@ class CreateByOutgoingRoutingAndRoutingPattern
         RoutingPatternInterface $pattern = null
     ) {
         $lcrRuleDto = LcrRule::createDto();
-        $condition = 'fax';
         if (is_null($pattern)) {
             // Fax route
             $lcrRuleDto
                 ->setTag('fax')
+                ->setPrefix('fax')
                 ->setDescription('Special route for fax');
         } else {
             // Non-fax route
@@ -51,12 +51,11 @@ class CreateByOutgoingRoutingAndRoutingPattern
                 ->setTag(
                     $pattern->getName()->getEn()
                 )
+                ->setPrefix($pattern->getPrefix())
                 ->setDescription(
                     $pattern->getDescription()->getEn()
                 )
                 ->setRoutingPatternId($pattern->getId());
-
-            $condition = $pattern->getRegExp();
         }
 
         $brandId = $entity->getBrand()->getId();
@@ -84,8 +83,6 @@ class CreateByOutgoingRoutingAndRoutingPattern
         $lcrRule = $this
             ->createEntityFromDTO
             ->execute(LcrRule::class, $lcrRuleDto);
-
-        $lcrRule->setCondition($condition);
 
         // Setting Outgoing Routing also sets from_uri (see model)
         $lcrRule->setOutgoingRouting($entity);

--- a/library/Ivoz/Provider/Domain/Service/LcrRule/UpdateByRoutingPattern.php
+++ b/library/Ivoz/Provider/Domain/Service/LcrRule/UpdateByRoutingPattern.php
@@ -47,8 +47,6 @@ class UpdateByRoutingPattern implements RoutingPatternLifecycleEventHandlerInter
 
         foreach ($lcrRules as $lcrRule) {
 
-            $lcrRule->setCondition($entity->getRegExp());
-
             /**
              * @var LcrRuleDTO $lcrRuleDTO
              */

--- a/library/Ivoz/Provider/Domain/Service/RoutingPattern/UpdateByBrand.php
+++ b/library/Ivoz/Provider/Domain/Service/RoutingPattern/UpdateByBrand.php
@@ -70,7 +70,7 @@ class UpdateByBrand implements BrandLifecycleEventHandlerInterface
                 ->setNameEn($country->getName()->getEn())
                 ->setDescriptionEs('')
                 ->setDescriptionEn('')
-                ->setRegExp((string) $country->getCountryCode())
+                ->setPrefix((string) $country->getCountryCode())
                 ->setBrandId($entity->getId());
 
             $routingPattern = $this->entityPersister->persistDto(

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/RoutingPattern.RoutingPatternAbstract.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/RoutingPattern.RoutingPatternAbstract.orm.yml
@@ -8,13 +8,12 @@ Ivoz\Provider\Domain\Model\RoutingPattern\RoutingPatternAbstract:
       class: Description
       columnPrefix: false
   fields:
-    regExp:
+    prefix:
       type: string
       nullable: false
       length: 80
       options:
         fixed: false
-      column: '`regExp`'
   manyToOne:
     brand:
       targetEntity: \Ivoz\Provider\Domain\Model\Brand\BrandInterface

--- a/library/spec/Ivoz/Provider/Domain/Model/LcrRule/LcrRuleSpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Model/LcrRule/LcrRuleSpec.php
@@ -28,30 +28,4 @@ class LcrRuleSpec extends ObjectBehavior
     {
         $this->shouldHaveType(LcrRule::class);
     }
-
-    function it_throws_exception_on_non_numeric_requesturi()
-    {
-        $this
-            ->shouldThrow('\Exception')
-            ->during('setRequestUri', ['abc']);
-
-        $this
-            ->shouldThrow('\Exception')
-            ->during('setRequestUri', ['12a']);
-
-        $this
-            ->shouldThrow('\Exception')
-            ->during('setRequestUri', [':@']);
-    }
-
-    function it_accepts_numeric_requesturi()
-    {
-        $this
-            ->shouldNotThrow('\Exception')
-            ->during('setRequestUri', [null]);
-
-        $this
-            ->shouldNotThrow('\Exception')
-            ->during('setRequestUri', [':something@']);
-    }
 }

--- a/library/spec/Ivoz/Provider/Domain/Service/LcrRule/CreateByOutgoingRoutingAndRoutingPatternSpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Service/LcrRule/CreateByOutgoingRoutingAndRoutingPatternSpec.php
@@ -79,10 +79,6 @@ class CreateByOutgoingRoutingAndRoutingPatternSpec extends ObjectBehavior
     ) {
         $this->createExampleBase($entity, $brand, $lcrRule);
 
-        $lcrRule
-            ->setCondition('fax')
-            ->shouldBeCalled();
-
         $this
             ->entityPersister
             ->persist(Argument::type(LcrRule::class), true);
@@ -96,10 +92,6 @@ class CreateByOutgoingRoutingAndRoutingPatternSpec extends ObjectBehavior
         LcrRuleInterface $lcrRule
     ) {
         $this->createExampleBase($entity, $brand, $lcrRule);
-
-        $lcrRule
-            ->setCondition('fax')
-            ->shouldBeCalled();
 
         $validatorCallback = function (LcrRule $lcrRule) {
             if ($lcrRule->getTag() !== 'fax') {
@@ -135,12 +127,8 @@ class CreateByOutgoingRoutingAndRoutingPatternSpec extends ObjectBehavior
             ->shouldBeCalled();
 
         $pattern
-            ->getRegExp()
-            ->willReturn('regExp')
-            ->shouldBeCalled();
-
-        $lcrRule
-            ->setCondition('regExp')
+            ->getPrefix()
+            ->willReturn('prefix')
             ->shouldBeCalled();
 
         $pattern
@@ -157,7 +145,7 @@ class CreateByOutgoingRoutingAndRoutingPatternSpec extends ObjectBehavior
                 return false;
             }
 
-            if ($lcrRule->getCondition() !== 'regExp') {
+            if ($lcrRule->getPrefix() !== 'prefix') {
                 return false;
             }
 
@@ -188,10 +176,6 @@ class CreateByOutgoingRoutingAndRoutingPatternSpec extends ObjectBehavior
             ->getId()
             ->willReturn(2);
 
-        $lcrRule
-            ->setCondition('fax')
-            ->shouldBeCalled();
-
         $validatorCallback = function (LcrRule $lcrRule) {
             return $lcrRule->getFromUri() === '^b1c2$';
         };
@@ -213,10 +197,6 @@ class CreateByOutgoingRoutingAndRoutingPatternSpec extends ObjectBehavior
         $entity
             ->getCompany()
             ->willReturn(null)
-            ->shouldBeCalled();
-
-        $lcrRule
-            ->setCondition('fax')
             ->shouldBeCalled();
 
         $validatorCallback = function (LcrRule $lcrRule) {

--- a/library/spec/Ivoz/Provider/Domain/Service/LcrRule/UpdateByRoutingPatternSpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Service/LcrRule/UpdateByRoutingPatternSpec.php
@@ -50,12 +50,10 @@ class UpdateByRoutingPatternSpec extends ObjectBehavior
         RoutingPatternInterface $entity,
         LcrRuleInterface $lcrRule
     ) {
-        $regExp = 'a-z';
         $this->getterProphecy(
             $entity,
             [
                 'getLcrRules' => [$lcrRule],
-                'getRegExp' => $regExp,
                 'getName' => new Name('en', 'es'),
                 'getDescription' => new Description('en', 'es')
             ]
@@ -65,10 +63,6 @@ class UpdateByRoutingPatternSpec extends ObjectBehavior
         $lcrRule
             ->toDto()
             ->willReturn($lcrRuleDto);
-
-        $lcrRule
-            ->setCondition($regExp)
-            ->shouldBeCalled();
 
         $this
             ->entityPersister

--- a/scheme/app/DoctrineMigrations/Version20180523162834.php
+++ b/scheme/app/DoctrineMigrations/Version20180523162834.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20180523162834 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE RoutingPatterns CHANGE `regexp` prefix VARCHAR(80) NOT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE RoutingPatterns CHANGE prefix `regExp` VARCHAR(80) NOT NULL COLLATE utf8_general_ci');
+    }
+}

--- a/web/admin/application/configs/klear/model/OutgoingRouting.yaml
+++ b/web/admin/application/configs/klear/model/OutgoingRouting.yaml
@@ -35,8 +35,8 @@ production:
             fields:
               - name${lang}
               - description${lang}
-              - regExp
-            template: '%name${lang}% %description${lang}% (%regExp%)'
+              - prefix
+            template: '%name${lang}% %description${lang}% (%prefix%)'
           order:
             RoutingPattern.name.${lang}: asc
     routingPatternGroup:

--- a/web/admin/application/configs/klear/model/RoutingPatterns.yaml
+++ b/web/admin/application/configs/klear/model/RoutingPatterns.yaml
@@ -13,16 +13,17 @@ production:
       isMultilang: true
       type: text
       maxLength: 55
-    regExp:
-      title: _('Reg exp / Prefix')
+    prefix:
+      title: _('Prefix')
       type: text
+      pattern: '\+[0-9]*'
       required: true
       maxLength: 80
       info:
         type: box
         position: left
         icon: help
-        text: _("If you want a prefix, use only digits. Otherwise, define your regular expresion.")
+        text: _("Must start with '+' followed by zero or more digits.")
         label: _("Need help?")
     brand:
       title: ngettext('Brand', 'Brands', 1)

--- a/web/admin/application/languages/en_US/en_US.po
+++ b/web/admin/application/languages/en_US/en_US.po
@@ -953,13 +953,6 @@ msgstr ""
 "If no queue member answers before time this seconds, the timeout queue logic "
 "will be activated. Leave empty to disable."
 
-msgid ""
-"If you want a prefix, use only digits. Otherwise, define your regular "
-"expresion."
-msgstr ""
-"If you want a prefix, use only digits. Otherwise, define your regular "
-"expresion."
-
 msgid "Ignore"
 msgstr "Ignore"
 
@@ -1349,6 +1342,9 @@ msgid "Music on Hold"
 msgid_plural "Musics on Hold"
 msgstr[0] "Music on Hold"
 msgstr[1] "Musics on Hold"
+
+msgid "Must start with '+' followed by zero or more digits."
+msgstr "Must start with '+' followed by zero or more digits."
 
 msgid "Must start with sip or sips followed by colon"
 msgstr "Must start with sip or sips followed by colon"
@@ -1794,9 +1790,6 @@ msgstr "Referee"
 
 msgid "Referrer"
 msgstr "Referrer"
-
-msgid "Reg exp / Prefix"
-msgstr "Reg exp / Prefix"
 
 msgid "Registrar Server URI"
 msgstr "Registrar Server URI"

--- a/web/admin/application/languages/es_ES/es_ES.po
+++ b/web/admin/application/languages/es_ES/es_ES.po
@@ -968,12 +968,6 @@ msgstr ""
 "Si ningún miembro de la cola contesta en estos segundos, se activará la "
 "lógica de no contesta. Dejar vacío para deshabilitar."
 
-msgid ""
-"If you want a prefix, use only digits. Otherwise, define your regular "
-"expresion."
-msgstr ""
-"Si desea un prefijo, use solo dígitos. Si no, defina una expresión regular."
-
 msgid "Ignore"
 msgstr "Ignorar"
 
@@ -1367,6 +1361,9 @@ msgid_plural "Musics on Hold"
 msgstr[0] "Música en espera"
 msgstr[1] "Músicas en espera"
 
+msgid "Must start with '+' followed by zero or more digits."
+msgstr "Debe comenzar con '+' seguido de cero o más dígitos."
+
 msgid "Must start with sip or sips followed by colon"
 msgstr "Debe comenzar con sip o sips seguido de dos puntos"
 
@@ -1689,8 +1686,9 @@ msgid_plural "Prepaid Balances"
 msgstr[0] "Saldo prepago"
 msgstr[1] "Saldos prepago"
 
+#, fuzzy
 msgid "Prepend this field to callee"
-msgstr "Añadir este campo como prefijo del número destino"
+msgstr "Evitar llamadas perdidas"
 
 msgid "Prevent missed calls"
 msgstr "Evitar llamadas perdidas"
@@ -1760,10 +1758,11 @@ msgstr[0] "Miembro de cola"
 msgstr[1] "Miembros de cola"
 
 msgid "R-URI customization (after numeric transformations)"
-msgstr "Transformaciones R-URI posteriores a las transformaciones numéricas"
+msgstr ""
 
+#, fuzzy
 msgid "R-URI params"
-msgstr "Parámetros R-URI"
+msgstr "Patrón R-URI"
 
 msgid "R-URI pattern"
 msgstr "Patrón R-URI"
@@ -1815,9 +1814,6 @@ msgstr "Referee"
 
 msgid "Referrer"
 msgstr "Referrer"
-
-msgid "Reg exp / Prefix"
-msgstr "Expr. Regular / Prefijo"
 
 msgid "Registrar Server URI"
 msgstr "URI Servidor de registro"

--- a/web/rest/features/provider/routingPattern/getRoutingPattern.feature
+++ b/web/rest/features/provider/routingPattern/getRoutingPattern.feature
@@ -15,7 +15,7 @@ Feature: Retrieve routing patterns
     """
       [
           {
-              "regExp": "+34",
+              "prefix": "+34",
               "id": 1,
               "name": {
                   "en": "en",
@@ -23,7 +23,7 @@ Feature: Retrieve routing patterns
               }
           },
           {
-              "regExp": "+35",
+              "prefix": "+35",
               "id": 2,
               "name": {
                   "en": "en",
@@ -43,7 +43,7 @@ Feature: Retrieve routing patterns
     And the JSON should be like:
     """
       {
-          "regExp": "+34",
+          "prefix": "+34",
           "id": 1,
           "name": {
               "en": "en",

--- a/web/rest/features/provider/routingPattern/postRoutingPattern.feature
+++ b/web/rest/features/provider/routingPattern/postRoutingPattern.feature
@@ -11,7 +11,7 @@ Feature: Create routing patterns
     And I send a "POST" request to "/routing_patterns" with body:
     """
       {
-          "regExp": "+349",
+          "prefix": "+349",
           "id": 1,
           "name": {
               "en": "Spain",
@@ -30,7 +30,7 @@ Feature: Create routing patterns
     And the JSON should be equal to:
     """
       {
-          "regExp": "+349",
+          "prefix": "+349",
           "id": 3,
           "name": {
               "en": "Spain",
@@ -49,7 +49,7 @@ Feature: Create routing patterns
     And the JSON should be like:
     """
       {
-          "regExp": "+349",
+          "prefix": "+349",
           "id": 3,
           "name": {
               "en": "Spain",

--- a/web/rest/features/provider/routingPattern/putRoutingPattern.feature
+++ b/web/rest/features/provider/routingPattern/putRoutingPattern.feature
@@ -11,7 +11,7 @@ Feature: Update routing patterns
       And I send a "PUT" request to "/routing_patterns/1" with body:
     """
       {
-          "regExp": "+349",
+          "prefix": "+349",
           "name": {
               "en": "englishName",
               "es": "nombreEspañol"
@@ -29,7 +29,7 @@ Feature: Update routing patterns
      And the JSON should be equal to:
     """
       {
-          "regExp": "+349",
+          "prefix": "+349",
           "id": 1,
           "name": {
               "en": "englishName",

--- a/web/rest/features/provider/routingPatternGroupsRelPattern/getRoutingPatternGroupsRelPattern.feature
+++ b/web/rest/features/provider/routingPatternGroupsRelPattern/getRoutingPatternGroupsRelPattern.feature
@@ -17,7 +17,7 @@ Feature: Retrieve routing pattern groups rel patterns
           {
               "id": 1,
               "routingPattern": {
-                  "regExp": "+34",
+                  "prefix": "+34",
                   "id": 1,
                   "name": {
                       "en": "en",
@@ -39,7 +39,7 @@ Feature: Retrieve routing pattern groups rel patterns
           {
               "id": 2,
               "routingPattern": {
-                  "regExp": "+34",
+                  "prefix": "+34",
                   "id": 1,
                   "name": {
                       "en": "en",
@@ -73,7 +73,7 @@ Feature: Retrieve routing pattern groups rel patterns
       {
           "id": 1,
           "routingPattern": {
-              "regExp": "+34",
+              "prefix": "+34",
               "id": 1,
               "name": {
                   "en": "en",

--- a/web/rest/features/provider/routingPatternGroupsRelPattern/postRoutingPatternGroupsRelPattern.feature
+++ b/web/rest/features/provider/routingPatternGroupsRelPattern/postRoutingPatternGroupsRelPattern.feature
@@ -23,7 +23,7 @@ Feature: Create routing pattern groups rel patterns
       {
           "id": 3,
           "routingPattern": {
-              "regExp": "+35",
+              "prefix": "+35",
               "id": 2,
               "name": {
                   "en": "en",
@@ -56,7 +56,7 @@ Feature: Create routing pattern groups rel patterns
       {
           "id": 3,
           "routingPattern": {
-              "regExp": "+35",
+              "prefix": "+35",
               "id": 2,
               "name": {
                   "en": "en",

--- a/web/rest/features/provider/routingPatternGroupsRelPattern/putRoutingPatternGroupsRelPattern.feature
+++ b/web/rest/features/provider/routingPatternGroupsRelPattern/putRoutingPatternGroupsRelPattern.feature
@@ -23,7 +23,7 @@ Feature: Update routing pattern groups rel patterns
       {
           "id": 1,
           "routingPattern": {
-              "regExp": "+35",
+              "prefix": "+35",
               "id": 2,
               "name": {
                   "en": "en",


### PR DESCRIPTION
This PR introduces a breaking change:

- Routing patterns no longer admit a regexp, it can only be a prefix now.

- This prefix must start with '+' and may be followed with zero or more digits.

The reason behind this change is that Kamailio's LCR module orders selected gateways using prefix length as a main criteria and that's ok. But it does not compute matching length of regexp, producing unexpected results.

As regexps made possible to add a catch-all pattern (with ^[0-9]+$), this will be possible creating a pattern with just a '+' symbol.