### PR TITLE
core: clean up ivr state on user/extension delete

### DIFF
--- a/library/Ivoz/Provider/Domain/Model/Ivr/IvrRepository.php
+++ b/library/Ivoz/Provider/Domain/Model/Ivr/IvrRepository.php
@@ -4,6 +4,13 @@ namespace Ivoz\Provider\Domain\Model\Ivr;
 
 use Doctrine\Common\Persistence\ObjectRepository;
 use Doctrine\Common\Collections\Selectable;
+use Ivoz\Provider\Domain\Model\Extension\ExtensionInterface;
+use Ivoz\Provider\Domain\Model\User\UserInterface;
 
-interface IvrRepository extends ObjectRepository, Selectable {}
+interface IvrRepository extends ObjectRepository, Selectable
+{
+    public function findByExtension(ExtensionInterface $extension);
+
+    public function findByUser(UserInterface $user);
+}
 

--- a/library/Ivoz/Provider/Domain/Service/Ivr/UpdateByExtension.php
+++ b/library/Ivoz/Provider/Domain/Service/Ivr/UpdateByExtension.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Ivoz\Provider\Domain\Service\Ivr;
+
+use Ivoz\Core\Application\Service\EntityTools;
+use Ivoz\Provider\Domain\Model\Extension\ExtensionInterface;
+use Ivoz\Provider\Domain\Model\Ivr\Ivr;
+use Ivoz\Provider\Domain\Model\Ivr\IvrDto;
+use Ivoz\Provider\Domain\Model\Ivr\IvrRepository;
+use Ivoz\Provider\Domain\Service\Extension\ExtensionLifecycleEventHandlerInterface;
+
+/**
+ * Class UpdateByExtension
+ * @package Ivoz\Provider\Domain\Service\Ivr
+ */
+class UpdateByExtension implements ExtensionLifecycleEventHandlerInterface
+{
+    const PRE_REMOVE_PRIORITY = 10;
+
+    /**
+     * @var EntityTools
+     */
+    protected $entityTools;
+
+    /**
+     * @var IvrRepository
+     */
+    protected $ivrRepository;
+
+    public function __construct(
+        EntityTools $entityTools,
+        IvrRepository $ivrRepository
+    ) {
+        $this->entityTools = $entityTools;
+        $this->ivrRepository = $ivrRepository;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            self::EVENT_PRE_REMOVE => self::PRE_REMOVE_PRIORITY
+        ];
+    }
+
+    /**
+     * @param ExtensionInterface $extension
+     * @param $isNew
+     */
+    public function execute(ExtensionInterface $extension, $isNew)
+    {
+        /** @var Ivr[] $ivrs */
+        $ivrs = $this->ivrRepository->findByExtension($extension);
+        foreach ($ivrs as $ivr) {
+
+            $noInputExtension = $ivr->getNoInputExtension();
+            $errorExtension = $ivr->getErrorExtension();
+            /** @var IvrDto $ivrDto */
+            $ivrDto = $this->entityTools->entityToDto($ivr);
+
+            if ($noInputExtension && $noInputExtension->getId() === $extension->getId()) {
+                $ivrDto
+                    ->setNoInputRouteType(null)
+                    ->setNoInputExtensionId(null);
+
+                $this->entityTools->persistDto($ivrDto, $ivr);
+            }
+
+            if ($errorExtension && $errorExtension->getId() === $extension->getId()) {
+                $ivrDto
+                    ->setErrorRouteType(null)
+                    ->setErrorExtensionId(null);
+
+                $this->entityTools->persistDto($ivrDto, $ivr);
+            }
+        }
+    }
+}

