### PR TITLE
core: Ignore tp_cdrs default entry for invalid cost_details

### DIFF
--- a/library/Ivoz/Cgr/Domain/Model/TpCdr/TpCdr.php
+++ b/library/Ivoz/Cgr/Domain/Model/TpCdr/TpCdr.php
@@ -35,6 +35,10 @@ class TpCdr extends TpCdrAbstract implements TpCdrInterface
     public function getCostDetailsFirstTimespan()
     {
         $costDetails = $this->getCostDetails();
+        if (empty($costDetails)) {
+            return null;
+        }
+
         $timespans = $costDetails['Timespans'];
 
         return current($timespans);

--- a/library/Ivoz/Provider/Domain/Service/BillableCall/MigrateFromTrunksCdr.php
+++ b/library/Ivoz/Provider/Domain/Service/BillableCall/MigrateFromTrunksCdr.php
@@ -231,6 +231,10 @@ class MigrateFromTrunksCdr
             return $billableCallDto;
         }
 
+        if (!$defaultRunTpCdr->getCostDetailsFirstTimespan()) {
+            return $billableCallDto;
+        }
+
         $callee = $defaultRunTpCdr->getDestination()
             ? $defaultRunTpCdr->getDestination()
             : $billableCallDto->getCallee();


### PR DESCRIPTION
billable-calls scheduler task analyzes tp_cdrs.cost_details to get RatingPlanId
and DestinationId.

On failure scenarios, cost_details might be null and billable-calls crashes.

This commit makes billable-calls ignore tp_cdrs entries with a cost_details
from which DestinationId or RatingPlanId cannot be deduced.

One BillableCalls entry will be generated with the information of kam_trunks_cdrs
(no price, no cost). Later rerating may fix the entry to include it in an invoice.