### PR TITLE
web/admin: fix call simulator for Carrier rating profiles

### DIFF
--- a/web/admin/application/configs/klear/CarriersList.yaml
+++ b/web/admin/application/configs/klear/CarriersList.yaml
@@ -238,7 +238,9 @@ production:
 
     # Rating Profiles dialogs
     <<: *ratingProfiles_dialogsLink
-    <<: *simulateCall_dialogLink
+    simulateCall_dialog:
+      <<: *simulateCall_dialogLink
+      action: test-carrier-plans
 
     # balanceNotification dialogs:
     <<: *balanceNotification_dialogsLink


### PR DESCRIPTION
Carrier rating profiles section was using company call simulating, so the call simulator data displayed for carrier=1 was actually the company=1.

This PR adds the required logic to use carrier active rating profile to simulate a call.