--- a/library/Ivoz/Provider/Domain/Service/Ivr/UpdateByUser.php
+++ b/library/Ivoz/Provider/Domain/Service/Ivr/UpdateByUser.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Ivoz\Provider\Domain\Service\Ivr;
+
+use Ivoz\Core\Application\Service\EntityTools;
+use Ivoz\Provider\Domain\Model\User\UserInterface;
+use Ivoz\Provider\Domain\Model\Ivr\Ivr;
+use Ivoz\Provider\Domain\Model\Ivr\IvrDto;
+use Ivoz\Provider\Domain\Model\Ivr\IvrRepository;
+use Ivoz\Provider\Domain\Service\User\UserLifecycleEventHandlerInterface;
+
+/**
+ * Class UpdateByUser
+ * @package Ivoz\Provider\Domain\Service\Ivr
+ */
+class UpdateByUser implements UserLifecycleEventHandlerInterface
+{
+    const PRE_REMOVE_PRIORITY = 10;
+
+    /**
+     * @var EntityTools
+     */
+    protected $entityTools;
+
+    /**
+     * @var IvrRepository
+     */
+    protected $ivrRepository;
+
+    public function __construct(
+        EntityTools $entityTools,
+        IvrRepository $ivrRepository
+    ) {
+        $this->entityTools = $entityTools;
+        $this->ivrRepository = $ivrRepository;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            self::EVENT_PRE_REMOVE => self::PRE_REMOVE_PRIORITY
+        ];
+    }
+
+    /**
+     * @param UserInterface $user
+     * @param $isNew
+     */
+    public function execute(UserInterface $user, $isNew)
+    {
+        /** @var Ivr[] $ivrs */
+        $ivrs = $this->ivrRepository->findByUser($user);
+        foreach ($ivrs as $ivr) {
+
+            $noInputUser = $ivr->getNoInputVoiceMailUser();
+            $errorUser = $ivr->getErrorVoiceMailUser();
+
+            /** @var IvrDto $ivrDto */
+            $ivrDto = $this->entityTools->entityToDto($ivr);
+
+            if ($noInputUser && $noInputUser->getId() === $user->getId()) {
+                $ivrDto
+                    ->setNoInputRouteType(null)
+                    ->setNoInputVoiceMailUserId(null);
+
+                $this->entityTools->persistDto($ivrDto, $ivr);
+            }
+
+            if ($errorUser && $errorUser->getId() === $user->getId()) {
+                $ivrDto
+                    ->setErrorRouteType(null)
+                    ->setErrorVoiceMailUserId(null);
+
+                $this->entityTools->persistDto($ivrDto, $ivr);
+            }
+        }
+    }
+}

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/IvrDoctrineRepository.php
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/IvrDoctrineRepository.php
@@ -5,7 +5,9 @@ namespace Ivoz\Provider\Infrastructure\Persistence\Doctrine;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Ivoz\Provider\Domain\Model\Ivr\IvrRepository;
 use Ivoz\Provider\Domain\Model\Ivr\Ivr;
+use Ivoz\Provider\Domain\Model\User\UserInterface;
 use Symfony\Bridge\Doctrine\RegistryInterface;
