### PR TITLE
scheme: fix old migrations to avoid rating plans loss

### DIFF
--- a/scheme/app/DoctrineMigrations/Version20180726142227.php
+++ b/scheme/app/DoctrineMigrations/Version20180726142227.php
@@ -41,6 +41,7 @@ class Version20180726142227 extends AbstractMigration
         $this->addSql('INSERT INTO DestinationRates (destinationRateGroupId, rate, connectFee, rateIncrement, groupIntervalStart, destinationId) SELECT DRG.id, rate, connect_fee, TDR.rate_increment, group_interval_start, (SELECT id FROM Destinations WHERE prefix = TDR.prefix AND brandId = DRG.brandId) FROM tp_destination_rates TDR INNER JOIN DestinationRateGroups DRG ON DRG.id = TDR.destinationRateId');
 
         // Remove old residual data
+        $this->addSql('ALTER TABLE tp_rating_plans DROP FOREIGN KEY FK_4CC2BCAB4EB67480');
         $this->addSql('DELETE FROM DestinationRates WHERE destinationRateGroupId NOT IN (SELECT id FROM DestinationRateGroups)');
         $this->addSql('DELETE FROM tp_rates');
         $this->addSql('DELETE FROM tp_destination_rates');
@@ -128,5 +129,6 @@ class Version20180726142227 extends AbstractMigration
         $this->addSql('ALTER TABLE tp_rates ADD CONSTRAINT FK_DE7E762B2B3C4634 FOREIGN KEY (tpDestinationRateId) REFERENCES tp_destination_rates (id) ON DELETE CASCADE');
         $this->addSql('CREATE UNIQUE INDEX UNIQ_DE7E762B2B3C4634 ON tp_rates (tpDestinationRateId)');
         $this->addSql('CREATE UNIQUE INDEX unique_tprate ON tp_rates (tpid, tag, group_interval_start, tpDestinationRateId)');
+        $this->addSql('ALTER TABLE tp_rating_plans ADD CONSTRAINT FK_4CC2BCAB4EB67480 FOREIGN KEY (destinationRateId) REFERENCES DestinationRates (id) ON DELETE CASCADE');
     }
 }

--- a/scheme/app/DoctrineMigrations/Version20180802142456.php
+++ b/scheme/app/DoctrineMigrations/Version20180802142456.php
@@ -18,7 +18,6 @@ class Version20180802142456 extends AbstractMigration
         // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
-        $this->addSql('ALTER TABLE tp_rating_plans DROP FOREIGN KEY FK_4CC2BCAB4EB67480');
         $this->addSql('DROP INDEX IDX_4CC2BCAB4EB67480 ON tp_rating_plans');
         $this->addSql('ALTER TABLE tp_rating_plans ADD timing_type VARCHAR(10) DEFAULT \'always\' COMMENT \'[enum:always|custom]\', ADD time_in TIME NOT NULL, ADD monday TINYINT(1) DEFAULT \'1\', ADD tuesday TINYINT(1) DEFAULT \'1\', ADD wednesday TINYINT(1) DEFAULT \'1\', ADD thursday TINYINT(1) DEFAULT \'1\', ADD friday TINYINT(1) DEFAULT \'1\', ADD saturday TINYINT(1) DEFAULT \'1\', ADD sunday TINYINT(1) DEFAULT \'1\', CHANGE destinationrateid destinationRateGroupId INT UNSIGNED NOT NULL');
         $this->addSql('ALTER TABLE tp_rating_plans ADD CONSTRAINT FK_4CC2BCABC11683D9 FOREIGN KEY (destinationRateGroupId) REFERENCES DestinationRateGroups (id) ON DELETE CASCADE');
@@ -39,7 +38,6 @@ class Version20180802142456 extends AbstractMigration
         $this->addSql('ALTER TABLE tp_rating_plans DROP FOREIGN KEY FK_4CC2BCABC11683D9');
         $this->addSql('DROP INDEX IDX_4CC2BCABC11683D9 ON tp_rating_plans');
         $this->addSql('ALTER TABLE tp_rating_plans DROP timing_type, DROP time_in, DROP monday, DROP tuesday, DROP wednesday, DROP thursday, DROP friday, DROP saturday, DROP sunday, CHANGE destinationrategroupid destinationRateId INT UNSIGNED NOT NULL');
-        $this->addSql('ALTER TABLE tp_rating_plans ADD CONSTRAINT FK_4CC2BCAB4EB67480 FOREIGN KEY (destinationRateId) REFERENCES DestinationRates (id) ON DELETE CASCADE');
         $this->addSql('CREATE INDEX IDX_4CC2BCAB4EB67480 ON tp_rating_plans (destinationRateId)');
     }
 }


### PR DESCRIPTION
This PR fixes some old scheme migrations that caused tp_rating_plans contents to be removed due to a on-delete-cascade constraint with tp_destination_rates.

By removing the constraint before migrating tp_destination_rates we can keep the data for later migration. 

This was discovered while testing #681 