### PR TITLE
kamtrunks: Insert CGRateS LCR carriers in gw_uri_avp

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -134,7 +134,9 @@ loadmodule    "permissions.so"
 loadmodule    "diversion.so"
 loadmodule    "evapi.so"
 loadmodule    "json.so"
+loadmodule    "jansson.so"
 loadmodule    "jsonrpcs.so"
+loadmodule    "http_client.so"
 loadmodule    "ipops.so"
 
 #!ifdef WITH_ANTIFLOOD
@@ -143,6 +145,10 @@ loadmodule    "pike.so"
 
 # JSONRPC-S
 modparam("jsonrpcs", "fifo_name", "/tmp/kamailio_proxytrunks_fifo")
+
+# HTTP_CLIENT
+modparam("http_client", "httpcon", "cgrates=>http://trunks.ivozprovider.local:2080")
+modparam("http_client", "connection_timeout", 2)
 
 # DEBUGGER
 modparam("debugger", "mod_hash_size", 5)
@@ -496,6 +502,39 @@ route[LOAD_GWS] {
     if ($avp(gw_uri_avp) != $null) {
         # At least one gateway loaded, continue
 
+        # Print GWs added by Kamailio lcr module
+        $var(i) = 0;
+        xinfo("[$dlg_var(cidhash)] LOAD-GWS: Carriers added by Kamailio lcr module\n");
+        while(is_avp_set("$(avp(gw_uri_avp)[$var(i)])")) {
+            xinfo("[$dlg_var(cidhash)] LOAD-GWS: [$var(i)]: $(avp(gw_uri_avp)[$var(i)])\n");
+            $var(i) = $var(i) + 1;
+        }
+
+        # Lookup for dummy GWs and replace them with CGRateS LCR gateways
+        $var(i) = 0;
+        while(is_avp_set("$(avp(gw_uri_avp)[$var(i)])")) {
+            $var(gw_id) = $(avp(gw_uri_avp)[$var(i)]{s.select,0,|});
+            $var(rule_id) = $(avp(gw_uri_avp)[$var(i)]{s.select,-1,|});
+            if ($var(gw_id) == "0") {
+                xinfo("[$dlg_var(cidhash)] REPLACE-DUMMY-GWS: Dummy GW found, replace it with LCR gateways");
+                route(ADD_LCR_CARRIERS);
+            } else {
+                $avp(new_gw_uri_avp) = $(avp(gw_uri_avp)[$var(i)]);
+            }
+            $var(i) = $var(i) + 1;
+        }
+
+        $(avp(gw_uri_avp)[*]) = $null;
+        avp_copy("$avp(new_gw_uri_avp)", "$avp(gw_uri_avp)/gd");
+
+        # Print final GWs (static + dynamic)
+        $var(i) = 0;
+        xinfo("[$dlg_var(cidhash)] LOAD-GWS: Final carriers (static + dynamic rules)\n");
+        while(is_avp_set("$(avp(gw_uri_avp)[$var(i)])")) {
+            xinfo("[$dlg_var(cidhash)] LOAD-GWS: [$var(i)]: $(avp(gw_uri_avp)[$var(i)])\n");
+            $var(i) = $var(i) + 1;
+        }
+        
         # Store original ru value to reuse in SELECT-GW invocations
         $dlg_var(ru_before_lcr) = $ru;
 
@@ -505,6 +544,93 @@ route[LOAD_GWS] {
         send_reply("500", "Server Internal Error - No gateways");
         exit;
     }
+}
+
+# This route calls ADD_LCR_CARRIER for each Carrier in $avp(carriers)
+route[ADD_LCR_CARRIERS] {
+    # Prepare CGRateS request
+    $var(cgrTenant) = 'b' + $dlg_var(brandId);
+    $var(cgrAccount) = 'c' + $dlg_var(companyId);
+    $var(cgrDestination) = $rU;
+
+    if ($dlg_var(routingTagId) != $null) {
+        $var(cgrSubject) = $dlg_var(routingTag);
+    } else {
+        $var(cgrSubject) = "";
+    }
+
+    sql_xquery("cb", "SELECT outgoingRoutingId FROM kam_trunks_lcr_rules WHERE id='$var(rule_id)'", "ra");
+    $var(cgrCategory) = "or" + $xavp(ra=>outgoingRoutingId);
+
+    xinfo("[$dlg_var(cidhash)] GET-LCR-CARRIERS: Ask CGRateS for LCR carriers ($var(cgrTenant):$var(cgrAccount):$var(cgrSubject):$var(cgrDestination):$var(cgrCategory))");
+
+    # Ask CGRateS for LCR carriers
+    $var(rc) = http_connect("cgrates", "/jsonrpc", "application/json", "{\"method\":\"ApierV1.GetLcr\",\"params\":[{\"Tenant\":\"$var(cgrTenant)\",\"Category\":\"$var(cgrCategory)\",\"Account\":\"$var(cgrAccount)\",\"Subject\":\"$var(cgrSubject)\",\"Destination\":\"$var(cgrDestination)\",\"SetupTime\":\"2018-08-22T12:56:06Z\",\"Duration\":\"60s\"}],\"id\":1}", "$avp(response)");
+    xinfo("[$dlg_var(cidhash)] GET-LCR-CARRIERS: API-server HTTP connection result code: $var(rc)\n");
+    xinfo("[$dlg_var(cidhash)] GET-LCR-CARRIERS: API-server HTTP connection response: $avp(response)\n");
+
+    json_get_field("$avp(response)", "error", "$var(errorField)");
+    if ($var(rc) != "200" || $var(errorField) != '') {
+        xerr("[$dlg_var(cidhash)] GET-LCR-CARRIERS: Error non-empty or non-200 retcode");
+        return;
+    }
+    json_get_field("$avp(response)", "result", "$var(resultField)");
+
+    $var(count) = 0;
+    jansson_array_size("Suppliers", $var(resultField), "$var(size)");
+    while($var(count) < $var(size)) {
+        jansson_get("Suppliers[$var(count)]", $var(resultField), "$var(v)");
+        json_get_field("$var(v)", "Supplier", "$var(carrier)");
+        xinfo("[$dlg_var(cidhash)] GET-LCR-CARRIERS: Add carrier $var(carrier)");
+
+        $var(carrierId) = $(var(carrier){s.numeric});
+        route(ADD_LCR_CARRIER);
+
+        $var(count) = $var(count) + 1;
+    }
+}
+
+# This route calls ADD_LCR_CARRIERSERVER for each carrierServer in $var(carrierId)
+route[ADD_LCR_CARRIER] {
+    sql_query("cb", "SELECT id FROM CarrierServers WHERE carrierId=$var(carrierId)", "ra");
+
+    if ($dbr(ra=>rows) == 0) {
+        xwarn("[$dlg_var(cidhash)] ADD-LCR-CARRIERS: No CarrierServers found for carrierId '$var(carrierId)'\n");
+        return;
+    }
+
+    $var(k) = 0;
+    while ($var(k)<$dbr(ra=>rows)) {
+        $var(carrierServerId) = $dbr(ra=>[$var(k), 0]);
+        route(ADD_LCR_CARRIERSERVER);
+        $var(k) = $var(k) + 1;
+    }
+
+    sql_result_free("ra");
+}
+
+# This route adds one entry to $avp(new_gw_uri_avp) for CarrierServer in $var(carrierServerId)
+route[ADD_LCR_CARRIERSERVER]{
+    sql_xquery("cb", "SELECT id, uri_scheme, IFNULL(ip, '') AS ip, IFNULL(hostname, '') AS hostname, port, transport FROM kam_trunks_lcr_gateways WHERE carrierServerId=$var(carrierServerId)", "ra");
+
+    if ($xavp(ra=>scheme) == '2') {
+        $var(scheme) = 'sips:';
+    } else {
+        $var(scheme) = 'sip:';
+    }
+
+    if ($xavp(ra=>transport) == '2') {
+        $var(transport) = ';transport=tcp';
+    } else if ($xavp(ra=>transport) == '3') {
+        $var(transport) = ';transport=tls';
+    } else {
+        $var(transport) = ';transport=udp';
+    }
+
+    avp_printf("$avp(avp_new_entry)", "$xavp(ra=>id)|$var(scheme)|0|||$xavp(ra=>ip)|$xavp(ra=>hostname)|$xavp(ra=>port)||$var(transport)|$var(carrierServerId)|$var(rule_id)");
+    xinfo("[$dlg_var(cidhash)] ADD-LCR-CARRIERSERVER: New entry in gw_uri_avp for CarrierServer [$var(carrierServerId)]: '$avp(avp_new_entry)'");
+
+    $avp(new_gw_uri_avp) = $avp(avp_new_entry);
 }
 
 route[SELECT_GW] {


### PR DESCRIPTION
load_gws() Kamailio LCR module's function loads gateways to gw_uri_avp.

This new logic parses the elements of this AVP and calls CGRateS LCR whenever a
GW with gw_id=0 is found.

CGRateS gateways are inserted in the place of that dummy gateway.

This way, static and dynamic gateways are combined.

This PR is related to #529 