### PR TITLE
Update AGI wrapper with readLocution and playbackLocution

### DIFF
--- a/asterisk/agi/src/Agi/Action/ConditionalRouteAction.php
+++ b/asterisk/agi/src/Agi/Action/ConditionalRouteAction.php
@@ -130,7 +130,7 @@ class ConditionalRouteAction
         }
 
         // Play locution if requested
-        $this->agi->playback($locution);
+        $this->agi->playbackLocution($locution);
 
         // Route this!
         $this->routerAction->route();

--- a/asterisk/agi/src/Agi/Action/DdiAction.php
+++ b/asterisk/agi/src/Agi/Action/DdiAction.php
@@ -114,7 +114,7 @@ class DdiAction
             }
 
             // Play Welcome message
-            $this->agi->playback($externalCallFilter->getWelcomeLocution());
+            $this->agi->playbackLocution($externalCallFilter->getWelcomeLocution());
         }
 
         // Check if this DDI has custom Display Name

--- a/asterisk/agi/src/Agi/Action/ExternalFilterAction.php
+++ b/asterisk/agi/src/Agi/Action/ExternalFilterAction.php
@@ -96,9 +96,9 @@ class ExternalFilterAction
 
         // Play holiday locution
         if (!empty($this->eventLocution)) {
-            $this->agi->playback($this->eventLocution);
+            $this->agi->playbackLocution($this->eventLocution);
         } else {
-            $this->agi->playback($filter->getHolidayLocution());
+            $this->agi->playbackLocution($filter->getHolidayLocution());
         }
 
         // Set Diversion information
@@ -132,7 +132,7 @@ class ExternalFilterAction
         $this->agi->notice("Procesing OutOfSchedule filter %s for DDI %s", $filter, $ddi);
 
         // Play holiday locution
-        $this->agi->playback($this->filter->getOutOfScheduleLocution());
+        $this->agi->playbackLocution($this->filter->getOutOfScheduleLocution());
 
         // Set Diversion information
         $count = $this->agi->getRedirecting('count');

--- a/asterisk/agi/src/Agi/Action/HuntGroupStatusAction.php
+++ b/asterisk/agi/src/Agi/Action/HuntGroupStatusAction.php
@@ -86,7 +86,7 @@ class HuntGroupStatusAction
             $this->agi->verbose("Processing Hungroup %s no answer handler.", $huntGroup);
 
             // Play NoAnswer Locution
-            $this->agi->playback($huntGroup->getNoAnswerLocution());
+            $this->agi->playbackLocution($huntGroup->getNoAnswerLocution());
 
             // Route to destination
             $this->routerAction

--- a/asterisk/agi/src/Agi/Action/IvrAction.php
+++ b/asterisk/agi/src/Agi/Action/IvrAction.php
@@ -101,10 +101,10 @@ class IvrAction
                 $this->agi->notice("Entered value %d matches entry %s.", $userPressed, $entry->getEntry());
 
                 // Entered data matched one of the entries, play success (if any)
-                $this->agi->playback($ivr->getSuccessLocution());
+                $this->agi->playbackLocution($ivr->getSuccessLocution());
 
                 // Play entry success (if any)
-                $this->agi->playback($entry->getWelcomeLocution());
+                $this->agi->playbackLocution($entry->getWelcomeLocution());
 
                 // Route to destination
                 $this->routerAction
@@ -142,7 +142,7 @@ class IvrAction
                 $this->agi->notice("Entered value %d matches company extension %s", $userPressed, $extension);
 
                 // Entered data matched one of company extensions, play success (if any)
-                $this->agi->playback($ivr->getSuccessLocution());
+                $this->agi->playbackLocution($ivr->getSuccessLocution());
 
                 // Route to dialed extension
                 $this->routerAction
@@ -167,7 +167,7 @@ class IvrAction
         $this->agi->verbose("Processing IVR no input handler.");
 
         // Play No Input Locution
-        $this->agi->playback($this->ivr->getNoInputLocution());
+        $this->agi->playbackLocution($this->ivr->getNoInputLocution());
 
         // Route to destination
         $this->routerAction
@@ -186,7 +186,7 @@ class IvrAction
         $this->agi->verbose("Processing IVR error handler.");
 
         // Play Error Locution
-        $this->agi->playback($this->ivr->getErrorLocution());
+        $this->agi->playbackLocution($this->ivr->getErrorLocution());
 
         // Route to destination
         $this->routerAction

--- a/asterisk/agi/src/Agi/Action/QueueFullAction.php
+++ b/asterisk/agi/src/Agi/Action/QueueFullAction.php
@@ -61,7 +61,7 @@ class QueueFullAction
         $this->agi->notice("Processing Full queue handler");
 
         // Play timeout locution
-        $this->agi->playback($queue->getFullLocution());
+        $this->agi->playbackLocution($queue->getFullLocution());
 
         // Route to the timeout destination
         $this->routerAction

--- a/asterisk/agi/src/Agi/Action/QueueTimeoutAction.php
+++ b/asterisk/agi/src/Agi/Action/QueueTimeoutAction.php
@@ -61,7 +61,7 @@ class QueueTimeoutAction
         $this->agi->notice("Processing Timeout queue handler");
 
         // Play timeout locution
-        $this->agi->playback($queue->getFullLocution());
+        $this->agi->playbackLocution($queue->getFullLocution());
 
         // Route to the timeout destination
         $this->routerAction

