### PR TITLE
TpDestinations for RoutingPatterns LCRs

### DIFF
--- a/library/Ivoz/Cgr/Domain/Model/TpDestination/TpDestination.php
+++ b/library/Ivoz/Cgr/Domain/Model/TpDestination/TpDestination.php
@@ -19,6 +19,34 @@ class TpDestination extends TpDestinationAbstract implements TpDestinationInterf
         return $this->id;
     }
 
+    /**
+     * Set destination
+     *
+     * @param \Ivoz\Provider\Domain\Model\Destination\DestinationInterface | null $destination
+     *
+     * @return self
+     */
+    public function setDestination(\Ivoz\Provider\Domain\Model\Destination\DestinationInterface $destination = null)
+    {
+        if (!is_null($destination)) {
+            parent::setDestination($destination);
+        }
+        return $this;
+    }
 
+    /**
+     * Set routingPattern
+     *
+     * @param \Ivoz\Provider\Domain\Model\RoutingPattern\RoutingPatternInterface | null $routingPattern
+     *
+     * @return self
+     */
+    public function setRoutingPattern(\Ivoz\Provider\Domain\Model\RoutingPattern\RoutingPatternInterface $routingPattern = null)
+    {
+        if (!is_null($routingPattern)) {
+            parent::setRoutingPattern($routingPattern);
+        }
+        return $this;
+    }
 }
 

--- a/library/Ivoz/Cgr/Domain/Model/TpDestination/TpDestinationAbstract.php
+++ b/library/Ivoz/Cgr/Domain/Model/TpDestination/TpDestinationAbstract.php
@@ -39,6 +39,11 @@ abstract class TpDestinationAbstract
      */
     protected $destination;
 
+    /**
+     * @var \Ivoz\Provider\Domain\Model\RoutingPattern\RoutingPatternInterface
+     */
+    protected $routingPattern;
+
 
     use ChangelogTrait;
 
@@ -123,6 +128,7 @@ abstract class TpDestinationAbstract
         $self
             ->setTag($dto->getTag())
             ->setDestination($dto->getDestination())
+            ->setRoutingPattern($dto->getRoutingPattern())
         ;
 
         $self->sanitizeValues();
@@ -147,7 +153,8 @@ abstract class TpDestinationAbstract
             ->setTag($dto->getTag())
             ->setPrefix($dto->getPrefix())
             ->setCreatedAt($dto->getCreatedAt())
-            ->setDestination($dto->getDestination());
+            ->setDestination($dto->getDestination())
+            ->setRoutingPattern($dto->getRoutingPattern());
 
 
 
@@ -166,7 +173,8 @@ abstract class TpDestinationAbstract
             ->setTag(self::getTag())
             ->setPrefix(self::getPrefix())
             ->setCreatedAt(self::getCreatedAt())
-            ->setDestination(\Ivoz\Provider\Domain\Model\Destination\Destination::entityToDto(self::getDestination(), $depth));
+            ->setDestination(\Ivoz\Provider\Domain\Model\Destination\Destination::entityToDto(self::getDestination(), $depth))
+            ->setRoutingPattern(\Ivoz\Provider\Domain\Model\RoutingPattern\RoutingPattern::entityToDto(self::getRoutingPattern(), $depth));
     }
 
     /**
@@ -179,7 +187,8 @@ abstract class TpDestinationAbstract
             'tag' => self::getTag(),
             'prefix' => self::getPrefix(),
             'created_at' => self::getCreatedAt(),
-            'destinationId' => self::getDestination() ? self::getDestination()->getId() : null
+            'destinationId' => self::getDestination() ? self::getDestination()->getId() : null,
+            'routingPatternId' => self::getRoutingPattern() ? self::getRoutingPattern()->getId() : null
         ];
     }
 
@@ -320,6 +329,30 @@ abstract class TpDestinationAbstract
     public function getDestination()
     {
         return $this->destination;
+    }
+
+    /**
+     * Set routingPattern
+     *
+     * @param \Ivoz\Provider\Domain\Model\RoutingPattern\RoutingPatternInterface $routingPattern
+     *
+     * @return self
+     */
+    public function setRoutingPattern(\Ivoz\Provider\Domain\Model\RoutingPattern\RoutingPatternInterface $routingPattern)
+    {
+        $this->routingPattern = $routingPattern;
+
+        return $this;
+    }
+
+    /**
+     * Get routingPattern
+     *
+     * @return \Ivoz\Provider\Domain\Model\RoutingPattern\RoutingPatternInterface
+     */
+    public function getRoutingPattern()
+    {
+        return $this->routingPattern;
     }
 
 

