### PR TITLE
Virtual PBX as Brand feature

### DIFF
--- a/library/Ivoz/Provider/Domain/Model/Feature/Feature.php
+++ b/library/Ivoz/Provider/Domain/Model/Feature/Feature.php
@@ -23,6 +23,7 @@ class Feature extends FeatureAbstract implements FeatureInterface
     const RESIDENTIAL       = 9;
     const WHOLESALE         = 10;
     const RETAIL            = 11;
+    const VPBX              = 12;
 
     /**
      * @codeCoverageIgnore

--- a/scheme/app/DoctrineMigrations/Version20180718132230.php
+++ b/scheme/app/DoctrineMigrations/Version20180718132230.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20180718132230 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        // Create a Brand feature to enable this client type
+        $this->addSql('INSERT INTO Features (id, iden, name_en, name_es) VALUES (12, "vpbx", "vPBX Clients", "Clientes vPBX")');
+        // Enable this feature for all existing Brands
+        $this->addSql('INSERT INTO FeaturesRelBrands (brandId, featureId) SELECT id, 12 FROM Brands');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('DELETE FROM Features WHERE id = 12');
+    }
+}

--- a/web/admin/application/configs/klear/klear.yaml
+++ b/web/admin/application/configs/klear/klear.yaml
@@ -103,6 +103,7 @@ production:
           title: ngettext('Virtual PBX', 'Virtual PBXs', 0)
           class: ui-silk-building
           description: _("List of %s", ngettext('Virtual PBX', 'Virtual PBXs', 1))
+          showOnlyIf: ${auth.brandFeatures.vpbx.enabled}
         RetailClientsList:
           title: ngettext('Retail', 'Retails', 1)
           class: ui-silk-basket
@@ -122,6 +123,7 @@ production:
           title: ngettext('Prepaid Balance', 'Prepaid Balances', 0)
           class: ui-silk-money-yen
           description: _("List of %s", ngettext('Prepaid Balance', 'Prepaid Balances', 0))
+          showOnlyIf: ${auth.brandFeatures.billing.enabled}
         CompanyURLsList:
           title: ngettext('Portal URL', 'Portal URLs', 0)
           class: ui-silk-world
@@ -146,10 +148,12 @@ production:
           title: ngettext('Generic Music on Hold', 'Generic Musics on Hold', 0)
           class: ui-silk-music
           description: _("List of %s", ngettext('Generic Music on Hold', 'Generic Musics on Hold', 0))
+          showOnlyIf: ${auth.brandFeatures.vpbx.enabled}
         BrandServicesList:
           title: ngettext('Service', 'Services', 0)
           class: ui-silk-page-white-wrench
           description: _("List of %s", ngettext('Service', 'Services', 0))
+          showOnlyIf: ${auth.brandFeatures.vpbx.enabled}
         BrandDDIsList:
           title: ngettext('DDI', 'DDIs', 0)
           class: ui-silk-lightning-go
@@ -168,6 +172,7 @@ production:
           title: ngettext('Generic Match List', 'Generic Match Lists', 0)
           class: ui-silk-text-list-numbers
           description: _("List of %s", ngettext('Generic Match List', 'Generic Match Lists', 0))
+          showOnlyIf: ${auth.brandFeatures.vpbx.enabled}
         RoutingPatternsList:
           title: ngettext('Routing pattern', 'Routing patterns', 0)
           class: ui-silk-script-go

--- a/web/admin/application/library/IvozProvider/Klear/Filter/Features.php
+++ b/web/admin/application/library/IvozProvider/Klear/Filter/Features.php
@@ -39,6 +39,7 @@ class IvozProvider_Klear_Filter_Features implements KlearMatrix_Model_Field_Sele
             if ($featureId == Feature::RESIDENTIAL) continue;
             if ($featureId == Feature::WHOLESALE) continue;
             if ($featureId == Feature::RETAIL) continue;
+            if ($featureId == Feature::VPBX) continue;
             $featureIds[] = $featureId;
         }
 

--- a/web/admin/application/library/IvozProvider/Klear/Filter/ResidentialFeatures.php
+++ b/web/admin/application/library/IvozProvider/Klear/Filter/ResidentialFeatures.php
@@ -42,6 +42,7 @@ class IvozProvider_Klear_Filter_ResidentialFeatures implements KlearMatrix_Model
             Feature::RESIDENTIAL,
             Feature::RETAIL,
             Feature::WHOLESALE,
+            Feature::VPBX,
         );
 
         $featureIds = [];


### PR DESCRIPTION
Now that the other 3 client types have features to enable/disable its sections in portal, it makes sense to do the same with virtual pbx clients.

Disabling the feature at brand level will hide following sections in Brand configuration menu:

 - Virtual PBX
 - Generic Music on Hold
 - Generic Match Lists
 - Services

The migration also enables this feature for all existing brands (including the demo one for initial installations)