### PR TITLE
core: ensure cascade persist on n-m relationships

### DIFF
--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/ExternalCallFilter.ExternalCallFilter.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/ExternalCallFilter.ExternalCallFilter.orm.yml
@@ -29,3 +29,5 @@ Ivoz\Provider\Domain\Model\ExternalCallFilter\ExternalCallFilter:
     calendars:
       targetEntity: Ivoz\Provider\Domain\Model\ExternalCallFilterRelCalendar\ExternalCallFilterRelCalendar
       mappedBy: filter
+      cascade: ['persist']
+      orphanRemoval: true

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/Invoice.Invoice.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/Invoice.Invoice.orm.yml
@@ -16,3 +16,5 @@ Ivoz\Provider\Domain\Model\Invoice\Invoice:
     relFixedCosts:
       targetEntity: Ivoz\Provider\Domain\Model\FixedCostsRelInvoice\FixedCostsRelInvoice
       mappedBy: invoice
+      cascade: ['persist']
+      orphanRemoval: true

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/InvoiceScheduler.InvoiceScheduler.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/InvoiceScheduler.InvoiceScheduler.orm.yml
@@ -16,3 +16,5 @@ Ivoz\Provider\Domain\Model\InvoiceScheduler\InvoiceScheduler:
     relFixedCosts:
       targetEntity: Ivoz\Provider\Domain\Model\FixedCostsRelInvoiceScheduler\FixedCostsRelInvoiceScheduler
       mappedBy: invoiceScheduler
+      cascade: ['persist']
+      orphanRemoval: true

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/RoutingPattern.RoutingPattern.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/RoutingPattern.RoutingPattern.orm.yml
@@ -19,6 +19,8 @@ Ivoz\Provider\Domain\Model\RoutingPattern\RoutingPattern:
     relPatternGroups:
       targetEntity: Ivoz\Provider\Domain\Model\RoutingPatternGroupsRelPattern\RoutingPatternGroupsRelPatternInterface
       mappedBy: routingPattern
+      cascade: ['persist']
+      orphanRemoval: true
     lcrRules:
       targetEntity: Ivoz\Kam\Domain\Model\TrunksLcrRule\TrunksLcrRuleInterface
       mappedBy: routingPattern


### PR DESCRIPTION
Avoid 'A new entity was found through the relationship 'Ivoz\Provider\Domain\Model\XXX#yyy' that was not configured to cascade persist operations for entity' errors