--- a/library/Ivoz/Cgr/Domain/Model/TpDestination/TpDestinationDtoAbstract.php
+++ b/library/Ivoz/Cgr/Domain/Model/TpDestination/TpDestinationDtoAbstract.php
@@ -42,6 +42,11 @@ abstract class TpDestinationDtoAbstract implements DataTransferObjectInterface
      */
     private $destination;
 
+    /**
+     * @var \Ivoz\Provider\Domain\Model\RoutingPattern\RoutingPatternDto | null
+     */
+    private $routingPattern;
+
 
     use DtoNormalizer;
 
@@ -65,7 +70,8 @@ abstract class TpDestinationDtoAbstract implements DataTransferObjectInterface
             'prefix' => 'prefix',
             'createdAt' => 'createdAt',
             'id' => 'id',
-            'destinationId' => 'destination'
+            'destinationId' => 'destination',
+            'routingPatternId' => 'routingPattern'
         ];
     }
 
@@ -80,7 +86,8 @@ abstract class TpDestinationDtoAbstract implements DataTransferObjectInterface
             'prefix' => $this->getPrefix(),
             'createdAt' => $this->getCreatedAt(),
             'id' => $this->getId(),
-            'destination' => $this->getDestination()
+            'destination' => $this->getDestination(),
+            'routingPattern' => $this->getRoutingPattern()
         ];
     }
 
