### PR TITLE
core: clean up extensions properly on user delete

### DIFF
--- a/library/Ivoz/Provider/Domain/Service/Extension/UpdateByUser.php
+++ b/library/Ivoz/Provider/Domain/Service/Extension/UpdateByUser.php
@@ -11,29 +11,49 @@ use Ivoz\Provider\Domain\Service\User\UserLifecycleEventHandlerInterface;
  */
 class UpdateByUser implements UserLifecycleEventHandlerInterface
 {
+    const POST_PERSIST_PRIORITY = 20;
+    const POST_REMOVE_PRIORITY = 10;
+
     public function __construct() {}
 
     public static function getSubscribedEvents()
     {
         return [
-            self::EVENT_POST_PERSIST => 20
+            self::EVENT_POST_PERSIST => self::POST_PERSIST_PRIORITY,
+            self::EVENT_POST_REMOVE => self::POST_REMOVE_PRIORITY,
         ];
     }
 
-    public function execute(UserInterface $entity, $isNew)
+    public function execute(UserInterface $user, $isNew)
     {
-        $hasChangedExtension = $entity->hasChanged("extensionId");
+        $removed = ($user->hasChanged('id') && !$user->getId());
+        if ($removed) {
+            $this->cleanUpExtension($user);
+            return;
+        }
+
+        $hasChangedExtension = $user->hasChanged("extensionId");
         if (!$hasChangedExtension) {
             return;
         }
 
         // If extension has changed, update extension user
 
-        $extension = $entity->getExtension();
+        $extension = $user->getExtension();
         if ($extension) {
             $extension
                 ->setRouteType('user')
-                ->setUser($entity);
+                ->setUser($user);
+        }
+    }
+
+    private function cleanUpExtension(UserInterface $entity)
+    {
+        $extension = $entity->getExtension();
+        if ($extension) {
+            $extension
+                ->setRouteType(null)
+                ->setUser(null);
         }
     }
 }

--- a/library/Ivoz/Provider/Domain/Service/User/UpdateByExtension.php
+++ b/library/Ivoz/Provider/Domain/Service/User/UpdateByExtension.php
@@ -66,6 +66,11 @@ class UpdateByExtension implements ExtensionLifecycleEventHandlerInterface
                 'id' => $originalValue
             ]);
 
+            if (!$prevUser) {
+                // User has been removed
+                return;
+            }
+
             $prevUser->setExtension(null);
         }
 


### PR DESCRIPTION
Set extension routeType to null when user has been deleted

This PR aims to fix https://github.com/irontec/ivozprovider/issues/534 at artemis