+use Ivoz\Provider\Domain\Model\Extension\ExtensionInterface;
 
 /**
  * IvrDoctrineRepository
@@ -18,5 +20,39 @@ class IvrDoctrineRepository extends ServiceEntityRepository implements IvrReposi
     public function __construct(RegistryInterface $registry)
     {
         parent::__construct($registry, Ivr::class);
+    }
+
+    public function findByExtension(ExtensionInterface $extension)
+    {
+        $qb = $this->createQueryBuilder('self');
+
+        $qb
+            ->select('i')
+            ->from(Ivr::class, 'i')
+            ->where(
+                "i.noInputRouteType = 'extension' and i.noInputExtension = " . $extension->getId()
+            )
+            ->orWhere(
+                "i.errorRouteType = 'extension' and i.errorExtension = " . $extension->getId()
+            );
+
+        return $qb->getQuery()->getResult();
+    }
+
+    public function findByUser(UserInterface $user)
+    {
+        $qb = $this->createQueryBuilder('self');
+
+        $qb
+            ->select('i')
+            ->from(Ivr::class, 'i')
+            ->where(
+                "i.noInputRouteType = 'voicemail' and i.noInputVoiceMailUser = " . $user->getId()
+            )
+            ->orWhere(
+                "i.errorRouteType = 'voicemail' and i.errorVoiceMailUser = " . $user->getId()
+            );
+
+        return $qb->getQuery()->getResult();
     }
 }

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/IvrEntry.IvrEntryAbstract.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/IvrEntry.IvrEntryAbstract.orm.yml
@@ -60,7 +60,7 @@ Ivoz\Provider\Domain\Model\IvrEntry\IvrEntryAbstract:
       joinColumns:
         extensionId:
           referencedColumnName: id
-          onDelete: set null
+          onDelete: cascade
       orphanRemoval: false
     voiceMailUser:
       targetEntity: \Ivoz\Provider\Domain\Model\User\UserInterface
@@ -71,7 +71,7 @@ Ivoz\Provider\Domain\Model\IvrEntry\IvrEntryAbstract:
       joinColumns:
         voiceMailUserId:
           referencedColumnName: id
-          onDelete: set null
+          onDelete: cascade
       orphanRemoval: false
     conditionalRoute:
       targetEntity: \Ivoz\Provider\Domain\Model\ConditionalRoute\ConditionalRouteInterface
@@ -82,7 +82,7 @@ Ivoz\Provider\Domain\Model\IvrEntry\IvrEntryAbstract:
       joinColumns:
         conditionalRouteId:
           referencedColumnName: id
-          onDelete: set null
+          onDelete: cascade
       orphanRemoval: false
     numberCountry:
       targetEntity: \Ivoz\Provider\Domain\Model\Country\CountryInterface

--- a/library/spec/Ivoz/Provider/Domain/Service/Ivr/UpdateByExtensionSpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Service/Ivr/UpdateByExtensionSpec.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace spec\Ivoz\Provider\Domain\Service\Ivr;
+
+use Ivoz\Core\Application\Service\EntityTools;
+use Ivoz\Provider\Domain\Model\Extension\ExtensionInterface;
+use Ivoz\Provider\Domain\Model\Ivr\IvrDto;
+use Ivoz\Provider\Domain\Model\Ivr\IvrInterface;
+use Ivoz\Provider\Domain\Model\Ivr\IvrRepository;
+use Ivoz\Provider\Domain\Service\Ivr\UpdateByExtension;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class UpdateByExtensionSpec extends ObjectBehavior
+{
+    /**
+     * @var EntityTools
+     */
+    protected $entityTools;
+
+    /**
+     * @var IvrRepository
+     */
+    protected $ivrRepository;
+
+    public function let(
+        EntityTools $entityTools,
+        IvrRepository $ivrRepository
+    ) {
+        $this->entityTools = $entityTools;
+        $this->ivrRepository = $ivrRepository;
+
+        $this->beConstructedWith($entityTools, $ivrRepository);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(UpdateByExtension::class);
+    }
+
+    function it_cleans_up_no_input_extensions(
+        ExtensionInterface $extension,
+        IvrInterface $ivr,
+        IvrDto $ivrDto
+    ) {
+        $this
+            ->ivrRepository
+            ->findByExtension($extension)
+            ->willReturn([$ivr]);
+
+        $ivr
+            ->getNoInputExtension()
+            ->willReturn($extension)
+            ->shouldBeCalled();
+
+        $extension
+            ->getId()
+            ->willReturn(1)
+            ->shouldBeCalled();
+
+        $ivr
+            ->getErrorExtension()
+            ->willReturn(null)
+            ->shouldBeCalled();
+
+        $this
+            ->entityTools
+            ->entityToDto($ivr)
+            ->willReturn($ivrDto);
+
+        $ivrDto
+            ->setNoInputRouteType(null)
+            ->willReturn($ivrDto)
+            ->shouldBeCalled();
+
+        $ivrDto
+            ->setNoInputExtensionId(null)
+            ->willReturn($ivrDto)
+            ->shouldBeCalled();
+
+        $this
+            ->entityTools
+            ->persistDto($ivrDto, $ivr)
+            ->shouldBeCalled();
+
+        $this->execute($extension, false);
+    }
+
+
+
+    function it_cleans_up_no_error_extensions(
+        ExtensionInterface $extension,
+        IvrInterface $ivr,
+        IvrDto $ivrDto
+    ) {
+        $this
+            ->ivrRepository
+            ->findByExtension($extension)
+            ->willReturn([$ivr]);
+
+        $ivr
+            ->getNoInputExtension()
+            ->willReturn(null)
+            ->shouldBeCalled();
+
+        $extension
+            ->getId()
+            ->willReturn(1)
+            ->shouldBeCalled();
+
+        $ivr
+            ->getErrorExtension()
+            ->willReturn($extension)
+            ->shouldBeCalled();
+
+        $this
+            ->entityTools
+            ->entityToDto($ivr)
+            ->willReturn($ivrDto);
+
+        $ivrDto
+            ->setErrorRouteType(null)
+            ->willReturn($ivrDto)
+            ->shouldBeCalled();
+
+        $ivrDto
+            ->setErrorExtensionId(null)
+            ->willReturn($ivrDto)
+            ->shouldBeCalled();
+
+        $this
+            ->entityTools
+            ->persistDto($ivrDto, $ivr)
+            ->shouldBeCalled();
+
+        $this->execute($extension, false);
+    }
+}

