### PR TITLE
web/admin: improve CGRateS ghost fields error handling

### DIFF
--- a/library/Ivoz/Cgr/Infrastructure/Domain/Service/Cgrates/FetchCallStatsService.php
+++ b/library/Ivoz/Cgr/Infrastructure/Domain/Service/Cgrates/FetchCallStatsService.php
@@ -2,6 +2,7 @@
 
 namespace Ivoz\Cgr\Infrastructure\Domain\Service\Cgrates;
 
+use GuzzleHttp\Exception\RequestException;
 use Ivoz\Cgr\Domain\Service\TpCdrStat\FetchCallStatsServiceInterface;
 use Graze\GuzzleHttp\JsonRpc\Client;
 use Ivoz\Provider\Domain\Model\Carrier\CarrierInterface;
@@ -70,13 +71,22 @@ class FetchCallStatsService implements FetchCallStatsServiceInterface
 
     private function sendRequest($method, $payload)
     {
-        /** @var \Graze\GuzzleHttp\JsonRpc\Message\Response $request */
-        $request = $this->client
-            ->request(
-                1,
-                $method,
-                [$payload]
+        try {
+            /** @var \Graze\GuzzleHttp\JsonRpc\Message\Response $request */
+            $request = $this->client
+                ->request(
+                    1,
+                    $method,
+                    [$payload]
+                );
+        } catch (RequestException $e) {
+            throw new \DomainException(
+                "Unable to get information from Billing engine",
+                40003,
+                $e
             );
+        }
+
 
         $response = $this->client->send($request);
         $responseObject = json_decode(

--- a/library/Ivoz/Core/Infrastructure/Domain/Service/Cgrates/AbstractBalanceService.php
+++ b/library/Ivoz/Core/Infrastructure/Domain/Service/Cgrates/AbstractBalanceService.php
@@ -3,6 +3,7 @@
 namespace Ivoz\Core\Infrastructure\Domain\Service\Cgrates;
 
 use Graze\GuzzleHttp\JsonRpc\Client;
+use GuzzleHttp\Exception\RequestException;
 use Ivoz\Core\Domain\Model\EntityInterface;
 
 abstract class AbstractBalanceService
@@ -83,7 +84,17 @@ abstract class AbstractBalanceService
                 [$payload]
             );
 
-        $response = $this->client->send($request);
+        try {
+            $response = $this->client->send($request);
+        } catch (RequestException $e) {
+            throw new \DomainException(
+                "Unable to get information from Billing engine",
+                40003,
+                $e
+            );
+        }
+
+
         $payload = json_decode($response->getBody()->__toString());
 
         $balanceSum = [];

--- a/web/admin/application/library/IvozProvider/Klear/Ghost/Carriers.php
+++ b/web/admin/application/library/IvozProvider/Klear/Ghost/Carriers.php
@@ -33,9 +33,13 @@ class IvozProvider_Klear_Ghost_Carriers extends KlearMatrix_Model_Field_Ghost_Ab
      */
     public function getAsr($carrierDto)
     {
-        $response = $this->fetchCallStats->getAsr(
-            $carrierDto->getId()
-        );
+        try {
+            $response = $this->fetchCallStats->getAsr(
+                $carrierDto->getId()
+            );
+        } catch (Exception $exception) {
+            return Klear_Model_Gettext::gettextCheck('_("Unavailable")');
+        }
 
         if (!$response || $response == -1) {
             return '';
@@ -50,9 +54,13 @@ class IvozProvider_Klear_Ghost_Carriers extends KlearMatrix_Model_Field_Ghost_Ab
      */
     public function getAcd($carrierDto)
     {
-        $response = $this->fetchCallStats->getAcd(
-            $carrierDto->getId()
-        );
+        try {
+            $response = $this->fetchCallStats->getAcd(
+                $carrierDto->getId()
+            );
+        } catch (Exception $exception) {
+            return Klear_Model_Gettext::gettextCheck('_("Unavailable")');
+        }
 
         if (!$response || $response == -1) {
             return '';
@@ -71,9 +79,13 @@ class IvozProvider_Klear_Ghost_Carriers extends KlearMatrix_Model_Field_Ghost_Ab
             return Klear_Model_Gettext::gettextCheck('_("Disabled")');
         }
 
-        return $this->fetchCarrierBalance->getBalance(
-            $carrierDto->getBrandId(),
-            $carrierDto->getId()
-        );
+        try {
+            return $this->fetchCarrierBalance->getBalance(
+                $carrierDto->getBrandId(),
+                $carrierDto->getId()
+            );
+        } catch (Exception $exception) {
+            return Klear_Model_Gettext::gettextCheck('_("Unavailable")');
+        }
     }
 }

--- a/web/admin/application/library/IvozProvider/Klear/Ghost/Companies.php
+++ b/web/admin/application/library/IvozProvider/Klear/Ghost/Companies.php
@@ -48,9 +48,13 @@ class IvozProvider_Klear_Ghost_Companies extends KlearMatrix_Model_Field_Ghost_A
      */
     public function getBalance(CompanyDto $companyDto)
     {
-        return $this->fetchCompanyBalance->getBalance(
-            $companyDto->getBrandId(),
-            $companyDto->getId()
-        );
+        try {
+            return $this->fetchCompanyBalance->getBalance(
+                $companyDto->getBrandId(),
+                $companyDto->getId()
+            );
+        } catch (Exception $exception) {
+            return Klear_Model_Gettext::gettextCheck('_("Unavailable")');
+        }
     }
 }


### PR DESCRIPTION
Improve Ghost Fields to handle CGRateS connection exceptions.
Instead of crashing the whole screen, those ghost fields will display _Unavailable_