@@ -90,6 +97,7 @@ abstract class TpDestinationDtoAbstract implements DataTransferObjectInterface
     public function transformForeignKeys(ForeignKeyTransformerInterface $transformer)
     {
         $this->destination = $transformer->transform('Ivoz\\Provider\\Domain\\Model\\Destination\\Destination', $this->getDestinationId());
+        $this->routingPattern = $transformer->transform('Ivoz\\Provider\\Domain\\Model\\RoutingPattern\\RoutingPattern', $this->getRoutingPatternId());
     }
 
     /**
@@ -240,6 +248,52 @@ abstract class TpDestinationDtoAbstract implements DataTransferObjectInterface
     public function getDestinationId()
     {
         if ($dto = $this->getDestination()) {
+            return $dto->getId();
+        }
+
+        return null;
+    }
+
+    /**
+     * @param \Ivoz\Provider\Domain\Model\RoutingPattern\RoutingPatternDto $routingPattern
+     *
+     * @return static
+     */
+    public function setRoutingPattern(\Ivoz\Provider\Domain\Model\RoutingPattern\RoutingPatternDto $routingPattern = null)
+    {
+        $this->routingPattern = $routingPattern;
+
+        return $this;
+    }
+
+    /**
+     * @return \Ivoz\Provider\Domain\Model\RoutingPattern\RoutingPatternDto
+     */
+    public function getRoutingPattern()
+    {
+        return $this->routingPattern;
+    }
+
+    /**
+     * @param integer $id | null
+     *
+     * @return static
+     */
+    public function setRoutingPatternId($id)
+    {
+        $value = !is_null($id)
+            ? new \Ivoz\Provider\Domain\Model\RoutingPattern\RoutingPatternDto($id)
+            : null;
+
+        return $this->setRoutingPattern($value);
+    }
+
+    /**
+     * @return integer | null
+     */
+    public function getRoutingPatternId()
+    {
+        if ($dto = $this->getRoutingPattern()) {
             return $dto->getId();
         }
 

--- a/library/Ivoz/Cgr/Domain/Model/TpDestination/TpDestinationInterface.php
+++ b/library/Ivoz/Cgr/Domain/Model/TpDestination/TpDestinationInterface.php
@@ -7,6 +7,24 @@ use Ivoz\Core\Domain\Model\EntityInterface;
 interface TpDestinationInterface extends EntityInterface
 {
     /**
+     * Set destination
+     *
+     * @param \Ivoz\Provider\Domain\Model\Destination\DestinationInterface | null $destination
+     *
+     * @return self
+     */
+    public function setDestination(\Ivoz\Provider\Domain\Model\Destination\DestinationInterface $destination = null);
+
+    /**
+     * Set routingPattern
+     *
+     * @param \Ivoz\Provider\Domain\Model\RoutingPattern\RoutingPatternInterface | null $routingPattern
+     *
+     * @return self
+     */
+    public function setRoutingPattern(\Ivoz\Provider\Domain\Model\RoutingPattern\RoutingPatternInterface $routingPattern = null);
+
+    /**
      * Set tpid
      *
      * @param string $tpid
@@ -71,20 +89,18 @@ interface TpDestinationInterface extends EntityInterface
     public function getCreatedAt();
 
     /**
-     * Set destination
-     *
-     * @param \Ivoz\Provider\Domain\Model\Destination\DestinationInterface $destination
-     *
-     * @return self
-     */
-    public function setDestination(\Ivoz\Provider\Domain\Model\Destination\DestinationInterface $destination);
-
-    /**
      * Get destination
      *
      * @return \Ivoz\Provider\Domain\Model\Destination\DestinationInterface
      */
     public function getDestination();
+
+    /**
+     * Get routingPattern
+     *
+     * @return \Ivoz\Provider\Domain\Model\RoutingPattern\RoutingPatternInterface
+     */
+    public function getRoutingPattern();
 
 }
 

--- a/library/Ivoz/Cgr/Domain/Service/TpDestination/CreatedByRoutingPattern.php
+++ b/library/Ivoz/Cgr/Domain/Service/TpDestination/CreatedByRoutingPattern.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Ivoz\Cgr\Domain\Service\TpDestination;
+
+use Ivoz\Cgr\Domain\Model\TpDestination\TpDestination;
+use Ivoz\Cgr\Domain\Model\TpDestination\TpDestinationInterface;
+use Ivoz\Cgr\Domain\Model\TpDestination\TpDestinationDto;
+use Ivoz\Core\Application\Service\EntityTools;
+use Ivoz\Core\Domain\Service\EntityPersisterInterface;
+use Ivoz\Provider\Domain\Model\Destination\DestinationInterface;
+use Ivoz\Provider\Domain\Model\RoutingPattern\RoutingPatternInterface;
+use Ivoz\Provider\Domain\Service\Destination\DestinationLifecycleEventHandlerInterface;
+use Ivoz\Provider\Domain\Service\RoutingPattern\RoutingPatternLifecycleEventHandlerInterface;
+
+class CreatedByRoutingPattern implements RoutingPatternLifecycleEventHandlerInterface
+{
+    CONST POST_PERSIST_PRIORITY = self::PRIORITY_NORMAL;
+
+    /**
+     * @var EntityTools
+     */
+    protected $entityTools;
+
+    /**
+     * CreatedByRoutingPattern constructor.
+     * @param EntityTools $entityTools
+     */
+    public function __construct(
+        EntityTools $entityTools
+    ) {
+        $this->entityTools = $entityTools;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            self::EVENT_POST_PERSIST => self::POST_PERSIST_PRIORITY
+        ];
+    }
+
+    /**
+     * Create a new TpDestination when a RoutingPattern is created
+     *
+     * @param RoutingPatternInterface $routingPattern
+     * @param $isNew
+     */
+    public function execute(RoutingPatternInterface $routingPattern, $isNew)
+    {
+        $tpDestination = $routingPattern->getTpDestination();
+
+        /** @var TpDestinationDto $tpDestinationDto */
+        $tpDestinationDto = is_null($tpDestination)
+            ? TpDestination::createDto()
+            : $this->entityTools->entityToDto($tpDestination);
+
+        $tpDestinationDto
+            ->setPrefix($routingPattern->getPrefix())
+            ->setRoutingPatternId($routingPattern->getId())
+            ->setTag($routingPattern->getCgrTag());
+
+        $tpDestination = $this->entityTools->persistDto(
+            $tpDestinationDto,
+            $tpDestination,
+            true
+        );
+
+        $routingPattern->setTpDestination($tpDestination);
+    }
+
+}

--- a/library/Ivoz/Cgr/Infrastructure/Persistence/Doctrine/Mapping/TpDestination.TpDestinationAbstract.orm.yml
+++ b/library/Ivoz/Cgr/Infrastructure/Persistence/Doctrine/Mapping/TpDestination.TpDestinationAbstract.orm.yml
@@ -48,5 +48,14 @@ Ivoz\Cgr\Domain\Model\TpDestination\TpDestinationAbstract:
       joinColumn:
         name: destinationId
         referencedColumnName: id
-        nullable: false
+        nullable: true
+        onDelete: cascade
+    routingPattern:
+      targetEntity: \Ivoz\Provider\Domain\Model\RoutingPattern\RoutingPatternInterface
+      inversedBy: tpDestination
+      fetch: LAZY
+      joinColumn:
+        name: routingPatternId
+        referencedColumnName: id
+        nullable: true
         onDelete: cascade

