### PR TITLE
Improve global administration portal fallback (oasis)

### DIFF
--- a/library/IvozProvider/Klear/Dynamic/Builder.php
+++ b/library/IvozProvider/Klear/Dynamic/Builder.php
@@ -89,7 +89,12 @@ class Builder
         self::$_brandURL = $brandURLMapper->findOneByField('url', $urls);
 
         if (!self::$_brandURL instanceof \IvozProvider\Model\BrandURLs) {
-            self::$_brandURL = $brandURLMapper->findOneByField('urlType', 'god');
+            self::$_brandURL = new \IvozProvider\Model\BrandURLs();
+            self::$_brandURL
+                ->setName('Global Administration portal')
+                ->setUrlType('god')
+                ->setKlearTheme('redmond');
+
             return false;
         }
 


### PR DESCRIPTION
When current URL doesn't match one of the existing BrandURLs, the logic simply search the table for an entry of type god. If none is found, then the portal crashes.

This PR improves that logic to avoid searching for any god url, but instead create a dynamic BrandURL object with title Global Administration Portal and Redmon as theme.

This fixes #581 for oasis release