### PR TITLE
agis: fix agi read and playback apps

### DIFF
--- a/asterisk/agi/src/Agi/Action/ServiceAction.php
+++ b/asterisk/agi/src/Agi/Action/ServiceAction.php
@@ -376,7 +376,7 @@ class ServiceAction
 
         do {
             $this->agi->playback($sound);
-            $entered.= $digit = $this->agi->read("", 60, 1);
+            $entered.= $digit = $this->agi->readInSilence(60, 1);
             $sound = "hello/$digit";
         } while (substr($entered, -3) != 777);
 


### PR DESCRIPTION
read and playback functions in agi-wrapper were not deducing file paths correctly.

This caused that trying to play a locution in AGIs ended in CLI errors and no locution was played.