--- a/asterisk/agi/src/Agi/Action/ServiceAction.php
+++ b/asterisk/agi/src/Agi/Action/ServiceAction.php
@@ -376,7 +376,7 @@ class ServiceAction
 
         do {
             $this->agi->playback($sound);
-            $entered.= $digit = $this->agi->readInSilence(60, 1);
+            $entered.= $digit = $this->agi->read("", 60, 1);
             $sound = "hello/$digit";
         } while (substr($entered, -3) != 777);
 

--- a/asterisk/agi/src/Agi/Action/VoiceMailAction.php
+++ b/asterisk/agi/src/Agi/Action/VoiceMailAction.php
@@ -72,7 +72,7 @@ class VoiceMailAction
             if ($this->playBanner) {
                 if ($voicemail->getVoiceMailLocution()) {
                     $this->agi->verbose("Playing custom user Voicemail Locution.");
-                    $this->agi->playback($voicemail->getVoiceMailLocution());
+                    $this->agi->playbackLocution($voicemail->getVoiceMailLocution());
                     $vmopts .= "s";     // Skip welcome message
                 }
             } else {

--- a/asterisk/agi/src/Agi/Wrapper.php
+++ b/asterisk/agi/src/Agi/Wrapper.php
@@ -152,36 +152,39 @@ class Wrapper
         return $this;
     }
 
-
     /**
      *
-     * @param LocutionInterface|null $file
+     * @param LocutionInterface|null $locution
      * @param string $options
      */
-    public function playback($file = null, $options = "")
+    public function playbackLocution(LocutionInterface $locution = null, $options = "")
     {
-        if (is_null($file) || empty($file)) {
+        if (empty($locution)) {
             return;
         }
 
-        if ($file instanceof LocutionInterface) {
-            $this->locutionPathResolver->setOriginalFileName(
-                $file->getEncodedFile()->getBaseName()
-            );
+        $this->locutionPathResolver->setOriginalFileName(
+            $locution->getEncodedFile()->getBaseName()
+        );
 
-            $file = $this
-                ->locutionPathResolver
-                ->getFilePath($file);
+        $file = $this
+            ->locutionPathResolver
+            ->getFilePath($locution);
 
-            if (!file_exists($file)) {
-                $this->error("Locution $file not found in filesystem.");
-                return;
-            }
-
-            $file = pathinfo($file, PATHINFO_DIRNAME) . DIRECTORY_SEPARATOR . pathinfo($file, PATHINFO_FILENAME);
+        if (!file_exists($file)) {
+            $this->error("Locution $file not found in filesystem.");
+            return;
         }
 
-        $this->fastagi->exec("Playback", "$file,$options");
+        $filename = pathinfo($file, PATHINFO_DIRNAME) . DIRECTORY_SEPARATOR . pathinfo($file, PATHINFO_FILENAME);
+
+        $this->playback($filename, $options);
+
+    }
+
+    public function playback($filename = "", $options = "")
+    {
+        $this->fastagi->exec("Playback", "$filename,$options");
     }
 
     public function pickup($interface = "")
@@ -197,14 +200,18 @@ class Wrapper
     /**
      * Read DTMF digits while playing a locution
      *
-     * @param $locution
+     * @param LocutionInterface | null $locution
      * @param int $timeout
      * @param int $maxdigits
      *
      * @return string
      */
-    public function read(LocutionInterface $locution, $timeout = 0, $maxdigits = 0)
+    public function readLocution(LocutionInterface $locution = null, $timeout = 0, $maxdigits = 0)
     {
+        if (!$locution) {
+            return $this->read("", $timeout, $maxdigits);
+        }
+
         $this->locutionPathResolver->setOriginalFileName(
             $locution->getEncodedFile()->getBaseName()
         );
@@ -215,23 +222,18 @@ class Wrapper
 
         if (!file_exists($file)) {
             $this->error("Locution $file not found in filesystem.");
-            return $this->readInSilence($timeout, $maxdigits);
+            return $this->read("", $timeout, $maxdigits);
         }
 
         // Remove extension for Read application
         $filename = pathinfo($file, PATHINFO_DIRNAME) . DIRECTORY_SEPARATOR . pathinfo($file, PATHINFO_FILENAME);
 
-        $this->fastagi->exec('Read', "PRESSED,$filename,$maxdigits,,,$timeout");
-        if ($this->getVariable("READSTATUS") == "HANGUP") {
-            return "HANGUP";
-        }
-
-        return $this->getVariable("PRESSED");
+        return $this->read($filename, $timeout, $maxdigits);
     }
 
-    public function readInSilence($timeout = 0, $maxdigits = 0)
+    public function read($filename = "", $timeout = 0, $maxdigits = 0)
     {
-        $this->fastagi->exec('Read', "PRESSED,,$maxdigits,,,$timeout");
+        $this->fastagi->exec('Read', "PRESSED,$filename,$maxdigits,,,$timeout");
         if ($this->getVariable("READSTATUS") == "HANGUP") {
             return "HANGUP";
         }


### PR DESCRIPTION
This commit adds two new functions (_readLocution_ and _playbackLocution_) to agi wrapper for properly checking Locutions in dialplan.

Original functions (_read_ and _playback_) will only handle the locution string or full path to the filename of a Locution entity.