### PR TITLE
i18n: improved tests to detect empty and fuzzy translations

### DIFF
--- a/library/bin/test-i18n
+++ b/library/bin/test-i18n
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+EXITCODE=0
 
 # check Documentation translations
 pushd /opt/irontec/ivozprovider/doc/sphinx
@@ -13,8 +13,25 @@ pushd /opt/irontec/ivozprovider/doc/sphinx
     if [ -n "$(git status -s .)" ]; then
         echo "These translation changes have not been commited."
         git --no-pager diff
-        exit 1
+        EXITCODE=1
     fi
+
+# @TODO
+#    for POFILE in locale/*/LC_MESSAGES/*.po; do
+#        # Check there are no empty translations
+#        msggrep -v -T -e "." ${POFILE} -o ${POFILE}.empty
+#        if [ -f ${POFILE}.empty ]; then
+#            echo "Following messages has no translation"
+#            cat ${POFILE}.empty
+#            EXITCODE=1
+#        fi
+#
+#        # Check there are no fuzzy translations
+#        grep -A3 fuzzy ${POFILE}
+#        if [ $? -eq 0 ]; then
+#            EXITCODE=1
+#        fi
+#    done
 popd
 
 # check Administration portal translations
@@ -26,6 +43,25 @@ pushd /opt/irontec/ivozprovider/web/admin
     if [ -n "$(git status -s .)" ]; then
         echo "These translation changes have not been commited."
         git --no-pager diff
-        exit 1
+        EXITCODE=1
     fi
