### PR TITLE
web/admin: Carrier/Company balances changed to ghost fields

### DIFF
--- a/library/CoreBundle/Resources/config/services/infraestructure/cgrates.yml
+++ b/library/CoreBundle/Resources/config/services/infraestructure/cgrates.yml
@@ -5,13 +5,14 @@ services:
     public: false
 
   Ivoz\Core\Infrastructure\Domain\Service\Cgrates\CompanyBalanceService: ~
-  Ivoz\Core\Infrastructure\Domain\Service\Cgrates\CarrierBalanceService: ~
-
   Ivoz\Provider\Domain\Service\Company\CompanyBalanceServiceInterface:
-    '@Ivoz\Core\Infrastructure\Domain\Service\Cgrates\CompanyBalanceService'
+    alias: Ivoz\Core\Infrastructure\Domain\Service\Cgrates\CompanyBalanceService
+    public: true
 
+  Ivoz\Core\Infrastructure\Domain\Service\Cgrates\CarrierBalanceService: ~
   Ivoz\Provider\Domain\Service\Carrier\CarrierBalanceServiceInterface:
-      '@Ivoz\Core\Infrastructure\Domain\Service\Cgrates\CarrierBalanceService'
+    alias: Ivoz\Core\Infrastructure\Domain\Service\Cgrates\CarrierBalanceService
+    public: true
 
   Ivoz\Core\Infrastructure\Domain\Service\Cgrates\BillingService:
     public: true
@@ -37,7 +38,7 @@ services:
   Ivoz\Kam\Domain\Service\TrunksCdr\RerateCallServiceInterface:
     '@Ivoz\Core\Infrastructure\Domain\Service\Cgrates\RerateCallService'
 
-  Ivoz\Cgr\Infrastructure\Domain\Service\Cgrates\FetchCallStatsService:
-    public: true
+  Ivoz\Cgr\Infrastructure\Domain\Service\Cgrates\FetchCallStatsService: ~
   Ivoz\Cgr\Domain\Service\TpCdrStat\FetchCallStatsServiceInterface:
-    '@Ivoz\Core\Infrastructure\Domain\Service\Cgrates\FetchCallStatsService'
+    alias: Ivoz\Cgr\Infrastructure\Domain\Service\Cgrates\FetchCallStatsService
+    public: true

--- a/web/admin/application/configs/klear/model/Companies.yaml
+++ b/web/admin/application/configs/klear/model/Companies.yaml
@@ -392,8 +392,11 @@ production:
             title: _("Pseudo-prepaid")
     balance:
       title: _('Balance')
-      type: text
+      type: ghost
       readonly: true
+      source:
+        class: IvozProvider_Klear_Ghost_Companies
+        method: getBalance
     typeIcon:
       title: _('Type')
       type: ghost

--- a/web/admin/application/library/IvozProvider/Klear/Ghost/Carriers.php
+++ b/web/admin/application/library/IvozProvider/Klear/Ghost/Carriers.php
@@ -1,19 +1,29 @@
 <?php
 
-use Ivoz\Cgr\Infrastructure\Domain\Service\Cgrates\FetchCallStatsService;
+use Ivoz\Provider\Domain\Model\Carrier\CarrierDto;
+use Ivoz\Cgr\Domain\Service\TpCdrStat\FetchCallStatsServiceInterface;
+use Ivoz\Provider\Domain\Service\Carrier\CarrierBalanceServiceInterface;
 
 class IvozProvider_Klear_Ghost_Carriers extends KlearMatrix_Model_Field_Ghost_Abstract
 {
     /**
-     * @var FetchCallStatsService
+     * @var FetchCallStatsServiceInterface
      */
     private $fetchCallStats;
+
+    /**
+     * @var CarrierBalanceServiceInterface
+     */
+    private $fetchCarrierBalance;
 
     public function __construct()
     {
         $serviceContainer = \Zend_Registry::get('container');
         $this->fetchCallStats = $serviceContainer->get(
-            FetchCallStatsService::class
+            FetchCallStatsServiceInterface::class
+        );
+        $this->fetchCarrierBalance = $serviceContainer->get(
+            CarrierBalanceServiceInterface::class
         );
     }
 
@@ -52,15 +62,18 @@ class IvozProvider_Klear_Ghost_Carriers extends KlearMatrix_Model_Field_Ghost_Ab
     }
 
     /**
-     * @param \Ivoz\Provider\Domain\Model\Carrier\CarrierDto $carrier
+     * @param CarrierDto $carrierDto
      * @return string
      */
-    public function getBalance($carrierDto)
+    public function getBalance(CarrierDto $carrierDto)
     {
         if (!$carrierDto->getCalculateCost()) {
             return Klear_Model_Gettext::gettextCheck('_("Disabled")');
         }
 
-        return $carrierDto->getBalance();
+        return $this->fetchCarrierBalance->getBalance(
+            $carrierDto->getBrandId(),
+            $carrierDto->getId()
+        );
     }
 }

--- a/web/admin/application/library/IvozProvider/Klear/Ghost/Companies.php
+++ b/web/admin/application/library/IvozProvider/Klear/Ghost/Companies.php
@@ -1,14 +1,27 @@
 <?php
 
-use Ivoz\Core\Application\Service\DataGateway;
 use Ivoz\Provider\Domain\Model\Brand\Brand;
 use Ivoz\Provider\Domain\Model\Brand\BrandDto;
 use Ivoz\Provider\Domain\Model\Company\Company;
 use Ivoz\Provider\Domain\Model\Company\CompanyDto;
+use Ivoz\Provider\Domain\Service\Company\CompanyBalanceServiceInterface;
 use IvozProvider\Utils\SizeFormatter;
 
 class IvozProvider_Klear_Ghost_Companies extends KlearMatrix_Model_Field_Ghost_Abstract
 {
+    /**
+     * @var CompanyBalanceServiceInterface
+     */
+    private $fetchCompanyBalance;
+
+    public function __construct()
+    {
+        $serviceContainer = \Zend_Registry::get('container');
+        $this->fetchCompanyBalance = $serviceContainer->get(
+            CompanyBalanceServiceInterface::class
+        );
+    }
+
     /**
      * @param CompanyDto $model
      * @return string
@@ -27,5 +40,17 @@ class IvozProvider_Klear_Ghost_Companies extends KlearMatrix_Model_Field_Ghost_A
             default:
                 return $model->getType();
         }
+    }
+
+    /**
+     * @param CompanyDto $companyDto
+     * @return string
+     */
+    public function getBalance(CompanyDto $companyDto)
+    {
+        return $this->fetchCompanyBalance->getBalance(
+            $companyDto->getBrandId(),
+            $companyDto->getId()
+        );
     }
 }


### PR DESCRIPTION
This PR fixes #655 by replacing current balance fields with a ghost field that request current balance status to CGRateS.

The request already existed in a service so I just changed the field type and updated the existing ghosts.