--- a/library/spec/Ivoz/Provider/Domain/Service/Ivr/UpdateByUserSpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Service/Ivr/UpdateByUserSpec.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace spec\Ivoz\Provider\Domain\Service\Ivr;
+
+use Ivoz\Core\Application\Service\EntityTools;
+use Ivoz\Provider\Domain\Model\Ivr\IvrDto;
+use Ivoz\Provider\Domain\Model\Ivr\IvrInterface;
+use Ivoz\Provider\Domain\Model\Ivr\IvrRepository;
+use Ivoz\Provider\Domain\Model\User\UserInterface;
+use Ivoz\Provider\Domain\Service\Ivr\UpdateByUser;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class UpdateByUserSpec extends ObjectBehavior
+{
+    /**
+     * @var EntityTools
+     */
+    protected $entityTools;
+
+    /**
+     * @var IvrRepository
+     */
+    protected $ivrRepository;
+
+    public function let(
+        EntityTools $entityTools,
+        IvrRepository $ivrRepository
+    ) {
+        $this->entityTools = $entityTools;
+        $this->ivrRepository = $ivrRepository;
+
+        $this->beConstructedWith($entityTools, $ivrRepository);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(UpdateByUser::class);
+    }
+
+    function it_cleans_up_no_input_voicemail_user(
+        UserInterface $user,
+        IvrInterface $ivr,
+        IvrDto $ivrDto
+    ) {
+        $this
+            ->ivrRepository
+            ->findByUser($user)
+            ->willReturn([$ivr]);
+
+        $ivr
+            ->getNoInputVoiceMailUser()
+            ->willReturn($user)
+            ->shouldBeCalled();
+
+        $user
+            ->getId()
+            ->willReturn(1)
+            ->shouldBeCalled();
+
+        $ivr
+            ->getErrorVoiceMailUser()
+            ->willReturn(null)
+            ->shouldBeCalled();
+
+        $this
+            ->entityTools
+            ->entityToDto($ivr)
+            ->willReturn($ivrDto);
+
+        $ivrDto
+            ->setNoInputRouteType(null)
+            ->willReturn($ivrDto)
+            ->shouldBeCalled();
+
+        $ivrDto
+            ->setNoInputVoiceMailUserId(null)
+            ->willReturn($ivrDto)
+            ->shouldBeCalled();
+
+        $this
+            ->entityTools
+            ->persistDto($ivrDto, $ivr)
+            ->shouldBeCalled();
+
+        $this->execute($user, false);
+    }
+
+    function it_cleans_up_no_error_voicemail_user(
+        UserInterface $user,
+        IvrInterface $ivr,
+        IvrDto $ivrDto
+    ) {
+        $this
+            ->ivrRepository
+            ->findByUser($user)
+            ->willReturn([$ivr]);
+
+        $ivr
+            ->getNoInputVoiceMailUser()
+            ->willReturn(null)
+            ->shouldBeCalled();
+
+        $user
+            ->getId()
+            ->willReturn(1)
+            ->shouldBeCalled();
+
+        $ivr
+            ->getErrorVoiceMailUser()
+            ->willReturn($user)
+            ->shouldBeCalled();
+
+        $this
+            ->entityTools
+            ->entityToDto($ivr)
+            ->willReturn($ivrDto);
+
+        $ivrDto
+            ->setErrorRouteType(null)
+            ->willReturn($ivrDto)
+            ->shouldBeCalled();
+
+        $ivrDto
+            ->setErrorVoiceMailUserId(null)
+            ->willReturn($ivrDto)
+            ->shouldBeCalled();
+
+        $this
+            ->entityTools
+            ->persistDto($ivrDto, $ivr)
+            ->shouldBeCalled();
+
+        $this->execute($user, false);
+    }
+}

