### PR TITLE
kamtrunks: kamailio.cfg changes after carrier/ddiprovider split

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -211,7 +211,7 @@ modparam("acc", "cdr_on_failed", 0)
 modparam("acc", "cdr_expired_dlg_enable", 1)
 modparam("acc", "cdr_start_on_confirmed", 1)
 modparam("acc", "cdr_facility", "LOG_LOCAL3")
-modparam("acc", "cdr_extra", "brandId=$dlg_var(brandId);companyId=$dlg_var(companyId);caller=$dlg_var(caller);callee=$dlg_var(callee);callid=$dlg_var(callid);callidHash=$dlg_var(cidhash);xcallid=$dlg_var(xcallid);diversion=$dlg_var(diversion);peeringContractId=$dlg_var(peeringContractId);referrer=$dlg_var(referrer);direction=$dlg_var(direction);bounced=$dlg_var(bounced);cgrid=$dlg_var(cgrid)")
+modparam("acc", "cdr_extra", "brandId=$dlg_var(brandId);companyId=$dlg_var(companyId);caller=$dlg_var(caller);callee=$dlg_var(callee);callid=$dlg_var(callid);callidHash=$dlg_var(cidhash);xcallid=$dlg_var(xcallid);diversion=$dlg_var(diversion);carrierId=$dlg_var(carrierId);referrer=$dlg_var(referrer);direction=$dlg_var(direction);bounced=$dlg_var(bounced);cgrid=$dlg_var(cgrid)")
 modparam("acc", "cdr_extra_nullable", 1)
 
 # DIALOG
@@ -237,9 +237,9 @@ modparam("htable", "htable", "ipban=>size=8;autoexpire=300")
 modparam("htable", "htable", "cgrconn=>size=1;")
 
 # UAC
-modparam("uac", "auth_realm_avp","$avp(realm)")
-modparam("uac", "auth_username_avp","$avp(provideruser)")
-modparam("uac", "auth_password_avp","$avp(secret)")
+modparam("uac", "auth_realm_avp","$avp(auth_realm)")
+modparam("uac", "auth_username_avp","$avp(auth_user)")
+modparam("uac", "auth_password_avp","$avp(auth_secret)")
 modparam("uac", "restore_mode","auto")
 modparam("uac", "restore_dlg", 1)
 modparam("uac", "reg_db_url", DBURL)
@@ -258,8 +258,8 @@ modparam("lcr", "ip_addr_column", "ip")
 modparam("lcr", "lcr_id_column", "lcr_id")
 modparam("lcr", "gw_uri_avp", "$avp(gw_uri_avp)")
 modparam("lcr", "ruri_user_avp", "$avp(i:500)")
-modparam("lcr", "flags_avp", "$avp(s:peerServerId)")
-modparam("lcr", "flags_column", "peerServerId")
+modparam("lcr", "flags_avp", "$avp(s:carrierServerId)")
+modparam("lcr", "flags_column", "carrierServerId")
 modparam("lcr", "defunct_capability", 1)
 modparam("lcr", "lcr_id_avp", "$avp(lcr_id_avp)")
 modparam("lcr", "defunct_gw_avp", "$avp(defunct_gw_avp)")
