### PR TITLE
trunks: LCR AVPs and database fields reordered

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -265,8 +265,8 @@ modparam("lcr", "ip_addr_column", "ip")
 modparam("lcr", "lcr_id_column", "lcr_id")
 modparam("lcr", "gw_uri_avp", "$avp(gw_uri_avp)")
 modparam("lcr", "ruri_user_avp", "$avp(i:500)")
-modparam("lcr", "tag_avp", "$avp(lcr_tag)")
-modparam("lcr", "flags_avp", "$avp(s:caller_method)")
+modparam("lcr", "flags_avp", "$avp(s:peerServerId)")
+modparam("lcr", "flags_column", "peerServerId")
 modparam("lcr", "defunct_capability", 1)
 modparam("lcr", "lcr_id_avp", "$avp(lcr_id_avp)")
 modparam("lcr", "defunct_gw_avp", "$avp(defunct_gw_avp)")
@@ -525,14 +525,14 @@ route[SELECT_GW] {
     xinfo("[$dlg_var(cidhash)] SELECT-GW: New RURI $ru\n");
 
     # Obtain info about selected GW
-    sql_xquery("cb", "SELECT PC.externallyRated, PS.auth_needed, PS.auth_user, PS.auth_password, PS.peeringContractId, PS.from_user, PS.from_domain FROM PeerServers PS JOIN PeeringContracts PC ON PS.peeringContractId=PC.id WHERE PS.id=$avp(lcr_tag)", "ra");
+    sql_xquery("cb", "SELECT PC.externallyRated, PS.sendPAI, PS.sendRPID, PS.auth_needed, PS.auth_user, PS.auth_password, PS.peeringContractId, PS.from_user, PS.from_domain FROM PeerServers PS JOIN PeeringContracts PC ON PS.peeringContractId=PC.id WHERE PS.id=$avp(peerServerId)", "ra");
 
     if ( $(xavp(ra=>peeringContractId){s.len}) ) {
         $avp(peeringContractId) = $xavp(ra=>peeringContractId);
         $avp(externallyRated) = $xavp(ra=>externallyRated);
         xinfo("[$dlg_var(cidhash)] SELECT-GW: peeringContractId: $avp(peeringContractId)\n");
     } else {
-        xerr("[$dlg_var(cidhash)] SELECT-GW: Error obtaining 'peeringContractId' for peerServerId '$avp(lcr_tag)'\n");
+        xerr("[$dlg_var(cidhash)] SELECT-GW: Error obtaining 'peeringContractId' for peerServerId '$avp(peerServerId)'\n");
         send_reply("500", "Server Internal Error");
         exit;
     }
@@ -541,13 +541,13 @@ route[SELECT_GW] {
         if ( $(xavp(ra=>auth_user){s.len}) ) {
             $avp(provideruser) = $xavp(ra=>auth_user);
         } else {
-            xwarn("[$dlg_var(cidhash)] SELECT-GW: Error obtaining 'provideruser' for peerServerId '$avp(lcr_tag)'\n");
+            xwarn("[$dlg_var(cidhash)] SELECT-GW: Error obtaining 'provideruser' for peerServerId '$avp(peerServerId)'\n");
         }
 
         if ( $(xavp(ra=>auth_password){s.len}) ) {
             $avp(secret) = $xavp(ra=>auth_password);
         } else {
-            xwarn("[$dlg_var(cidhash)] SELECT-GW: Error obtaining 'secret' for peerServerId '$avp(lcr_tag)'\n");
+            xwarn("[$dlg_var(cidhash)] SELECT-GW: Error obtaining 'secret' for peerServerId '$avp(peerServerId)'\n");
         }
     } else {
         $avp(provideruser) = $null;
@@ -565,6 +565,9 @@ route[SELECT_GW] {
     } else {
         $avp(from_domain) = $null;
     }
+
+    $avp(send_pai) = $xavp(ra=>sendPAI);
+    $avp(send_rpid) = $xavp(ra=>sendRPID);
 
     # Reset auth flag
     $avp(auth_done) = '0';
@@ -808,20 +811,14 @@ route[TRANSFORMATE_OUT] {
     # Keep this in dlg_var as uac_replace_from does not work for display name
     $dlg_var(newfromdisplay) = '"' + $var(newfromuser) + '"';
 
-    # avp(caller_method): bitwise flag AB (in DB integer from 0-3)
-    # A: RPID flag (2)
-    # B: PAI flag (1)
-    #
-    # e.g. 3: Use both RPID and PAI
-
     # Use PAI?
-    if (avp_check("$avp(caller_method)", "and/i:0x01")) {
+    if ($avp(send_pai)) {
         xinfo("[$dlg_var(cidhash)] MANAGE-BRANCH-GW: Set PAI to: $dlg_var(newfromdisplay) <$var(newfromuri)>\n");
         append_hf("P-Asserted-Identity: $dlg_var(newfromdisplay) <$var(newfromuri)>\r\n");
     }
 
     # Use RPID?
-    if (avp_check("$avp(caller_method)", "and/i:0x02")) {
+    if ($avp(send_rpid)) {
         xinfo("[$dlg_var(cidhash)] MANAGE-BRANCH-GW: Set RPID to: $dlg_var(newfromdisplay) <$var(newfromuri)>\n");
         append_hf("Remote-Party-ID: $dlg_var(newfromdisplay) <$var(newfromuri)>;privacy=off;screen=no\r\n");
     }

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -1601,9 +1601,6 @@ route[ACCOUNTING] {
 onreply_route {
     if ($dlg_var(log)) xlog("L_NOTICE", "[$dlg_var(cidhash)] Response: '$rs $rr' to '$cs $rm' from '$fu' ($si:$sp) [$proto]\n");
     route(IS_FROM_INSIDE);
-    if ($var(is_from_inside)) {
-        xlog("reply is from inside");
-    }
 }
 
 # Reply generic route (additional, for all replies)

--- a/library/DataFixtures/ORM/ProviderLcrGateway.php
+++ b/library/DataFixtures/ORM/ProviderLcrGateway.php
@@ -29,8 +29,6 @@ class ProviderLcrGateway extends Fixture implements DependentFixtureInterface
         $item1->setParams("");
         $item1->setUriScheme(true);
         $item1->setTransport(true);
-        $item1->setTag("1");
-        $item1->setFlags(0);
         $item1->setPeerServer($this->getReference('_reference_ProviderPeerServer1'));
         $this->addReference('_reference_ProviderLcrGateway1', $item1);
         $this->sanitizeEntityValues($item1);

--- a/library/DataFixtures/ORM/ProviderLcrRule.php
+++ b/library/DataFixtures/ORM/ProviderLcrRule.php
@@ -26,7 +26,6 @@ class ProviderLcrRule extends Fixture implements DependentFixtureInterface
         $item3->setFromUri("^b1c[0-9]+\$");
         $item3->setStopper(0);
         $item3->setEnabled(1);
-        $item3->setTag("Afghanistan");
         $item3->setRoutingPattern($this->getReference('_reference_ProviderRoutingPatternRoutingPattern68'));
         $item3->setOutgoingRouting($this->getReference('_reference_ProviderOutgoingRouting2'));
         $this->addReference('_reference_ProviderLcrRule3', $item3);
@@ -39,7 +38,6 @@ class ProviderLcrRule extends Fixture implements DependentFixtureInterface
         $item4->setFromUri("^b1c1\$");
         $item4->setStopper(0);
         $item4->setEnabled(1);
-        $item4->setTag("Afghanistan");
         $item4->setRoutingPattern($this->getReference('_reference_ProviderRoutingPatternRoutingPattern68'));
         $item4->setOutgoingRouting($this->getReference('_reference_ProviderOutgoingRouting1'));
         $this->addReference('_reference_ProviderLcrRule4', $item4);

--- a/library/Ivoz/Provider/Domain/Model/LcrGateway/LcrGatewayAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/LcrGateway/LcrGatewayAbstract.php
@@ -74,11 +74,6 @@ abstract class LcrGatewayAbstract
     /**
      * @var integer
      */
-    protected $flags = '0';
-
-    /**
-     * @var integer
-     */
     protected $defunct;
 
     /**
@@ -92,11 +87,10 @@ abstract class LcrGatewayAbstract
     /**
      * Constructor
      */
-    protected function __construct($lcrId, $gwName, $flags)
+    protected function __construct($lcrId, $gwName)
     {
         $this->setLcrId($lcrId);
         $this->setGwName($gwName);
-        $this->setFlags($flags);
     }
 
     abstract public function getId();
@@ -164,8 +158,7 @@ abstract class LcrGatewayAbstract
 
         $self = new static(
             $dto->getLcrId(),
-            $dto->getGwName(),
-            $dto->getFlags());
+            $dto->getGwName());
 
         $self
             ->setIp($dto->getIp())
@@ -210,7 +203,6 @@ abstract class LcrGatewayAbstract
             ->setStrip($dto->getStrip())
             ->setPrefix($dto->getPrefix())
             ->setTag($dto->getTag())
-            ->setFlags($dto->getFlags())
             ->setDefunct($dto->getDefunct())
             ->setPeerServer($dto->getPeerServer());
 
@@ -238,7 +230,6 @@ abstract class LcrGatewayAbstract
             ->setStrip(self::getStrip())
             ->setPrefix(self::getPrefix())
             ->setTag(self::getTag())
-            ->setFlags(self::getFlags())
             ->setDefunct(self::getDefunct())
             ->setPeerServer(\Ivoz\Provider\Domain\Model\PeerServer\PeerServer::entityToDto(self::getPeerServer(), $depth));
     }
@@ -260,7 +251,6 @@ abstract class LcrGatewayAbstract
             'strip' => self::getStrip(),
             'prefix' => self::getPrefix(),
             'tag' => self::getTag(),
-            'flags' => self::getFlags(),
             'defunct' => self::getDefunct(),
             'peerServerId' => self::getPeerServer() ? self::getPeerServer()->getId() : null
         ];
@@ -577,34 +567,6 @@ abstract class LcrGatewayAbstract
     public function getTag()
     {
         return $this->tag;
-    }
-
-    /**
-     * Set flags
-     *
-     * @param integer $flags
-     *
-     * @return self
-     */
-    public function setFlags($flags)
-    {
-        Assertion::notNull($flags, 'flags value "%s" is null, but non null value was expected.');
-        Assertion::integerish($flags, 'flags value "%s" is not an integer or a number castable to integer.');
-        Assertion::greaterOrEqualThan($flags, 0, 'flags provided "%s" is not greater or equal than "%s".');
-
-        $this->flags = $flags;
-
-        return $this;
-    }
-
-    /**
-     * Get flags
-     *
-     * @return integer
-     */
-    public function getFlags()
-    {
-        return $this->flags;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/LcrGateway/LcrGatewayDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/LcrGateway/LcrGatewayDtoAbstract.php
@@ -70,11 +70,6 @@ abstract class LcrGatewayDtoAbstract implements DataTransferObjectInterface
     /**
      * @var integer
      */
-    private $flags = '0';
-
-    /**
-     * @var integer
-     */
     private $defunct;
 
     /**
@@ -116,7 +111,6 @@ abstract class LcrGatewayDtoAbstract implements DataTransferObjectInterface
             'strip' => 'strip',
             'prefix' => 'prefix',
             'tag' => 'tag',
-            'flags' => 'flags',
             'defunct' => 'defunct',
             'id' => 'id',
             'peerServerId' => 'peerServer'
@@ -140,7 +134,6 @@ abstract class LcrGatewayDtoAbstract implements DataTransferObjectInterface
             'strip' => $this->getStrip(),
             'prefix' => $this->getPrefix(),
             'tag' => $this->getTag(),
-            'flags' => $this->getFlags(),
             'defunct' => $this->getDefunct(),
             'id' => $this->getId(),
             'peerServer' => $this->getPeerServer()
@@ -381,26 +374,6 @@ abstract class LcrGatewayDtoAbstract implements DataTransferObjectInterface
     public function getTag()
     {
         return $this->tag;
-    }
-
-    /**
-     * @param integer $flags
-     *
-     * @return static
-     */
-    public function setFlags($flags = null)
-    {
-        $this->flags = $flags;
-
-        return $this;
-    }
-
-    /**
-     * @return integer
-     */
-    public function getFlags()
-    {
-        return $this->flags;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/LcrGateway/LcrGatewayInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/LcrGateway/LcrGatewayInterface.php
@@ -189,22 +189,6 @@ interface LcrGatewayInterface extends LoggableEntityInterface
     public function getTag();
 
     /**
-     * Set flags
-     *
-     * @param integer $flags
-     *
-     * @return self
-     */
-    public function setFlags($flags);
-
-    /**
-     * Get flags
-     *
-     * @return integer
-     */
-    public function getFlags();
-
-    /**
      * Set defunct
      *
      * @param integer $defunct

--- a/library/Ivoz/Provider/Domain/Model/LcrRule/LcrRuleAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/LcrRule/LcrRuleAbstract.php
@@ -53,16 +53,6 @@ abstract class LcrRuleAbstract
     protected $enabled = '1';
 
     /**
-     * @var string
-     */
-    protected $tag;
-
-    /**
-     * @var string
-     */
-    protected $description = '';
-
-    /**
      * @var \Ivoz\Provider\Domain\Model\RoutingPattern\RoutingPatternInterface
      */
     protected $routingPattern;
@@ -78,18 +68,11 @@ abstract class LcrRuleAbstract
     /**
      * Constructor
      */
-    protected function __construct(
-        $lcrId,
-        $stopper,
-        $enabled,
-        $tag,
-        $description
-    ) {
+    protected function __construct($lcrId, $stopper, $enabled)
+    {
         $this->setLcrId($lcrId);
         $this->setStopper($stopper);
         $this->setEnabled($enabled);
-        $this->setTag($tag);
-        $this->setDescription($description);
     }
 
     abstract public function getId();
@@ -158,9 +141,7 @@ abstract class LcrRuleAbstract
         $self = new static(
             $dto->getLcrId(),
             $dto->getStopper(),
-            $dto->getEnabled(),
-            $dto->getTag(),
-            $dto->getDescription());
+            $dto->getEnabled());
 
         $self
             ->setPrefix($dto->getPrefix())
@@ -196,8 +177,6 @@ abstract class LcrRuleAbstract
             ->setMtTvalue($dto->getMtTvalue())
             ->setStopper($dto->getStopper())
             ->setEnabled($dto->getEnabled())
-            ->setTag($dto->getTag())
-            ->setDescription($dto->getDescription())
             ->setRoutingPattern($dto->getRoutingPattern())
             ->setOutgoingRouting($dto->getOutgoingRouting());
 
@@ -221,8 +200,6 @@ abstract class LcrRuleAbstract
             ->setMtTvalue(self::getMtTvalue())
             ->setStopper(self::getStopper())
             ->setEnabled(self::getEnabled())
-            ->setTag(self::getTag())
-            ->setDescription(self::getDescription())
             ->setRoutingPattern(\Ivoz\Provider\Domain\Model\RoutingPattern\RoutingPattern::entityToDto(self::getRoutingPattern(), $depth))
             ->setOutgoingRouting(\Ivoz\Provider\Domain\Model\OutgoingRouting\OutgoingRouting::entityToDto(self::getOutgoingRouting(), $depth));
     }
@@ -240,8 +217,6 @@ abstract class LcrRuleAbstract
             'mt_tvalue' => self::getMtTvalue(),
             'stopper' => self::getStopper(),
             'enabled' => self::getEnabled(),
-            'tag' => self::getTag(),
-            'description' => self::getDescription(),
             'routingPatternId' => self::getRoutingPattern() ? self::getRoutingPattern()->getId() : null,
             'outgoingRoutingId' => self::getOutgoingRouting() ? self::getOutgoingRouting()->getId() : null
         ];
@@ -444,60 +419,6 @@ abstract class LcrRuleAbstract
     public function getEnabled()
     {
         return $this->enabled;
-    }
-
-    /**
-     * Set tag
-     *
-     * @param string $tag
-     *
-     * @return self
-     */
-    public function setTag($tag)
-    {
-        Assertion::notNull($tag, 'tag value "%s" is null, but non null value was expected.');
-        Assertion::maxLength($tag, 55, 'tag value "%s" is too long, it should have no more than %d characters, but has %d characters.');
-
-        $this->tag = $tag;
-
-        return $this;
-    }
-
-    /**
-     * Get tag
-     *
-     * @return string
-     */
-    public function getTag()
-    {
-        return $this->tag;
-    }
-
-    /**
-     * Set description
-     *
-     * @param string $description
-     *
-     * @return self
-     */
-    public function setDescription($description)
-    {
-        Assertion::notNull($description, 'description value "%s" is null, but non null value was expected.');
-        Assertion::maxLength($description, 500, 'description value "%s" is too long, it should have no more than %d characters, but has %d characters.');
-
-        $this->description = $description;
-
-        return $this;
-    }
-
-    /**
-     * Get description
-     *
-     * @return string
-     */
-    public function getDescription()
-    {
-        return $this->description;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/LcrRule/LcrRuleDto.php
+++ b/library/Ivoz/Provider/Domain/Model/LcrRule/LcrRuleDto.php
@@ -15,7 +15,6 @@ class LcrRuleDto extends LcrRuleDtoAbstract
                 'id' => 'id',
                 'prefix' => 'prefix',
                 'fromUri' => 'fromUri',
-                'tag' => 'tag',
             ];
         }
 

--- a/library/Ivoz/Provider/Domain/Model/LcrRule/LcrRuleDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/LcrRule/LcrRuleDtoAbstract.php
@@ -48,16 +48,6 @@ abstract class LcrRuleDtoAbstract implements DataTransferObjectInterface
     private $enabled = '1';
 
     /**
-     * @var string
-     */
-    private $tag;
-
-    /**
-     * @var string
-     */
-    private $description = '';
-
-    /**
      * @var integer
      */
     private $id;
@@ -97,8 +87,6 @@ abstract class LcrRuleDtoAbstract implements DataTransferObjectInterface
             'mtTvalue' => 'mtTvalue',
             'stopper' => 'stopper',
             'enabled' => 'enabled',
-            'tag' => 'tag',
-            'description' => 'description',
             'id' => 'id',
             'routingPatternId' => 'routingPattern',
             'outgoingRoutingId' => 'outgoingRouting'
@@ -118,8 +106,6 @@ abstract class LcrRuleDtoAbstract implements DataTransferObjectInterface
             'mtTvalue' => $this->getMtTvalue(),
             'stopper' => $this->getStopper(),
             'enabled' => $this->getEnabled(),
-            'tag' => $this->getTag(),
-            'description' => $this->getDescription(),
             'id' => $this->getId(),
             'routingPattern' => $this->getRoutingPattern(),
             'outgoingRouting' => $this->getOutgoingRouting()
@@ -281,46 +267,6 @@ abstract class LcrRuleDtoAbstract implements DataTransferObjectInterface
     public function getEnabled()
     {
         return $this->enabled;
-    }
-
-    /**
-     * @param string $tag
-     *
-     * @return static
-     */
-    public function setTag($tag = null)
-    {
-        $this->tag = $tag;
-
-        return $this;
-    }
-
-    /**
-     * @return string
-     */
-    public function getTag()
-    {
-        return $this->tag;
-    }
-
-    /**
-     * @param string $description
-     *
-     * @return static
-     */
-    public function setDescription($description = null)
-    {
-        $this->description = $description;
-
-        return $this;
-    }
-
-    /**
-     * @return string
-     */
-    public function getDescription()
-    {
-        return $this->description;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/LcrRule/LcrRuleInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/LcrRule/LcrRuleInterface.php
@@ -125,38 +125,6 @@ interface LcrRuleInterface extends LoggableEntityInterface
     public function getEnabled();
 
     /**
-     * Set tag
-     *
-     * @param string $tag
-     *
-     * @return self
-     */
-    public function setTag($tag);
-
-    /**
-     * Get tag
-     *
-     * @return string
-     */
-    public function getTag();
-
-    /**
-     * Set description
-     *
-     * @param string $description
-     *
-     * @return self
-     */
-    public function setDescription($description);
-
-    /**
-     * Get description
-     *
-     * @return string
-     */
-    public function getDescription();
-
-    /**
      * Set routingPattern
      *
      * @param \Ivoz\Provider\Domain\Model\RoutingPattern\RoutingPatternInterface $routingPattern

--- a/library/Ivoz/Provider/Domain/Model/PeerServer/PeerServer.php
+++ b/library/Ivoz/Provider/Domain/Model/PeerServer/PeerServer.php
@@ -106,11 +106,6 @@ class PeerServer extends PeerServerAbstract implements PeerServerInterface
         return parent::setIp($ip);
     }
 
-    public function getFlags()
-    {
-        return $this->getSendPAI() + ($this->getSendRPID()*2);
-    }
-
     public function getName()
     {
         return

--- a/library/Ivoz/Provider/Domain/Model/PeerServer/PeerServerInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/PeerServer/PeerServerInterface.php
@@ -16,8 +16,6 @@ interface PeerServerInterface extends LoggableEntityInterface
      */
     public function setIp($ip = null);
 
-    public function getFlags();
-
     public function getName();
 
     /**

--- a/library/Ivoz/Provider/Domain/Service/LcrGateway/UpdateByPeerServer.php
+++ b/library/Ivoz/Provider/Domain/Service/LcrGateway/UpdateByPeerServer.php
@@ -46,8 +46,6 @@ class UpdateByPeerServer implements PeerServerLifecycleEventHandlerInterface
             ->setPort($entity->getPort())
             ->setUriScheme($entity->getUriScheme())
             ->setTransport($entity->getTransport())
-            ->setTag((string) $entity->getId())
-            ->setFlags($entity->getFlags())
             ->setPeerServerId($entity->getId());
 
         $lcrGateway = $this->entityPersister->persistDto(

--- a/library/Ivoz/Provider/Domain/Service/LcrRule/CreateByOutgoingRoutingAndRoutingPattern.php
+++ b/library/Ivoz/Provider/Domain/Service/LcrRule/CreateByOutgoingRoutingAndRoutingPattern.php
@@ -42,19 +42,11 @@ class CreateByOutgoingRoutingAndRoutingPattern
         if (is_null($pattern)) {
             // Fax route
             $lcrRuleDto
-                ->setTag('fax')
-                ->setPrefix('fax')
-                ->setDescription('Special route for fax');
+                ->setPrefix('fax');
         } else {
             // Non-fax route
             $lcrRuleDto
-                ->setTag(
-                    $pattern->getName()->getEn()
-                )
                 ->setPrefix($pattern->getPrefix())
-                ->setDescription(
-                    $pattern->getDescription()->getEn()
-                )
                 ->setRoutingPatternId($pattern->getId());
         }
 

--- a/library/Ivoz/Provider/Domain/Service/LcrRule/UpdateByRoutingPattern.php
+++ b/library/Ivoz/Provider/Domain/Service/LcrRule/UpdateByRoutingPattern.php
@@ -51,9 +51,6 @@ class UpdateByRoutingPattern implements RoutingPatternLifecycleEventHandlerInter
              * @var LcrRuleDTO $lcrRuleDTO
              */
             $lcrRuleDTO = $lcrRule->toDto();
-            $lcrRuleDTO
-                ->setTag($entity->getName()->getEn())
-                ->setDescription($entity->getDescription()->getEn());
 
             return $this
                 ->entityPersister

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/LcrGateway.LcrGatewayAbstract.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/LcrGateway.LcrGatewayAbstract.orm.yml
@@ -74,12 +74,6 @@ Ivoz\Provider\Domain\Model\LcrGateway\LcrGatewayAbstract:
       length: 64
       options:
         fixed: false
-    flags:
-      type: integer
-      nullable: false
-      options:
-        unsigned: true
-        default: '0'
     defunct:
       type: integer
       nullable: true

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/LcrRule.LcrRuleAbstract.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/LcrRule.LcrRuleAbstract.orm.yml
@@ -51,19 +51,6 @@ Ivoz\Provider\Domain\Model\LcrRule\LcrRuleAbstract:
       options:
         unsigned: true
         default: '1'
-    tag:
-      type: string
-      nullable: false
-      length: 55
-      options:
-        fixed: false
-    description:
-      type: string
-      nullable: false
-      length: 500
-      options:
-        fixed: false
-        default: ''
   manyToOne:
     routingPattern:
       targetEntity: \Ivoz\Provider\Domain\Model\RoutingPattern\RoutingPatternInterface

--- a/library/spec/Ivoz/Provider/Domain/Model/LcrRule/LcrRuleSpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Model/LcrRule/LcrRuleSpec.php
@@ -14,9 +14,7 @@ class LcrRuleSpec extends ObjectBehavior
         $dto = new LcrRuleDto();
         $dto->setLcrId(1)
             ->setStopper(1)
-            ->setEnabled(1)
-            ->setTag('tag')
-            ->setDescription('description');
+            ->setEnabled(1);
 
         $this->beConstructedThrough(
             'fromDto',

--- a/library/spec/Ivoz/Provider/Domain/Service/LcrGateway/UpdateByPeerServerSpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Service/LcrGateway/UpdateByPeerServerSpec.php
@@ -48,7 +48,6 @@ class UpdateByPeerServerSpec extends ObjectBehavior
                 'getPort' => null,
                 'getUriScheme' => null,
                 'getTransport' => null,
-                'getFlags' => null,
                 'getId' => null
             ]
         );
@@ -84,7 +83,6 @@ class UpdateByPeerServerSpec extends ObjectBehavior
                 'getPort' => null,
                 'getUriScheme' => null,
                 'getTransport' => null,
-                'getFlags' => null,
                 'getId' => null
             ]
         );

