### PR TITLE
core: fix external call filter

### DIFF
--- a/library/Ivoz/Provider/Domain/Model/ExternalCallFilter/ExternalCallFilter.php
+++ b/library/Ivoz/Provider/Domain/Model/ExternalCallFilter/ExternalCallFilter.php
@@ -115,7 +115,6 @@ class ExternalCallFilter extends ExternalCallFilterAbstract implements ExternalC
         }
 
         $datetime = new \DateTime('now');
-        $date = $datetime->format('Y-m-d');
 
         /**
          * @var ExternalCallFilterRelCalendar $externalCallFilterRelCalendar
@@ -132,7 +131,7 @@ class ExternalCallFilter extends ExternalCallFilterAbstract implements ExternalC
                 ->where(
                     $expressionBuilder->eq(
                         'eventDate',
-                        $date
+                        $datetime
                     )
                 );
 
@@ -178,7 +177,7 @@ class ExternalCallFilter extends ExternalCallFilterAbstract implements ExternalC
             }
         }
 
-        return $scheduleMatched;
+        return !$scheduleMatched;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/Schedule/Schedule.php
+++ b/library/Ivoz/Provider/Domain/Model/Schedule/Schedule.php
@@ -40,9 +40,19 @@ class Schedule extends ScheduleAbstract implements ScheduleInterface
                 ->format('H:i:s')
         );
 
+        $timeIn = strtotime(
+            $this->getTimeIn()
+                ->format('H:i:s')
+        );
+
+        $timeOut = strtotime(
+            $this->getTimeout()
+                ->format('H:i:s')
+        );
+
         $isInTimeRange =
-            ($time > strtotime($this->getTimeIn()))
-            && ($time < strtotime($this->getTimeout()));
+            ($time > $timeIn)
+            && ($time < $timeOut);
 
         return $isInTimeRange;
     }


### PR DESCRIPTION
As soon as a external call filter is assigned to a DDI, incoming calls crash.

This PR tries to fix #676 