### PR TITLE
web/admin: fix list filtering using Ddi.ddi field

### DIFF
--- a/web/admin/application/configs/klear/BrandDDIsList.yaml
+++ b/web/admin/application/configs/klear/BrandDDIsList.yaml
@@ -27,7 +27,7 @@ production:
       fields:
         order: &dDIsFieldsOder_Link
           country: true
-          DDI: true
+          ddi: true
           company: true
           carrier: true
         blacklist:

--- a/web/admin/application/configs/klear/DdiProvidersList.yaml
+++ b/web/admin/application/configs/klear/DdiProvidersList.yaml
@@ -127,7 +127,7 @@ production:
       fields:
         order:
           country: true
-          DDI: true
+          ddi: true
           company: true
         blacklist:
           user: true

--- a/web/admin/application/configs/klear/DdisList.yaml
+++ b/web/admin/application/configs/klear/DdisList.yaml
@@ -26,7 +26,7 @@ production:
       fields:
         order: &ddisFieldsOder_Link
           country: true
-          DDI: true
+          ddi: true
           externalCallFilter: true
           routeType: true
           target: true
@@ -61,7 +61,7 @@ production:
           colsPerRow: 3
           fields:
             country: 1
-            DDI: 1
+            ddi: 1
             ddiProvider: 1
             displayName: 2
             language: 1
@@ -160,7 +160,7 @@ production:
           billInboundCalls: true
           recordCalls: ${auth.companyFeatures.recordings.disabled}
         readOnly:
-          DDI: true
+          ddi: true
           country: true
       fixedPositions:
         <<: *ddisFixedPositions_Link

--- a/web/admin/application/configs/klear/RetailDdisList.yaml
+++ b/web/admin/application/configs/klear/RetailDdisList.yaml
@@ -28,7 +28,7 @@ production:
       fields:
         order: &ddisFieldsOder_Link
           country: true
-          DDI: true
+          ddi: true
           externalCallFilter: true
           routeType: true
           target: true
@@ -65,7 +65,7 @@ production:
           colsPerRow: 3
           fields:
             country: 1
-            DDI: 1
+            ddi: 1
             ddiProvider: 1
             displayName: 2
             language: 1
@@ -141,7 +141,7 @@ production:
         blacklist:
           <<: *ddisBlacklist_Link
         readOnly:
-          DDI: true
+          ddi: true
           country: true
       fixedPositions:
         <<: *ddisFixedPositions_Link

--- a/web/admin/application/configs/klear/model/Ddis.yaml
+++ b/web/admin/application/configs/klear/model/Ddis.yaml
@@ -18,7 +18,7 @@ production:
             template: '%name%'
           order:
             Company.name: asc
-    DDI:
+    ddi:
       title: ngettext('DDI', 'DDIs', 1)
       type: text
       trim: both


### PR DESCRIPTION
This PR fixes  #665 and the other screens that have ddi number as possible filter field.

This field is a bit messy. According to [orm definition](https://github.com/irontec/ivozprovider/blob/bleeding/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/Ddi.DdiAbstract.orm.yml#L9), the field is LowerCamelCase (ddi), but the column is UpperCamelCase (Ddi) , but actually the database column is Uppercase (DDI).

There are other DDIs fields like outgoingDDI, forcedDDI and multiDDI, but I left them untouched.