--- a/library/Ivoz/Provider/Domain/Model/RoutingPattern/RoutingPattern.php
+++ b/library/Ivoz/Provider/Domain/Model/RoutingPattern/RoutingPattern.php
@@ -31,5 +31,18 @@ class RoutingPattern extends RoutingPatternAbstract implements RoutingPatternInt
         }
         return parent::setPrefix($prefix);
     }
+
+    /**
+     * @return string
+     */
+    public function getCgrTag()
+    {
+        return sprintf(
+            "b%dlcrdst%d",
+            $this->getBrand()->getId(),
+            $this->getId()
+        );
+    }
+
 }
 

--- a/library/Ivoz/Provider/Domain/Model/RoutingPattern/RoutingPatternAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/RoutingPattern/RoutingPatternAbstract.php
@@ -29,6 +29,11 @@ abstract class RoutingPatternAbstract
     protected $description;
 
     /**
+     * @var \Ivoz\Cgr\Domain\Model\TpDestination\TpDestinationInterface
+     */
+    protected $tpDestination;
+
+    /**
      * @var \Ivoz\Provider\Domain\Model\Brand\BrandInterface
      */
     protected $brand;
@@ -229,6 +234,30 @@ abstract class RoutingPatternAbstract
     public function getPrefix()
     {
         return $this->prefix;
+    }
+
+    /**
+     * Set tpDestination
+     *
+     * @param \Ivoz\Cgr\Domain\Model\TpDestination\TpDestinationInterface $tpDestination
+     *
+     * @return self
+     */
+    public function setTpDestination(\Ivoz\Cgr\Domain\Model\TpDestination\TpDestinationInterface $tpDestination = null)
+    {
+        $this->tpDestination = $tpDestination;
+
+        return $this;
+    }
+
+    /**
+     * Get tpDestination
+     *
+     * @return \Ivoz\Cgr\Domain\Model\TpDestination\TpDestinationInterface
+     */
+    public function getTpDestination()
+    {
+        return $this->tpDestination;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/RoutingPattern/RoutingPatternDto.php
+++ b/library/Ivoz/Provider/Domain/Model/RoutingPattern/RoutingPatternDto.php
@@ -18,7 +18,12 @@ class RoutingPatternDto extends RoutingPatternDtoAbstract
             ];
         }
 
-        return parent::getPropertyMap(...func_get_args());
+        $response =  parent::getPropertyMap(...func_get_args());
+
+        // Remove application entity relation
+        unset($response['tpDestinationId']);
+
+        return $response;
     }
 }
 

--- a/library/Ivoz/Provider/Domain/Model/RoutingPattern/RoutingPatternDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/RoutingPattern/RoutingPatternDtoAbstract.php
@@ -43,6 +43,11 @@ abstract class RoutingPatternDtoAbstract implements DataTransferObjectInterface
     private $descriptionEs;
 
     /**
+     * @var \Ivoz\Cgr\Domain\Model\TpDestination\TpDestinationDto | null
+     */
+    private $tpDestination;
+
+    /**
      * @var \Ivoz\Provider\Domain\Model\Brand\BrandDto | null
      */
     private $brand;
@@ -84,6 +89,7 @@ abstract class RoutingPatternDtoAbstract implements DataTransferObjectInterface
             'id' => 'id',
             'name' => ['en','es'],
             'description' => ['en','es'],
+            'tpDestinationId' => 'tpDestination',
             'brandId' => 'brand'
         ];
     }
@@ -104,6 +110,7 @@ abstract class RoutingPatternDtoAbstract implements DataTransferObjectInterface
                 'en' => $this->getDescriptionEn(),
                 'es' => $this->getDescriptionEs()
             ],
+            'tpDestination' => $this->getTpDestination(),
             'brand' => $this->getBrand(),
             'outgoingRoutings' => $this->getOutgoingRoutings(),
             'relPatternGroups' => $this->getRelPatternGroups(),
