### PR TITLE
Add support for Timings to Rating plans

### DIFF
--- a/debian/systemd/cgrates-loader.service
+++ b/debian/systemd/cgrates-loader.service
@@ -3,4 +3,4 @@ Description=Run cgr-loader with database tariff plans
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/cgr-loader -from_stordb -validate -cleanup -safety_key tp_changed_at
+ExecStart=/usr/bin/cgr-loader -from_stordb -validate -cleanup -timezone UTC -safety_key tp_changed_at

--- a/library/Ivoz/Cgr/Domain/Model/TpRatingPlan/TpRatingPlan.php
+++ b/library/Ivoz/Cgr/Domain/Model/TpRatingPlan/TpRatingPlan.php
@@ -2,12 +2,17 @@
 
 namespace Ivoz\Cgr\Domain\Model\TpRatingPlan;
 
+use Ivoz\Cgr\Domain\Model\TpTiming\TpTiming;
+
 /**
  * TpRatingPlan
  */
 class TpRatingPlan extends TpRatingPlanAbstract implements TpRatingPlanInterface
 {
     use TpRatingPlanTrait;
+
+    const TIMING_TYPE_ALWAYS = 'always';
+    const TIMING_TYPE_CUSTOM = 'custom';
 
     /**
      * Get id
@@ -19,6 +24,43 @@ class TpRatingPlan extends TpRatingPlanAbstract implements TpRatingPlanInterface
         return $this->id;
     }
 
+    protected function sanitizeValues()
+    {
+        if ($this->getTimingType() == TpRatingPlan::TIMING_TYPE_ALWAYS) {
+            $this
+                ->setTimingTag(TpTiming::TIMING_ANY)
+                ->setMonday(true)
+                ->setTuesday(true)
+                ->setWednesday(true)
+                ->setThursday(true)
+                ->setFriday(true)
+                ->setSaturday(true)
+                ->setSunday(true)
+                ->setTimeIn(new \DateTime('00:00:00'));
+        }
+    }
 
+    public function getWeekDays()
+    {
+        $daysMap = [
+            1 => $this->getMonday(),
+            2 => $this->getTuesday(),
+            3 => $this->getWednesday(),
+            4 => $this->getThursday(),
+            5 => $this->getFriday(),
+            6 => $this->getSaturday(),
+            7 => $this->getSunday(),
+        ];
+
+        $weekDays = array_filter($daysMap, function ($v) {
+            return $v !== 0;
+        });
+
+        if (count($weekDays) == 7) {
+            return TpTiming::TIMING_ANY;
+        }
+
+        return implode(';', array_keys($weekDays));
+    }
 }
 

--- a/library/Ivoz/Cgr/Domain/Model/TpRatingPlan/TpRatingPlanAbstract.php
+++ b/library/Ivoz/Cgr/Domain/Model/TpRatingPlan/TpRatingPlanAbstract.php
@@ -47,6 +47,54 @@ abstract class TpRatingPlanAbstract
     protected $createdAt;
 
     /**
+     * column: timing_type
+     * comment: enum:always|custom
+     * @var string
+     */
+    protected $timingType = 'always';
+
+    /**
+     * column: time_in
+     * @var \DateTime
+     */
+    protected $timeIn;
+
+    /**
+     * @var boolean
+     */
+    protected $monday = '1';
+
+    /**
+     * @var boolean
+     */
+    protected $tuesday = '1';
+
+    /**
+     * @var boolean
+     */
+    protected $wednesday = '1';
+
+    /**
+     * @var boolean
+     */
+    protected $thursday = '1';
+
+    /**
+     * @var boolean
+     */
+    protected $friday = '1';
+
+    /**
+     * @var boolean
+     */
+    protected $saturday = '1';
+
+    /**
+     * @var boolean
+     */
+    protected $sunday = '1';
+
+    /**
      * @var \Ivoz\Cgr\Domain\Model\TpTiming\TpTimingInterface
      */
     protected $timing;
@@ -57,9 +105,9 @@ abstract class TpRatingPlanAbstract
     protected $ratingPlan;
 
     /**
-     * @var \Ivoz\Provider\Domain\Model\DestinationRate\DestinationRateInterface
+     * @var \Ivoz\Provider\Domain\Model\DestinationRateGroup\DestinationRateGroupInterface
      */
-    protected $destinationRate;
+    protected $destinationRateGroup;
 
 
     use ChangelogTrait;
@@ -67,12 +115,18 @@ abstract class TpRatingPlanAbstract
     /**
      * Constructor
      */
-    protected function __construct($tpid, $timingTag, $weight, $createdAt)
-    {
+    protected function __construct(
+        $tpid,
+        $timingTag,
+        $weight,
+        $createdAt,
+        $timeIn
+    ) {
         $this->setTpid($tpid);
         $this->setTimingTag($timingTag);
         $this->setWeight($weight);
         $this->setCreatedAt($createdAt);
+        $this->setTimeIn($timeIn);
     }
 
     abstract public function getId();
@@ -142,14 +196,23 @@ abstract class TpRatingPlanAbstract
             $dto->getTpid(),
             $dto->getTimingTag(),
             $dto->getWeight(),
-            $dto->getCreatedAt());
+            $dto->getCreatedAt(),
+            $dto->getTimeIn());
 
         $self
             ->setTag($dto->getTag())
             ->setDestratesTag($dto->getDestratesTag())
+            ->setTimingType($dto->getTimingType())
+            ->setMonday($dto->getMonday())
+            ->setTuesday($dto->getTuesday())
+            ->setWednesday($dto->getWednesday())
+            ->setThursday($dto->getThursday())
+            ->setFriday($dto->getFriday())
+            ->setSaturday($dto->getSaturday())
+            ->setSunday($dto->getSunday())
             ->setTiming($dto->getTiming())
             ->setRatingPlan($dto->getRatingPlan())
-            ->setDestinationRate($dto->getDestinationRate())
+            ->setDestinationRateGroup($dto->getDestinationRateGroup())
         ;
 
         $self->sanitizeValues();
@@ -176,9 +239,18 @@ abstract class TpRatingPlanAbstract
             ->setTimingTag($dto->getTimingTag())
             ->setWeight($dto->getWeight())
             ->setCreatedAt($dto->getCreatedAt())
+            ->setTimingType($dto->getTimingType())
+            ->setTimeIn($dto->getTimeIn())
+            ->setMonday($dto->getMonday())
+            ->setTuesday($dto->getTuesday())
+            ->setWednesday($dto->getWednesday())
+            ->setThursday($dto->getThursday())
+            ->setFriday($dto->getFriday())
+            ->setSaturday($dto->getSaturday())
+            ->setSunday($dto->getSunday())
             ->setTiming($dto->getTiming())
             ->setRatingPlan($dto->getRatingPlan())
