### PR TITLE
Fix manual inovice generation from web interface

### DIFF
--- a/library/Ivoz/Provider/Domain/Model/Invoice/Invoice.php
+++ b/library/Ivoz/Provider/Domain/Model/Invoice/Invoice.php
@@ -12,6 +12,8 @@ class Invoice extends InvoiceAbstract implements InvoiceInterface, FileContainer
 {
     const STATUS_WAITING = 'waiting';
     const STATUS_PROCESSING = 'processing';
+    const STATUS_CREATED = 'created';
+    const STATUS_ERROR = 'error';
 
     use InvoiceTrait;
     use TempFileContainnerTrait;
@@ -51,18 +53,6 @@ class Invoice extends InvoiceAbstract implements InvoiceInterface, FileContainer
     public function isProcessing()
     {
         return $this->getStatus() === self::STATUS_PROCESSING;
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function setStatus($status = null)
-    {
-        if (is_null($status)) {
-            $status = self::STATUS_WAITING;
-        }
-
-        return parent::setStatus($status);
     }
 
     public function setNumber($number = null)

--- a/library/Ivoz/Provider/Domain/Model/Invoice/InvoiceInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/Invoice/InvoiceInterface.php
@@ -23,11 +23,6 @@ interface InvoiceInterface extends LoggableEntityInterface
      */
     public function isProcessing();
 
-    /**
-     * @inheritdoc
-     */
-    public function setStatus($status = null);
-
     public function setNumber($number = null);
 
     /**
@@ -116,6 +111,15 @@ interface InvoiceInterface extends LoggableEntityInterface
      * @return string
      */
     public function getTotalWithTax();
+
+    /**
+     * Set status
+     *
+     * @param string $status
+     *
+     * @return self
+     */
+    public function setStatus($status = null);
 
     /**
      * Get status

--- a/library/Ivoz/Provider/Domain/Service/Invoice/CreateByScheduler.php
+++ b/library/Ivoz/Provider/Domain/Service/Invoice/CreateByScheduler.php
@@ -5,6 +5,7 @@ namespace Ivoz\Provider\Domain\Service\Invoice;
 use Ivoz\Core\Application\Service\EntityTools;
 use Ivoz\Provider\Domain\Model\FixedCostsRelInvoice\FixedCostsRelInvoice;
 use Ivoz\Provider\Domain\Model\FixedCostsRelInvoiceScheduler\FixedCostsRelInvoiceSchedulerInterface;
+use Ivoz\Provider\Domain\Model\Invoice\Invoice;
 use Ivoz\Provider\Domain\Model\Invoice\InvoiceDto;
 use Ivoz\Provider\Domain\Model\Invoice\InvoiceInterface;
 use Ivoz\Provider\Domain\Model\InvoiceScheduler\InvoiceSchedulerInterface;
@@ -80,6 +81,7 @@ class CreateByScheduler
         $company = $scheduler->getCompany();
         $invoiceDto = new InvoiceDto();
         $invoiceDto
+            ->setStatus(Invoice::STATUS_WAITING)
             ->setInDate($inDate)
             ->setOutDate($outDate)
             ->setTaxRate(

--- a/library/Ivoz/Provider/Domain/Service/Invoice/SendGenerateOrder.php
+++ b/library/Ivoz/Provider/Domain/Service/Invoice/SendGenerateOrder.php
@@ -3,6 +3,7 @@
 namespace Ivoz\Provider\Domain\Service\Invoice;
 
 use Ivoz\Core\Infrastructure\Domain\Service\Gearman\Jobs\Invoicer;
+use Ivoz\Provider\Domain\Model\Invoice\Invoice;
 use Ivoz\Provider\Domain\Model\Invoice\InvoiceInterface;
 
 class SendGenerateOrder implements InvoiceLifecycleEventHandlerInterface
@@ -27,7 +28,7 @@ class SendGenerateOrder implements InvoiceLifecycleEventHandlerInterface
 
     public function execute(InvoiceInterface $entity)
     {
-        $pendingStatus = $entity->getStatus() === 'waiting';
+        $pendingStatus = $entity->getStatus() === Invoice::STATUS_WAITING;
         $statusHasChanged = $entity->hasChanged('status');
 
         if ($pendingStatus && $statusHasChanged) {

--- a/library/spec/Ivoz/Provider/Domain/Model/Invoice/InvoiceSpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Model/Invoice/InvoiceSpec.php
@@ -48,13 +48,4 @@ class InvoiceSpec extends ObjectBehavior
     {
         $this->shouldHaveType(Invoice::class);
     }
-
-    function it_turns_null_status_into_waiting()
-    {
-        $this->setStatus(null);
-
-        $this
-            ->getStatus()
-            ->shouldBe('waiting');
-    }
 }

--- a/web/admin/application/configs/klear/InvoicesList.yaml
+++ b/web/admin/application/configs/klear/InvoicesList.yaml
@@ -63,7 +63,6 @@ production:
       shortcutOption: N
       forcedValues:
         <<: *forcedBrand
-        status: waiting
       fields:
         order:
           <<: *invoicesOrder_Link


### PR DESCRIPTION
This PR restores the old invoice generation behaviour for manual invoices.

Invoices generated from web/admin must be created in some steps:

1. Generate an Invoice entry with all invoice information
2. Add Fixed costs to the invoice or update its information (Optional)
3. Press generate invoice button in the interface