+
+
+    for POFILE in application/languages/*/*.po; do
+        # Check there are no empty translations
+        msggrep -v -T -e "." ${POFILE} -o ${POFILE}.empty
+        if [ -f ${POFILE}.empty ]; then
+            echo "Following messages has no translation"
+            cat ${POFILE}.empty
+            EXITCODE=1
+        fi
+
+        # Check there are no fuzzy translations
+        grep -A3 fuzzy ${POFILE}
+        if [ $? -eq 0 ]; then
+            EXITCODE=1
+        fi
+    done
 popd
+
+exit $EXITCODE

--- a/web/admin/application/configs/klear/model/Carriers.yaml
+++ b/web/admin/application/configs/klear/model/Carriers.yaml
@@ -94,7 +94,7 @@ production:
         type: box
         position: left
         icon: help
-        text: _("Average Call Duration: <a href='%s' target='_blank' >more info</a>", _("https://en.wikipedia.org/wiki/Average_call_duration"))
+        text: "<a href='https://en.wikipedia.org/wiki/Average_call_duration' target='_blank'>Average Call Duration</a>"
         label: _("Need help?")
     asr:
       title: _('ASR')
@@ -107,7 +107,7 @@ production:
         type: box
         position: left
         icon: help
-        text: _("Answer-Seizure Ratio: <a href='%s' target='_blank' >more info</a>", _("https://en.wikipedia.org/wiki/Answer-seizure_ratio"))
+        text: "<a href='https://en.wikipedia.org/wiki/Answer-seizure_ratio' target='_blank'>Answer-Seizure Ratio</a>"
         label: _("Need help?")
 staging:
   _extends: production

--- a/web/admin/application/languages/en_US/en_US.po
+++ b/web/admin/application/languages/en_US/en_US.po
@@ -145,10 +145,6 @@ msgstr "An error occurred: check files format and content."
 msgid "Announce"
 msgstr "Announce"
 
-#, python-format
-msgid "Answer-Seizure Ratio: <a href='%s' target='_blank' >more info</a>"
-msgstr ""
-
 msgid "Antiflood trusted IP"
 msgid_plural "Antiflood trusted IPs"
 msgstr[0] "Antiflood trusted IP"
@@ -206,10 +202,6 @@ msgstr[1] "Authorized sources"
 
 msgid "Automatic creation of rules"
 msgstr "Automatic creation of rules"
-
-#, python-format
-msgid "Average Call Duration: <a href='%s' target='_blank' >more info</a>"
-msgstr ""
 
 msgid "Balance"
 msgstr "Balance"
@@ -1316,7 +1308,7 @@ msgstr ""
 "Mail address shown as source when sending mails. MTA must allow this value."
 
 msgid "Mail address where this notification will be sent"
-msgstr ""
+msgstr "Mail address where this notification will be sent"
 
 msgid "Main Settings"
 msgstr "Main Settings"
@@ -2316,6 +2308,8 @@ msgid ""
 "This importer expects values to be within quotation marks and separated by "
 "semicolons."
 msgstr ""
+"This importer expects values to be within quotation marks and separated by "
+"semicolons."
 
 msgid ""
 "This prefix will be added to the callee after carrier's numeric "
@@ -2518,8 +2512,8 @@ msgstr "View Outgoing %s %s"
 
 msgid "Virtual PBX"
 msgid_plural "Virtual PBXs"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Virtual PBX"
+msgstr[1] "Virtual PBXs"
 
 msgid "Voicemail"
 msgid_plural "Voicemails"
@@ -2673,12 +2667,6 @@ msgstr "encoding"
 
 msgid "error"
 msgstr "error"
-
-msgid "https://en.wikipedia.org/wiki/Answer-seizure_ratio"
-msgstr ""
-
-msgid "https://en.wikipedia.org/wiki/Average_call_duration"
-msgstr ""
 
 msgid "ignore"
 msgstr "ignore"

--- a/web/admin/application/languages/es_ES/es_ES.po
+++ b/web/admin/application/languages/es_ES/es_ES.po
@@ -150,12 +150,6 @@ msgstr ""
 msgid "Announce"
 msgstr "Anuncio"
 
-#, python-format
-msgid "Answer-Seizure Ratio: <a href='%s' target='_blank' >more info</a>"
-msgstr ""
-"Tasa de llamadas contestadas (Answer-Seizure Ratio): <a href='%s' "
-"target='_blank' >más información</a>"
-
 msgid "Antiflood trusted IP"
 msgid_plural "Antiflood trusted IPs"
 msgstr[0] "IP de confianza"
@@ -213,12 +207,6 @@ msgstr[1] "Redes autorizadas"
 
 msgid "Automatic creation of rules"
 msgstr "Creación automática de reglas"
-
-#, python-format
-msgid "Average Call Duration: <a href='%s' target='_blank' >more info</a>"
-msgstr ""
-"Duración media de llamada (Average Call Duration): <a href='%s' "
-"target='_blank' >más información</a>"
 
 msgid "Balance"
 msgstr "Saldo"
@@ -1337,7 +1325,7 @@ msgstr ""
 "permitir este valor."
 
 msgid "Mail address where this notification will be sent"
-msgstr ""
+msgstr "Dirección donde esta notificación será enviada"
 
 msgid "Main Settings"
 msgstr "Configuración principal"
@@ -2345,6 +2333,8 @@ msgid ""
 "This importer expects values to be within quotation marks and separated by "
 "semicolons."
 msgstr ""
+"Este importador espera los valores entrecomillados y separados por punto y "
+"coma."
 
 msgid ""
 "This prefix will be added to the callee after carrier's numeric "
@@ -2433,6 +2423,7 @@ msgid ""
 "invoices issued: eg 'registered in the commercial register of bizkaia, tome "
 "xxxx, book and, folio zzz, sheet aa-bbbb'"
 msgstr ""
+"Información de facturación que será includida en las facturas generadas."
 
 msgid "Transformation Rule"
 msgid_plural "Transformation Rules"
@@ -2709,12 +2700,6 @@ msgstr "Codificando"
 
 msgid "error"
 msgstr "Error"
-
-msgid "https://en.wikipedia.org/wiki/Answer-seizure_ratio"
-msgstr ""
-
-msgid "https://en.wikipedia.org/wiki/Average_call_duration"
-msgstr ""
 
 msgid "ignore"
 msgstr "ignorar"


### PR DESCRIPTION
This updates _test-i18_ to also handle empty and fuzzy translations

I have also added these checks to documentation translations, but I have commented them out because there are too many errors and we're scheduling a documentation revision for next patch release.