-            ->setDestinationRate($dto->getDestinationRate());
+            ->setDestinationRateGroup($dto->getDestinationRateGroup());
 
 
 
@@ -199,9 +271,18 @@ abstract class TpRatingPlanAbstract
             ->setTimingTag(self::getTimingTag())
             ->setWeight(self::getWeight())
             ->setCreatedAt(self::getCreatedAt())
+            ->setTimingType(self::getTimingType())
+            ->setTimeIn(self::getTimeIn())
+            ->setMonday(self::getMonday())
+            ->setTuesday(self::getTuesday())
+            ->setWednesday(self::getWednesday())
+            ->setThursday(self::getThursday())
+            ->setFriday(self::getFriday())
+            ->setSaturday(self::getSaturday())
+            ->setSunday(self::getSunday())
             ->setTiming(\Ivoz\Cgr\Domain\Model\TpTiming\TpTiming::entityToDto(self::getTiming(), $depth))
             ->setRatingPlan(\Ivoz\Provider\Domain\Model\RatingPlan\RatingPlan::entityToDto(self::getRatingPlan(), $depth))
-            ->setDestinationRate(\Ivoz\Provider\Domain\Model\DestinationRate\DestinationRate::entityToDto(self::getDestinationRate(), $depth));
+            ->setDestinationRateGroup(\Ivoz\Provider\Domain\Model\DestinationRateGroup\DestinationRateGroup::entityToDto(self::getDestinationRateGroup(), $depth));
     }
 
     /**
@@ -216,9 +297,18 @@ abstract class TpRatingPlanAbstract
             'timing_tag' => self::getTimingTag(),
             'weight' => self::getWeight(),
             'created_at' => self::getCreatedAt(),
+            'timing_type' => self::getTimingType(),
+            'time_in' => self::getTimeIn(),
+            'monday' => self::getMonday(),
+            'tuesday' => self::getTuesday(),
+            'wednesday' => self::getWednesday(),
+            'thursday' => self::getThursday(),
+            'friday' => self::getFriday(),
+            'saturday' => self::getSaturday(),
+            'sunday' => self::getSunday(),
             'timingId' => self::getTiming() ? self::getTiming()->getId() : null,
             'ratingPlanId' => self::getRatingPlan() ? self::getRatingPlan()->getId() : null,
-            'destinationRateId' => self::getDestinationRate() ? self::getDestinationRate()->getId() : null
+            'destinationRateGroupId' => self::getDestinationRateGroup() ? self::getDestinationRateGroup()->getId() : null
         ];
     }
 
@@ -393,6 +483,260 @@ abstract class TpRatingPlanAbstract
     }
 
     /**
+     * Set timingType
+     *
+     * @param string $timingType
+     *
+     * @return self
+     */
+    public function setTimingType($timingType = null)
+    {
+        if (!is_null($timingType)) {
+            Assertion::maxLength($timingType, 10, 'timingType value "%s" is too long, it should have no more than %d characters, but has %d characters.');
+        Assertion::choice($timingType, array (
+          0 => 'always',
+          1 => 'custom',
+        ), 'timingTypevalue "%s" is not an element of the valid values: %s');
+        }
+
+        $this->timingType = $timingType;
+
+        return $this;
+    }
+
+    /**
+     * Get timingType
+     *
+     * @return string
+     */
+    public function getTimingType()
+    {
+        return $this->timingType;
+    }
+
+    /**
+     * Set timeIn
+     *
+     * @param \DateTime $timeIn
+     *
+     * @return self
+     */
+    public function setTimeIn($timeIn)
+    {
+        Assertion::notNull($timeIn, 'timeIn value "%s" is null, but non null value was expected.');
+
+        $this->timeIn = $timeIn;
+
+        return $this;
+    }
+
+    /**
+     * Get timeIn
+     *
+     * @return \DateTime
+     */
+    public function getTimeIn()
+    {
+        return $this->timeIn;
+    }
+
+    /**
+     * Set monday
+     *
+     * @param boolean $monday
+     *
+     * @return self
+     */
+    public function setMonday($monday = null)
+    {
+        if (!is_null($monday)) {
+            Assertion::between(intval($monday), 0, 1, 'monday provided "%s" is not a valid boolean value.');
+        }
+
+        $this->monday = $monday;
+
+        return $this;
+    }
+
+    /**
+     * Get monday
+     *
+     * @return boolean
+     */
+    public function getMonday()
+    {
+        return $this->monday;
+    }
+
+    /**
+     * Set tuesday
+     *
+     * @param boolean $tuesday
+     *
+     * @return self
+     */
+    public function setTuesday($tuesday = null)
+    {
+        if (!is_null($tuesday)) {
+            Assertion::between(intval($tuesday), 0, 1, 'tuesday provided "%s" is not a valid boolean value.');
+        }
+
+        $this->tuesday = $tuesday;
+
+        return $this;
+    }
+
+    /**
+     * Get tuesday
+     *
+     * @return boolean
+     */
+    public function getTuesday()
+    {
+        return $this->tuesday;
+    }
+
+    /**
+     * Set wednesday
+     *
+     * @param boolean $wednesday
+     *
+     * @return self
+     */
+    public function setWednesday($wednesday = null)
+    {
+        if (!is_null($wednesday)) {
+            Assertion::between(intval($wednesday), 0, 1, 'wednesday provided "%s" is not a valid boolean value.');
+        }
+
+        $this->wednesday = $wednesday;
+
+        return $this;
+    }
+
+    /**
+     * Get wednesday
+     *
+     * @return boolean
+     */
+    public function getWednesday()
+    {
+        return $this->wednesday;
+    }
+
+    /**
+     * Set thursday
+     *
+     * @param boolean $thursday
+     *
+     * @return self
+     */
+    public function setThursday($thursday = null)
+    {
+        if (!is_null($thursday)) {
+            Assertion::between(intval($thursday), 0, 1, 'thursday provided "%s" is not a valid boolean value.');
+        }
+
+        $this->thursday = $thursday;
+
+        return $this;
+    }
+
+    /**
+     * Get thursday
+     *
+     * @return boolean
+     */
+    public function getThursday()
+    {
+        return $this->thursday;
+    }
+
+    /**
+     * Set friday
+     *
+     * @param boolean $friday
+     *
+     * @return self
+     */
+    public function setFriday($friday = null)
+    {
+        if (!is_null($friday)) {
+            Assertion::between(intval($friday), 0, 1, 'friday provided "%s" is not a valid boolean value.');
+        }
+
+        $this->friday = $friday;
+
+        return $this;
+    }
+
+    /**
+     * Get friday
+     *
+     * @return boolean
+     */
+    public function getFriday()
+    {
+        return $this->friday;
+    }
+
+    /**
+     * Set saturday
+     *
+     * @param boolean $saturday
+     *
+     * @return self
+     */
+    public function setSaturday($saturday = null)
+    {
+        if (!is_null($saturday)) {
+            Assertion::between(intval($saturday), 0, 1, 'saturday provided "%s" is not a valid boolean value.');
+        }
+
+        $this->saturday = $saturday;
+
+        return $this;
+    }
+
+    /**
+     * Get saturday
+     *
+     * @return boolean
+     */
+    public function getSaturday()
+    {
+        return $this->saturday;
+    }
+
+    /**
+     * Set sunday
+     *
+     * @param boolean $sunday
+     *
+     * @return self
+     */
+    public function setSunday($sunday = null)
+    {
+        if (!is_null($sunday)) {
+            Assertion::between(intval($sunday), 0, 1, 'sunday provided "%s" is not a valid boolean value.');
+        }
+
+        $this->sunday = $sunday;
+
+        return $this;
+    }
+
+    /**
+     * Get sunday
+     *
+     * @return boolean
+     */
+    public function getSunday()
+    {
+        return $this->sunday;
+    }
+
+    /**
      * Set timing
      *
      * @param \Ivoz\Cgr\Domain\Model\TpTiming\TpTimingInterface $timing
@@ -441,27 +785,27 @@ abstract class TpRatingPlanAbstract
     }
 
     /**
-     * Set destinationRate
+     * Set destinationRateGroup
      *
-     * @param \Ivoz\Provider\Domain\Model\DestinationRate\DestinationRateInterface $destinationRate
+     * @param \Ivoz\Provider\Domain\Model\DestinationRateGroup\DestinationRateGroupInterface $destinationRateGroup
      *
      * @return self
      */
