### PR TITLE
web/admin: add uniques to destinationRate-timings

### DIFF
--- a/library/CoreBundle/Resources/config/lifecycle/provider/rating_plan.yml
+++ b/library/CoreBundle/Resources/config/lifecycle/provider/rating_plan.yml
@@ -1,0 +1,13 @@
+services:
+  _defaults:
+    autowire: true
+    public: false
+
+  ##################################
+  ## error_handler
+  ##################################
+
+  Ivoz\Provider\Domain\Service\RatingPlan\PersistErrorHandler:
+    tags:
+      - { name: provider.lifecycle.rating_plan.error_handler, priority: 10 }
+    arguments: ~

--- a/library/Ivoz/Cgr/Infrastructure/Persistence/Doctrine/Mapping/TpRatingPlan.TpRatingPlanAbstract.orm.yml
+++ b/library/Ivoz/Cgr/Infrastructure/Persistence/Doctrine/Mapping/TpRatingPlan.TpRatingPlanAbstract.orm.yml
@@ -15,6 +15,7 @@ Ivoz\Cgr\Domain\Model\TpRatingPlan\TpRatingPlanAbstract:
         - tag
         - destrates_tag
         - timing_tag
+        - weight
   fields:
     tpid:
       type: string

--- a/library/Ivoz/Kam/Infrastructure/Persistence/Doctrine/TrunksCdrDoctrineRepository.php
+++ b/library/Ivoz/Kam/Infrastructure/Persistence/Doctrine/TrunksCdrDoctrineRepository.php
@@ -82,5 +82,4 @@ class TrunksCdrDoctrineRepository extends ServiceEntityRepository implements Tru
 
         return $qb->getQuery()->execute();
     }
-
 }

--- a/library/Ivoz/Provider/Domain/Service/RatingPlan/PersistErrorHandler.php
+++ b/library/Ivoz/Provider/Domain/Service/RatingPlan/PersistErrorHandler.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Ivoz\Provider\Domain\Service\RatingPlan;
+
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Ivoz\Core\Domain\Service\PersistErrorHandlerInterface;
+
+/**
+ * Class PersistErrorHandler
+ * @package Ivoz\Provider\Domain\Service\RatingPlan
+ * @lifecycle on_error
+ */
+class PersistErrorHandler implements PersistErrorHandlerInterface
+{
+    /*
+     * Mysql error code list:
+     * https://dev.mysql.com/doc/refman/5.5/en/error-messages-server.html
+     */
+    const MYSQL_ERROR_DUPLICATE_ENTRY = 1062;
+
+    const RATING_PLAN_DUPLICATED_WEIGHT = 40002;
+
+    public function __construct()
+    {
+    }
+
+    public function handle(\Exception $exception)
+    {
+        if (!$exception instanceof UniqueConstraintViolationException) {
+            return;
+        }
+
+        $pdoException = $exception->getPrevious();
+        if (!$pdoException instanceof \PDOException) {
+            return;
+        }
+
+        $isDuplicatedWeightError = $pdoException->getErrorCode() === self::MYSQL_ERROR_DUPLICATE_ENTRY;
+
+        if ($isDuplicatedWeightError) {
+            throw new \DomainException(
+                "Selected weight is already in use",
+                self::RATING_PLAN_DUPLICATED_WEIGHT,
+                $exception
+            );
+        }
+
+        throw $exception;
+    }
+}

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/RatingPlan.RatingPlanAbstract.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/RatingPlan.RatingPlanAbstract.orm.yml
@@ -1,5 +1,10 @@
 Ivoz\Provider\Domain\Model\RatingPlan\RatingPlanAbstract:
   type: mappedSuperclass
+  uniqueConstraints:
+    ratingPlan_ratingPlanGroup_weight:
+      columns:
+        - ratingPlanGroupId
+        - weight
   fields:
     weight:
       type: decimal

--- a/scheme/app/DoctrineMigrations/Version20180919144526.php
+++ b/scheme/app/DoctrineMigrations/Version20180919144526.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20180919144526 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('CREATE UNIQUE INDEX ratingPlan_ratingPlanGroup_weight ON RatingPlans (ratingPlanGroupId, weight)');
+        $this->addSql('DROP INDEX tpid_rplid_destrates_timings_weight ON tp_rating_plans');
+        $this->addSql('CREATE UNIQUE INDEX tpid_rplid_destrates_timings_weight ON tp_rating_plans (tpid, tag, destrates_tag, timing_tag, weight)');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP INDEX ratingPlan_ratingPlanGroup_weight ON RatingPlans');
+        $this->addSql('DROP INDEX tpid_rplid_destrates_timings_weight ON tp_rating_plans');
+        $this->addSql('CREATE UNIQUE INDEX tpid_rplid_destrates_timings_weight ON tp_rating_plans (tpid, tag, destrates_tag, timing_tag)');
+    }
+}

--- a/web/admin/application/configs/klear/RatingPlansList.yaml
+++ b/web/admin/application/configs/klear/RatingPlansList.yaml
@@ -8,6 +8,9 @@ production:
   screens: &ratingPlans_screensLink
     ratingPlansList_screen: &ratingPlansList_screenLink
       controller: list
+      order:
+        field:
+          - RatingPlan.weight desc
       pagination:
         items: 25
       <<: *RatingPlans

--- a/web/admin/application/configs/klear/errors.yaml
+++ b/web/admin/application/configs/klear/errors.yaml
@@ -9,6 +9,7 @@ production:
     30200: _("There is a call forward with that call type. You can't add this call forward")
     40000: _("'Valid From' must be earlier than 'Valid to'")
     40001: _("You can't create a pricing plan that starts in de past")
+    40002: _("Selected weight is already in use")
     50001: _("There are unmetered calls.")
     50002: _("There are unbilled calls before in date.")
     50003: _("There are invoices in the same range of date.")

--- a/web/admin/application/languages/en_US/en_US.po
+++ b/web/admin/application/languages/en_US/en_US.po
@@ -2116,6 +2116,9 @@ msgstr "Select the brand you want to emulate."
 msgid "Select the company you want to emulate"
 msgstr "Select the company you want to emulate"
 
+msgid "Selected weight is already in use"
+msgstr "Selected weight is already in use"
+
 msgid "Send"
 msgstr "Send"
 

--- a/web/admin/application/languages/es_ES/es_ES.po
+++ b/web/admin/application/languages/es_ES/es_ES.po
@@ -2143,6 +2143,9 @@ msgstr "Seleccione la marca que desea emular."
 msgid "Select the company you want to emulate"
 msgstr "Seleccione la empresa que desea emular"
 
+msgid "Selected weight is already in use"
+msgstr "El peso seleccionado ya está en uso"
+
 msgid "Send"
 msgstr "Enviar"
 


### PR DESCRIPTION
Timings usage is quite misleading as different timings may collide.

This PR forces each destinationRate - timing association to have a different weight. It also orders entries sorting by descending weight.

This aims to make this feature a bit more usable.