### PR TITLE
pkg: make rtpengine private address configurable from install menu

### DIFF
--- a/debian/ivozprovider-profile-proxy.config
+++ b/debian/ivozprovider-profile-proxy.config
@@ -60,7 +60,7 @@ function check_valid_ip4()
 
 function configure_dns_address()
 {
-    # Rquest Kamailio users listen address
+    # Request Kamailio users listen address
     db_input high ivozprovider/dns_address                 || true
     db_go                                                  || true
     db_get ivozprovider/dns_address                        || true
@@ -75,7 +75,7 @@ function configure_dns_address()
 
 function configure_media_relay_address()
 {
-    # Rquest Kamailio users listen address
+    # Request public Media relay address
     db_input high ivozprovider/media_relay_address         || true
     db_go                                                  || true
     db_get ivozprovider/media_relay_address                || true
@@ -84,10 +84,24 @@ function configure_media_relay_address()
     if ! check_valid_ip4 $RET; then
         db_input high ivozprovider/invalid_ip              || true
         db_go                                              || true
-        configure_dns_address
+        configure_media_relay_address
     fi
 }
 
+function configure_media_relay_control()
+{
+    # Request private Media relay address
+    db_input high ivozprovider/media_relay_control         || true
+    db_go                                                  || true
+    db_get ivozprovider/media_relay_control                || true
+
+    # Check entered IP is valid
+    if ! check_valid_ip4 $RET; then
+        db_input high ivozprovider/invalid_ip              || true
+        db_go                                              || true
+        configure_media_relay_control
+    fi
+}
 
 # This profile configuration has been done from another task/tool
 db_get ivozprovider/preseed && exit 0

--- a/debian/ivozprovider-profile-proxy.postinst
+++ b/debian/ivozprovider-profile-proxy.postinst
@@ -12,9 +12,13 @@ function setup_media_relays()
     # Get Media relay public IP from debconf
     db_get ivozprovider/media_relay_address            || true
     MEDIA_RELAY_ADDRESS=$RET
+    # Get Media relay control socket IP from debconf
+    db_get ivozprovider/media_relay_control            || true
+    MEDIA_RELAY_CONTROL=$RET
 
     # Configure Media relay IPs
     sed -i -r "s/(AUDIO_SOCK *= *).*/\1$MEDIA_RELAY_ADDRESS/"  /etc/default/rtpengine
+    sed -i -r "s/(CONTROL_SOCK *= *).*/\1$MEDIA_RELAY_CONTROL:22223/"  /etc/default/rtpengine
 }
 
 #######################################################################################################################

--- a/debian/ivozprovider-profile-proxy.templates
+++ b/debian/ivozprovider-profile-proxy.templates
@@ -1,8 +1,8 @@
 Template: ivozprovider/menu_proxy
 Type: select
-Choices: configure_dns_address, configure_mysql_password, configure_media_relay_address, configure_finish
-Choices-es.UTF-8: Configurar dirección DNS local, Configurar password de MySQL, Configurar Servidor de Media, >> Finalizar configuración
-Choices-en.UTF-8: Configure local DNS address, Configure MySQL root password, Configure Media Relay, >> Finish configurating
+Choices: configure_dns_address, configure_mysql_password, configure_media_relay_address, configure_media_relay_control, configure_finish
+Choices-es.UTF-8: Configurar dirección DNS local, Configurar password de MySQL, Configurar IP pública Servidor de Media, Configurar IP privada Servidor de Media, >> Finalizar configuración
+Choices-en.UTF-8: Configure local DNS address, Configure MySQL root password, Configure Media Relay public address, Configure Media Relay private address >> Finish configurating
 Default: configure_dns_address
 Description:
  Welcome to IVOZ Provider Proxy Node setup.
@@ -31,4 +31,18 @@ Description-es.UTF-8:
  Los nodos de Proxy cuentan con un Servidor de Media local configurado con la IP pública del nodo.
  .
  Introduzca la IP publica para el Servidor de Media:
+ .
+
+Template: ivozprovider/media_relay_control
+Type: string
+Default: 127.0.0.1
+Description:
+ Proxy nodes has a local media relay configured.
+ .
+ Enter Private Media relay Control IP address used to communicate with SIP proxy:
+ .
+Description-es.UTF-8:
+ Los nodos de Proxy cuentan con un Servidor de Media local configurado.
+ .
+ Introduzca la IP privada de Control para la comunicacion con el Proxy SIP:
  .


### PR DESCRIPTION
This PR fixes #678 by adding a new configurable option to debconf.

This option can be configured using ivozprovider-profile-proxy menu like the AUDIO_SOCK value.