--- a/scheme/app/DoctrineMigrations/Version20180611142317.php
+++ b/scheme/app/DoctrineMigrations/Version20180611142317.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20180611142317 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE IVREntries DROP FOREIGN KEY FK_E847DD7C12AB7F65');
+        $this->addSql('ALTER TABLE IVREntries DROP FOREIGN KEY FK_E847DD7C9E2CE667');
+        $this->addSql('ALTER TABLE IVREntries DROP FOREIGN KEY FK_E847DD7CAF230FFD');
+        $this->addSql('ALTER TABLE IVREntries ADD CONSTRAINT FK_E847DD7C12AB7F65 FOREIGN KEY (extensionId) REFERENCES Extensions (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE IVREntries ADD CONSTRAINT FK_E847DD7C9E2CE667 FOREIGN KEY (conditionalRouteId) REFERENCES ConditionalRoutes (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE IVREntries ADD CONSTRAINT FK_E847DD7CAF230FFD FOREIGN KEY (voiceMailUserId) REFERENCES Users (id) ON DELETE CASCADE');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE IVREntries DROP FOREIGN KEY FK_E847DD7C12AB7F65');
+        $this->addSql('ALTER TABLE IVREntries DROP FOREIGN KEY FK_E847DD7CAF230FFD');
+        $this->addSql('ALTER TABLE IVREntries DROP FOREIGN KEY FK_E847DD7C9E2CE667');
+        $this->addSql('ALTER TABLE IVREntries ADD CONSTRAINT FK_E847DD7C12AB7F65 FOREIGN KEY (extensionId) REFERENCES Extensions (id) ON DELETE SET NULL');
+        $this->addSql('ALTER TABLE IVREntries ADD CONSTRAINT FK_E847DD7CAF230FFD FOREIGN KEY (voiceMailUserId) REFERENCES Users (id) ON DELETE SET NULL');
+        $this->addSql('ALTER TABLE IVREntries ADD CONSTRAINT FK_E847DD7C9E2CE667 FOREIGN KEY (conditionalRouteId) REFERENCES ConditionalRoutes (id) ON DELETE SET NULL');
+    }
+}


### PR DESCRIPTION
Set noInputRouteType and errorRouteType to null when target entities have been deleted.
Set on delete cascade constraints in IvrEntry

This PR aims to fix https://github.com/irontec/ivozprovider/issues/538 at artemis and #534 