@@ -116,6 +123,7 @@ abstract class RoutingPatternDtoAbstract implements DataTransferObjectInterface
      */
     public function transformForeignKeys(ForeignKeyTransformerInterface $transformer)
     {
+        $this->tpDestination = $transformer->transform('Ivoz\\Cgr\\Domain\\Model\\TpDestination\\TpDestination', $this->getTpDestinationId());
         $this->brand = $transformer->transform('Ivoz\\Provider\\Domain\\Model\\Brand\\Brand', $this->getBrandId());
         if (!is_null($this->outgoingRoutings)) {
             $items = $this->getOutgoingRoutings();
@@ -289,6 +297,52 @@ abstract class RoutingPatternDtoAbstract implements DataTransferObjectInterface
     public function getDescriptionEs()
     {
         return $this->descriptionEs;
+    }
+
+    /**
+     * @param \Ivoz\Cgr\Domain\Model\TpDestination\TpDestinationDto $tpDestination
+     *
+     * @return static
+     */
+    public function setTpDestination(\Ivoz\Cgr\Domain\Model\TpDestination\TpDestinationDto $tpDestination = null)
+    {
+        $this->tpDestination = $tpDestination;
+
+        return $this;
+    }
+
+    /**
+     * @return \Ivoz\Cgr\Domain\Model\TpDestination\TpDestinationDto
+     */
+    public function getTpDestination()
+    {
+        return $this->tpDestination;
+    }
+
+    /**
+     * @param integer $id | null
+     *
+     * @return static
+     */
+    public function setTpDestinationId($id)
+    {
+        $value = !is_null($id)
+            ? new \Ivoz\Cgr\Domain\Model\TpDestination\TpDestinationDto($id)
+            : null;
+
+        return $this->setTpDestination($value);
+    }
+
+    /**
+     * @return integer | null
+     */
+    public function getTpDestinationId()
+    {
+        if ($dto = $this->getTpDestination()) {
+            return $dto->getId();
+        }
+
+        return null;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/RoutingPattern/RoutingPatternInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/RoutingPattern/RoutingPatternInterface.php
@@ -13,11 +13,32 @@ interface RoutingPatternInterface extends EntityInterface
     public function setPrefix($prefix = null);
 
     /**
+     * @return string
+     */
+    public function getCgrTag();
+
+    /**
      * Get prefix
      *
      * @return string
      */
     public function getPrefix();
+
+    /**
+     * Set tpDestination
+     *
+     * @param \Ivoz\Cgr\Domain\Model\TpDestination\TpDestinationInterface $tpDestination
+     *
+     * @return self
+     */
+    public function setTpDestination(\Ivoz\Cgr\Domain\Model\TpDestination\TpDestinationInterface $tpDestination = null);
+
+    /**
+     * Get tpDestination
+     *
+     * @return \Ivoz\Cgr\Domain\Model\TpDestination\TpDestinationInterface
+     */
+    public function getTpDestination();
 
     /**
      * Set brand

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/RoutingPattern.RoutingPatternAbstract.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/RoutingPattern.RoutingPatternAbstract.orm.yml
@@ -27,3 +27,8 @@ Ivoz\Provider\Domain\Model\RoutingPattern\RoutingPatternAbstract:
           nullable: false
           onDelete: cascade
       orphanRemoval: false
+  oneToOne:
+    tpDestination:
+      targetEntity: \Ivoz\Cgr\Domain\Model\TpDestination\TpDestinationInterface
+      mappedBy: routingPattern
+      fetch: LAZY

--- a/scheme/app/DoctrineMigrations/Version20180822121335.php
+++ b/scheme/app/DoctrineMigrations/Version20180822121335.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20180822121335 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE tp_destinations ADD routingPatternId INT UNSIGNED DEFAULT NULL, CHANGE destinationId destinationId INT UNSIGNED DEFAULT NULL');
+        $this->addSql('ALTER TABLE tp_destinations ADD CONSTRAINT FK_C98068856D661974 FOREIGN KEY (routingPatternId) REFERENCES RoutingPatterns (id) ON DELETE CASCADE');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_C98068856D661974 ON tp_destinations (routingPatternId)');
+
+        // Create Destination Rates for existing RoutingPatterns
+        $this->addSql('INSERT INTO tp_destinations (tag, prefix, routingPatternId) SELECT CONCAT("b", brandId, "lcrdst", id), prefix, id FROM RoutingPatterns');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        // Remove Routing pattern's tp_destinations
+        $this->addSql('DELETE FROM tp_destinations WHERE routingPatternId IS NOT NULL');
+
+        $this->addSql('ALTER TABLE tp_destinations DROP FOREIGN KEY FK_C98068856D661974');
+        $this->addSql('DROP INDEX UNIQ_C98068856D661974 ON tp_destinations');
+        $this->addSql('ALTER TABLE tp_destinations DROP routingPatternId, CHANGE destinationId destinationId INT UNSIGNED NOT NULL');
+    }
+}


### PR DESCRIPTION
This PR adds a relation between RoutingPatterns and TpDestinations required to implement #529 

TpDestinations can now belong to a Destination or RoutingPattern. The CGRates chosen tags are `bXdstX` for the first ones and `bXlcrdstX` for the second ones, but this can change if you find a better tag naming :)