--- a/library/spec/Ivoz/Provider/Domain/Service/LcrRule/CreateByOutgoingRoutingAndRoutingPatternSpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Service/LcrRule/CreateByOutgoingRoutingAndRoutingPatternSpec.php
@@ -94,11 +94,9 @@ class CreateByOutgoingRoutingAndRoutingPatternSpec extends ObjectBehavior
         $this->createExampleBase($entity, $brand, $lcrRule);
 
         $validatorCallback = function (LcrRule $lcrRule) {
-            if ($lcrRule->getTag() !== 'fax') {
+            if ($lcrRule->getPrefix() !== 'fax') {
                 return false;
             }
-
-            return $lcrRule->getDescription() === 'Special route for fax';
         };
 
         $this
@@ -117,16 +115,6 @@ class CreateByOutgoingRoutingAndRoutingPatternSpec extends ObjectBehavior
         $this->createExampleBase($entity, $brand, $lcrRule);
 
         $pattern
-            ->getName()
-            ->willReturn(new Name('nameEn', 'nameEs'))
-            ->shouldBeCalled();
-
-        $pattern
-            ->getDescription()
-            ->willReturn(new Description('descEn', 'descEs'))
-            ->shouldBeCalled();
-
-        $pattern
             ->getPrefix()
             ->willReturn('prefix')
             ->shouldBeCalled();
@@ -137,14 +125,6 @@ class CreateByOutgoingRoutingAndRoutingPatternSpec extends ObjectBehavior
             ->shouldBeCalled();
 
         $validatorCallback = function (LcrRule $lcrRule) {
-            if ($lcrRule->getTag() !== 'nameEn') {
-                return false;
-            }
-
-            if ($lcrRule->getDescription() !== 'descEn') {
-                return false;
-            }
-
             if ($lcrRule->getPrefix() !== 'prefix') {
                 return false;
             }

--- a/library/spec/Ivoz/Provider/Domain/Service/LcrRule/UpdateByRoutingPatternSpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Service/LcrRule/UpdateByRoutingPatternSpec.php
@@ -54,8 +54,6 @@ class UpdateByRoutingPatternSpec extends ObjectBehavior
             $entity,
             [
                 'getLcrRules' => [$lcrRule],
-                'getName' => new Name('en', 'es'),
-                'getDescription' => new Description('en', 'es')
             ]
         );
 

--- a/scheme/app/DoctrineMigrations/Version20180524170318.php
+++ b/scheme/app/DoctrineMigrations/Version20180524170318.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20180524170318 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE LcrRules DROP tag, DROP description');
+        $this->addSql('ALTER TABLE LcrGateways DROP flags');
+        $this->addSql('UPDATE LcrGateways SET tag=NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE LcrGateways ADD flags INT UNSIGNED DEFAULT 0 NOT NULL');
+        $this->addSql('ALTER TABLE LcrRules ADD tag VARCHAR(55) NOT NULL COLLATE utf8_general_ci, ADD description VARCHAR(500) DEFAULT \'\' NOT NULL COLLATE utf8_general_ci');
+        $this->addSql('UPDATE LcrGateways SET tag=peerServerId');
+        $this->addSql('UPDATE LcrGateways LG LEFT JOIN PeerServers PS ON LG.peerServerId=PS.id SET flags=(PS.sendPAI + 2* PS.sendRPID)');
+    }
+}


### PR DESCRIPTION
This PR:

- Drops LcrRules.tag and LcrRules.descriptions from database as they were not used anywhere.

- Drops LcrGateways.flags as LCR module loads peerServerId directly now.

- Removes awkward RPID/PAI logic from trunks kamailio.cfg

- Removes unnecessary logics that kept synced some database fields.

No functional changes.