### PR TITLE
core: clean up ivr state on user/extension delete

### DIFF
--- a/library/IvozProvider/Mapper/Sql/Extensions.php
+++ b/library/IvozProvider/Mapper/Sql/Extensions.php
@@ -80,4 +80,46 @@ class Extensions extends Raw\Extensions
         return $pk;
     }
 
+    /**
+     * @inheritdoc
+     */
+    public function delete(\IvozProvider\Model\Raw\ModelAbstract $model)
+    {
+        // IVRCustom
+        $customIvrsByTimeoutExtension = $model->getIVRCustomByTimeoutExtension();
+        foreach ($customIvrsByTimeoutExtension as $ivrByTimeoutExtension) {
+            $ivrByTimeoutExtension
+                ->setTimeoutTargetType(null)
+                ->setTimeoutExtensionId(null)
+                ->save();
+        }
+
+        $customIvrsByErrorExtension = $model->getIVRCustomByErrorExtension();
+        foreach ($customIvrsByErrorExtension as $ivrByErrorExtension) {
+            $ivrByErrorExtension
+                ->setErrorTargetType(null)
+                ->setErrorExtensionId(null)
+                ->save();
+        }
+
+        // IVRCommon
+        $commonIvrsByTimeoutExtension = $model->getIVRCommonByTimeoutExtension();
+        foreach ($commonIvrsByTimeoutExtension as $ivrByTimeoutExtension) {
+            $ivrByTimeoutExtension
+                ->setTimeoutTargetType(null)
+                ->setTimeoutExtensionId(null)
+                ->save();
+        }
+
+        $commonIvrsByErrorExtension = $model->getIVRCommonByErrorExtension();
+        foreach ($commonIvrsByErrorExtension as $ivrByErrorExtension) {
+            $ivrByErrorExtension
+                ->setErrorTargetType(null)
+                ->setErrorExtensionId(null)
+                ->save();
+        }
+
+        return parent::delete($model);
+    }
+
 }

--- a/library/IvozProvider/Mapper/Sql/Users.php
+++ b/library/IvozProvider/Mapper/Sql/Users.php
@@ -215,6 +215,40 @@ class Users extends Raw\Users
                 ->save();
         }
 
+        // IVRCustom
+        $customIvrsByTimeoutVoiceMailUser = $model->getIVRCustomByTimeoutVoiceMailUser();
+        foreach ($customIvrsByTimeoutVoiceMailUser as $ivrByTimeoutVoiceMailUser) {
+            $ivrByTimeoutVoiceMailUser
+                ->setTimeoutTargetType(null)
+                ->setTimeoutExtensionId(null)
+                ->save();
+        }
+
+        $customIvrsByErrorVoiceMailUser = $model->getIVRCustomByErrorVoiceMailUser();
+        foreach ($customIvrsByErrorVoiceMailUser as $ivrByErrorVoiceMailUser) {
+            $ivrByErrorVoiceMailUser
+                ->setErrorTargetType(null)
+                ->setErrorExtensionId(null)
+                ->save();
+        }
+
+        // IVRCommon
+        $commonIvrsByTimeoutVoiceMailUser = $model->getIVRCommonByTimeoutVoiceMailUser();
+        foreach ($commonIvrsByTimeoutVoiceMailUser as $ivrByTimeoutVoiceMailUser) {
+            $ivrByTimeoutVoiceMailUser
+                ->setTimeoutTargetType(null)
+                ->setTimeoutExtensionId(null)
+                ->save();
+        }
+
+        $commonIvrsByErrorVoiceMailUser = $model->getIVRCommonByErrorVoiceMailUser();
+        foreach ($commonIvrsByErrorVoiceMailUser as $ivrByErrorVoiceMailUser) {
+            $ivrByErrorVoiceMailUser
+                ->setErrorTargetType(null)
+                ->setErrorExtensionId(null)
+                ->save();
+        }
+
         return parent::delete($model);
     }
 

--- a/library/IvozProvider/Model/Raw/Users.php
+++ b/library/IvozProvider/Model/Raw/Users.php
@@ -693,6 +693,7 @@ class Users extends ModelAbstract
             'CallForwardSettings_ibfk_1',
             'CallForwardSettings_ibfk_3',
             'HuntGroupsRelUsers_ibfk_2',
+            'IVRCustomEntries_ibfk_4',
             'PickUpRelUsers_ibfk_2',
             'QueueMembers_ibfk_2'
         ));
@@ -711,7 +712,6 @@ class Users extends ModelAbstract
             'IVRCommon_ibfk_9',
             'IVRCustom_ibfk_8',
             'IVRCustom_ibfk_9',
-            'IVRCustomEntries_ibfk_4',
             'Queues_ibfk_5',
             'Queues_ibfk_8',
             'Users_ibfk_11'

--- a/scheme/deltas/084-ivr-custom-entries-cascade-constraint.sql
+++ b/scheme/deltas/084-ivr-custom-entries-cascade-constraint.sql
@@ -1,0 +1,7 @@
+ALTER TABLE `IVRCustomEntries` DROP FOREIGN KEY `IVRCustomEntries_ibfk_3`;
+ALTER TABLE `IVRCustomEntries` DROP FOREIGN KEY `IVRCustomEntries_ibfk_4`;
+ALTER TABLE `IVRCustomEntries` DROP FOREIGN KEY `IVRCustomEntries_ibfk_5`;
+
+ALTER TABLE `IVRCustomEntries` ADD CONSTRAINT `IVRCustomEntries_ibfk_3` FOREIGN KEY (`targetExtensionId`) REFERENCES `Extensions` (`id`) ON DELETE CASCADE;
+ALTER TABLE `IVRCustomEntries` ADD CONSTRAINT `IVRCustomEntries_ibfk_4` FOREIGN KEY (`targetVoiceMailUserId`) REFERENCES `Users` (`id`) ON DELETE CASCADE;
+ALTER TABLE `IVRCustomEntries` ADD CONSTRAINT `IVRCustomEntries_ibfk_5` FOREIGN KEY (`targetConditionalRouteId`) REFERENCES `ConditionalRoutes` (`id`) ON DELETE CASCADE;


### PR DESCRIPTION
Set targetTypes to null when target entities have been deleted.
Set on delete cascade constraints on IvrCustomEntries

This PR aims to fix #538 at oasis