@@ -406,7 +406,7 @@ request_route {
 
         # Evaluate rating logic
         if ($avp(externallyRated) == '1') {
-            xinfo("[$dlg_var(cidhash)] Externally rating is enabled for this PeeringContract, proceed");
+            xinfo("[$dlg_var(cidhash)] Externally rating is enabled for this carrier, proceed");
             route(RELAY);
         } else {
             route(CGRATES_AUTH_REQUEST);
@@ -447,7 +447,7 @@ route[BOUNCE] {
         xinfo("[$dlg_var(cidhash)] BOUNCE: Bounce call to myself\n");
         $du = "sip:trunks.ivozprovider.local:" + SIP_PORT;
         $rd = "trunks.ivozprovider.local";
-        $dlg_var(peeringContractId) = $avp(peeringContractId);
+        $dlg_var(carrierId) = $avp(carrierId);
         $dlg_var(bounced) = '1';
     }
 }
@@ -527,43 +527,43 @@ route[SELECT_GW] {
     }
 
     # Obtain info about selected GW
-    sql_xquery("cb", "SELECT PC.externallyRated, PS.sendPAI, PS.sendRPID, PS.auth_needed, PS.auth_user, PS.auth_password, PS.peeringContractId, PS.from_user, PS.from_domain FROM PeerServers PS JOIN PeeringContracts PC ON PS.peeringContractId=PC.id WHERE PS.id=$avp(peerServerId)", "ra");
+    sql_xquery("cb", "SELECT C.externallyRated, CS.sendPAI, CS.sendRPID, CS.authNeeded, CS.authUser, CS.authPassword, CS.carrierId, CS.fromUser, CS.fromDomain FROM CarrierServers CS JOIN Carriers C ON CS.carrierId=C.id WHERE CS.id=$avp(carrierServerId)", "ra");
 
-    if ( $(xavp(ra=>peeringContractId){s.len}) ) {
-        $avp(peeringContractId) = $xavp(ra=>peeringContractId);
+    if ( $(xavp(ra=>carrierId){s.len}) ) {
+        $avp(carrierId) = $xavp(ra=>carrierId);
         $avp(externallyRated) = $xavp(ra=>externallyRated);
-        xinfo("[$dlg_var(cidhash)] SELECT-GW: peeringContractId: $avp(peeringContractId)\n");
+        xinfo("[$dlg_var(cidhash)] SELECT-GW: carrierId: $avp(carrierId)\n");
     } else {
-        xerr("[$dlg_var(cidhash)] SELECT-GW: Error obtaining 'peeringContractId' for peerServerId '$avp(peerServerId)'\n");
+        xerr("[$dlg_var(cidhash)] SELECT-GW: Error obtaining 'carrierId' for carrierServerId '$avp(carrierServerId)'\n");
         send_reply("500", "Server Internal Error");
         exit;
     }
 
-    if ($xavp(ra=>auth_needed) == 'yes') {
-        if ( $(xavp(ra=>auth_user){s.len}) ) {
-            $avp(provideruser) = $xavp(ra=>auth_user);
+    if ($xavp(ra=>authNeeded) == 'yes') {
+        if ( $(xavp(ra=>authUser){s.len}) ) {
+            $avp(auth_user) = $xavp(ra=>authUser);
         } else {
-            xwarn("[$dlg_var(cidhash)] SELECT-GW: Error obtaining 'provideruser' for peerServerId '$avp(peerServerId)'\n");
+            xwarn("[$dlg_var(cidhash)] SELECT-GW: Error obtaining 'provideruser' for carrierServerId '$avp(carrierServerId)'\n");
         }
 
-        if ( $(xavp(ra=>auth_password){s.len}) ) {
-            $avp(secret) = $xavp(ra=>auth_password);
+        if ( $(xavp(ra=>authPassword){s.len}) ) {
+            $avp(auth_secret) = $xavp(ra=>authPassword);
         } else {
-            xwarn("[$dlg_var(cidhash)] SELECT-GW: Error obtaining 'secret' for peerServerId '$avp(peerServerId)'\n");
+            xwarn("[$dlg_var(cidhash)] SELECT-GW: Error obtaining 'secret' for carrierServerId '$avp(carrierServerId)'\n");
         }
     } else {
-        $avp(provideruser) = $null;
-        $avp(secret) = $null;
+        $avp(auth_user) = $null;
+        $avp(auth_secret) = $null;
     }
 
-    if ( $(xavp(ra=>from_user){s.len}) ) {
-        $avp(from_user) = $xavp(ra=>from_user);
+    if ( $(xavp(ra=>fromUser){s.len}) ) {
+        $avp(from_user) = $xavp(ra=>fromUser);
     } else {
         $avp(from_user) = $null;
     }
 
-    if ( $(xavp(ra=>from_domain){s.len}) ) {
-        $avp(from_domain) = $xavp(ra=>from_domain);
+    if ( $(xavp(ra=>fromDomain){s.len}) ) {
+        $avp(from_domain) = $xavp(ra=>fromDomain);
     } else {
         $avp(from_domain) = $null;
     }
@@ -658,7 +658,7 @@ route[GET_TRANSFORMATIONS_IN] {
     if (src_ip == myself) return; # Bounced calls already in E.164
 
     # Get all DDI candidates
-    sql_query("cb", "SELECT D.DDIE164, CONCAT(P.transformationRuleSetId, 1) AS callee_in, CONCAT(P.transformationRuleSetId, 0) AS caller_in, CONCAT(P.transformationRuleSetId, 2) AS caller_out, CONCAT(P.transformationRuleSetId, 3) AS callee_out FROM DDIs D INNER JOIN PeeringContracts P ON D.peeringContractId = P.id WHERE '$rU' REGEXP CONCAT('[0-9]*', DDI) ORDER BY LENGTH(DDIE164) DESC", "ra");
+    sql_query("cb", "SELECT D.DDIE164, CONCAT(P.transformationRuleSetId, 1) AS callee_in, CONCAT(P.transformationRuleSetId, 0) AS caller_in, CONCAT(P.transformationRuleSetId, 2) AS caller_out, CONCAT(P.transformationRuleSetId, 3) AS callee_out FROM DDIs D INNER JOIN Carriers P ON D.carrierId = P.id WHERE '$rU' REGEXP CONCAT('[0-9]*', DDI) ORDER BY LENGTH(DDIE164) DESC", "ra");
 
     # Are there any candidates?
     if ($dbr(ra=>rows) == 0) {
@@ -819,7 +819,7 @@ route[SET_CALLER] {
 }
 
 route[GET_TRANSFORMATIONS_OUT] {
-    sql_xquery("cb", "SELECT CONCAT(transformationRuleSetId, 0) AS caller_in, CONCAT(transformationRuleSetId, 1) AS callee_in, CONCAT(transformationRuleSetId, 2) AS caller_out, CONCAT(transformationRuleSetId, 3) AS callee_out FROM PeeringContracts WHERE id=$avp(peeringContractId)", "ra");
+    sql_xquery("cb", "SELECT CONCAT(transformationRuleSetId, 0) AS caller_in, CONCAT(transformationRuleSetId, 1) AS callee_in, CONCAT(transformationRuleSetId, 2) AS caller_out, CONCAT(transformationRuleSetId, 3) AS callee_out FROM Carriers WHERE id=$avp(carrierId)", "ra");
 
     $dlg_var(tr_caller_in) = $xavp(ra=>caller_in);
     $dlg_var(tr_callee_in) = $xavp(ra=>callee_in);
@@ -1147,13 +1147,13 @@ failure_route[MANAGE_FAILURE_GW] {
 
     if (t_check_status("(401)|(407)") && $avp(auth_done) != '1') {
         # Get ready for SIP auth
-        #   username:  $avp(provideruser) set in SELECT-GW
-        #   password:  $avp(secret) from DB below
+        #   username:  $avp(auth_user) set in SELECT-GW
+        #   password:  $avp(auth_secret) from DB below
         #   realm:     take it from 401/407 leaving it empty
-        $avp(realm) = '';
+        $avp(auth_realm) = '';
 
-        # $avp(secret) is available?
-        if (is_avp_set("$avp(secret)")) {
+        # $avp(auth_secret) is available?
+        if (is_avp_set("$avp(auth_secret)")) {
             # Sends INVITE with AUTH (and adapts CSeq)
             uac_auth();
             $avp(auth_done) = '1'; # Set avp to avoid using invalid credentials more than once
@@ -1186,7 +1186,7 @@ failure_route[MANAGE_FAILURE_GW] {
     route(SELECT_GW);
 
     if ($avp(externallyRated) == '1') {
-        xinfo("[$dlg_var(cidhash)] MANAGE-FAILURE-GW: Externally rating is enabled for this PeeringContract, proceed");
+        xinfo("[$dlg_var(cidhash)] MANAGE-FAILURE-GW: Externally rating is enabled for this carrier, proceed");
         $dlg_var(cgrid) = $null;
         route(RELAY);
     } else {
@@ -1259,7 +1259,7 @@ event_route[dialog:start] {
     xnotice("[$dlg_var(cidhash)] $dlg_var(direction) call confirmed for company '$dlg_var(companyId)' [$ci]\n");
 
     if ($dlg_var(direction) == 'outbound') {
-        $dlg_var(peeringContractId) = $avp(peeringContractId);
+        $dlg_var(carrierId) = $avp(carrierId);
         if ($dlg_var(cgrid) == $null) {
             xinfo("[$dlg_var(cidhash)] No cgrid, skip rating logic");
             return;

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -297,7 +297,7 @@ modparam("dialplan", "attrs_pvar", "$avp(s:appliedrule)")
 
 # PERMISSIONS
 modparam("permissions", "db_url", DBURL)
-modparam("permissions", "address_table", "kam_trunks_address") # Not used
+modparam("permissions", "address_table", "kam_trunks_address") # Allowed addresses per DDI provider
 modparam("permissions", "trusted_table", "kam_trusted") # IPs excluded from pike checking and wholesale IPs
 modparam("permissions", "db_mode", 1)
 modparam("permissions", "peer_tag_avp", "$avp(trustedTag)")
@@ -1038,6 +1038,12 @@ route[ANTIFLOOD] {
     # Trusted sources
     if (allow_trusted($si, 'any') && $avp(trustedTag) == $null) {
         xinfo("[$dlg_var(cidhash)] ANTIFLOOD: $si is not checked against antiflood (IP added in antiflood trusted IPs)\n");
+        return;
+    }
+    # Allowed sources by DDI provider
+    $var(group) = allow_source_address_group();
+    if ($var(group) != -1) {
+        xinfo("[$dlg_var(cidhash)] ANTIFLOOD: $si is not checked against antiflood (allowed source for ddiProviderId '$var(group)')\n");
         return;
     }
 

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -658,7 +658,7 @@ route[GET_TRANSFORMATIONS_IN] {
     if (src_ip == myself) return; # Bounced calls already in E.164
 
     # Get all DDI candidates
-    sql_query("cb", "SELECT D.DDIE164, CONCAT(P.transformationRuleSetId, 1) AS callee_in, CONCAT(P.transformationRuleSetId, 0) AS caller_in, CONCAT(P.transformationRuleSetId, 2) AS caller_out, CONCAT(P.transformationRuleSetId, 3) AS callee_out FROM DDIs D INNER JOIN Carriers P ON D.carrierId = P.id WHERE '$rU' REGEXP CONCAT('[0-9]*', DDI) ORDER BY LENGTH(DDIE164) DESC", "ra");
+    sql_query("cb", "SELECT D.DDIE164, CONCAT(DP.transformationRuleSetId, 1) AS callee_in, CONCAT(DP.transformationRuleSetId, 0) AS caller_in, CONCAT(DP.transformationRuleSetId, 2) AS caller_out, CONCAT(DP.transformationRuleSetId, 3) AS callee_out FROM DDIProviderAddresses DPA INNER JOIN DDIProviders DP ON DPA.ddiProviderId=DP.id INNER JOIN DDIs D ON D.ddiProviderId=DP.id WHERE ip='$si'", "ra");
 
     # Are there any candidates?
     if ($dbr(ra=>rows) == 0) {

--- a/library/CoreBundle/Resources/config/lifecycle/core/xml_rpc.yml
+++ b/library/CoreBundle/Resources/config/lifecycle/core/xml_rpc.yml
@@ -38,6 +38,14 @@ services:
       $enabled:
         '@=service("kernel").getEnvironment() != "test"'
 
+  XmlRpc\XmlRpcTrunksRequest::PermissionsAddressReload:
+    class: Ivoz\Core\Infrastructure\Domain\Service\XmlRpc\XmlRpcTrunksRequest
+    arguments:
+      $rpcMethod:
+        'permissions.addressReload'
+      $enabled:
+        '@=service("kernel").getEnvironment() != "test"'
+
   XmlRpc\XmlRpcTrunksRequest::UacRegReload:
     class: Ivoz\Core\Infrastructure\Domain\Service\XmlRpc\XmlRpcTrunksRequest
     arguments:
@@ -74,6 +82,14 @@ services:
     arguments:
       $rpcMethod:
         'permissions.trustedReload'
+      $enabled:
+        '@=service("kernel").getEnvironment() != "test"'
+
+  XmlRpc\XmlRpcUsersRequest::PermissionsAddressReload:
+    class: Ivoz\Core\Infrastructure\Domain\Service\XmlRpc\XmlRpcUsersRequest
+    arguments:
+      $rpcMethod:
+        'permissions.addressReload'
       $enabled:
         '@=service("kernel").getEnvironment() != "test"'
 

--- a/library/CoreBundle/Resources/config/lifecycle/kam/trunks_address.yml
+++ b/library/CoreBundle/Resources/config/lifecycle/kam/trunks_address.yml
@@ -6,8 +6,8 @@ services:
   ##################################
   ## on_commit
   ##################################
-  Ivoz\Kam\Infrastructure\Domain\Service\UsersAddress\SendUsersPermissionsReloadRequest:
+  Ivoz\Kam\Infrastructure\Domain\Service\TrunksAddress\SendTrunksPermissionsReloadRequest:
     tags: [{ name: 'domain.service'}]
     arguments:
-      $usersPermissionsReload:
-        '@XmlRpc\XmlRpcUsersRequest::PermissionsAddressReload'
+      $trunksPermissionsReload:
+        '@XmlRpc\XmlRpcTrunksRequest::PermissionsAddressReload'

--- a/library/Ivoz/Kam/Domain/Model/TrunksAddress/TrunksAddressAbstract.php
+++ b/library/Ivoz/Kam/Domain/Model/TrunksAddress/TrunksAddressAbstract.php
@@ -39,6 +39,11 @@ abstract class TrunksAddressAbstract
      */
     protected $tag;
 
+    /**
+     * @var \Ivoz\Provider\Domain\Model\DdiProviderAddress\DdiProviderAddressInterface
+     */
+    protected $ddiProviderAddress;
+
 
     use ChangelogTrait;
 
@@ -123,6 +128,7 @@ abstract class TrunksAddressAbstract
         $self
             ->setIpAddr($dto->getIpAddr())
             ->setTag($dto->getTag())
+            ->setDdiProviderAddress($dto->getDdiProviderAddress())
         ;
 
         $self->sanitizeValues();
@@ -147,7 +153,8 @@ abstract class TrunksAddressAbstract
             ->setIpAddr($dto->getIpAddr())
             ->setMask($dto->getMask())
             ->setPort($dto->getPort())
-            ->setTag($dto->getTag());
+            ->setTag($dto->getTag())
+            ->setDdiProviderAddress($dto->getDdiProviderAddress());
 
 
 
@@ -166,7 +173,8 @@ abstract class TrunksAddressAbstract
             ->setIpAddr(self::getIpAddr())
             ->setMask(self::getMask())
             ->setPort(self::getPort())
-            ->setTag(self::getTag());
+            ->setTag(self::getTag())
+            ->setDdiProviderAddress(\Ivoz\Provider\Domain\Model\DdiProviderAddress\DdiProviderAddress::entityToDto(self::getDdiProviderAddress(), $depth));
     }
 
     /**
@@ -179,7 +187,8 @@ abstract class TrunksAddressAbstract
             'ip_addr' => self::getIpAddr(),
             'mask' => self::getMask(),
             'port' => self::getPort(),
-            'tag' => self::getTag()
+            'tag' => self::getTag(),
+            'ddiProviderAddressId' => self::getDdiProviderAddress() ? self::getDdiProviderAddress()->getId() : null
         ];
     }
 
@@ -322,6 +331,30 @@ abstract class TrunksAddressAbstract
     public function getTag()
     {
         return $this->tag;
+    }
+
+    /**
+     * Set ddiProviderAddress
+     *
+     * @param \Ivoz\Provider\Domain\Model\DdiProviderAddress\DdiProviderAddressInterface $ddiProviderAddress
+     *
+     * @return self
+     */
+    public function setDdiProviderAddress(\Ivoz\Provider\Domain\Model\DdiProviderAddress\DdiProviderAddressInterface $ddiProviderAddress)
+    {
+        $this->ddiProviderAddress = $ddiProviderAddress;
+
+        return $this;
+    }
+
+    /**
+     * Get ddiProviderAddress
+     *
+     * @return \Ivoz\Provider\Domain\Model\DdiProviderAddress\DdiProviderAddressInterface
+     */
+    public function getDdiProviderAddress()
+    {
+        return $this->ddiProviderAddress;
     }
 
 

--- a/library/Ivoz/Kam/Domain/Model/TrunksAddress/TrunksAddressDtoAbstract.php
+++ b/library/Ivoz/Kam/Domain/Model/TrunksAddress/TrunksAddressDtoAbstract.php
@@ -42,6 +42,11 @@ abstract class TrunksAddressDtoAbstract implements DataTransferObjectInterface
      */
     private $id;
 
+    /**
+     * @var \Ivoz\Provider\Domain\Model\DdiProviderAddress\DdiProviderAddressDto | null
+     */
+    private $ddiProviderAddress;
+
 
     use DtoNormalizer;
 
@@ -65,7 +70,8 @@ abstract class TrunksAddressDtoAbstract implements DataTransferObjectInterface
             'mask' => 'mask',
             'port' => 'port',
             'tag' => 'tag',
-            'id' => 'id'
+            'id' => 'id',
+            'ddiProviderAddressId' => 'ddiProviderAddress'
         ];
     }
 
@@ -80,7 +86,8 @@ abstract class TrunksAddressDtoAbstract implements DataTransferObjectInterface
             'mask' => $this->getMask(),
             'port' => $this->getPort(),
             'tag' => $this->getTag(),
-            'id' => $this->getId()
+            'id' => $this->getId(),
+            'ddiProviderAddress' => $this->getDdiProviderAddress()
         ];
     }
 
@@ -89,7 +96,7 @@ abstract class TrunksAddressDtoAbstract implements DataTransferObjectInterface
      */
     public function transformForeignKeys(ForeignKeyTransformerInterface $transformer)
     {
-
+        $this->ddiProviderAddress = $transformer->transform('Ivoz\\Provider\\Domain\\Model\\DdiProviderAddress\\DdiProviderAddress', $this->getDdiProviderAddressId());
     }
 
     /**
@@ -218,6 +225,52 @@ abstract class TrunksAddressDtoAbstract implements DataTransferObjectInterface
     public function getId()
     {
         return $this->id;
+    }
+
+    /**
+     * @param \Ivoz\Provider\Domain\Model\DdiProviderAddress\DdiProviderAddressDto $ddiProviderAddress
+     *
+     * @return static
+     */
+    public function setDdiProviderAddress(\Ivoz\Provider\Domain\Model\DdiProviderAddress\DdiProviderAddressDto $ddiProviderAddress = null)
+    {
+        $this->ddiProviderAddress = $ddiProviderAddress;
+
+        return $this;
+    }
+
+    /**
+     * @return \Ivoz\Provider\Domain\Model\DdiProviderAddress\DdiProviderAddressDto
+     */
+    public function getDdiProviderAddress()
+    {
+        return $this->ddiProviderAddress;
+    }
+
+    /**
+     * @param integer $id | null
+     *
+     * @return static
+     */
+    public function setDdiProviderAddressId($id)
+    {
+        $value = !is_null($id)
+            ? new \Ivoz\Provider\Domain\Model\DdiProviderAddress\DdiProviderAddressDto($id)
+            : null;
+
+        return $this->setDdiProviderAddress($value);
+    }
+
+    /**
+     * @return integer | null
+     */
+    public function getDdiProviderAddressId()
+    {
+        if ($dto = $this->getDdiProviderAddress()) {
+            return $dto->getId();
+        }
+
+        return null;
     }
 }
 

--- a/library/Ivoz/Kam/Domain/Model/TrunksAddress/TrunksAddressInterface.php
+++ b/library/Ivoz/Kam/Domain/Model/TrunksAddress/TrunksAddressInterface.php
@@ -92,5 +92,21 @@ interface TrunksAddressInterface extends LoggableEntityInterface
      */
     public function getTag();
 
+    /**
+     * Set ddiProviderAddress
+     *
+     * @param \Ivoz\Provider\Domain\Model\DdiProviderAddress\DdiProviderAddressInterface $ddiProviderAddress
+     *
+     * @return self
+     */
+    public function setDdiProviderAddress(\Ivoz\Provider\Domain\Model\DdiProviderAddress\DdiProviderAddressInterface $ddiProviderAddress);
+
+    /**
+     * Get ddiProviderAddress
+     *
+     * @return \Ivoz\Provider\Domain\Model\DdiProviderAddress\DdiProviderAddressInterface
+     */
+    public function getDdiProviderAddress();
+
 }
 

--- a/library/Ivoz/Kam/Domain/Service/TrunksAddress/TrunksAddressLifecycleEventHandlerInterface.php
+++ b/library/Ivoz/Kam/Domain/Service/TrunksAddress/TrunksAddressLifecycleEventHandlerInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Ivoz\Kam\Domain\Service\TrunksAddress;
+
+use Ivoz\Core\Domain\Service\LifecycleEventHandlerInterface;
+use Ivoz\Kam\Domain\Model\TrunksAddress\TrunksAddressInterface;
+
+interface TrunksAddressLifecycleEventHandlerInterface extends LifecycleEventHandlerInterface
+{
+    public function execute(TrunksAddressInterface $entity);
+}

--- a/library/Ivoz/Kam/Domain/Service/TrunksAddress/TrunksAddressLifecycleServiceCollection.php
+++ b/library/Ivoz/Kam/Domain/Service/TrunksAddress/TrunksAddressLifecycleServiceCollection.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Ivoz\Kam\Domain\Service\TrunksAddress;
+
+use Ivoz\Core\Domain\Service\LifecycleServiceCollectionInterface;
+use Ivoz\Core\Domain\Service\LifecycleServiceCollectionTrait;
+
+class TrunksAddressLifecycleServiceCollection implements LifecycleServiceCollectionInterface
+{
+    use LifecycleServiceCollectionTrait;
+
+    protected function addService(TrunksAddressLifecycleEventHandlerInterface $service)
+    {
+        $this->services[] = $service;
+    }
+}

--- a/library/Ivoz/Kam/Domain/Service/TrunksAddress/UpdateByDdiProviderAddress.php
+++ b/library/Ivoz/Kam/Domain/Service/TrunksAddress/UpdateByDdiProviderAddress.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Ivoz\Kam\Domain\Service\TrunksAddress;
+
+use Ivoz\Core\Application\Service\EntityTools;
+use Ivoz\Kam\Domain\Model\TrunksAddress\TrunksAddressDto;
+use Ivoz\Provider\Domain\Model\DdiProviderAddress\DdiProviderAddressInterface;
+use Ivoz\Provider\Domain\Service\DdiProviderAddress\DdiProviderAddressLifecycleEventHandlerInterface;
+
+/**
+ * Class UpdateByDdiProviderAddress
+ * @package Ivoz\Kam\Domain\Service\TrunksLcrGateway
+ */
+class UpdateByDdiProviderAddress implements DdiProviderAddressLifecycleEventHandlerInterface
+{
+    CONST POST_PERSIST_PRIORITY = self::PRIORITY_NORMAL;
+
+    /**
+     * @var EntityTools
+     */
+    protected $entityTools;
+
+    public function __construct(
+        EntityTools $entityTools
+    ) {
+        $this->entityTools = $entityTools;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            self::EVENT_POST_PERSIST => self::POST_PERSIST_PRIORITY
+        ];
+    }
+
+    public function execute(DdiProviderAddressInterface $ddiProviderAddress, $isNew)
+    {
+        $trunksAddress = $ddiProviderAddress->getTrunksAddress();
+
+        $trunksAddressDto = ($trunksAddress)
+            ? $this->entityTools->entityToDto($trunksAddress)
+            : new TrunksAddressDto();
+
+        // Update/Create Trunks Address for this DDI Provider Address
+        $trunksAddressDto
+            ->setIpAddr($ddiProviderAddress->getIp())
+            ->setGrp($ddiProviderAddress->getDdiProvider()->getId())
+            ->setDdiProviderAddressId($ddiProviderAddress->getId());
+
+        $trunksAddress = $this->entityTools->persistDto(
+            $trunksAddressDto,
+            $trunksAddress,
+            true
+        );
+
+        $ddiProviderAddress->setTrunksAddress($trunksAddress);
+    }
+}

--- a/library/Ivoz/Kam/Infrastructure/Domain/Service/TrunksAddress/SendTrunksPermissionsReloadRequest.php
+++ b/library/Ivoz/Kam/Infrastructure/Domain/Service/TrunksAddress/SendTrunksPermissionsReloadRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Ivoz\Kam\Infrastructure\Domain\Service\TrunksAddress;
+
+use Ivoz\Core\Infrastructure\Domain\Service\XmlRpc\XmlRpcTrunksRequest;
+use Ivoz\Kam\Domain\Model\TrunksAddress\TrunksAddressInterface;
+use Ivoz\Kam\Domain\Service\TrunksAddress\TrunksAddressLifecycleEventHandlerInterface;
+
+class SendTrunksPermissionsReloadRequest implements TrunksAddressLifecycleEventHandlerInterface
+{
+    CONST ON_COMMIT_PRIORITY = self::PRIORITY_NORMAL;
+
+    protected $trunksPermissionsReload;
+
+    public function __construct(
+        XmlRpcTrunksRequest $trunksPermissionsReload
+    ) {
+        $this->trunksPermissionsReload = $trunksPermissionsReload;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            self::EVENT_ON_COMMIT => self::ON_COMMIT_PRIORITY
+        ];
+    }
+
+    public function execute(TrunksAddressInterface $entity)
+    {
+        $this->trunksPermissionsReload->send();
+    }
+}

--- a/library/Ivoz/Kam/Infrastructure/Persistence/Doctrine/Mapping/TrunksAddress.TrunksAddressAbstract.orm.yml
+++ b/library/Ivoz/Kam/Infrastructure/Persistence/Doctrine/Mapping/TrunksAddress.TrunksAddressAbstract.orm.yml
@@ -1,9 +1,5 @@
 Ivoz\Kam\Domain\Model\TrunksAddress\TrunksAddressAbstract:
   type: mappedSuperclass
-  uniqueConstraints:
-    grp:
-      columns:
-        - grp
   fields:
     grp:
       type: integer
@@ -36,3 +32,13 @@ Ivoz\Kam\Domain\Model\TrunksAddress\TrunksAddressAbstract:
       length: 64
       options:
         fixed: false
+  oneToOne:
+    ddiProviderAddress:
+      targetEntity: \Ivoz\Provider\Domain\Model\DdiProviderAddress\DdiProviderAddressInterface
+      inversedBy: trunksAddress
+      fetch: LAZY
+      joinColumn:
+        name: ddiProviderAddressId
+        referencedColumnName: id
+        nullable: false
+        onDelete: cascade

--- a/library/Ivoz/Provider/Domain/Model/DdiProviderAddress/DdiProviderAddressAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/DdiProviderAddress/DdiProviderAddressAbstract.php
@@ -24,6 +24,11 @@ abstract class DdiProviderAddressAbstract
     protected $description;
 
     /**
+     * @var \Ivoz\Kam\Domain\Model\TrunksAddress\TrunksAddressInterface
+     */
+    protected $trunksAddress;
+
+    /**
      * @var \Ivoz\Provider\Domain\Model\DdiProvider\DdiProviderInterface
      */
     protected $ddiProvider;
@@ -219,6 +224,30 @@ abstract class DdiProviderAddressAbstract
     public function getDescription()
     {
         return $this->description;
+    }
+
+    /**
+     * Set trunksAddress
+     *
+     * @param \Ivoz\Kam\Domain\Model\TrunksAddress\TrunksAddressInterface $trunksAddress
+     *
+     * @return self
+     */
+    public function setTrunksAddress(\Ivoz\Kam\Domain\Model\TrunksAddress\TrunksAddressInterface $trunksAddress = null)
+    {
+        $this->trunksAddress = $trunksAddress;
+
+        return $this;
+    }
+
+    /**
+     * Get trunksAddress
+     *
+     * @return \Ivoz\Kam\Domain\Model\TrunksAddress\TrunksAddressInterface
+     */
+    public function getTrunksAddress()
+    {
+        return $this->trunksAddress;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/DdiProviderAddress/DdiProviderAddressDto.php
+++ b/library/Ivoz/Provider/Domain/Model/DdiProviderAddress/DdiProviderAddressDto.php
@@ -5,7 +5,26 @@ namespace Ivoz\Provider\Domain\Model\DdiProviderAddress;
 
 class DdiProviderAddressDto extends DdiProviderAddressDtoAbstract
 {
+    /**
+     * @inheritdoc
+     */
+    public static function getPropertyMap(string $context = '')
+    {
+        if ($context === self::CONTEXT_COLLECTION) {
+            return [
+                'ip' => 'ip',
+                'description' => 'description',
+                'id' => 'id'
+            ];
+        }
 
+        $response = parent::getPropertyMap(...func_get_args());
+        if (array_key_exists('trunksAddressId', $response)) {
+            unset($response['trunksAddressId']);
+        }
+
+        return $response;
+    }
 }
 
 

--- a/library/Ivoz/Provider/Domain/Model/DdiProviderAddress/DdiProviderAddressDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/DdiProviderAddress/DdiProviderAddressDtoAbstract.php
@@ -28,6 +28,11 @@ abstract class DdiProviderAddressDtoAbstract implements DataTransferObjectInterf
     private $id;
 
     /**
+     * @var \Ivoz\Kam\Domain\Model\TrunksAddress\TrunksAddressDto | null
+     */
+    private $trunksAddress;
+
+    /**
      * @var \Ivoz\Provider\Domain\Model\DdiProvider\DdiProviderDto | null
      */
     private $ddiProvider;
@@ -53,6 +58,7 @@ abstract class DdiProviderAddressDtoAbstract implements DataTransferObjectInterf
             'ip' => 'ip',
             'description' => 'description',
             'id' => 'id',
+            'trunksAddressId' => 'trunksAddress',
             'ddiProviderId' => 'ddiProvider'
         ];
     }
@@ -66,6 +72,7 @@ abstract class DdiProviderAddressDtoAbstract implements DataTransferObjectInterf
             'ip' => $this->getIp(),
             'description' => $this->getDescription(),
             'id' => $this->getId(),
+            'trunksAddress' => $this->getTrunksAddress(),
             'ddiProvider' => $this->getDdiProvider()
         ];
     }
@@ -75,6 +82,7 @@ abstract class DdiProviderAddressDtoAbstract implements DataTransferObjectInterf
      */
     public function transformForeignKeys(ForeignKeyTransformerInterface $transformer)
     {
+        $this->trunksAddress = $transformer->transform('Ivoz\\Kam\\Domain\\Model\\TrunksAddress\\TrunksAddress', $this->getTrunksAddressId());
         $this->ddiProvider = $transformer->transform('Ivoz\\Provider\\Domain\\Model\\DdiProvider\\DdiProvider', $this->getDdiProviderId());
     }
 
@@ -144,6 +152,52 @@ abstract class DdiProviderAddressDtoAbstract implements DataTransferObjectInterf
     public function getId()
     {
         return $this->id;
+    }
+
+    /**
+     * @param \Ivoz\Kam\Domain\Model\TrunksAddress\TrunksAddressDto $trunksAddress
+     *
+     * @return static
+     */
+    public function setTrunksAddress(\Ivoz\Kam\Domain\Model\TrunksAddress\TrunksAddressDto $trunksAddress = null)
+    {
+        $this->trunksAddress = $trunksAddress;
+
+        return $this;
+    }
+
+    /**
+     * @return \Ivoz\Kam\Domain\Model\TrunksAddress\TrunksAddressDto
+     */
+    public function getTrunksAddress()
+    {
+        return $this->trunksAddress;
+    }
+
+    /**
+     * @param integer $id | null
+     *
+     * @return static
+     */
+    public function setTrunksAddressId($id)
+    {
+        $value = !is_null($id)
+            ? new \Ivoz\Kam\Domain\Model\TrunksAddress\TrunksAddressDto($id)
+            : null;
+
+        return $this->setTrunksAddress($value);
+    }
+
+    /**
+     * @return integer | null
+     */
+    public function getTrunksAddressId()
+    {
+        if ($dto = $this->getTrunksAddress()) {
+            return $dto->getId();
+        }
+
+        return null;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/DdiProviderAddress/DdiProviderAddressInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/DdiProviderAddress/DdiProviderAddressInterface.php
@@ -41,6 +41,22 @@ interface DdiProviderAddressInterface extends LoggableEntityInterface
     public function getDescription();
 
     /**
+     * Set trunksAddress
+     *
+     * @param \Ivoz\Kam\Domain\Model\TrunksAddress\TrunksAddressInterface $trunksAddress
+     *
+     * @return self
+     */
+    public function setTrunksAddress(\Ivoz\Kam\Domain\Model\TrunksAddress\TrunksAddressInterface $trunksAddress = null);
+
+    /**
+     * Get trunksAddress
+     *
+     * @return \Ivoz\Kam\Domain\Model\TrunksAddress\TrunksAddressInterface
+     */
+    public function getTrunksAddress();
+
+    /**
      * Set ddiProvider
      *
      * @param \Ivoz\Provider\Domain\Model\DdiProvider\DdiProviderInterface $ddiProvider

--- a/library/Ivoz/Provider/Domain/Service/DdiProviderAddress/DdiProviderAddressLifecycleEventHandlerInterface.php
+++ b/library/Ivoz/Provider/Domain/Service/DdiProviderAddress/DdiProviderAddressLifecycleEventHandlerInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Ivoz\Provider\Domain\Service\DdiProviderAddress;
+
+use Ivoz\Core\Domain\Service\LifecycleEventHandlerInterface;
+use Ivoz\Provider\Domain\Model\DdiProviderAddress\DdiProviderAddressInterface;
+
+interface DdiProviderAddressLifecycleEventHandlerInterface extends LifecycleEventHandlerInterface
+{
+    public function execute(DdiProviderAddressInterface $entity, $isNew);
+}

--- a/library/Ivoz/Provider/Domain/Service/DdiProviderAddress/DdiProviderAddressLifecycleServiceCollection.php
+++ b/library/Ivoz/Provider/Domain/Service/DdiProviderAddress/DdiProviderAddressLifecycleServiceCollection.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Ivoz\Provider\Domain\Service\DdiProviderAddress;
+
+use Ivoz\Core\Domain\Service\LifecycleServiceCollectionInterface;
+use Ivoz\Core\Domain\Service\LifecycleServiceCollectionTrait;
+
+/**
+ * @codeCoverageIgnore
+ */
+class DdiProviderAddressLifecycleServiceCollection implements LifecycleServiceCollectionInterface
+{
+    use LifecycleServiceCollectionTrait;
+
+    protected function addService(DdiProviderAddressLifecycleEventHandlerInterface $service)
+    {
+        $this->services[] = $service;
+    }
+}

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/DdiProviderAddress.DdiProviderAddressAbstract.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/DdiProviderAddress.DdiProviderAddressAbstract.orm.yml
@@ -26,3 +26,8 @@ Ivoz\Provider\Domain\Model\DdiProviderAddress\DdiProviderAddressAbstract:
           nullable: false
           onDelete: cascade
       orphanRemoval: false
+  oneToOne:
+    trunksAddress:
+      targetEntity: Ivoz\Kam\Domain\Model\TrunksAddress\TrunksAddressInterface
+      mappedBy: ddiProviderAddress
+      fetch: LAZY

--- a/scheme/app/DoctrineMigrations/Version20180717150551.php
+++ b/scheme/app/DoctrineMigrations/Version20180717150551.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20180717150551 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP INDEX grp ON kam_trunks_address');
+        $this->addSql('ALTER TABLE kam_trunks_address ADD ddiProviderAddressId INT UNSIGNED NOT NULL');
+        $this->addSql('ALTER TABLE kam_trunks_address ADD CONSTRAINT FK_873EF06250736B8 FOREIGN KEY (ddiProviderAddressId) REFERENCES DDIProviderAddresses (id) ON DELETE CASCADE');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_873EF06250736B8 ON kam_trunks_address (ddiProviderAddressId)');
+        $this->addSql('INSERT INTO kam_trunks_address (grp, ip_addr, ddiProviderAddressId) SELECT ddiProviderId, ip, id FROM DDIProviderAddresses');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE kam_trunks_address DROP FOREIGN KEY FK_873EF06250736B8');
+        $this->addSql('DROP INDEX UNIQ_873EF06250736B8 ON kam_trunks_address');
+        $this->addSql('ALTER TABLE kam_trunks_address DROP ddiProviderAddressId');
+        $this->addSql('CREATE UNIQUE INDEX grp ON kam_trunks_address (grp)');
+    }
+}

--- a/web/rest/features/provider/ddiProviderAddress/getDdiProviderAddress.feature
+++ b/web/rest/features/provider/ddiProviderAddress/getDdiProviderAddress.feature
@@ -15,6 +15,8 @@ Feature: Retrieve ddi provider addresses
     """
       [
           {
+              "ip": "127.0.0.1",
+              "description": "DDI Provider Address 1",
               "id": 1
           }
       ]

--- a/web/rest/features/provider/ddiProviderAddress/postDdiProviderAddress.feature
+++ b/web/rest/features/provider/ddiProviderAddress/postDdiProviderAddress.feature
@@ -22,6 +22,8 @@ Feature: Create ddi provider addresses
      And the JSON should be equal to:
     """
       {
+          "ip": "1.1.1.1",
+          "description": "NewDDIProviderAddress",
           "id": 2
       }
     """


### PR DESCRIPTION
This PR complements #527 and makes both incoming and outgoing calls work after changes in #578 and #585 .