### PR TITLE
core: remove orphaned TrunksLcrRuleTargets service

### DIFF
--- a/library/Ivoz/Kam/Domain/Model/TrunksLcrRuleTarget/TrunksLcrRuleTargetRepository.php
+++ b/library/Ivoz/Kam/Domain/Model/TrunksLcrRuleTarget/TrunksLcrRuleTargetRepository.php
@@ -21,5 +21,17 @@ interface TrunksLcrRuleTargetRepository extends ObjectRepository, Selectable
         TrunksLcrRuleInterface $lcrRule,
         TrunksLcrGatewayInterface $lcrGateway
     );
+
+    /**
+     * Find obsolete LcrRuleTargets after applying OutgoingRouting changes
+     *
+     * This must be done by comparing active LcrRuleTargetss generated in other services with
+     * stored ones in database as there is no valid constraint to delete cascade them.
+     *
+     * @see TrunksLcrRuleTargetDoctrineRepository::findOrphanLcrRuleTargets()
+     *
+     * @param OutgoingRoutingInterface $outgoingRouting
+     */
+    public function findOrphanLcrRuleTargets(OutgoingRoutingInterface $outgoingRouting);
 }
 

--- a/library/Ivoz/Kam/Domain/Service/TrunksLcrRuleTarget/RemoveByOutgoingRouting.php
+++ b/library/Ivoz/Kam/Domain/Service/TrunksLcrRuleTarget/RemoveByOutgoingRouting.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Ivoz\Kam\Domain\Service\TrunksLcrRuleTarget;
+
+use Ivoz\Core\Application\Service\EntityTools;
+use Ivoz\Kam\Domain\Model\TrunksLcrRuleTarget\TrunksLcrRuleTargetRepository;
+use Ivoz\Provider\Domain\Model\OutgoingRouting\OutgoingRoutingInterface;
+use Ivoz\Provider\Domain\Service\OutgoingRouting\OutgoingRoutingLifecycleEventHandlerInterface;
+
+/**
+ * Class RemoveByOutgoingRouting
+ *
+ * @package Ivoz\Kam\Domain\Service\TrunksLcrGateway
+ */
+class RemoveByOutgoingRouting implements OutgoingRoutingLifecycleEventHandlerInterface
+{
+    const POST_PERSIST_PRIORITY = UpdateByOutgoingRouting::POST_PERSIST_PRIORITY + 10;
+
+    /**
+     * @var EntityTools
+     */
+    protected $entityTools;
+
+    /**
+     * @var TrunksLcrRuleTargetRepository
+     */
+    protected $trunksLcrRuleTargetRepository;
+
+    /**
+     * RemoveByOutgoingRouting constructor.
+     *
+     * @param EntityTools $entityTools
+     * @param TrunksLcrRuleTargetRepository $trunksLcrRuleTargetRepository
+     */
+    public function __construct(
+        EntityTools $entityTools,
+        TrunksLcrRuleTargetRepository $trunksLcrRuleTargetRepository
+    ) {
+        $this->entityTools = $entityTools;
+        $this->trunksLcrRuleTargetRepository = $trunksLcrRuleTargetRepository;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            self::EVENT_POST_PERSIST => self::POST_PERSIST_PRIORITY
+        ];
+    }
+
+    /**
+     * This Service remove obsolete LcrRuleTargets after applying OutgoingRouting changes
+     *
+     * This must be done by comparing active LcrRuleTargets generated in other services with
+     * stored ones in database as there is no valid constraint to delete cascade them.
+     *
+     * @see TrunksLcrRuleTargetDoctrineRepository::findOrphanLcrRules()
+     *
+     * @param OutgoingRoutingInterface $outgoingRouting
+     */
+    public function execute(OutgoingRoutingInterface $outgoingRouting)
+    {
+        // Find all orphan database TrunksLcrRuleTargetss for this OutgoingRouting
+        $orphanLcrRuleTargets = $this->trunksLcrRuleTargetRepository->findOrphanLcrRuleTargets(
+            $outgoingRouting
+        );
+
+        foreach ($orphanLcrRuleTargets as $orphanLcrRuleTarget) {
+            $this->entityTools->remove($orphanLcrRuleTarget);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new service to remove orphaned entries in kam_trunks_lcr_rule_targets after OutgoingRouting updates. It fixes a problem where old entries were being kept after changing Carriers servers in OutgoingRouting.