-    public function setDestinationRate(\Ivoz\Provider\Domain\Model\DestinationRate\DestinationRateInterface $destinationRate)
+    public function setDestinationRateGroup(\Ivoz\Provider\Domain\Model\DestinationRateGroup\DestinationRateGroupInterface $destinationRateGroup)
     {
-        $this->destinationRate = $destinationRate;
+        $this->destinationRateGroup = $destinationRateGroup;
 
         return $this;
     }
 
     /**
-     * Get destinationRate
+     * Get destinationRateGroup
      *
-     * @return \Ivoz\Provider\Domain\Model\DestinationRate\DestinationRateInterface
+     * @return \Ivoz\Provider\Domain\Model\DestinationRateGroup\DestinationRateGroupInterface
      */
-    public function getDestinationRate()
+    public function getDestinationRateGroup()
     {
-        return $this->destinationRate;
+        return $this->destinationRateGroup;
     }
 
 

--- a/library/Ivoz/Cgr/Domain/Model/TpRatingPlan/TpRatingPlanDtoAbstract.php
+++ b/library/Ivoz/Cgr/Domain/Model/TpRatingPlan/TpRatingPlanDtoAbstract.php
@@ -43,6 +43,51 @@ abstract class TpRatingPlanDtoAbstract implements DataTransferObjectInterface
     private $createdAt = 'CURRENT_TIMESTAMP';
 
     /**
+     * @var string
+     */
+    private $timingType = 'always';
+
+    /**
+     * @var \DateTime
+     */
+    private $timeIn;
+
+    /**
+     * @var boolean
+     */
+    private $monday = '1';
+
+    /**
+     * @var boolean
+     */
+    private $tuesday = '1';
+
+    /**
+     * @var boolean
+     */
+    private $wednesday = '1';
+
+    /**
+     * @var boolean
+     */
+    private $thursday = '1';
+
+    /**
+     * @var boolean
+     */
+    private $friday = '1';
+
+    /**
+     * @var boolean
+     */
+    private $saturday = '1';
+
+    /**
+     * @var boolean
+     */
+    private $sunday = '1';
+
+    /**
      * @var integer
      */
     private $id;
@@ -58,9 +103,9 @@ abstract class TpRatingPlanDtoAbstract implements DataTransferObjectInterface
     private $ratingPlan;
 
     /**
-     * @var \Ivoz\Provider\Domain\Model\DestinationRate\DestinationRateDto | null
+     * @var \Ivoz\Provider\Domain\Model\DestinationRateGroup\DestinationRateGroupDto | null
      */
-    private $destinationRate;
+    private $destinationRateGroup;
 
 
     use DtoNormalizer;
@@ -86,10 +131,19 @@ abstract class TpRatingPlanDtoAbstract implements DataTransferObjectInterface
             'timingTag' => 'timingTag',
             'weight' => 'weight',
             'createdAt' => 'createdAt',
+            'timingType' => 'timingType',
+            'timeIn' => 'timeIn',
+            'monday' => 'monday',
+            'tuesday' => 'tuesday',
+            'wednesday' => 'wednesday',
+            'thursday' => 'thursday',
+            'friday' => 'friday',
+            'saturday' => 'saturday',
+            'sunday' => 'sunday',
             'id' => 'id',
             'timingId' => 'timing',
             'ratingPlanId' => 'ratingPlan',
-            'destinationRateId' => 'destinationRate'
+            'destinationRateGroupId' => 'destinationRateGroup'
         ];
     }
 
@@ -105,10 +159,19 @@ abstract class TpRatingPlanDtoAbstract implements DataTransferObjectInterface
             'timingTag' => $this->getTimingTag(),
             'weight' => $this->getWeight(),
             'createdAt' => $this->getCreatedAt(),
+            'timingType' => $this->getTimingType(),
+            'timeIn' => $this->getTimeIn(),
+            'monday' => $this->getMonday(),
+            'tuesday' => $this->getTuesday(),
+            'wednesday' => $this->getWednesday(),
+            'thursday' => $this->getThursday(),
+            'friday' => $this->getFriday(),
+            'saturday' => $this->getSaturday(),
+            'sunday' => $this->getSunday(),
             'id' => $this->getId(),
             'timing' => $this->getTiming(),
             'ratingPlan' => $this->getRatingPlan(),
-            'destinationRate' => $this->getDestinationRate()
+            'destinationRateGroup' => $this->getDestinationRateGroup()
         ];
     }
 
