### PR TITLE
library: fixed email charset header

### DIFF
--- a/asterisk/agi/application/controllers/VoicemailController.php
+++ b/asterisk/agi/application/controllers/VoicemailController.php
@@ -110,7 +110,7 @@ class VoicemailController extends Zend_Controller_Action
                 $subject = str_replace($search, $replace, $subject);
             }
 
-            $mail = new Zend_Mail('utf8');
+            $mail = new Zend_Mail('UTF-8');
             $mail->setBodyText($body);
             $mail->setSubject($subject);
             $mail->setFrom($fromAddress, $fromName);

--- a/asterisk/agi/library/Agi/Action/FaxCallAction.php
+++ b/asterisk/agi/library/Agi/Action/FaxCallAction.php
@@ -174,7 +174,7 @@ class FaxCallAction extends RouterAction
                 $subject = str_replace($search, $replace, $subject);
             }
 
-            $mail = new \Zend_Mail('utf8');
+            $mail = new \Zend_Mail('UTF-8');
             $mail->setBodyText($body);
             $mail->setSubject($subject);
             $mail->setFrom($fromAddress, $fromName);

--- a/kamailio/recordings/application/controllers/RecordingsController.php
+++ b/kamailio/recordings/application/controllers/RecordingsController.php
@@ -317,7 +317,7 @@ class RecordingsController extends Zend_Controller_Action
                 $subject = str_replace($search, $replace, $subject);
             }
 
-            $mail = new Zend_Mail('utf8');
+            $mail = new Zend_Mail('UTF-8');
             $mail->setBodyText($body);
             $mail->setSubject($subject);
             $mail->setFrom($fromAddress, $fromName);
@@ -360,7 +360,7 @@ class RecordingsController extends Zend_Controller_Action
                 $subject = str_replace($search, $replace, $subject);
             }
 
-            $mail = new Zend_Mail('utf8');
+            $mail = new Zend_Mail('UTF-8');
             $mail->setBodyText($body);
             $mail->setSubject($subject);
             $mail->setFrom($fromAddress, $fromName);

--- a/portals/application/workers/XmlrpcWorker.php
+++ b/portals/application/workers/XmlrpcWorker.php
@@ -95,7 +95,7 @@ class XmlrpcWorker extends Iron_Gearman_Worker
         $options = $this->_bootstrap->getOption('gearmand');
         $mailOptions = $options["mail"];
 
-        $mail = new \Zend_Mail();
+        $mail = new \Zend_Mail('UTF-8');
         $mail
         ->setBodyText($message)
         ->setSubject($mailOptions["subject"])

--- a/portals/application/workers/XmlrpcdelayedproxytrunksWorker.php
+++ b/portals/application/workers/XmlrpcdelayedproxytrunksWorker.php
@@ -152,7 +152,7 @@ class XmlrpcdelayedproxytrunksWorker extends Iron_Gearman_Worker
         $options = $this->_bootstrap->getOption('gearmand');
         $mailOptions = $options["mail"];
 
-        $mail = new \Zend_Mail();
+        $mail = new \Zend_Mail('UTF-8');
         $mail
             ->setBodyText($message)
             ->setSubject($mailOptions["subject"])


### PR DESCRIPTION
Fixed utf-8 charset typo

This PR aims to fix the issue reported at https://github.com/irontec/ivozprovider/issues/565