### PR TITLE
Show Call registries for retail/residential client types

### DIFF
--- a/library/Ivoz/Kam/Domain/Model/UsersCdr/UsersCdr.php
+++ b/library/Ivoz/Kam/Domain/Model/UsersCdr/UsersCdr.php
@@ -9,6 +9,9 @@ class UsersCdr extends UsersCdrAbstract implements UsersCdrInterface
 {
     use UsersCdrTrait;
 
+    const DIRECTION_OUTBOUND = "outbound";
+    const DIRECTION_INBOUND = "inbound";
+
     /**
      * Get id
      *
@@ -18,5 +21,40 @@ class UsersCdr extends UsersCdrAbstract implements UsersCdrInterface
     {
         return $this->id;
     }
+
+    /**
+     * @return string
+     */
+    public function getOwner()
+    {
+        if (!is_null($this->getUser())) {
+            return $this->getUser()->getFullNameExtension();
+        } elseif (!is_null($this->getFriend())) {
+            return $this->getFriend()->getName();
+        } elseif (!is_null($this->getRetailAccount())) {
+            return $this->getRetailAccount()->getName();
+        } elseif (!is_null($this->getResidentialDevice())) {
+            return $this->getResidentialDevice()->getName();
+        }
+
+        if ($this->getDirection() === UsersCdr::DIRECTION_OUTBOUND) {
+            return $this->getCaller();
+        } else {
+            return $this->getCallee();
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getParty()
+    {
+        if ($this->getDirection() === UsersCdr::DIRECTION_OUTBOUND) {
+            return $this->getCallee();
+        } else {
+            return $this->getCaller();
+        }
+    }
+
 }
 

--- a/library/Ivoz/Kam/Domain/Model/UsersCdr/UsersCdrInterface.php
+++ b/library/Ivoz/Kam/Domain/Model/UsersCdr/UsersCdrInterface.php
@@ -7,6 +7,16 @@ use Ivoz\Core\Domain\Model\EntityInterface;
 interface UsersCdrInterface extends EntityInterface
 {
     /**
+     * @return string
+     */
+    public function getOwner();
+
+    /**
+     * @return string
+     */
+    public function getParty();
+
+    /**
      * Set startTime
      *
      * @param \DateTime $startTime

--- a/library/Ivoz/Provider/Domain/Model/User/User.php
+++ b/library/Ivoz/Provider/Domain/Model/User/User.php
@@ -419,5 +419,17 @@ class User extends UserAbstract implements UserInterface, AdvancedUserInterface,
 
         return $this->getCompany()->getDefaultTimezone();
     }
+
+    /**
+     * @return string
+     */
+    public function getFullNameExtension()
+    {
+        return sprintf("%s %s (%s)",
+            $this->getName(),
+            $this->getLastname(),
+            $this->getExtensionNumber()
+        );
+    }
 }
 

--- a/library/Ivoz/Provider/Domain/Model/User/UserInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/User/UserInterface.php
@@ -125,6 +125,11 @@ interface UserInterface extends LoggableEntityInterface
     public function getTimezone();
 
     /**
+     * @return string
+     */
+    public function getFullNameExtension();
+
+    /**
      * Set name
      *
      * @param string $name

--- a/web/admin/application/configs/klear/KamUsersCdrsList.yaml
+++ b/web/admin/application/configs/klear/KamUsersCdrsList.yaml
@@ -21,20 +21,18 @@ production:
         <<: *forcedCompany
       fields: &kamUsersCdrs_fieldsLink
         blacklist:
-          endTime: true
-          callidHash: true
-          user: true
-          friend: true
-          residentialDevice: ${auth.companyVPBX}
-          direction: ${auth.companyVPBX}
-          brand: true
           callid: true
+          callidHash: true
           xcallid: true
+          caller: ${auth.companyVPBX}
+          callee: ${auth.companyVPBX}
+          party: ${auth.companyNotVPBX}
         order:
           startTime: true
-          residentialDevice: true
+          owner: true
           direction: true
           caller: true
+          party: true
           callee: true
           duration: true
         options:
@@ -51,25 +49,24 @@ production:
       disableSave: true
       labelOnPostAction: _("View %s %2s", ngettext('Call', 'Calls', 1), "[format| (%item%)]")
       title: _("View %s %2s", ngettext('Call', 'Calls', 1), "[format| (%item%)]")
+      forcedValues:
+        <<: *forcedCompany
       fields:
         blacklist:
           callidHash: ${auth.isCompanyOperator}
           callid: ${auth.isCompanyOperator}
           xcallid: ${auth.isCompanyOperator}
-          brand: true
-          user: true
-          friend: true
-          residentialDevice: ${auth.companyVPBX}
-          direction: ${auth.companyVPBX}
-          company: true
-          endTime: true
+          caller: ${auth.companyVPBX}
+          callee: ${auth.companyVPBX}
+          party: ${auth.companyNotVPBX}
         order:
           startTime: true
           duration: true
-          caller: true
-          callee: true
-          residentialDevice: true
+          owner: true
           direction: true
+          caller: true
+          party: true
+          callee: true
           callid: true
           callidHash: true
           xcallid: true
@@ -80,17 +77,17 @@ production:
           fields:
             startTime: 6
             duration: 6
-            endTime: 6
-            caller: 6
-            callee: 6
-            residentialDevice: 6
+            owner: 6
             direction: 6
+            caller: 6
+            party: 6
+            callee: 6
         group2:
-          label: _("Identify Call")
+          label: _("Extra Information")
           colsPerRow: 12
           fields:
-            callid: 12
-            callidHash: 12
+            callid: 8
+            callidHash: 4
             xcallid: 12
 
 staging:

--- a/web/admin/application/configs/klear/KamUsersCdrsResidentialList.yaml
+++ b/web/admin/application/configs/klear/KamUsersCdrsResidentialList.yaml
@@ -1,3 +1,0 @@
-#include conf.d/mapperList.yaml
-#include conf.d/actions.yaml
-#include KamUsersCdrsList.yaml

--- a/web/admin/application/configs/klear/klear.yaml
+++ b/web/admin/application/configs/klear/klear.yaml
@@ -45,8 +45,8 @@ production:
 
   menu:
     General:
-      title:  _("Platform Configuration")
-      description: _("Platform Configuration")
+      title:  _("Global Configuration")
+      description: _("Global Configuration")
       showOnlyIf: ${auth.canSeeMain}
       submenus:
         BrandsList:
@@ -235,7 +235,7 @@ production:
           description: _("List of %s", ngettext('Billable call', 'Billable calls', 0))
           showOnlyIf: ${auth.brandFeatures.billing.enabled}
     Admin:
-      title: _("Company Configuration")
+      title: _("Client Configuration")
       meta: "[mine:${auth.isCompanyAdmin}|company:${auth.companyId}|type:${auth.companyType}|name:${auth.companyName}]"
       showOnlyIf: ${auth.canSeeCompany}
       description: _("Admin")
@@ -390,12 +390,7 @@ production:
           title: ngettext('Call registry', 'Call registries', 1)
           class: ui-silk-application-view-list
           description: _("List of %s", ngettext('Call', 'Calls', 0))
-          showOnlyIf: ${auth.companyVPBX}
-        KamUsersCdrsResidentialList:
-          title: ngettext('Call registry', 'Call registries', 1)
-          class: ui-silk-application-view-list
-          description: _("List of %s", ngettext('Call', 'Calls', 0))
-          showOnlyIf: ${auth.companyResidential}
+          showOnlyIf: ${auth.companyNotWholesale}
         BillableCallsClientList:
           title: ngettext('Billable call', 'Billable calls', 0)
           class: ui-silk-application-view-list

--- a/web/admin/application/configs/klear/model/KamUsersCdrs.yaml
+++ b/web/admin/application/configs/klear/model/KamUsersCdrs.yaml
@@ -1,20 +1,6 @@
 production:
   entity: Ivoz\Kam\Domain\Model\UsersCdr\UsersCdr
   fields:
-    brand:
-      title: ngettext('Brand', 'Brands', 1)
-      type: select
-      required: true
-      source:
-        data: mapper
-        config:
-          entity: \Ivoz\Provider\Domain\Model\Brand\Brand
-          fieldName:
-            fields:
-              - name
-            template: '%name%'
-          order:
-            Brand.name: asc
     company:
       title: ngettext('Company', 'Companies', 1)
       type: select
@@ -38,14 +24,6 @@ production:
         control: datetime
         settings:
           disabled: 'false'
-    endTime:
-      title: _('End time')
-      type: picker
-      defaultValue: 2000-01-01 00:00:00
-      source:
-        control: datetime
-        settings:
-          disabled: 'false'
     duration:
       title: _('Duration')
       type: ghost
@@ -54,13 +32,19 @@ production:
         method: getDuration
     direction:
       title: _('Direction')
-      type: text
+      type: select
+      source:
+        data: inline
+        values:
+          'inbound':
+            title: _("Inbound")
+          'outbound':
+            title: _("Outbound")
     caller:
       title: _('Source')
       type: text
     callee:
       title: _('Destination')
-      type: text
     callid:
       title: _('Callid')
       type: text
@@ -70,53 +54,18 @@ production:
     callidHash:
       title: _('CallidHash')
       type: text
-    user:
-      title: _('User')
-      type: select
-      required: true
+    owner:
+      title: _('Owner')
+      type: ghost
       source:
-        data: mapper
-        config:
-          entity: \Ivoz\Provider\Domain\Model\User\User
-          filterClass: IvozProvider_Klear_Filter_Company
-          fieldName:
-            fields:
-              - name
-              - lastname
-            template: '%name% %lastname%'
-          order:
-            User.name: asc
-        'null': _("Unassigned")
-    residentialDevice:
-      title: _('Residential Device')
-      type: select
+        class: IvozProvider_Klear_Ghost_UsersCdr
+        method: getCallOwner
+    party:
+      title: _('Party')
+      type: ghost
       source:
-        data: mapper
-        config:
-          entity: \Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDevice
-          filterClass: IvozProvider_Klear_Filter_Company
-          fieldName:
-            fields:
-              - name
-            template: '%name%'
-          order:
-            ResidentialDevice.name: asc
-        'null': _("Unassigned")
-    friend:
-      title: _('Friend')
-      type: select
-      source:
-        data: mapper
-        config:
-          entity: \Ivoz\Provider\Domain\Model\Friend\Friend
-          filterClass: IvozProvider_Klear_Filter_Company
-          fieldName:
-            fields:
-              - name
-            template: '%name%'
-          order:
-            Friend.name: asc
-        'null': _("Unassigned")
+        class: IvozProvider_Klear_Ghost_UsersCdr
+        method: getCallParty
 staging:
   _extends: production
 testing:

--- a/web/admin/application/languages/en_US/en_US.po
+++ b/web/admin/application/languages/en_US/en_US.po
@@ -411,6 +411,9 @@ msgstr "Charge period"
 msgid "Check documentation for this section"
 msgstr "Check documentation for this section"
 
+msgid "Client Configuration"
+msgstr "Client Configuration"
+
 msgid "Client's default"
 msgstr "Client's default"
 
@@ -433,9 +436,6 @@ msgid "Company"
 msgid_plural "Companies"
 msgstr[0] "Company"
 msgstr[1] "Companies"
-
-msgid "Company Configuration"
-msgstr "Company Configuration"
 
 msgid "Company URL"
 msgid_plural "Company URLs"
@@ -942,6 +942,9 @@ msgstr "Generic template"
 msgid "Geographic Configuration"
 msgstr "Geographic Configuration"
 
+msgid "Global Configuration"
+msgstr "Global Configuration"
+
 msgid "God"
 msgstr "God"
 
@@ -1013,9 +1016,6 @@ msgid "Iden"
 msgid_plural "Idens"
 msgstr[0] "Iden"
 msgstr[1] "Idens"
-
-msgid "Identify Call"
-msgstr "Identify Call"
 
 msgid ""
 "If no queue member answers before time this seconds, the timeout queue logic "
@@ -1640,6 +1640,9 @@ msgid_plural "Outgoing routings"
 msgstr[0] "Outgoing routing"
 msgstr[1] "Outgoing routings"
 
+msgid "Owner"
+msgstr "Owner"
+
 msgid "PDF File"
 msgid_plural "PDF Files"
 msgstr[0] "PDF File"
@@ -1653,6 +1656,9 @@ msgstr "Parse file and import"
 
 msgid "Parsed"
 msgstr "Parsed"
+
+msgid "Party"
+msgstr "Party"
 
 msgid "Password"
 msgstr "Password"
@@ -1708,9 +1714,6 @@ msgstr "Pin code"
 
 msgid "Pin protected"
 msgstr "Pin protected"
-
-msgid "Platform Configuration"
-msgstr "Platform Configuration"
 
 msgid "Please select only uninvoiced calls"
 msgstr "Please select only uninvoiced calls"

--- a/web/admin/application/languages/es_ES/es_ES.po
+++ b/web/admin/application/languages/es_ES/es_ES.po
@@ -422,6 +422,9 @@ msgstr "Período de facturación"
 msgid "Check documentation for this section"
 msgstr "Ver documentación de esta sección"
 
+msgid "Client Configuration"
+msgstr "Configuración de Cliente"
+
 msgid "Client's default"
 msgstr "Usar configuración cliente"
 
@@ -444,9 +447,6 @@ msgid "Company"
 msgid_plural "Companies"
 msgstr[0] "Empresa"
 msgstr[1] "Empresas"
-
-msgid "Company Configuration"
-msgstr "Configuración de Empresa"
 
 msgid "Company URL"
 msgid_plural "Company URLs"
@@ -961,6 +961,9 @@ msgstr "Plantilla genérica"
 msgid "Geographic Configuration"
 msgstr "Configuración Geográfica"
 
+msgid "Global Configuration"
+msgstr "Configuración Global"
+
 msgid "God"
 msgstr "God"
 
@@ -1032,9 +1035,6 @@ msgid "Iden"
 msgid_plural "Idens"
 msgstr[0] "Iden"
 msgstr[1] "Idens"
-
-msgid "Identify Call"
-msgstr "Identificar Llamada"
 
 msgid ""
 "If no queue member answers before time this seconds, the timeout queue logic "
@@ -1664,6 +1664,9 @@ msgid_plural "Outgoing routings"
 msgstr[0] "Ruta saliente"
 msgstr[1] "Rutas salientes"
 
+msgid "Owner"
+msgstr "Dueño"
+
 msgid "PDF File"
 msgid_plural "PDF Files"
 msgstr[0] "Fichero PDF"
@@ -1677,6 +1680,9 @@ msgstr "Analizar fichero e importar"
 
 msgid "Parsed"
 msgstr "Parseada"
+
+msgid "Party"
+msgstr "Interlocutor"
 
 msgid "Password"
 msgstr "Contraseña"
@@ -1734,9 +1740,6 @@ msgstr "Contraseña"
 
 msgid "Pin protected"
 msgstr "Con contraseña"
-
-msgid "Platform Configuration"
-msgstr "Configuración de Plataforma"
 
 msgid "Please select only uninvoiced calls"
 msgstr "Por favor, seleccione únicamente llamadas no facturadas"

--- a/web/admin/application/library/IvozProvider/Klear/Auth/User.php
+++ b/web/admin/application/library/IvozProvider/Klear/Auth/User.php
@@ -74,9 +74,13 @@ class User extends \Klear_Model_UserAdvanced
         $this->companyName = $company->getName();
         $this->companyType = $company->getType();
         $this->companyVPBX = $company->getType() === Company::VPBX;
+        $this->companyNotVPBX = $company->getType() != Company::VPBX;
         $this->companyResidential = $company->getType() === Company::RESIDENTIAL;
+        $this->companyNotResidential = $company->getType() != Company::RESIDENTIAL;
         $this->companyWholesale = $company->getType() === Company::WHOLESALE;
+        $this->companyNotWholesale = $company->getType() != Company::WHOLESALE;
         $this->companyRetail = $company->getType() === Company::RETAIL;
+        $this->companyNotRetail = $company->getType() != Company::RETAIL;
     }
 
     public function getCompany()

--- a/web/admin/application/library/IvozProvider/Klear/Dynamic/Config/BrandOperator.php
+++ b/web/admin/application/library/IvozProvider/Klear/Dynamic/Config/BrandOperator.php
@@ -17,7 +17,7 @@ class BrandOperator extends Base
             $this->_subTitle = "Main Operator: <strong>". $this->_user->getusername()."</strong>";
 
             if ($this->_user->companyId) {
-                $this->_subTitle .= sprintf('<br />Emulated company: <strong>%s</strong>',  $this->_user->companyName);
+                $this->_subTitle .= sprintf('<br />Emulated client: <strong>%s</strong>',  $this->_user->companyName);
             }
         }
     }

--- a/web/admin/application/library/IvozProvider/Klear/Dynamic/Config/MainOperator.php
+++ b/web/admin/application/library/IvozProvider/Klear/Dynamic/Config/MainOperator.php
@@ -19,7 +19,7 @@ class MainOperator extends Base
             }
 
             if ($this->_user->companyId) {
-                $this->_subTitle .= sprintf('<br />Emulated company: <strong>%s</strong>',  $this->_user->companyName);
+                $this->_subTitle .= sprintf('<br />Emulated client: <strong>%s</strong>',  $this->_user->companyName);
             }
         }
     }

--- a/web/admin/application/library/IvozProvider/Klear/Ghost/UsersCdr.php
+++ b/web/admin/application/library/IvozProvider/Klear/Ghost/UsersCdr.php
@@ -1,6 +1,9 @@
 <?php
 
 use Ivoz\Kam\Domain\Model\UsersCdr\UsersCdrDto;
+use Ivoz\Core\Application\Service\DataGateway;
+use Ivoz\Kam\Domain\Model\UsersCdr\UsersCdr;
+
 
 class IvozProvider_Klear_Ghost_UsersCdr extends KlearMatrix_Model_Field_Ghost_Abstract
 {
@@ -14,4 +17,39 @@ class IvozProvider_Klear_Ghost_UsersCdr extends KlearMatrix_Model_Field_Ghost_Ab
         return round($model->getDuration());
     }
 
+    /**
+     * @param UsersCdrDto $model
+     * @return string with owner of the call
+     * @throws Zend_Exception
+     */
+    public function getCallOwner($model)
+    {
+        /** @var DataGateway $dataGateway */
+        $dataGateway = \Zend_Registry::get('data_gateway');
+
+        return $dataGateway->remoteProcedureCall(
+            UsersCdr::class,
+            $model->getId(),
+            'getOwner',
+            []
+        );
+    }
+
+    /**
+     * @param UsersCdrDto $model
+     * @return string with other party of the call
+     * @throws Zend_Exception
+     */
+    public function getCallParty($model)
+    {
+        /** @var DataGateway $dataGateway */
+        $dataGateway = \Zend_Registry::get('data_gateway');
+
+        return $dataGateway->remoteProcedureCall(
+            UsersCdr::class,
+            $model->getId(),
+            'getParty',
+            []
+        );
+    }
 }


### PR DESCRIPTION
Besides Billable Calls, retail and residential clients need call registries to show incoming calls.