### PR TITLE
Invoice scheduler fixes

### DIFF
--- a/library/Ivoz/Provider/Domain/Model/InvoiceScheduler/InvoiceScheduler.php
+++ b/library/Ivoz/Provider/Domain/Model/InvoiceScheduler/InvoiceScheduler.php
@@ -35,7 +35,9 @@ class InvoiceScheduler extends InvoiceSchedulerAbstract implements InvoiceSchedu
      */
     public function setEmail($email)
     {
-        Assertion::email($email);
+        if (!empty($email)) {
+            Assertion::email($email);
+        }
         return parent::setEmail($email);
     }
 

--- a/library/Ivoz/Provider/Domain/Service/InvoiceScheduler/NextExecutionResolver.php
+++ b/library/Ivoz/Provider/Domain/Service/InvoiceScheduler/NextExecutionResolver.php
@@ -52,14 +52,16 @@ class NextExecutionResolver implements InvoiceSchedulerLifecycleEventHandlerInte
 
         switch ($unit) {
             case 'year':
+                $nextExecution->modify('first day of january, next year');
+                break;
             case 'week':
                 $nextExecution->modify('next monday');
                 break;
             case 'month':
-                $nextExecution->modify('next month');
+                $nextExecution->modify('first day of next month');
                 break;
             default:
-                throw new \DomainException('Unkown unit ' . $unit);
+                throw new \DomainException('Unknown unit ' . $unit);
         }
 
 

--- a/web/admin/application/configs/klear/InvoiceSchedulersList.yaml
+++ b/web/admin/application/configs/klear/InvoiceSchedulersList.yaml
@@ -34,7 +34,7 @@ production:
         order:
           name: true
           company: true
-          frecuency: true
+          frequency: true
           unit: true
         blacklist:
           email: true

--- a/web/admin/application/configs/klear/model/InvoiceSchedulers.yaml
+++ b/web/admin/application/configs/klear/model/InvoiceSchedulers.yaml
@@ -20,9 +20,9 @@ production:
       title: _('Unit')
       type: select
       required: true
+      defaultValue: 'month'
       source:
         data: inline
-        values:
         values:
           'week': _('Week')
           'month': _('Month')
@@ -108,7 +108,6 @@ production:
               __default__:
                 show: []
                 hide: ["number"]
-        'null': _("Unassigned")
     invoiceTemplate:
       title: _('Template')
       type: select
@@ -124,7 +123,6 @@ production:
             template: '%name%'
           order:
             InvoiceTemplate.name: asc
-        'null': _("Unassigned")
 staging:
   _extends: production
 testing:

--- a/web/admin/application/library/IvozProvider/Klear/Filter/InvoiceSchedulerCompany.php
+++ b/web/admin/application/library/IvozProvider/Klear/Filter/InvoiceSchedulerCompany.php
@@ -14,6 +14,9 @@ class IvozProvider_Klear_Filter_InvoiceSchedulerCompany extends IvozProvider_Kle
         }
 
         $schedulerId = $routeDispatcher->getParam("pk", false);
+        if (is_array($schedulerId)) {
+            return true;
+        }
 
         // Add parent filters
         parent::setRouteDispatcher($routeDispatcher);


### PR DESCRIPTION
Small fixes related to invoice schedulers #579 

web/admin:

- Reorder columns in Invoice Scheduler list
- Set default frequency to months
- Allow empty email
- Remove optional unassigned InoviceNumbers and InvoiceTemplate

core:
- Fixed calculation of next execution for Month and Year frequencies