### PR TITLE
portals: fix extension for CallForwardsettings edit screen

### DIFF
--- a/portals/application/configs/klear/CallForwardSettingsList.yaml
+++ b/portals/application/configs/klear/CallForwardSettingsList.yaml
@@ -79,7 +79,6 @@ production:
       title: _("Edit %s %2s", ngettext('Call forward setting', 'Call forward settings', 1), "[format| (%item%)]")
       fields:
         blacklist:
-          extensionId: true
           targetTypeValue: true
           userId: true
           retailAccountId: true


### PR DESCRIPTION
Extension combobox is not displayed in edit screen in CallForwardSettings