@@ -119,7 +182,7 @@ abstract class TpRatingPlanDtoAbstract implements DataTransferObjectInterface
     {
         $this->timing = $transformer->transform('Ivoz\\Cgr\\Domain\\Model\\TpTiming\\TpTiming', $this->getTimingId());
         $this->ratingPlan = $transformer->transform('Ivoz\\Provider\\Domain\\Model\\RatingPlan\\RatingPlan', $this->getRatingPlanId());
-        $this->destinationRate = $transformer->transform('Ivoz\\Provider\\Domain\\Model\\DestinationRate\\DestinationRate', $this->getDestinationRateId());
+        $this->destinationRateGroup = $transformer->transform('Ivoz\\Provider\\Domain\\Model\\DestinationRateGroup\\DestinationRateGroup', $this->getDestinationRateGroupId());
     }
 
     /**
@@ -251,6 +314,186 @@ abstract class TpRatingPlanDtoAbstract implements DataTransferObjectInterface
     }
 
     /**
+     * @param string $timingType
+     *
+     * @return static
+     */
+    public function setTimingType($timingType = null)
+    {
+        $this->timingType = $timingType;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTimingType()
+    {
+        return $this->timingType;
+    }
+
+    /**
+     * @param \DateTime $timeIn
+     *
+     * @return static
+     */
+    public function setTimeIn($timeIn = null)
+    {
+        $this->timeIn = $timeIn;
+
+        return $this;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getTimeIn()
+    {
+        return $this->timeIn;
+    }
+
+    /**
+     * @param boolean $monday
+     *
+     * @return static
+     */
+    public function setMonday($monday = null)
+    {
+        $this->monday = $monday;
+
+        return $this;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getMonday()
+    {
+        return $this->monday;
+    }
+
+    /**
+     * @param boolean $tuesday
+     *
+     * @return static
+     */
+    public function setTuesday($tuesday = null)
+    {
+        $this->tuesday = $tuesday;
+
+        return $this;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getTuesday()
+    {
+        return $this->tuesday;
+    }
+
+    /**
+     * @param boolean $wednesday
+     *
+     * @return static
+     */
+    public function setWednesday($wednesday = null)
+    {
+        $this->wednesday = $wednesday;
+
+        return $this;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getWednesday()
+    {
+        return $this->wednesday;
+    }
+
+    /**
+     * @param boolean $thursday
+     *
+     * @return static
+     */
+    public function setThursday($thursday = null)
+    {
+        $this->thursday = $thursday;
+
+        return $this;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getThursday()
+    {
+        return $this->thursday;
+    }
+
+    /**
+     * @param boolean $friday
+     *
+     * @return static
+     */
+    public function setFriday($friday = null)
+    {
+        $this->friday = $friday;
+
+        return $this;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getFriday()
+    {
+        return $this->friday;
+    }
+
+    /**
+     * @param boolean $saturday
+     *
+     * @return static
+     */
+    public function setSaturday($saturday = null)
+    {
+        $this->saturday = $saturday;
+
+        return $this;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getSaturday()
+    {
+        return $this->saturday;
+    }
+
+    /**
+     * @param boolean $sunday
+     *
+     * @return static
+     */
+    public function setSunday($sunday = null)
+    {
+        $this->sunday = $sunday;
+
+        return $this;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getSunday()
+    {
+        return $this->sunday;
+    }
+
+    /**
      * @param integer $id
      *
      * @return static
@@ -363,23 +606,23 @@ abstract class TpRatingPlanDtoAbstract implements DataTransferObjectInterface
     }
 
     /**
-     * @param \Ivoz\Provider\Domain\Model\DestinationRate\DestinationRateDto $destinationRate
+     * @param \Ivoz\Provider\Domain\Model\DestinationRateGroup\DestinationRateGroupDto $destinationRateGroup
      *
      * @return static
      */
-    public function setDestinationRate(\Ivoz\Provider\Domain\Model\DestinationRate\DestinationRateDto $destinationRate = null)
+    public function setDestinationRateGroup(\Ivoz\Provider\Domain\Model\DestinationRateGroup\DestinationRateGroupDto $destinationRateGroup = null)
     {
-        $this->destinationRate = $destinationRate;
+        $this->destinationRateGroup = $destinationRateGroup;
 
         return $this;
     }
 
     /**
-     * @return \Ivoz\Provider\Domain\Model\DestinationRate\DestinationRateDto
+     * @return \Ivoz\Provider\Domain\Model\DestinationRateGroup\DestinationRateGroupDto
      */
-    public function getDestinationRate()
+    public function getDestinationRateGroup()
     {
-        return $this->destinationRate;
+        return $this->destinationRateGroup;
     }
 
     /**
@@ -387,21 +630,21 @@ abstract class TpRatingPlanDtoAbstract implements DataTransferObjectInterface
      *
      * @return static
      */
-    public function setDestinationRateId($id)
+    public function setDestinationRateGroupId($id)
     {
         $value = !is_null($id)
-            ? new \Ivoz\Provider\Domain\Model\DestinationRate\DestinationRateDto($id)
+            ? new \Ivoz\Provider\Domain\Model\DestinationRateGroup\DestinationRateGroupDto($id)
             : null;
 
-        return $this->setDestinationRate($value);
+        return $this->setDestinationRateGroup($value);
     }
 
     /**
      * @return integer | null
      */
-    public function getDestinationRateId()
+    public function getDestinationRateGroupId()
     {
-        if ($dto = $this->getDestinationRate()) {
+        if ($dto = $this->getDestinationRateGroup()) {
             return $dto->getId();
         }
 

--- a/library/Ivoz/Cgr/Domain/Model/TpRatingPlan/TpRatingPlanInterface.php
+++ b/library/Ivoz/Cgr/Domain/Model/TpRatingPlan/TpRatingPlanInterface.php
@@ -6,6 +6,8 @@ use Ivoz\Core\Domain\Model\EntityInterface;
 
 interface TpRatingPlanInterface extends EntityInterface
 {
+    public function getWeekDays();
+
     /**
      * Set tpid
      *
@@ -103,6 +105,150 @@ interface TpRatingPlanInterface extends EntityInterface
     public function getCreatedAt();
 
     /**
+     * Set timingType
+     *
+     * @param string $timingType
+     *
+     * @return self
+     */
+    public function setTimingType($timingType = null);
+
+    /**
+     * Get timingType
+     *
+     * @return string
+     */
+    public function getTimingType();
+
+    /**
+     * Set timeIn
+     *
+     * @param \DateTime $timeIn
+     *
+     * @return self
+     */
+    public function setTimeIn($timeIn);
+
+    /**
+     * Get timeIn
+     *
+     * @return \DateTime
+     */
+    public function getTimeIn();
+
+    /**
+     * Set monday
+     *
+     * @param boolean $monday
+     *
+     * @return self
+     */
+    public function setMonday($monday = null);
+
+    /**
+     * Get monday
+     *
+     * @return boolean
+     */
+    public function getMonday();
+
+    /**
+     * Set tuesday
+     *
+     * @param boolean $tuesday
+     *
+     * @return self
+     */
+    public function setTuesday($tuesday = null);
+
+    /**
+     * Get tuesday
+     *
+     * @return boolean
+     */
+    public function getTuesday();
+
+    /**
+     * Set wednesday
+     *
+     * @param boolean $wednesday
+     *
+     * @return self
+     */
+    public function setWednesday($wednesday = null);
+
+    /**
+     * Get wednesday
+     *
+     * @return boolean
+     */
+    public function getWednesday();
+
+    /**
+     * Set thursday
+     *
+     * @param boolean $thursday
+     *
+     * @return self
+     */
+    public function setThursday($thursday = null);
+
+    /**
+     * Get thursday
+     *
+     * @return boolean
+     */
+    public function getThursday();
+
+    /**
+     * Set friday
+     *
+     * @param boolean $friday
+     *
+     * @return self
+     */
+    public function setFriday($friday = null);
+
+    /**
+     * Get friday
+     *
+     * @return boolean
+     */
+    public function getFriday();
+
+    /**
+     * Set saturday
+     *
+     * @param boolean $saturday
+     *
+     * @return self
+     */
+    public function setSaturday($saturday = null);
+
+    /**
+     * Get saturday
+     *
+     * @return boolean
+     */
+    public function getSaturday();
+
+    /**
+     * Set sunday
+     *
+     * @param boolean $sunday
+     *
+     * @return self
+     */
+    public function setSunday($sunday = null);
+
+    /**
+     * Get sunday
+     *
+     * @return boolean
+     */
+    public function getSunday();
+
+    /**
      * Set timing
      *
      * @param \Ivoz\Cgr\Domain\Model\TpTiming\TpTimingInterface $timing
@@ -135,20 +281,20 @@ interface TpRatingPlanInterface extends EntityInterface
     public function getRatingPlan();
 
     /**
-     * Set destinationRate
+     * Set destinationRateGroup
      *
-     * @param \Ivoz\Provider\Domain\Model\DestinationRate\DestinationRateInterface $destinationRate
+     * @param \Ivoz\Provider\Domain\Model\DestinationRateGroup\DestinationRateGroupInterface $destinationRateGroup
      *
      * @return self
      */
-    public function setDestinationRate(\Ivoz\Provider\Domain\Model\DestinationRate\DestinationRateInterface $destinationRate);
+    public function setDestinationRateGroup(\Ivoz\Provider\Domain\Model\DestinationRateGroup\DestinationRateGroupInterface $destinationRateGroup);
 
     /**
-     * Get destinationRate
+     * Get destinationRateGroup
      *
-     * @return \Ivoz\Provider\Domain\Model\DestinationRate\DestinationRateInterface
+     * @return \Ivoz\Provider\Domain\Model\DestinationRateGroup\DestinationRateGroupInterface
      */
-    public function getDestinationRate();
+    public function getDestinationRateGroup();
 
 }
 

--- a/library/Ivoz/Cgr/Domain/Model/TpTiming/TpTiming.php
+++ b/library/Ivoz/Cgr/Domain/Model/TpTiming/TpTiming.php
@@ -9,6 +9,10 @@ class TpTiming extends TpTimingAbstract implements TpTimingInterface
 {
     use TpTimingTrait;
 
+    const TIMING_ANY    = '*any';
+    const TIMING_ALL    = '*all';
+    const TIMING_ASAP   = '*asap';
+
     /**
      * Get id
      * @codeCoverageIgnore

--- a/library/Ivoz/Cgr/Domain/Service/TpRatingPlan/InheritRatingPlanTag.php
+++ b/library/Ivoz/Cgr/Domain/Service/TpRatingPlan/InheritRatingPlanTag.php
@@ -21,15 +21,8 @@ class InheritRatingPlanTag implements TpRatingPlanLifecycleEventHandlerInterface
         );
 
         $entity->setDestratesTag(
-            $entity->getDestinationRate()->getTag()
+            $entity->getDestinationRateGroup()->getCgrTag()
         );
-
-        $timing = $entity->getTiming();
-        if (!is_null($timing)) {
-            $entity->setTimingTag(
-                $entity->getTiming()->getTag()
-            );
-        }
     }
 
 }

--- a/library/Ivoz/Cgr/Domain/Service/TpTiming/CreatedByTpRatingPlan.php
+++ b/library/Ivoz/Cgr/Domain/Service/TpTiming/CreatedByTpRatingPlan.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Ivoz\Cgr\Domain\Service\TpTiming;
+
+use Ivoz\Cgr\Domain\Model\TpRatingPlan\TpRatingPlan;
+use Ivoz\Cgr\Domain\Model\TpRatingPlan\TpRatingPlanInterface;
+use Ivoz\Cgr\Domain\Model\TpTiming\TpTiming;
+use Ivoz\Cgr\Domain\Model\TpTiming\TpTimingDto;
+use Ivoz\Cgr\Domain\Service\TpRatingPlan\TpRatingPlanLifecycleEventHandlerInterface;
+use Ivoz\Core\Application\Service\EntityTools;
+
+class CreatedByTpRatingPlan implements TpRatingPlanLifecycleEventHandlerInterface
+{
+    CONST POST_PERSIST_PRIORITY = self::PRIORITY_NORMAL;
+
+    /**
+     * @var EntityTools
+     */
+    protected $entityTools;
+
+    /**
+     * CreatedByTpRatingPlan constructor.
+     *
+     * @param EntityTools $entityTools
+     */
+    public function __construct(
+        EntityTools $entityTools
+    ) {
+        $this->entityTools = $entityTools;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            self::EVENT_POST_PERSIST => self::POST_PERSIST_PRIORITY
+        ];
+    }
+
+    public function execute(TpRatingPlanInterface $entity)
+    {
+        $timing = $entity->getTiming();
+
+        // Always timings don't have timing entity related
+        if ($entity->getTimingType() == TpRatingPlan::TIMING_TYPE_ALWAYS) {
+            if ($timing) {
+                // Delete custom timing if exists
+                $this->entityTools->remove($entity->getTiming());
+            }
+        } else {
+
+            // Update related timing or create a new one
+            if (is_null($timing)) {
+                $timingDto = new TpTimingDto();
+            } else {
+                $timingDto = $timing->toDto();
+            }
+
+            $timingTag = sprintf("b%dtm%d",
+                $entity->getRatingPlan()->getBrand()->getId(),
+                $entity->getId()
+            );
+
+            // Update/Insert endpoint data
+            $timingDto
+                ->setTag($timingTag)
+                ->setYears(TpTiming::TIMING_ANY)
+                ->setMonths(TpTiming::TIMING_ANY)
+                ->setMonthDays(TpTiming::TIMING_ANY)
+                ->setWeekDays($entity->getWeekDays())
+                ->setTime($entity->getTimeIn()->format("H:i:s"));
+
+            $timing = $this->entityTools
+                ->persistDto(
+                    $timingDto,
+                    $timing,
+                    true
+                );
+
+            $entity
+                ->setTiming($timing)
+                ->setTimingTag($timingTag);
+
+        }
+    }
+
+}

--- a/library/Ivoz/Cgr/Domain/Service/TpTiming/DeletedByTpRatingPlan.php
+++ b/library/Ivoz/Cgr/Domain/Service/TpTiming/DeletedByTpRatingPlan.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Ivoz\Cgr\Domain\Service\TpTiming;
+
+use Ivoz\Cgr\Domain\Model\TpRatingPlan\TpRatingPlanInterface;
+use Ivoz\Cgr\Domain\Service\TpRatingPlan\TpRatingPlanLifecycleEventHandlerInterface;
+use Ivoz\Core\Application\Service\EntityTools;
+
+class DeletedByTpRatingPlan implements TpRatingPlanLifecycleEventHandlerInterface
+{
+    CONST POST_REMOVE_PRIORITY = self::PRIORITY_NORMAL;
+
+
+    /**
+     * @var EntityTools
+     */
+    protected $entityTools;
+
+    /**
+     * DeletedByTpRatingPlan constructor.
+     *
+     * @param EntityTools $entityTools
+     */
+    public function __construct(
+        EntityTools $entityTools
+    ) {
+        $this->entityTools = $entityTools;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            self::EVENT_POST_REMOVE => self::POST_REMOVE_PRIORITY
+        ];
+    }
+
+    public function execute(TpRatingPlanInterface $entity)
+    {
+        $timing = $entity->getTiming();
+
+        if ($timing) {
+            // Delete custom timing if exists
+            $this->entityTools->remove($entity->getTiming());
+        }
+    }
+}

--- a/library/Ivoz/Cgr/Domain/Service/TpTiming/TpTimingLifecycleEventHandlerInterface.php
+++ b/library/Ivoz/Cgr/Domain/Service/TpTiming/TpTimingLifecycleEventHandlerInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Ivoz\Cgr\Domain\Service\TpTiming;
+
+use Ivoz\Cgr\Domain\Model\TpTiming\TpTimingInterface;
+use Ivoz\Core\Domain\Service\LifecycleEventHandlerInterface;
+
+interface TpTimingLifecycleEventHandlerInterface extends LifecycleEventHandlerInterface
+{
+    public function execute(TpTimingInterface $entity);
+}

--- a/library/Ivoz/Cgr/Domain/Service/TpTiming/TpTimingLifecycleServiceCollection.php
+++ b/library/Ivoz/Cgr/Domain/Service/TpTiming/TpTimingLifecycleServiceCollection.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Ivoz\Cgr\Domain\Service\TpTiming;
+
+use Ivoz\Core\Domain\Service\LifecycleServiceCollectionInterface;
+use Ivoz\Core\Domain\Service\LifecycleServiceCollectionTrait;
+
+/**
+ * @codeCoverageIgnore
+ */
+class TpTimingLifecycleServiceCollection implements LifecycleServiceCollectionInterface
+{
+    use LifecycleServiceCollectionTrait;
+
+    protected function addService(TpTimingLifecycleEventHandlerInterface $service)
+    {
+        $this->services[] = $service;
+    }
+}

--- a/library/Ivoz/Cgr/Domain/Service/TpTiming/UpdatedTpTimingNotificator.php
+++ b/library/Ivoz/Cgr/Domain/Service/TpTiming/UpdatedTpTimingNotificator.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Ivoz\Cgr\Domain\Service\TpTiming;
+
+use Ivoz\Cgr\Domain\Model\TpTiming\TpTimingInterface;
+use Ivoz\Core\Infrastructure\Domain\Service\Redis\Client as RedisClient;
+
+class UpdatedTpTimingNotificator implements TpTimingLifecycleEventHandlerInterface
+{
+    CONST ON_COMMIT_PRIORITY = self::PRIORITY_NORMAL;
+
+    private $client;
+
+    public function __construct(RedisClient $client)
+    {
+        $this->client = $client;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            self::EVENT_ON_COMMIT => self::ON_COMMIT_PRIORITY
+        ];
+    }
+
+    public function execute(TpTimingInterface $entity)
+    {
+        $this->client->scheduleFullReload();
+    }
+}

--- a/library/Ivoz/Cgr/Infrastructure/Persistence/Doctrine/Mapping/TpRatingPlan.TpRatingPlanAbstract.orm.yml
+++ b/library/Ivoz/Cgr/Infrastructure/Persistence/Doctrine/Mapping/TpRatingPlan.TpRatingPlanAbstract.orm.yml
@@ -58,6 +58,54 @@ Ivoz\Cgr\Domain\Model\TpRatingPlan\TpRatingPlanAbstract:
       options:
         default: CURRENT_TIMESTAMP
       column: created_at
+    timingType:
+      type: string
+      nullable: true
+      length: 10
+      options:
+        fixed: false
+        comment: '[enum:always|custom]'
+        default: 'always'
+      column: timing_type
+    timeIn:
+      type: time
+      nullable: false
+      column: time_in
+    monday:
+      type: boolean
+      nullable: true
+      options:
+        default: '1'
+    tuesday:
+      type: boolean
+      nullable: true
+      options:
+        default: '1'
+    wednesday:
+      type: boolean
+      nullable: true
+      options:
+        default: '1'
+    thursday:
+      type: boolean
+      nullable: true
+      options:
+        default: '1'
+    friday:
+      type: boolean
+      nullable: true
+      options:
+        default: '1'
+    saturday:
+      type: boolean
+      nullable: true
+      options:
+        default: '1'
+    sunday:
+      type: boolean
+      nullable: true
+      options:
+        default: '1'
   manyToOne:
     ratingPlan:
       targetEntity: \Ivoz\Provider\Domain\Model\RatingPlan\RatingPlanInterface
@@ -71,14 +119,14 @@ Ivoz\Cgr\Domain\Model\TpRatingPlan\TpRatingPlanAbstract:
           referencedColumnName: id
           onDelete: cascade
       orphanRemoval: false
-    destinationRate:
-      targetEntity: \Ivoz\Provider\Domain\Model\DestinationRate\DestinationRateInterface
+    destinationRateGroup:
+      targetEntity: \Ivoz\Provider\Domain\Model\DestinationRateGroup\DestinationRateGroupInterface
       cascade: {  }
       fetch: LAZY
       mappedBy: null
       inversedBy: null
       joinColumns:
-        destinationRateId:
+        destinationRateGroupId:
           nullable: false
           referencedColumnName: id
           onDelete: cascade

--- a/library/Ivoz/Core/Infrastructure/Domain/Service/DoctrineEntityPersister.php
+++ b/library/Ivoz/Core/Infrastructure/Domain/Service/DoctrineEntityPersister.php
@@ -2,7 +2,6 @@
 
 namespace Ivoz\Core\Infrastructure\Domain\Service;
 
-use Doctrine\Common\EventArgs;
 use Ivoz\Core\Application\Service\CreateEntityFromDTO;
 use Ivoz\Core\Application\Service\UpdateEntityFromDTO;
 use Ivoz\Core\Application\DataTransferObjectInterface;

--- a/library/Ivoz/Core/Infrastructure/Domain/Service/Lifecycle/DoctrineEventSubscriber.php
+++ b/library/Ivoz/Core/Infrastructure/Domain/Service/Lifecycle/DoctrineEventSubscriber.php
@@ -151,6 +151,10 @@ class DoctrineEventSubscriber implements EventSubscriber
         }
 
         foreach ($this->flushedEntities as $entity) {
+
+            if (!$entity->__isInitialized__) {
+                continue;
+            }
             $entity->initChangelog();
         }
 

--- a/library/Ivoz/Provider/Domain/Model/Destination/Destination.php
+++ b/library/Ivoz/Provider/Domain/Model/Destination/Destination.php
@@ -49,7 +49,8 @@ class Destination extends DestinationAbstract implements DestinationInterface
     public function getCgrTag()
     {
         return sprintf(
-            "dst%d",
+            "b%ddst%d",
+            $this->getBrand()->getId(),
             $this->getId()
         );
     }

--- a/library/Ivoz/Provider/Domain/Model/DestinationRate/DestinationRate.php
+++ b/library/Ivoz/Provider/Domain/Model/DestinationRate/DestinationRate.php
@@ -34,7 +34,7 @@ class DestinationRate extends DestinationRateAbstract implements DestinationRate
      */
     public function getCgrTag()
     {
-        return sprintf("dr%d", $this->getDestinationRateGroup()->getId());
+        return $this->getDestinationRateGroup()->getCgrTag();
     }
 
     /**
@@ -42,7 +42,11 @@ class DestinationRate extends DestinationRateAbstract implements DestinationRate
      */
     public function getCgrRatesTag()
     {
-        return sprintf("rt%d", $this->getId());
+        return sprintf(
+            "b%drt%d",
+            $this->getDestinationRateGroup()->getBrand()->getId(),
+            $this->getId()
+        );
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/DestinationRateGroup/DestinationRateGroup.php
+++ b/library/Ivoz/Provider/Domain/Model/DestinationRateGroup/DestinationRateGroup.php
@@ -58,5 +58,17 @@ class DestinationRateGroup extends DestinationRateGroupAbstract implements Desti
         }
         $this->_addTmpFile($fldName, $file);
     }
+
+    /**
+     * @return string
+     */
+    public function getCgrTag()
+    {
+        return sprintf(
+            "b%ddr%d",
+            $this->getBrand()->getId(),
+            $this->getId()
+        );
+    }
 }
 

--- a/library/Ivoz/Provider/Domain/Model/DestinationRateGroup/DestinationRateGroupInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/DestinationRateGroup/DestinationRateGroupInterface.php
@@ -27,6 +27,11 @@ interface DestinationRateGroupInterface extends LoggableEntityInterface
     public function addTmpFile($fldName, \Ivoz\Core\Domain\Service\TempFile $file);
 
     /**
+     * @return string
+     */
+    public function getCgrTag();
+
+    /**
      * Set status
      *
      * @param string $status

--- a/scheme/app/DoctrineMigrations/Version20180802142456.php
+++ b/scheme/app/DoctrineMigrations/Version20180802142456.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20180802142456 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE tp_rating_plans DROP FOREIGN KEY FK_4CC2BCAB4EB67480');
+        $this->addSql('DROP INDEX IDX_4CC2BCAB4EB67480 ON tp_rating_plans');
+        $this->addSql('ALTER TABLE tp_rating_plans ADD timing_type VARCHAR(10) DEFAULT \'always\' COMMENT \'[enum:always|custom]\', ADD time_in TIME NOT NULL, ADD monday TINYINT(1) DEFAULT \'1\', ADD tuesday TINYINT(1) DEFAULT \'1\', ADD wednesday TINYINT(1) DEFAULT \'1\', ADD thursday TINYINT(1) DEFAULT \'1\', ADD friday TINYINT(1) DEFAULT \'1\', ADD saturday TINYINT(1) DEFAULT \'1\', ADD sunday TINYINT(1) DEFAULT \'1\', CHANGE destinationrateid destinationRateGroupId INT UNSIGNED NOT NULL');
+        $this->addSql('ALTER TABLE tp_rating_plans ADD CONSTRAINT FK_4CC2BCABC11683D9 FOREIGN KEY (destinationRateGroupId) REFERENCES DestinationRateGroups (id) ON DELETE CASCADE');
+        $this->addSql('CREATE INDEX IDX_4CC2BCABC11683D9 ON tp_rating_plans (destinationRateGroupId)');
+
+        // Delete ALWAYS unused timing
+        $this->addSql("DELETE FROM tp_timings WHERE tag='ALWAYS'");
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE tp_rating_plans DROP FOREIGN KEY FK_4CC2BCABC11683D9');
+        $this->addSql('DROP INDEX IDX_4CC2BCABC11683D9 ON tp_rating_plans');
+        $this->addSql('ALTER TABLE tp_rating_plans DROP timing_type, DROP time_in, DROP monday, DROP tuesday, DROP wednesday, DROP thursday, DROP friday, DROP saturday, DROP sunday, CHANGE destinationrategroupid destinationRateId INT UNSIGNED NOT NULL');
+        $this->addSql('ALTER TABLE tp_rating_plans ADD CONSTRAINT FK_4CC2BCAB4EB67480 FOREIGN KEY (destinationRateId) REFERENCES DestinationRates (id) ON DELETE CASCADE');
+        $this->addSql('CREATE INDEX IDX_4CC2BCAB4EB67480 ON tp_rating_plans (destinationRateId)');
+    }
+}

--- a/web/admin/application/configs/klear/TpRatingPlansList.yaml
+++ b/web/admin/application/configs/klear/TpRatingPlansList.yaml
@@ -50,8 +50,20 @@ production:
         group1:
           colsPerRow: 4
           fields:
-            destinationRate: 3
+            destinationRateGroup: 3
             weight: 1
+        group2:
+          colsPerRow: 6
+          fields:
+            timingType: 3
+            timeIn: 3
+            monday: 1
+            tuesday: 1
+            wednesday: 1
+            thursday: 1
+            friday: 1
+            saturday: 1
+            sunday: 1
 
     tpRatingPlansEdit_screen: &tpRatingPlansEdit_screenLink
       <<: *TpRatingPlans

--- a/web/admin/application/configs/klear/model/TpRatingPlans.yaml
+++ b/web/admin/application/configs/klear/model/TpRatingPlans.yaml
@@ -18,20 +18,20 @@ production:
             template: '%name${lang}%'
           order:
             RatingPlan.name.${lang}: asc
-    destinationRate:
+    destinationRateGroup:
       title: ngettext('Destination rate', 'Destination rates', 1)
       type: select
       source:
         data: mapper
         config:
-          entity: \Ivoz\Provider\Domain\Model\DestinationRate\DestinationRate
+          entity: \Ivoz\Provider\Domain\Model\DestinationRateGroup\DestinationRateGroup
           filterClass: IvozProvider_Klear_Filter_Brand
           fieldName:
             fields:
               - name${lang}
             template: '%name${lang}%'
           order:
-            DestinationRate.name.${lang}: asc
+            DestinationRateGroup.name.${lang}: asc
     timing:
       title: ngettext('Timing', 'Timing', 1)
       type: select
@@ -59,6 +59,68 @@ production:
         icon: help
         text: _("In case of colliding prefixes, destination rate with highest weight will be used.")
         label: _("Need help?")
+    timingType:
+      title: _('Timing type')
+      type: select
+      source:
+        data: inline
+        values:
+          'always':
+            title: _("Always")
+            visualFilter:
+              show: [ ]
+              hide: &timingFields
+                - timeIn
+                - monday
+                - tuesday
+                - wednesday
+                - thursday
+                - friday
+                - saturday
+                - sunday
+          'custom':
+            title: _("Custom")
+            visualFilter:
+              show:
+                <<: *timingFields
+              hide: []
+    timeIn:
+      title: _('Time in')
+      type: picker
+      required: true
+      defaultValue: 00:00:00
+      source:
+        control: time
+        settings:
+          disabled: 'false'
+    monday:
+      title: _('Monday')
+      type: checkbox
+      defaultValue: 1
+    tuesday:
+      title: _('Tuesday')
+      type: checkbox
+      defaultValue: 1
+    wednesday:
+      title: _('Wednesday')
+      type: checkbox
+      defaultValue: 1
+    thursday:
+      title: _('Thursday')
+      type: checkbox
+      defaultValue: 1
+    friday:
+      title: _('Friday')
+      type: checkbox
+      defaultValue: 1
+    saturday:
+      title: _('Saturday')
+      type: checkbox
+      defaultValue: 1
+    sunday:
+      title: _('Sunday')
+      type: checkbox
+      defaultValue: 1
 staging:
   _extends: production
 testing:

--- a/web/admin/application/languages/en_US/en_US.po
+++ b/web/admin/application/languages/en_US/en_US.po
@@ -124,6 +124,9 @@ msgstr "Allowed characters: a-z, A-Z, 0-9, underscore and '-'"
 msgid "Allowed video codecs"
 msgstr "Allowed video codecs"
 
+msgid "Always"
+msgstr "Always"
+
 msgid "An error occurred"
 msgstr "An error occurred"
 
@@ -484,6 +487,9 @@ msgstr "Country code"
 
 msgid "Created"
 msgstr "Created"
+
+msgid "Custom"
+msgstr "Custom"
 
 msgid "DDI"
 msgid_plural "DDIs"
@@ -2302,6 +2308,9 @@ msgid "Timing"
 msgid_plural "Timing"
 msgstr[0] "Timing"
 msgstr[1] "Timings"
+
+msgid "Timing type"
+msgstr "Timing type"
 
 msgid "To address"
 msgstr "To address"

--- a/web/admin/application/languages/es_ES/es_ES.po
+++ b/web/admin/application/languages/es_ES/es_ES.po
@@ -128,6 +128,9 @@ msgstr "Los carácteres permitidos son a-z, A-Z, 0-9, guión bajo y '-'"
 msgid "Allowed video codecs"
 msgstr "Codecs video permitidos"
 
+msgid "Always"
+msgstr "Siempre"
+
 msgid "An error occurred"
 msgstr "Ha ocurrido un error"
 
@@ -491,6 +494,9 @@ msgstr "Código de País"
 
 msgid "Created"
 msgstr "Creado"
+
+msgid "Custom"
+msgstr "A medida"
 
 msgid "DDI"
 msgid_plural "DDIs"
@@ -2327,6 +2333,9 @@ msgid "Timing"
 msgid_plural "Timing"
 msgstr[0] "Timing"
 msgstr[1] "Timings"
+
+msgid "Timing type"
+msgstr "Tipo timing"
 
 msgid "To address"
 msgstr "Dirección destino"

--- a/web/admin/application/library/IvozProvider/Klear/Filter/RouteTag.php
+++ b/web/admin/application/library/IvozProvider/Klear/Filter/RouteTag.php
@@ -17,11 +17,16 @@ class IvozProvider_Klear_Filter_RouteTag extends IvozProvider_Klear_Filter_Brand
         /** @var \Ivoz\Provider\Domain\Model\CompanyRelRoutingTag\CompanyRelRoutingTagDto $tags */
         $tags = $dataGateway->findBy(
             \Ivoz\Provider\Domain\Model\CompanyRelRoutingTag\CompanyRelRoutingTag::class,
-            ["CompanyRelRoutingTag.company = '$companyId'"]
+            [   "CompanyRelRoutingTag.company = '$companyId'"   ]
         );
 
         $tagIds = array_map(function ($tag) { return $tag->getRoutingtagId(); }, $tags);;
-        $this->_condition[] = "self::id in (''," . implode(",", $tagIds) . ")";
+        if (count($tagIds) > 0) {
+            $this->_condition[] = "self::id in (" . implode(",", $tagIds) . ")";
+        } else {
+            $this->_condition[] = "FALSE = TRUE";
+        }
+
 
         return true;
     }


### PR DESCRIPTION
This PR closes #543 by adding timing fields in TpRatingPlan structure.

Depending on how those fields are filled, the default _*any_ timing will be used or a new one will be created with the configured data.