### PR TITLE
kam: fix bounce scenarios in non-AS calls

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -376,7 +376,9 @@ request_route {
     remove_hf("Route");
 
     # Manage dialog
-    dlg_manage();
+    if (!is_known_dlg() || src_ip == myself) {
+        dlg_manage();
+    }
 
     # Calculate cidhash if not set
     if ($dlg_var(cidhash) == $null)

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -294,6 +294,7 @@ modparam("dialog", "send_bye", 1)
 modparam("dialog", "enable_stats", 1)
 modparam("dialog", "default_timeout", MAX_DIALOG_TIMEOUT)
 modparam("dialog", "dlg_extra_hdrs", "Hint: inactivity timeout\r\n") # Added to requests generated locally by the module (e.g. BYE)
+modparam("dialog", "detect_spirals", 0)
 
 # TM
 modparam("tm", "fr_timer", 5000)
@@ -452,7 +453,10 @@ request_route {
     route(PRESENCE);
 
     # From now on, everything is for INVITEs: track dialog
-    dlg_manage();
+    if (!is_known_dlg() || $si == $var(trunksAddress)) {
+        dlg_manage();
+        route(CIDHASH);
+    }
 
     # Inspect new request
     route(CLASSIFY);

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -436,38 +436,34 @@ request_route {
 
     ### only initial requests (no To tag)
 
-    # Inspect new request
-    route(CLASSIFY);
-
     # Discard unsupported methods
     route(FILTER_METHODS);
-
-    # Manage authentication
-    route(AUTH);
 
     # Remove preloaded route headers
     remove_hf("Route");
 
+    # Manage authentication
+    route(AUTH);
+
     # Handle REGISTER
     route(REGISTER);
-
-    # Add record-route to INVITE and SUBSCRIBE requests
-    if (is_method("INVITE|SUBSCRIBE")) {
-        record_route();
-    }
 
     # Handle SUBSCRIBE and PUBLISH
     route(PRESENCE);
 
     # From now on, everything is for INVITEs: track dialog
+    dlg_manage();
+
+    # Inspect new request
+    route(CLASSIFY);
+
+    # Add record-route to INVITE requests
+    record_route();
 
     # Set caller and callee to generate PUBLISH
     route(GENERATE_PUBLISH);
 
-    dlg_manage();
-
     # Route by source
-
     if ($var(is_from_inside)) {
         xinfo("[$dlg_var(cidhash)] $dlg_var(type) inside call\n");
         route(REPLACES);
@@ -507,19 +503,16 @@ route[IS_FROM_INSIDE] {
 }
 
 route[FILTER_METHODS] {
-    if ($dlg_var(type) == 'vpbx') {
-        if (is_method("INVITE|REGISTER|SUBSCRIBE|PUBLISH")) return;
-    } else if ($dlg_var(type) == 'residential') {
-        if (is_method("INVITE|REGISTER")) return;
-    } else if ($dlg_var(type) == 'retail') {
-        if (is_method("INVITE|REGISTER")) return;
-    } else { # type: wholesale
-        if (is_method("INVITE")) return;
+    if (!is_method("INVITE|REGISTER|SUBSCRIBE|PUBLISH")) {
+        xwarn("[$dlg_var(cidhash)] FILTER-METHODS: $rm not supported for $dlg_var(type)\n");
+        send_reply("501", "Not Implemented");
+        exit;
     }
 
-    xwarn("[$dlg_var(cidhash)] FILTER-METHODS: $rm not supported for $dlg_var(type)\n");
-    send_reply("501", "Not Implemented");
-    exit;
+    if (is_method("PUBLISH") && src_ip != myself) {
+        send_reply("405", "Method Not Allowed");
+        exit;
+    }
 }
 
 # Sets dlg_var(cidhash)
@@ -529,7 +522,7 @@ route[CIDHASH] {
 }
 
 route[DDI_IN] {
-    if ($dlg_var(ddi_in) != 'yes') return;
+    if ($var(ddi_in) != 'yes') return;
 
     # Use callee as destination instead of username
     xinfo("[$dlg_var(cidhash)] DDI-IN: Set callee as destination ($rU -> $dlg_var(callee))\n");
@@ -1074,7 +1067,7 @@ route[STATIC_LOCATION] {
         return;
     }
 
-    $dlg_var(ddi_in) = 'yes'; # May be configurable in the future
+    $var(ddi_in) = 'yes'; # May be configurable in the future
 
     sql_xquery("cb", "SELECT name, domain, directConnectivity, ip, port, transport FROM $var(table) t LEFT JOIN Domains D ON t.domainId=D.id WHERE t.name='$rU' AND D.domain='$rd'", "rb");
     if ($xavp(rb=>directConnectivity) == 'no') return;
@@ -1281,7 +1274,7 @@ route[IS_INTERNAL] {
 route[AUTH] {
     if (is_method("PUBLISH") && src_ip==myself) return;
     if (src_ip==myself || $var(is_from_inside)) return;
-    if ($dlg_var(type) == 'wholesale') return; # No AUTH for wholesale clients
+    if (!$var(is_from_inside) && allow_trusted($si, 'any') && $avp(trustedTag) != $null) return; # No AUTH for wholesale clients
 
     if (is_method("REGISTER") || from_uri==myself) {
         # authenticate requests
@@ -1506,9 +1499,6 @@ route[ANTIFLOOD] {
     # Inside call
     if (src_ip==myself || $var(is_from_inside)) return;
 
-    # Wholesale client
-    if ($dlg_var(type) == 'wholesale') return;
-
     # Trusted sources
     if (allow_trusted($si, 'any')) {
         xinfo("[$dlg_var(cidhash)] ANTIFLOOD: $si is not checked against antiflood (IP added in kam_trusted)\n");
@@ -1590,11 +1580,6 @@ route[NATDETECT] {
     force_rport();
 
     if (nat_uac_test("18")) {
-        if ($dlg_var(type) == 'wholesale') {
-           xerr("[$dlg_var(cidhash)] NATDETECT: Wholesale behind NAT not supported\n");
-           send_reply("400", "Wholesale behind NAT not supported");
-           exit;
-        }
         xinfo("[$dlg_var(cidhash)] NATDETECT: NAT detected\n");
         setflag(FLT_NATS);
 
@@ -1937,6 +1922,7 @@ route[PRESENCE] {
         handle_publish();
         t_release();
     } else if(is_method("SUBSCRIBE")) {
+        record_route();
         handle_subscribe();
         t_release();
     }

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -61,18 +61,8 @@
 
 ####### Runtime cfg values (kamcmd cfg.list) #########
 
-# Log dialogs initiated by these SIP methods
-dolog.invite    = 1 desc "If 1, log invite transactions"
-dolog.register  = 1 desc "If 1, log register transactions"
-dolog.publish   = 1 desc "If 1, log publish transactions"
-dolog.subscribe = 1 desc "If 1, log subscribe transactions"
-dolog.notify    = 1 desc "If 1, log notify transactions"
-dolog.options   = 1 desc "If 1, log options transactions"
-dolog.message   = 1 desc "If 1, log message transactions"
-dolog.refer     = 1 desc "If 1, log refer transactions"
+# Enable/disable debug logs
 dolog.websocket = 1 desc "If 1, debug WS connection upgrade"
-
-# Debug
 dolog.xmlrpc    = 0 desc "If 1, debug XMLRPC"
 
 ####### Global Parameters #########
@@ -402,7 +392,7 @@ request_route {
 
     route(IS_FROM_INSIDE);
 
-    route(CONFIGURE_XLOG);
+    route(CIDHASH);
 
     if (is_method("OPTIONS")) {
         force_rport();
@@ -410,7 +400,7 @@ request_route {
         exit;
     }
 
-    if ($dlg_var(log)) xlog("L_NOTICE", "[$dlg_var(cidhash)] Request: $rm '$ru' ($cs $rm) from '$fu' ($proto:$si:$sp) [$ci]\n");
+    xlog("L_NOTICE", "[$dlg_var(cidhash)] Request: $rm '$ru' ($cs $rm) from '$fu' ($proto:$si:$sp) [$ci]\n");
 
     route(ANTIFLOOD);
 
@@ -418,14 +408,14 @@ request_route {
 
     # CANCEL processing
     if (is_method("CANCEL")) {
-        if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] ----> $rm from $si\n");
+        xlog("L_INFO", "[$dlg_var(cidhash)] ----> $rm from $si\n");
         if (t_check_trans()) {
             setflag(FLT_ACC);       # do accounting
             setflag(FLT_ACCFAILED); # even if the transaction fails
             route(RELAY);
         }
 
-        if ($dlg_var(log)) xlog("L_ERR", "[$dlg_var(cidhash)] ----> $rm from $si is not from a known transaction, drop\n");
+        xlog("L_ERR", "[$dlg_var(cidhash)] ----> $rm from $si is not from a known transaction, drop\n");
         exit;
     }
 
@@ -479,7 +469,7 @@ request_route {
     # Route by source
 
     if ($var(is_from_inside)) {
-        if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] $dlg_var(type) inside call\n");
+        xlog("L_INFO", "[$dlg_var(cidhash)] $dlg_var(type) inside call\n");
         route(REPLACES);
         route(PARSE_X_HEADERS);
         route(GET_INFO_FROM_CALLEE);
@@ -490,7 +480,7 @@ request_route {
         route(DDI_IN);
         route(ADAPT_RURI_OUT);
     } else {
-        if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] $dlg_var(type) outside call\n");
+        xlog("L_INFO", "[$dlg_var(cidhash)] $dlg_var(type) outside call\n");
         route(GET_INFO_FROM_CALLER);
         route(FILTER_BY_SCR_ADDR);
         route(CONTROL_MAXCALLS);
@@ -527,16 +517,22 @@ route[FILTER_METHODS] {
         if (is_method("INVITE")) return;
     }
 
-    if ($dlg_var(log)) xlog("L_WARN", "[$dlg_var(cidhash)] FILTER-METHODS: $rm not supported for $dlg_var(type)\n");
+    xlog("L_WARN", "[$dlg_var(cidhash)] FILTER-METHODS: $rm not supported for $dlg_var(type)\n");
     send_reply("501", "Not Implemented");
     exit;
+}
+
+# Sets dlg_var(cidhash)
+route[CIDHASH] {
+    if ($dlg_var(cidhash) == $null)
+        $dlg_var(cidhash) = $(ci{s.md5}{s.substr,0,8});
 }
 
 route[DDI_IN] {
     if ($dlg_var(ddi_in) != 'yes') return;
 
     # Use callee as destination instead of username
-    if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] DDI-IN: Set callee as destination ($rU -> $dlg_var(callee))\n");
+    xlog("L_INFO", "[$dlg_var(cidhash)] DDI-IN: Set callee as destination ($rU -> $dlg_var(callee))\n");
     $rU = $dlg_var(callee);
 }
 
@@ -544,12 +540,12 @@ route[ADAPT_RURI_OUT] {
     # Need adaptation?
     if ($(rU{s.substr,0,1}) == '+') {
         $var(number) = $rU;
-        if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-RURI-OUT: Before -> $var(number)\n");
+        xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-RURI-OUT: Before -> $var(number)\n");
         $var(transformation) = $dlg_var(tr_callee_out);
-        if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-RURI-OUT: Adapt '$var(number)' using rule '$var(transformation)'\n");
+        xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-RURI-OUT: Adapt '$var(number)' using rule '$var(transformation)'\n");
         route(APPLY_TRANSFORMATION);
         $rU = $var(transformated);
-        if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-RURI-OUT: After -> $var(transformated) (applied rule: '$avp(appliedrule)')\n");
+        xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-RURI-OUT: After -> $var(transformated) (applied rule: '$avp(appliedrule)')\n");
     }
 }
 
@@ -560,13 +556,13 @@ route[ADAPT_RURI_IN] {
     $var(number) = $rU;
     route(IS_INTERNAL);
     if ($avp(is_internal) == '1') {
-        if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-RURI-IN: '$var(number)' is internal, do not transformate\n");
+        xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-RURI-IN: '$var(number)' is internal, do not transformate\n");
         return;
     }
 
     $var(transformation) = $dlg_var(tr_callee_in);
 
-    if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-RURI-IN: Adapt '$var(number)' using rule '$var(transformation)'\n");
+    xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-RURI-IN: Adapt '$var(number)' using rule '$var(transformation)'\n");
     route(APPLY_TRANSFORMATION);
     $rU = $var(transformated);
 }
@@ -611,7 +607,7 @@ route[ADAPT_REFERTO] {
     if($dlg_var(type ) != 'vpbx') return;
 
     if (search_hf("Refer-To", "Replaces", "a")) {
-        if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-REFERTO: Replacer found in Refer-To, return\n");
+        xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-REFERTO: Replacer found in Refer-To, return\n");
         return;
     }
 
@@ -619,13 +615,13 @@ route[ADAPT_REFERTO] {
 
     route(IS_INTERNAL);
     if ($avp(is_internal) == '1') {
-        if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-REFERTO: '$var(number)' is internal, do not transformate\n");
+        xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-REFERTO: '$var(number)' is internal, do not transformate\n");
         return;
     }
 
     $var(transformation) = $dlg_var(tr_callee_in);
 
-    if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-REFERTO: Adapt '$var(number)' using rule '$var(transformation)'\n");
+    xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-REFERTO: Adapt '$var(number)' using rule '$var(transformation)'\n");
     route(APPLY_TRANSFORMATION);
     $var(newreferto) = '<sip:' + $var(transformated) + '@' + $(rt{uri.host}) + '>';
     remove_hf("Refer-To");
@@ -669,7 +665,7 @@ route[ADAPT_CALLER] {
 
     route(IS_INTERNAL);
     if ($avp(is_internal) == '1') {
-        if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-CALLER: '$var(number)' is internal, do not transformate\n");
+        xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-CALLER: '$var(number)' is internal, do not transformate\n");
         return;
     }
 
@@ -679,7 +675,7 @@ route[ADAPT_CALLER] {
         $var(transformation) = $dlg_var(tr_caller_in);
     }
 
-    if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-CALLER: Adapt '$var(number)' using rule '$var(transformation)'\n");
+    xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-CALLER: Adapt '$var(number)' using rule '$var(transformation)'\n");
     route(APPLY_TRANSFORMATION); # Apply $var(transformation) to $var(number)
 
     if ($var(is_from_inside)) {
@@ -701,13 +697,13 @@ route[ADAPT_CALLER] {
 route[GET_CALLER] {
     # Where is my caller? PAI/RPID/From?
     if (is_present_hf("P-Asserted-Identity")) {
-        if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] GET-CALLER: PAI present: $(ai{uri.user})\n");
+        xlog("L_INFO", "[$dlg_var(cidhash)] GET-CALLER: PAI present: $(ai{uri.user})\n");
         $var(number) = $(ai{uri.user});
     } else if (is_present_hf("Remote-Party-ID")) {
-        if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] GET-CALLER: RPID present: $(re{uri.user})\n");
+        xlog("L_INFO", "[$dlg_var(cidhash)] GET-CALLER: RPID present: $(re{uri.user})\n");
         $var(number) = $(re{uri.user});
     } else {
-        if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] GET-CALLER: Nor PAI nor RPID present, only From ($fU)! :(\n");
+        xlog("L_INFO", "[$dlg_var(cidhash)] GET-CALLER: Nor PAI nor RPID present, only From ($fU)! :(\n");
         $var(number) = $fU;
     }
 }
@@ -765,7 +761,7 @@ route[ADAPT_CONTACT] {
     if (!is_present_hf("Contact")) return;
 
     if ($var(is_from_inside)) {
-        if ($dlg_var(log)) xlog("L_ERR", "[$dlg_var(cidhash)] ADAPT-CONTACT: 3XX reply from AS, this shouldn't happen\n");
+        xlog("L_ERR", "[$dlg_var(cidhash)] ADAPT-CONTACT: 3XX reply from AS, this shouldn't happen\n");
         return;
     }
 
@@ -773,12 +769,12 @@ route[ADAPT_CONTACT] {
 
     route(IS_INTERNAL);
     if ($avp(is_internal) == '1') {
-        if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-CONTACT: '$var(number)' is internal, do not transformate\n");
+        xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-CONTACT: '$var(number)' is internal, do not transformate\n");
         return;
     }
 
     $var(transformation) = $dlg_var(tr_callee_in);
-    if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-CONTACT: After -> $var(transformated) (applied rule: '$avp(appliedrule)')\n");
+    xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-CONTACT: After -> $var(transformated) (applied rule: '$avp(appliedrule)')\n");
     route(APPLY_TRANSFORMATION);
     $var(newcontact) = '<sip:' + $var(transformated) + '@' + @contact.uri.host + '>';
     remove_hf("Contact");
@@ -792,20 +788,20 @@ route[ADAPT_DIVERSION] {
     # Only adapt first Diversion header
     $var(number) = $(di{uri.user});
     if ($var(number) == $null) {
-        if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-DIVERSION: No number extracted, return\n");
+        xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-DIVERSION: No number extracted, return\n");
         return;
     }
 
     route(IS_INTERNAL);
     if ($avp(is_internal) == '1') {
-        if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-DIVERSION: '$var(number)' is internal, do not transformate\n");
+        xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-DIVERSION: '$var(number)' is internal, do not transformate\n");
         $dlg_var(diversion) = $var(number);
         return;
     }
 
     $avp(reason) = @hf_value.diversion[0].param['reason'];
     if ($avp(reason) == $null) {
-        if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-DIVERSION: No reason extracted, set 'deflection'\n");
+        xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-DIVERSION: No reason extracted, set 'deflection'\n");
         $avp(reason) = 'deflection';
     }
 
@@ -815,7 +811,7 @@ route[ADAPT_DIVERSION] {
         $var(transformation) = $dlg_var(tr_caller_in);
     }
 
-    if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-DIVERSION: Adapt '$var(number)' using rule '$var(transformation)'\n");
+    xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-DIVERSION: Adapt '$var(number)' using rule '$var(transformation)'\n");
     route(APPLY_TRANSFORMATION);
     if ($dlg_var(type) == "retail" && !$var(is_from_inside)) {
         # Check if Diversion is valid before proceeding
@@ -823,7 +819,7 @@ route[ADAPT_DIVERSION] {
         route(VALIDATE_CLID_NUMBER);
 
         if ($dlg_var(valid_clid) == "no") {
-            if ($dlg_var(log)) xlog("L_WARN", "[$dlg_var(cidhash)] ADAPT-DIVERSION: Remove Diversion headers as $var(number) is not valid for retail account $dlg_var(retailAccountId)\n");
+            xlog("L_WARN", "[$dlg_var(cidhash)] ADAPT-DIVERSION: Remove Diversion headers as $var(number) is not valid for retail account $dlg_var(retailAccountId)\n");
             remove_hf("Diversion");
             return;
         }
@@ -848,12 +844,12 @@ route[CALLER_CHECK] {
 
     $var(fallback_ddi) = $xavp(ra=>DDIE164);
     if (!$var(fallback_ddi)) {
-        if ($dlg_var(log)) xlog("L_ERR", "[$dlg_var(cidhash)] CALLER-CHECK: No fallback DDI for retail account $dlg_var(retailAccountId)\n");
+        xlog("L_ERR", "[$dlg_var(cidhash)] CALLER-CHECK: No fallback DDI for retail account $dlg_var(retailAccountId)\n");
         send_reply("403", "Forbidden (invalid CLID)");
         exit;
     }
 
-    if ($dlg_var(log)) xlog("L_WARN", "[$dlg_var(cidhash)] CALLER-CHECK: Force $var(fallback_ddi) as PAI/RPID ($var(number)) is not valid for retail account $dlg_var(retailAccountId)\n");
+    xlog("L_WARN", "[$dlg_var(cidhash)] CALLER-CHECK: Force $var(fallback_ddi) as PAI/RPID ($var(number)) is not valid for retail account $dlg_var(retailAccountId)\n");
     $var(number) = $var(fallback_ddi);
 }
 
@@ -897,7 +893,7 @@ route[APPLY_TRANSFORMATION] {
     if ($avp(appliedrule) == $null)
         $var(transformated) = $var(number);
 
-    if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] APPLY-TRANSFORMATION: Number after: $var(transformated) (applied rule: '$avp(appliedrule)')\n");
+    xlog("L_INFO", "[$dlg_var(cidhash)] APPLY-TRANSFORMATION: Number after: $var(transformated) (applied rule: '$avp(appliedrule)')\n");
 }
 
 route[REQINIT] {
@@ -944,15 +940,15 @@ route[GENERATE_PUBLISH] {
 
 route[MAXCALLS_USER] {
     if (!$dlg_var(maxcallsUser)){
-        if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] MAXCALLS-USER: '$tU@$td' has no call-limit, proceed\n");
+        xlog("L_INFO", "[$dlg_var(cidhash)] MAXCALLS-USER: '$tU@$td' has no call-limit, proceed\n");
         return;
     }
 
     get_profile_size("callsPerAor", "$tU@$td", "$var(currentCalls)");
-    if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] MAXCALLS-USER: '$tU@$td' has $var(currentCalls) out of $dlg_var(maxcallsUser) active calls\n");
+    xlog("L_INFO", "[$dlg_var(cidhash)] MAXCALLS-USER: '$tU@$td' has $var(currentCalls) out of $dlg_var(maxcallsUser) active calls\n");
 
     if ($var(currentCalls) >= $dlg_var(maxcallsUser)) {
-        if ($dlg_var(log)) xlog("L_WARN", "[$dlg_var(cidhash)] MAXCALLS-USER: Reject call\n");
+        xlog("L_WARN", "[$dlg_var(cidhash)] MAXCALLS-USER: Reject call\n");
         send_reply("486", "Maxcalls exceeded");
         exit;
     } else {
@@ -967,19 +963,19 @@ route[REPLACES] {
     if (! is_present_hf("Replaces")) return;
 
     # AS sending an INVITE with REPLACE header, guess which AS is the proper destination
-    if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] REPLACES: AS sending a INVITE with Replaces header, forward to proper AS\n");
+    xlog("L_INFO", "[$dlg_var(cidhash)] REPLACES: AS sending a INVITE with Replaces header, forward to proper AS\n");
 
     # Extract CallId from Replaces header
     $var(replace_uri) = $(hdr(Replaces){s.select,0,;});
-    if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] REPLACES: Which AS is handling $(hdr(Replaces){s.select,0,;})?\n");
+    xlog("L_INFO", "[$dlg_var(cidhash)] REPLACES: Which AS is handling $(hdr(Replaces){s.select,0,;})?\n");
 
     if ($sht(dialogs=>$var(replace_uri)::applicationserver) != $null) {
         $du = $sht(dialogs=>$var(replace_uri)::applicationserver);
-        if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] REPLACES: Forward to '$du'\n");
+        xlog("L_INFO", "[$dlg_var(cidhash)] REPLACES: Forward to '$du'\n");
         $fu = 'sip:replacer@users.ivozprovider.local'; # Change From header too
         route(RELAY);
     } else {
-        if ($dlg_var(log)) xlog("L_ERROR", "[$dlg_var(cidhash)] REPLACES: CallID not found, 500\n");
+        xlog("L_ERROR", "[$dlg_var(cidhash)] REPLACES: CallID not found, 500\n");
         send_reply("500", "CallID not found");
         exit;
     }
@@ -998,32 +994,32 @@ route[DISPATCH] {
     # Static routing to specific AS?
     if ($avp(distributeMethod) == 'static') {
         $du = "sip:" + $avp(asAddress) + ":6060";
-        if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] DISPATCH: Company has static routing enabled\n");
+        xlog("L_INFO", "[$dlg_var(cidhash)] DISPATCH: Company has static routing enabled\n");
         t_on_failure("MANAGE_FAILURE");
     } else {
         if ($avp(distributeMethod) == 'hash') {
             $avp(hash) = $dlg_var(companyId);
             # hash over $avp(hash)
-            if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] DISPATCH: Dispatch hashing '$avp(hash)'\n");
+            xlog("L_INFO", "[$dlg_var(cidhash)] DISPATCH: Dispatch hashing '$avp(hash)'\n");
             $var(alg) = 7;
         } else {
             # round robin dispatching on ASs (distributeMethod == 'rr')
-            if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] DISPATCH: dispatch to any AS (round robin)\n");
+            xlog("L_INFO", "[$dlg_var(cidhash)] DISPATCH: dispatch to any AS (round robin)\n");
             $var(alg) = 4;
         }
 
         if(!ds_select_dst("1", "$var(alg)")) {
-            if ($dlg_var(log)) xlog("L_ERR", "[$dlg_var(cidhash)] DISPATCH: No destination found\n");
+            xlog("L_ERR", "[$dlg_var(cidhash)] DISPATCH: No destination found\n");
             send_reply("404", "No destination");
             exit;
         } else {
-            if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] DISPATCH: $avp(AVP_CNT) destination(s) found\n");
+            xlog("L_INFO", "[$dlg_var(cidhash)] DISPATCH: $avp(AVP_CNT) destination(s) found\n");
         }
 
         t_on_failure("MANAGE_FAILURE_AS");
     }
 
-    if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] DISPATCH: going to <$ru> via <$du>\n");
+    xlog("L_INFO", "[$dlg_var(cidhash)] DISPATCH: going to <$ru> via <$du>\n");
 
     # Save CallID <-> AS relationship
     $sht(dialogs=>$ci::applicationserver) = $du;
@@ -1036,31 +1032,31 @@ route[LOOKUP] {
     lookup("kam_users_location");
     switch ($?) {
         case -1:
-            if ($dlg_var(log)) xlog("L_ERR", "[$dlg_var(cidhash)] LOOKUP: Contact not found for $ru, 404\n");
+            xlog("L_ERR", "[$dlg_var(cidhash)] LOOKUP: Contact not found for $ru, 404\n");
             send_reply("404", "Not Found");
             exit;
         case -2:
-            if ($dlg_var(log)) xlog("L_ERR", "[$dlg_var(cidhash)] LOOKUP: Contacts found, but method not supported for $ru, 404\n");
+            xlog("L_ERR", "[$dlg_var(cidhash)] LOOKUP: Contacts found, but method not supported for $ru, 404\n");
             send_reply("404", "Not Found");
             exit;
         case -3:
-            if ($dlg_var(log)) xlog("L_ERR", "[$dlg_var(cidhash)] LOOKUP: Internal error during processing lookup for $ru, 404\n");
+            xlog("L_ERR", "[$dlg_var(cidhash)] LOOKUP: Internal error during processing lookup for $ru, 404\n");
             send_reply("404", "Not Found");
             exit;
     };
 
     # Handle multiple contacts
     if (!t_load_contacts()) {
-        if ($dlg_var(log)) xlog("L_ERR", "[$dlg_var(cidhash)] LOOKUP: Error loading contacts for $rU\n");
+        xlog("L_ERR", "[$dlg_var(cidhash)] LOOKUP: Error loading contacts for $rU\n");
         send_reply("500", "Server Internal Error - Cannot load contacts");
         exit;
     }
 
     # Load contact or contacts
     if (!t_next_contacts()) {
-        if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] LOOKUP: t_next_contacts - One contact found for $tu, calling $ru\n");
+        xlog("L_INFO", "[$dlg_var(cidhash)] LOOKUP: t_next_contacts - One contact found for $tu, calling $ru\n");
     } else {
-        if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] LOOKUP: t_next_contacts - Multiple contacts found for $tu, parallel forking\n");
+        xlog("L_INFO", "[$dlg_var(cidhash)] LOOKUP: t_next_contacts - Multiple contacts found for $tu, parallel forking\n");
     }
 }
 
@@ -1093,7 +1089,7 @@ route[STATIC_LOCATION] {
         $var(location) = $var(location) + ';transport=' + $xavp(rb=>transport);
     }
 
-    if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] STATIC-LOCATION: Call for static $xavp(ra=>type), route to '$var(location)'\n");
+    xlog("L_INFO", "[$dlg_var(cidhash)] STATIC-LOCATION: Call for static $xavp(ra=>type), route to '$var(location)'\n");
     $ru = $var(location);
 
     setbflag(FLB_NATB); # Assume behind NAT (port-forwarding direct connectivity)
@@ -1193,14 +1189,14 @@ route[GET_INFO_FROM_FROM] {
 
 route[FILTER_BY_SCR_ADDR] {
     if ($var(ipFilter) == '0') {
-        if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] FILTER-BY-SCR-ADDR: IP filter is disabled for company '$dlg_var(companyId)'\n");
+        xlog("L_INFO", "[$dlg_var(cidhash)] FILTER-BY-SCR-ADDR: IP filter is disabled for company '$dlg_var(companyId)'\n");
         return;
     }
 
     # Company has IP check enabled
 
     if (allow_source_address($dlg_var(companyId))) {
-        if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] FILTER-BY-SCR-ADDR: Valid source $si for company '$dlg_var(companyId)'\n");
+        xlog("L_INFO", "[$dlg_var(cidhash)] FILTER-BY-SCR-ADDR: Valid source $si for company '$dlg_var(companyId)'\n");
         return;
     }
 
@@ -1210,17 +1206,17 @@ route[FILTER_BY_SCR_ADDR] {
         $avp(externalIpCalls) = $xavp(rp=>externalIpCalls);
         if ($avp(externalIpCalls) > 0) {
             get_profile_size("outgoingCallsPerAor", "$fU@$fd", "$var(currentOutgoingCalls)");
-            if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] FILTER-BY-SCR-ADDR: '$fU@$fd' has $var(currentOutgoingCalls) out of $avp(externalIpCalls) outgoing calls\n");
+            xlog("L_INFO", "[$dlg_var(cidhash)] FILTER-BY-SCR-ADDR: '$fU@$fd' has $var(currentOutgoingCalls) out of $avp(externalIpCalls) outgoing calls\n");
 
             if ($var(currentOutgoingCalls) < $avp(externalIpCalls)) {
-                if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] FILTER-BY-SCR-ADDR: Allow roadwarrior call\n");
+                xlog("L_INFO", "[$dlg_var(cidhash)] FILTER-BY-SCR-ADDR: Allow roadwarrior call\n");
                 set_dlg_profile("outgoingCallsPerAor", "$fU@$fd");
                 return;
             }
         }
     }
 
-    if ($dlg_var(log)) xlog("L_WARN", "[$dlg_var(cidhash)] FILTER-BY-SCR-ADDR: $si is not valid for company '$dlg_var(companyId)'\n");
+    xlog("L_WARN", "[$dlg_var(cidhash)] FILTER-BY-SCR-ADDR: $si is not valid for company '$dlg_var(companyId)'\n");
     if ($dlg_var(type) == "retail") {
         send_reply("403", "Forbidden (invalid IP)");
         exit;
@@ -1240,7 +1236,7 @@ route[PARSE_X_HEADERS] {
     $var(header) = 'X-Call-Id';
     route(PARSE_MANDATORY_X_HEADER);
     $dlg_var(xcallid) = $var(header-value);
-    if ($dlg_var(log)) xlog("L_NOTICE", "[$dlg_var(cidhash)] Related leg: $dlg_var(xcallid)\n");
+    xlog("L_NOTICE", "[$dlg_var(cidhash)] Related leg: $dlg_var(xcallid)\n");
 }
 
 # Header MUST be present and with not null value
@@ -1249,7 +1245,7 @@ route[PARSE_MANDATORY_X_HEADER] {
         $var(header-value) = $hdr($var(header));
         remove_hf($var(header));
     } else {
-        if ($dlg_var(log)) xlog("L_ERR", "[$dlg_var(cidhash)] PARSE-MANDATORY-X-HEADER: $var(header) not present or not valid, aborting\n");
+        xlog("L_ERR", "[$dlg_var(cidhash)] PARSE-MANDATORY-X-HEADER: $var(header) not present or not valid, aborting\n");
         send_reply("500", "Missing $var(header)");
         exit;
     }
@@ -1275,7 +1271,7 @@ route[IS_INTERNAL] {
 
     # Not recognized as internal, must start with '+' if AS talking
     if ($(var(number){s.substr,0,1}) != '+' && $var(is_from_inside)) {
-        if ($dlg_var(log)) xlog("L_ERR", "[$dlg_var(cidhash)] IS-INTERNAL: Not internal number '$var(number)' not starting with '+', this shouldn't happen\n");
+        xlog("L_ERR", "[$dlg_var(cidhash)] IS-INTERNAL: Not internal number '$var(number)' not starting with '+', this shouldn't happen\n");
     }
 
     return;
@@ -1290,39 +1286,39 @@ route[AUTH] {
     if (is_method("REGISTER") || from_uri==myself) {
         # authenticate requests
         if (!auth_check("$fd", "kam_users", "1")) {
-            if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] AUTH: Auth needed\n");
+            xlog("L_INFO", "[$dlg_var(cidhash)] AUTH: Auth needed\n");
             auth_challenge("$fd", "0");
             exit;
         }
 
-        if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] AUTH: Authentication OK\n");
+        xlog("L_INFO", "[$dlg_var(cidhash)] AUTH: Authentication OK\n");
         # user authenticated - remove auth header
         consume_credentials();
     }
 
     # If caller is not local subscriber, reject (both AS and subscribers use my domain in from-domain)
     if (from_uri!=myself) {
-        if ($dlg_var(log)) xlog("L_ERR", "[$dlg_var(cidhash)] $fd is not my domain, 403 forbidden\n");
+        xlog("L_ERR", "[$dlg_var(cidhash)] $fd is not my domain, 403 forbidden\n");
         send_reply("403","Forbidden");
         exit;
     }
 
     # Check R-URI is for my domain
     if (uri!=myself) {
-        if ($dlg_var(log)) xlog("L_ERR", "[$dlg_var(cidhash)] R-URI not for my domain, 404 Not here\n");
+        xlog("L_ERR", "[$dlg_var(cidhash)] R-URI not for my domain, 404 Not here\n");
         send_reply("404", "Invalid domain in R-URI");
         exit;
     }
 
     # Domain strict checking
     if ( uri == myself && !is_uri_host_local() ) {
-        if ($dlg_var(log)) xlog("L_WARN", "[$dlg_var(cidhash)] $rd is my IP but domains should be used, reject\n");
+        xlog("L_WARN", "[$dlg_var(cidhash)] $rd is my IP but domains should be used, reject\n");
         send_reply("488", "Domain needed");
         exit;
     }
 
     if ( from_uri == myself && !is_from_local() ) {
-        if ($dlg_var(log)) xlog("L_WARN", "[$dlg_var(cidhash)] $fd is my IP but domains should be used, reject\n");
+        xlog("L_WARN", "[$dlg_var(cidhash)] $fd is my IP but domains should be used, reject\n");
         send_reply("488", "Domain needed");
         exit;
     }
@@ -1383,7 +1379,7 @@ route[WITHINDLG] {
 
 route[REFER] {
     if (is_present_hf("Refer-to") && $(hdr(Refer-to){s.len})) {
-        if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] REFER: $fU transfers call to $hdr(Refer-to)\n");
+        xlog("L_INFO", "[$dlg_var(cidhash)] REFER: $fU transfers call to $hdr(Refer-to)\n");
         $dlg_var(referee) = $hdr(Refer-to);
 
         if ($(hdr(Refer-to){nameaddr.uri}{uri.user}) =~ '^,?\*[0-9]{1,3}$') {
@@ -1395,11 +1391,11 @@ route[REFER] {
                 route(ONDEMANDRECORD);
             }
 
-            if ($dlg_var(log)) xlog("L_WARN", "[$dlg_var(cidhash)] REFER: That is NOT the code, relay\n");
+            xlog("L_WARN", "[$dlg_var(cidhash)] REFER: That is NOT the code, relay\n");
         }
 
     } else {
-        if ($dlg_var(log)) xlog("L_ERR", "[$dlg_var(cidhash)] REFER: No Refer-To header found, relay\n");
+        xlog("L_ERR", "[$dlg_var(cidhash)] REFER: No Refer-To header found, relay\n");
     }
 
     return;
@@ -1407,10 +1403,10 @@ route[REFER] {
 
 route[INFO] {
     if (is_present_hf("Record")) {
-        if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] INFO: On demand record using INFO, proceed\n");
+        xlog("L_INFO", "[$dlg_var(cidhash)] INFO: On demand record using INFO, proceed\n");
         route(ONDEMANDRECORD);
     } else {
-        if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] INFO: INFO without Record header, relay\n");
+        xlog("L_INFO", "[$dlg_var(cidhash)] INFO: INFO without Record header, relay\n");
     }
 
     return;
@@ -1420,10 +1416,10 @@ route[MESSAGE] {
     if (!$var(is_from_inside)) return;
 
     if (search_body("on-demand-record")) {
-        if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] MESSAGE: On demand record using MESSAGE, proceed\n");
+        xlog("L_INFO", "[$dlg_var(cidhash)] MESSAGE: On demand record using MESSAGE, proceed\n");
         route(ONDEMANDRECORD);
     } else {
-        if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] MESSAGE: MESSAGE without on-demand-record body, relay\n");
+        xlog("L_INFO", "[$dlg_var(cidhash)] MESSAGE: MESSAGE without on-demand-record body, relay\n");
     }
 
     return;
@@ -1431,13 +1427,13 @@ route[MESSAGE] {
 
 route[ONDEMANDRECORD] {
     if (!$dlg_var(onDemandRecordCode)) {
-        if ($dlg_var(log)) xlog("L_WARN", "[$dlg_var(cidhash)] ONDEMANDRECORD: On demand record not enabled, ignore\n");
+        xlog("L_WARN", "[$dlg_var(cidhash)] ONDEMANDRECORD: On demand record not enabled, ignore\n");
         send_reply("403", "Forbidden");
         exit;
     }
 
     if ($dlg_var(recording) != 'yes') {
-        if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] ONDEMANDRECORD: Start recording call\n");
+        xlog("L_INFO", "[$dlg_var(cidhash)] ONDEMANDRECORD: Start recording call\n");
         start_recording();
         $dlg_var(recording) = 'yes';
 
@@ -1447,7 +1443,7 @@ route[ONDEMANDRECORD] {
             send_reply("200", "Record On");
         }
     } else {
-        if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] ONDEMANDRECORD: Stop recording call\n");
+        xlog("L_INFO", "[$dlg_var(cidhash)] ONDEMANDRECORD: Stop recording call\n");
         stop_recording();
         $dlg_var(recording) = 'no';
 
@@ -1470,11 +1466,11 @@ route[RURIALIAS] {
     handle_ruri_alias();
     switch ($rc) {
     case -1:
-        if ($dlg_var(log)) xlog("L_ERR", "[$dlg_var(cidhash)] RURIALIAS: Failed to handle alias of R-URI $ru\n");
+        xlog("L_ERR", "[$dlg_var(cidhash)] RURIALIAS: Failed to handle alias of R-URI $ru\n");
         send_reply("400", "Bad request");
         exit;
     case 1:
-        if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] RURIALIAS: Alias parsed, routing $rm from $fu to $du\n");
+        xlog("L_INFO", "[$dlg_var(cidhash)] RURIALIAS: Alias parsed, routing $rm from $fu to $du\n");
         break;
     case 2:
         # ;alias not found
@@ -1515,25 +1511,25 @@ route[ANTIFLOOD] {
 
     # Trusted sources
     if (allow_trusted($si, 'any')) {
-        if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] ANTIFLOOD: $si is not checked against antiflood (IP added in kam_trusted)\n");
+        xlog("L_INFO", "[$dlg_var(cidhash)] ANTIFLOOD: $si is not checked against antiflood (IP added in kam_trusted)\n");
         return;
     }
 
     # Allowed sources by company
     $var(group) = allow_source_address_group();
     if ($var(group) != -1) {
-        if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] ANTIFLOOD: $si is not checked against antiflood (allowed source for companyId '$var(group)')\n");
+        xlog("L_INFO", "[$dlg_var(cidhash)] ANTIFLOOD: $si is not checked against antiflood (allowed source for companyId '$var(group)')\n");
         return;
     }
 
     # Evaluate PIKE
     if($sht(ipban=>$si) != $null) {
         # ip is already blocked
-        if ($dlg_var(log)) xlog("L_ERR", "[$dlg_var(cidhash)] ANTIFLOOD: request from blocked IP - $rm from $fu (IP:$si:$sp)\n");
+        xlog("L_ERR", "[$dlg_var(cidhash)] ANTIFLOOD: request from blocked IP - $rm from $fu (IP:$si:$sp)\n");
         exit;
     }
     if (!pike_check_req()) {
-        if ($dlg_var(log)) xlog("L_ERR", "[$dlg_var(cidhash)] ANTIFLOOD: ALERT: pike blocking $rm from $fu (IP:$si:$sp)\n");
+        xlog("L_ERR", "[$dlg_var(cidhash)] ANTIFLOOD: ALERT: pike blocking $rm from $fu (IP:$si:$sp)\n");
         $sht(ipban=>$si) = 1;
         exit;
     }
@@ -1550,10 +1546,10 @@ route[REGISTER] {
         setbflag(FLB_NATB);
         # Enable SIP NAT pinging
         if ($proto == 'udp') {
-            if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] REGISTER: Enable UDP SIP OPTIONS pinging\n");
+            xlog("L_INFO", "[$dlg_var(cidhash)] REGISTER: Enable UDP SIP OPTIONS pinging\n");
             setbflag(FLB_NATSIPPING);
         } else {
-            if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] REGISTER: Enable TCP raw NAT keeper\n");
+            xlog("L_INFO", "[$dlg_var(cidhash)] REGISTER: Enable TCP raw NAT keeper\n");
         }
     }
 
@@ -1564,20 +1560,20 @@ route[REGISTER] {
     save("kam_users_location");
     switch ($?) {
         case -1:
-            if ($dlg_var(log)) xlog("L_WARN", "[$dlg_var(cidhash)] REGISTER: Something went wrong when saving location\n");
+            xlog("L_WARN", "[$dlg_var(cidhash)] REGISTER: Something went wrong when saving location\n");
             sl_reply_error();
             break;
         case 1:
-            if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] REGISTER: Contacts inserted ($tu: $var(contact_uri))\n");
+            xlog("L_INFO", "[$dlg_var(cidhash)] REGISTER: Contacts inserted ($tu: $var(contact_uri))\n");
             break;
         case 2:
-            if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] REGISTER: Contacts updated ($tu: $var(contact_uri))\n");
+            xlog("L_INFO", "[$dlg_var(cidhash)] REGISTER: Contacts updated ($tu: $var(contact_uri))\n");
             break;
         case 3:
-            if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] REGISTER: Contacts deleted ($tu: $var(contact_uri))\n");
+            xlog("L_INFO", "[$dlg_var(cidhash)] REGISTER: Contacts deleted ($tu: $var(contact_uri))\n");
             break;
         case 4:
-            if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] REGISTER: Contacts returned\n");
+            xlog("L_INFO", "[$dlg_var(cidhash)] REGISTER: Contacts returned\n");
             break;
     };
 
@@ -1595,11 +1591,11 @@ route[NATDETECT] {
 
     if (nat_uac_test("18")) {
         if ($dlg_var(type) == 'wholesale') {
-           if ($dlg_var(log)) xlog("L_ERR", "[$dlg_var(cidhash)] NATDETECT: Wholesale behind NAT not supported\n");
+           xlog("L_ERR", "[$dlg_var(cidhash)] NATDETECT: Wholesale behind NAT not supported\n");
            send_reply("400", "Wholesale behind NAT not supported");
            exit;
         }
-        if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] NATDETECT: NAT detected\n");
+        xlog("L_INFO", "[$dlg_var(cidhash)] NATDETECT: NAT detected\n");
         setflag(FLT_NATS);
 
         if (is_method("REGISTER")) {
@@ -1610,7 +1606,7 @@ route[NATDETECT] {
             if(is_first_hop()) {
                 # Sets ;alias only if received ip and port differ from those in contact URI
                 if (!add_contact_alias()) {
-                   if ($dlg_var(log)) xlog("L_ERR", "[$dlg_var(cidhash)] NATDETECT: Error in aliasing contact $ct\n");
+                   xlog("L_ERR", "[$dlg_var(cidhash)] NATDETECT: Error in aliasing contact $ct\n");
                    send_reply("400", "Bad request");
                    exit;
                 }
@@ -1621,11 +1617,11 @@ route[NATDETECT] {
 
 route[WSFIX] {
     if ($dlg_var(type) == 'wholesale') {
-       if ($dlg_var(log)) xlog("L_ERR", "[$dlg_var(cidhash)] WSFIX: Wholesale using WSS\n");
+       xlog("L_ERR", "[$dlg_var(cidhash)] WSFIX: Wholesale using WSS\n");
        send_reply("400", "Invalid transport");
        exit;
     }
-    if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] WSFIX: Websockets detected, fix contact\n");
+    xlog("L_INFO", "[$dlg_var(cidhash)] WSFIX: Websockets detected, fix contact\n");
     # Do NAT traversal stuff for requests from a WebSocket
     # connection - even if it is not behind a NAT!
     # This won't be needed in the future if Kamailio and the
@@ -1665,56 +1661,11 @@ route[NATMANAGE] {
     if (is_reply() && isbflagset(FLB_NATB) && is_first_hop()) {
         # Sets ;alias only if received ip and port differ from those in contact URI
         if (!add_contact_alias()) {
-           if ($dlg_var(log)) xlog("L_ERR", "[$dlg_var(cidhash)] NATMANAGE: Error in aliasing contact $ct\n");
+           xlog("L_ERR", "[$dlg_var(cidhash)] NATMANAGE: Error in aliasing contact $ct\n");
            send_reply("400", "Bad request");
            exit;
         }
     }
-}
-
-# This route sets following dlg_vars: log, cidhash
-route[CONFIGURE_XLOG] {
-    # Evaluate only once for SIP methods that can initiate transaction
-    if ($dlg_var(log) == "0" || $dlg_var(log) == "1") return;
-
-    $dlg_var(log) = "0";
-
-    if (is_method("INVITE") && $sel(cfg_get.dolog.invite)) {
-        $dlg_var(log) = "1";
-    }
-
-    if (is_method("REGISTER") && $sel(cfg_get.dolog.register)) {
-        $dlg_var(log) = "1";
-    }
-
-    if (is_method("PUBLISH") && $sel(cfg_get.dolog.publish)) {
-        $dlg_var(log) = "1";
-    }
-
-    if (is_method("SUBSCRIBE") && $sel(cfg_get.dolog.subscribe)) {
-        $dlg_var(log) = "1";
-    }
-
-    if (is_method("NOTIFY") && $sel(cfg_get.dolog.notify)) {
-        $dlg_var(log) = "1";
-    }
-
-    if (is_method("OPTIONS") && $sel(cfg_get.dolog.options)) {
-        $dlg_var(log) = "1";
-    }
-
-    if (is_method("MESSAGE") && $sel(cfg_get.dolog.message)) {
-        $dlg_var(log) = "1";
-    }
-
-    if (is_method("REFER") && $sel(cfg_get.dolog.refer)) {
-        $dlg_var(log) = "1";
-    }
-
-    # Calculate callid hash
-    $dlg_var(cidhash) = $(ci{s.md5}{s.substr,0,8});
-
-    return;
 }
 
 # This route sets following dlg_vars: brandId, companyId, type
@@ -1748,12 +1699,12 @@ route[CLASSIFY] {
     }
 
     if ($dlg_var(type) == 'wholesale' && $var(is_from_inside)) {
-        if ($dlg_var(log)) xlog("L_ERR", "[$dlg_var(cidhash)] CLASSIFY: Wholesale inbound call, 501\n");
+        xlog("L_ERR", "[$dlg_var(cidhash)] CLASSIFY: Wholesale inbound call, 501\n");
         send_reply("501", "Not Implemented [WI]");
         exit;
     }
 
-    if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] CLASSIFY: '$dlg_var(type)' call (b$dlg_var(brandId):c$dlg_var(companyId))");
+    xlog("L_INFO", "[$dlg_var(cidhash)] CLASSIFY: '$dlg_var(type)' call (b$dlg_var(brandId):c$dlg_var(companyId))");
 }
 
 route[ACCOUNTING] {
@@ -1769,7 +1720,7 @@ route[ACCOUNTING] {
         if (is_present_hf("P-Asserted-Identity")) {
             $dlg_var(caller) = $(ai{uri.user});
         } else {
-            if ($dlg_var(log)) xlog("L_ERR", "[$dlg_var(cidhash)] ACCOUNTING: PAI not present in AS call\n");
+            xlog("L_ERR", "[$dlg_var(cidhash)] ACCOUNTING: PAI not present in AS call\n");
         }
     } else {
         # External world talking
@@ -1792,7 +1743,7 @@ route[ACCOUNTING] {
 
 # Reply generic route (all replies goes through this route)
 onreply_route {
-    if ($dlg_var(log)) xlog("L_NOTICE", "[$dlg_var(cidhash)] Response: '$rs $rr' to '$cs $rm' from '$fu' ($si:$sp) [$proto]\n");
+    xlog("L_NOTICE", "[$dlg_var(cidhash)] Response: '$rs $rr' to '$cs $rm' from '$fu' ($si:$sp) [$proto]\n");
     route(IS_FROM_INSIDE);
 }
 
@@ -1802,7 +1753,7 @@ onreply_route[MANAGE_REPLY] {
     if ($avp(AoR) != $null && !is_in_profile("callsPerAor", "$avp(AoR)")) {
         set_dlg_profile("callsPerAor", "$avp(AoR)");
         get_profile_size("callsPerAor", "$avp(AoR)", "$var(currentCalls)");
-        if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] MANAGE_REPLY: '$avp(AoR)' has $var(currentCalls) calls now\n");
+        xlog("L_INFO", "[$dlg_var(cidhash)] MANAGE_REPLY: '$avp(AoR)' has $var(currentCalls) calls now\n");
     }
 
     # Account user's missed calls if ringing
@@ -1834,25 +1785,25 @@ onreply_route[MANAGE_REPLY] {
 }
 
 failure_route[MANAGE_FAILURE] {
-    if ($dlg_var(log)) xlog("L_ERR", "[$dlg_var(cidhash)] MANAGE-FAILURE: $rm FAILED: '$T_reply_code $T_reply_reason' to '$cs $rm' from '$fu' ($si:$sp) [$proto]\n");
+    xlog("L_ERR", "[$dlg_var(cidhash)] MANAGE-FAILURE: $rm FAILED: '$T_reply_code $T_reply_reason' to '$cs $rm' from '$fu' ($si:$sp) [$proto]\n");
 
     route(IS_FROM_INSIDE);
     route(NATMANAGE);
 
     if (t_is_canceled()) {
-        if ($dlg_var(log)) xlog("L_ERR", "[$dlg_var(cidhash)] MANAGE-FAILURE: t_is_canceled, exit here\n");
+        xlog("L_ERR", "[$dlg_var(cidhash)] MANAGE-FAILURE: t_is_canceled, exit here\n");
         exit;
     }
 }
 
 failure_route[MANAGE_FAILURE_AS] {
-    if ($dlg_var(log)) xlog("L_ERR", "[$dlg_var(cidhash)] MANAGE-FAILURE-AS: $rm FAILED: '$T_reply_code $T_reply_reason' to '$cs $rm' from '$fu' ($si:$sp) [$proto]\n");
+    xlog("L_ERR", "[$dlg_var(cidhash)] MANAGE-FAILURE-AS: $rm FAILED: '$T_reply_code $T_reply_reason' to '$cs $rm' from '$fu' ($si:$sp) [$proto]\n");
 
     route(IS_FROM_INSIDE);
     route(NATMANAGE);
 
     if (t_is_canceled()) {
-        if ($dlg_var(log)) xlog("L_ERR", "[$dlg_var(cidhash)] MANAGE-FAILURE-AS: t_is_canceled, exit here\n");
+        xlog("L_ERR", "[$dlg_var(cidhash)] MANAGE-FAILURE-AS: t_is_canceled, exit here\n");
         exit;
     }
 
@@ -1860,22 +1811,22 @@ failure_route[MANAGE_FAILURE_AS] {
     if (t_check_status("404") or (t_branch_timeout() and !t_branch_replied())) {
         # Invalidate AS only if no response received
         if (t_branch_timeout() and !t_branch_replied()) {
-            if ($dlg_var(log)) xlog("L_ERR", "[$dlg_var(cidhash)] MANAGE-FAILURE-AS: Mark AS '$avp(AVP_DST)' as inactive\n");
+            xlog("L_ERR", "[$dlg_var(cidhash)] MANAGE-FAILURE-AS: Mark AS '$avp(AVP_DST)' as inactive\n");
             ds_mark_dst("ip");
         }
 
         if(ds_next_dst()) {
             t_on_failure("MANAGE_FAILURE_AS");
-            if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] MANAGE-FAILURE-AS: going to <$ru> via <$du>\n");
+            xlog("L_INFO", "[$dlg_var(cidhash)] MANAGE-FAILURE-AS: going to <$ru> via <$du>\n");
             route(RELAY);
             exit;
         } else {
-            if ($dlg_var(log)) xlog("L_ERR", "[$dlg_var(cidhash)] MANAGE-FAILURE-AS: No more AS-s available\n");
+            xlog("L_ERR", "[$dlg_var(cidhash)] MANAGE-FAILURE-AS: No more AS-s available\n");
             exit;
         }
     }
 
-    if ($dlg_var(log)) xlog("L_ERR", "[$dlg_var(cidhash)] MANAGE-FAILURE-AS: No failover for '$T_reply_code $T_reply_reason', forward reply\n");
+    xlog("L_ERR", "[$dlg_var(cidhash)] MANAGE-FAILURE-AS: No failover for '$T_reply_code $T_reply_reason', forward reply\n");
     exit;
 }
 
@@ -1889,14 +1840,14 @@ branch_route[MANAGE_BRANCH] {
 # Executed when dialog is confirmed with 2XX response code
 event_route[dialog:start] {
     if(isbflagset(FLB_WEBSOCKETS)) {
-        if ($dlg_var(log)) xlog("L_WARN", "[$dlg_var(cidhash)] Answered dialog involves websockets\n");
+        xlog("L_WARN", "[$dlg_var(cidhash)] Answered dialog involves websockets\n");
         $dlg_var(ws) = 'yes';
     }
 }
 
 # Executed when dialog is ended with BYE or timeout
 event_route[dialog:end] {
-    if ($dlg_var(log)) xlog("L_NOTICE", "[$dlg_var(cidhash)] Dialog ended, delete keys from dialogs htable starting with $ci\n");
+    xlog("L_NOTICE", "[$dlg_var(cidhash)] Dialog ended, delete keys from dialogs htable starting with $ci\n");
     sht_rm_name_re("dialogs=>$ci::.*");
 }
 
@@ -1946,26 +1897,26 @@ route[RTPENGINE] {
     $var(common_opts) = 'replace-session-connection replace-origin';
 
     if (nat_uac_test("18") && !$var(is_from_inside)) {
-        if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] RTPENGINE: NAT detected, do not trust SDP addresses\n");
+        xlog("L_INFO", "[$dlg_var(cidhash)] RTPENGINE: NAT detected, do not trust SDP addresses\n");
         $var(symmetry) = 'SIP-source-address';
     } else {
-        if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] RTPENGINE: No NAT detected, trust SDP addresses\n");
+        xlog("L_INFO", "[$dlg_var(cidhash)] RTPENGINE: No NAT detected, trust SDP addresses\n");
         $var(symmetry) = 'asymmetric trust-address';
     }
 
     if ($dlg_var(ws) == 'yes' || isbflagset(FLB_WEBSOCKETS)) {
         if ($proto == 'ws' || $proto == 'wss' ) {
-            if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] RTPENGINE: Is through $proto, convert to udp\n");
+            xlog("L_INFO", "[$dlg_var(cidhash)] RTPENGINE: Is through $proto, convert to udp\n");
             $var(wsopts) = 'ICE=remove RTP/AVP DTLS=no';
         } else {
-            if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] RTPENGINE: Is through $proto (non-ws), convert to wss\n");
+            xlog("L_INFO", "[$dlg_var(cidhash)] RTPENGINE: Is through $proto (non-ws), convert to wss\n");
             $var(wsopts) = 'ICE=force RTP/SAVPF DTLS=passive';
         }
     } else {
         $var(wsopts) ='ICE=remove RTP/AVP';
     }
 
-    if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] RTPENGINE: rtpengine_manage [$var(common_opts) $var(symmetry) $var(wsopts)]\n");
+    xlog("L_INFO", "[$dlg_var(cidhash)] RTPENGINE: rtpengine_manage [$var(common_opts) $var(symmetry) $var(wsopts)]\n");
     rtpengine_manage("$var(common_opts) $var(symmetry) $var(wsopts)");
 }
 
@@ -1994,33 +1945,33 @@ route[PRESENCE] {
 
 route[CONTROL_MAXCALLS] {
     if (get_profile_size("activeCallsCompany", "$dlg_var(companyId)", "$avp(activeCallsCompany)")) {
-        if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] CONTROL-MAXCALLS: company$dlg_var(companyId) $avp(activeCallsCompany)/$dlg_var(maxCallsCompany) calls\n");
+        xlog("L_INFO", "[$dlg_var(cidhash)] CONTROL-MAXCALLS: company$dlg_var(companyId) $avp(activeCallsCompany)/$dlg_var(maxCallsCompany) calls\n");
     } else {
-        if ($dlg_var(log)) xlog("L_ERR", "[$dlg_var(cidhash)] CONTROL-MAXCALLS: company$dlg_var(companyId) $avp(activeCallsCompany)/$dlg_var(maxCallsCompany) calls (error obtaining value)\n");
+        xlog("L_ERR", "[$dlg_var(cidhash)] CONTROL-MAXCALLS: company$dlg_var(companyId) $avp(activeCallsCompany)/$dlg_var(maxCallsCompany) calls (error obtaining value)\n");
         if ($dlg_var(maxCallsCompany) > 0) {
-            if ($dlg_var(log)) xlog("L_ERR", "[$dlg_var(cidhash)] CONTROL-MAXCALLS: Dropping call for security\n");
+            xlog("L_ERR", "[$dlg_var(cidhash)] CONTROL-MAXCALLS: Dropping call for security\n");
             send_reply("500", "Internal Server Error [MC]");
             exit;
         }
     }
 
     if (get_profile_size("activeCallsBrand", "$dlg_var(brandId)", "$avp(activeCallsBrand)")) {
-        if ($dlg_var(log)) xlog("L_INFO", "[$dlg_var(cidhash)] CONTROL-MAXCALLS: brand$dlg_var(brandId) $avp(activeCallsBrand)/$dlg_var(maxCallsBrand) calls\n");
+        xlog("L_INFO", "[$dlg_var(cidhash)] CONTROL-MAXCALLS: brand$dlg_var(brandId) $avp(activeCallsBrand)/$dlg_var(maxCallsBrand) calls\n");
     } else {
-        if ($dlg_var(log)) xlog("L_ERR", "[$dlg_var(cidhash)] CONTROL-MAXCALLS: brand$dlg_var(brandId) $avp(activeCallsBrand)/$dlg_var(maxCallsBrand) calls (error obtaining value)\n");
+        xlog("L_ERR", "[$dlg_var(cidhash)] CONTROL-MAXCALLS: brand$dlg_var(brandId) $avp(activeCallsBrand)/$dlg_var(maxCallsBrand) calls (error obtaining value)\n");
         if ($dlg_var(maxCallsBrand) > 0) {
-            if ($dlg_var(log)) xlog("L_ERR", "[$dlg_var(cidhash)] CONTROL-MAXCALLS: Dropping call for security\n");
+            xlog("L_ERR", "[$dlg_var(cidhash)] CONTROL-MAXCALLS: Dropping call for security\n");
             send_reply("500", "Internal Server Error [MC]");
             exit;
         }
     }
 
     if ($dlg_var(maxCallsBrand) > 0 && $avp(activeCallsBrand) >= $dlg_var(maxCallsBrand)) {
-        if ($dlg_var(log)) xlog("L_WARN", "[$dlg_var(cidhash)] CONTROL-MAXCALLS: Call NOT allowed for brand$dlg_var(brandId), 403 Maxcalls exceeded\n");
+        xlog("L_WARN", "[$dlg_var(cidhash)] CONTROL-MAXCALLS: Call NOT allowed for brand$dlg_var(brandId), 403 Maxcalls exceeded\n");
         send_reply("403", "Maxcalls exceeded");
         exit;
     } else if ($dlg_var(maxCallsCompany) > 0 && $avp(activeCallsCompany) >= $dlg_var(maxCallsCompany)) {
-        if ($dlg_var(log)) xlog("L_WARN", "[$dlg_var(cidhash)] CONTROL-MAXCALLS: Call NOT allowed for company$dlg_var(companyId), 403 Maxcalls exceeded\n");
+        xlog("L_WARN", "[$dlg_var(cidhash)] CONTROL-MAXCALLS: Call NOT allowed for company$dlg_var(companyId), 403 Maxcalls exceeded\n");
         send_reply("403", "Maxcalls exceeded");
         exit;
     } else {

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -400,7 +400,7 @@ request_route {
         exit;
     }
 
-    xlog("L_NOTICE", "[$dlg_var(cidhash)] Request: $rm '$ru' ($cs $rm) from '$fu' ($proto:$si:$sp) [$ci]\n");
+    xnotice("[$dlg_var(cidhash)] Request: $rm '$ru' ($cs $rm) from '$fu' ($proto:$si:$sp) [$ci]\n");
 
     route(ANTIFLOOD);
 
@@ -408,14 +408,14 @@ request_route {
 
     # CANCEL processing
     if (is_method("CANCEL")) {
-        xlog("L_INFO", "[$dlg_var(cidhash)] ----> $rm from $si\n");
+        xinfo("[$dlg_var(cidhash)] ----> $rm from $si\n");
         if (t_check_trans()) {
             setflag(FLT_ACC);       # do accounting
             setflag(FLT_ACCFAILED); # even if the transaction fails
             route(RELAY);
         }
 
-        xlog("L_ERR", "[$dlg_var(cidhash)] ----> $rm from $si is not from a known transaction, drop\n");
+        xerr("[$dlg_var(cidhash)] ----> $rm from $si is not from a known transaction, drop\n");
         exit;
     }
 
@@ -469,7 +469,7 @@ request_route {
     # Route by source
 
     if ($var(is_from_inside)) {
-        xlog("L_INFO", "[$dlg_var(cidhash)] $dlg_var(type) inside call\n");
+        xinfo("[$dlg_var(cidhash)] $dlg_var(type) inside call\n");
         route(REPLACES);
         route(PARSE_X_HEADERS);
         route(GET_INFO_FROM_CALLEE);
@@ -480,7 +480,7 @@ request_route {
         route(DDI_IN);
         route(ADAPT_RURI_OUT);
     } else {
-        xlog("L_INFO", "[$dlg_var(cidhash)] $dlg_var(type) outside call\n");
+        xinfo("[$dlg_var(cidhash)] $dlg_var(type) outside call\n");
         route(GET_INFO_FROM_CALLER);
         route(FILTER_BY_SCR_ADDR);
         route(CONTROL_MAXCALLS);
@@ -517,7 +517,7 @@ route[FILTER_METHODS] {
         if (is_method("INVITE")) return;
     }
 
-    xlog("L_WARN", "[$dlg_var(cidhash)] FILTER-METHODS: $rm not supported for $dlg_var(type)\n");
+    xwarn("[$dlg_var(cidhash)] FILTER-METHODS: $rm not supported for $dlg_var(type)\n");
     send_reply("501", "Not Implemented");
     exit;
 }
@@ -532,7 +532,7 @@ route[DDI_IN] {
     if ($dlg_var(ddi_in) != 'yes') return;
 
     # Use callee as destination instead of username
-    xlog("L_INFO", "[$dlg_var(cidhash)] DDI-IN: Set callee as destination ($rU -> $dlg_var(callee))\n");
+    xinfo("[$dlg_var(cidhash)] DDI-IN: Set callee as destination ($rU -> $dlg_var(callee))\n");
     $rU = $dlg_var(callee);
 }
 
@@ -540,12 +540,12 @@ route[ADAPT_RURI_OUT] {
     # Need adaptation?
     if ($(rU{s.substr,0,1}) == '+') {
         $var(number) = $rU;
-        xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-RURI-OUT: Before -> $var(number)\n");
+        xinfo("[$dlg_var(cidhash)] ADAPT-RURI-OUT: Before -> $var(number)\n");
         $var(transformation) = $dlg_var(tr_callee_out);
-        xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-RURI-OUT: Adapt '$var(number)' using rule '$var(transformation)'\n");
+        xinfo("[$dlg_var(cidhash)] ADAPT-RURI-OUT: Adapt '$var(number)' using rule '$var(transformation)'\n");
         route(APPLY_TRANSFORMATION);
         $rU = $var(transformated);
-        xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-RURI-OUT: After -> $var(transformated) (applied rule: '$avp(appliedrule)')\n");
+        xinfo("[$dlg_var(cidhash)] ADAPT-RURI-OUT: After -> $var(transformated) (applied rule: '$avp(appliedrule)')\n");
     }
 }
 
@@ -556,13 +556,13 @@ route[ADAPT_RURI_IN] {
     $var(number) = $rU;
     route(IS_INTERNAL);
     if ($avp(is_internal) == '1') {
-        xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-RURI-IN: '$var(number)' is internal, do not transformate\n");
+        xinfo("[$dlg_var(cidhash)] ADAPT-RURI-IN: '$var(number)' is internal, do not transformate\n");
         return;
     }
 
     $var(transformation) = $dlg_var(tr_callee_in);
 
-    xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-RURI-IN: Adapt '$var(number)' using rule '$var(transformation)'\n");
+    xinfo("[$dlg_var(cidhash)] ADAPT-RURI-IN: Adapt '$var(number)' using rule '$var(transformation)'\n");
     route(APPLY_TRANSFORMATION);
     $rU = $var(transformated);
 }
@@ -607,7 +607,7 @@ route[ADAPT_REFERTO] {
     if($dlg_var(type ) != 'vpbx') return;
 
     if (search_hf("Refer-To", "Replaces", "a")) {
-        xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-REFERTO: Replacer found in Refer-To, return\n");
+        xinfo("[$dlg_var(cidhash)] ADAPT-REFERTO: Replacer found in Refer-To, return\n");
         return;
     }
 
@@ -615,13 +615,13 @@ route[ADAPT_REFERTO] {
 
     route(IS_INTERNAL);
     if ($avp(is_internal) == '1') {
-        xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-REFERTO: '$var(number)' is internal, do not transformate\n");
+        xinfo("[$dlg_var(cidhash)] ADAPT-REFERTO: '$var(number)' is internal, do not transformate\n");
         return;
     }
 
     $var(transformation) = $dlg_var(tr_callee_in);
 
-    xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-REFERTO: Adapt '$var(number)' using rule '$var(transformation)'\n");
+    xinfo("[$dlg_var(cidhash)] ADAPT-REFERTO: Adapt '$var(number)' using rule '$var(transformation)'\n");
     route(APPLY_TRANSFORMATION);
     $var(newreferto) = '<sip:' + $var(transformated) + '@' + $(rt{uri.host}) + '>';
     remove_hf("Refer-To");
@@ -665,7 +665,7 @@ route[ADAPT_CALLER] {
 
     route(IS_INTERNAL);
     if ($avp(is_internal) == '1') {
-        xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-CALLER: '$var(number)' is internal, do not transformate\n");
+        xinfo("[$dlg_var(cidhash)] ADAPT-CALLER: '$var(number)' is internal, do not transformate\n");
         return;
     }
 
@@ -675,7 +675,7 @@ route[ADAPT_CALLER] {
         $var(transformation) = $dlg_var(tr_caller_in);
     }
 
-    xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-CALLER: Adapt '$var(number)' using rule '$var(transformation)'\n");
+    xinfo("[$dlg_var(cidhash)] ADAPT-CALLER: Adapt '$var(number)' using rule '$var(transformation)'\n");
     route(APPLY_TRANSFORMATION); # Apply $var(transformation) to $var(number)
 
     if ($var(is_from_inside)) {
@@ -697,13 +697,13 @@ route[ADAPT_CALLER] {
 route[GET_CALLER] {
     # Where is my caller? PAI/RPID/From?
     if (is_present_hf("P-Asserted-Identity")) {
-        xlog("L_INFO", "[$dlg_var(cidhash)] GET-CALLER: PAI present: $(ai{uri.user})\n");
+        xinfo("[$dlg_var(cidhash)] GET-CALLER: PAI present: $(ai{uri.user})\n");
         $var(number) = $(ai{uri.user});
     } else if (is_present_hf("Remote-Party-ID")) {
-        xlog("L_INFO", "[$dlg_var(cidhash)] GET-CALLER: RPID present: $(re{uri.user})\n");
+        xinfo("[$dlg_var(cidhash)] GET-CALLER: RPID present: $(re{uri.user})\n");
         $var(number) = $(re{uri.user});
     } else {
-        xlog("L_INFO", "[$dlg_var(cidhash)] GET-CALLER: Nor PAI nor RPID present, only From ($fU)! :(\n");
+        xinfo("[$dlg_var(cidhash)] GET-CALLER: Nor PAI nor RPID present, only From ($fU)! :(\n");
         $var(number) = $fU;
     }
 }
@@ -761,7 +761,7 @@ route[ADAPT_CONTACT] {
     if (!is_present_hf("Contact")) return;
 
     if ($var(is_from_inside)) {
-        xlog("L_ERR", "[$dlg_var(cidhash)] ADAPT-CONTACT: 3XX reply from AS, this shouldn't happen\n");
+        xerr("[$dlg_var(cidhash)] ADAPT-CONTACT: 3XX reply from AS, this shouldn't happen\n");
         return;
     }
 
@@ -769,12 +769,12 @@ route[ADAPT_CONTACT] {
 
     route(IS_INTERNAL);
     if ($avp(is_internal) == '1') {
-        xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-CONTACT: '$var(number)' is internal, do not transformate\n");
+        xinfo("[$dlg_var(cidhash)] ADAPT-CONTACT: '$var(number)' is internal, do not transformate\n");
         return;
     }
 
     $var(transformation) = $dlg_var(tr_callee_in);
-    xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-CONTACT: After -> $var(transformated) (applied rule: '$avp(appliedrule)')\n");
+    xinfo("[$dlg_var(cidhash)] ADAPT-CONTACT: After -> $var(transformated) (applied rule: '$avp(appliedrule)')\n");
     route(APPLY_TRANSFORMATION);
     $var(newcontact) = '<sip:' + $var(transformated) + '@' + @contact.uri.host + '>';
     remove_hf("Contact");
@@ -788,20 +788,20 @@ route[ADAPT_DIVERSION] {
     # Only adapt first Diversion header
     $var(number) = $(di{uri.user});
     if ($var(number) == $null) {
-        xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-DIVERSION: No number extracted, return\n");
+        xinfo("[$dlg_var(cidhash)] ADAPT-DIVERSION: No number extracted, return\n");
         return;
     }
 
     route(IS_INTERNAL);
     if ($avp(is_internal) == '1') {
-        xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-DIVERSION: '$var(number)' is internal, do not transformate\n");
+        xinfo("[$dlg_var(cidhash)] ADAPT-DIVERSION: '$var(number)' is internal, do not transformate\n");
         $dlg_var(diversion) = $var(number);
         return;
     }
 
     $avp(reason) = @hf_value.diversion[0].param['reason'];
     if ($avp(reason) == $null) {
-        xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-DIVERSION: No reason extracted, set 'deflection'\n");
+        xinfo("[$dlg_var(cidhash)] ADAPT-DIVERSION: No reason extracted, set 'deflection'\n");
         $avp(reason) = 'deflection';
     }
 
@@ -811,7 +811,7 @@ route[ADAPT_DIVERSION] {
         $var(transformation) = $dlg_var(tr_caller_in);
     }
 
-    xlog("L_INFO", "[$dlg_var(cidhash)] ADAPT-DIVERSION: Adapt '$var(number)' using rule '$var(transformation)'\n");
+    xinfo("[$dlg_var(cidhash)] ADAPT-DIVERSION: Adapt '$var(number)' using rule '$var(transformation)'\n");
     route(APPLY_TRANSFORMATION);
     if ($dlg_var(type) == "retail" && !$var(is_from_inside)) {
         # Check if Diversion is valid before proceeding
@@ -819,7 +819,7 @@ route[ADAPT_DIVERSION] {
         route(VALIDATE_CLID_NUMBER);
 
         if ($dlg_var(valid_clid) == "no") {
-            xlog("L_WARN", "[$dlg_var(cidhash)] ADAPT-DIVERSION: Remove Diversion headers as $var(number) is not valid for retail account $dlg_var(retailAccountId)\n");
+            xwarn("[$dlg_var(cidhash)] ADAPT-DIVERSION: Remove Diversion headers as $var(number) is not valid for retail account $dlg_var(retailAccountId)\n");
             remove_hf("Diversion");
             return;
         }
@@ -844,12 +844,12 @@ route[CALLER_CHECK] {
 
     $var(fallback_ddi) = $xavp(ra=>DDIE164);
     if (!$var(fallback_ddi)) {
-        xlog("L_ERR", "[$dlg_var(cidhash)] CALLER-CHECK: No fallback DDI for retail account $dlg_var(retailAccountId)\n");
+        xerr("[$dlg_var(cidhash)] CALLER-CHECK: No fallback DDI for retail account $dlg_var(retailAccountId)\n");
         send_reply("403", "Forbidden (invalid CLID)");
         exit;
     }
 
-    xlog("L_WARN", "[$dlg_var(cidhash)] CALLER-CHECK: Force $var(fallback_ddi) as PAI/RPID ($var(number)) is not valid for retail account $dlg_var(retailAccountId)\n");
+    xwarn("[$dlg_var(cidhash)] CALLER-CHECK: Force $var(fallback_ddi) as PAI/RPID ($var(number)) is not valid for retail account $dlg_var(retailAccountId)\n");
     $var(number) = $var(fallback_ddi);
 }
 
@@ -893,25 +893,25 @@ route[APPLY_TRANSFORMATION] {
     if ($avp(appliedrule) == $null)
         $var(transformated) = $var(number);
 
-    xlog("L_INFO", "[$dlg_var(cidhash)] APPLY-TRANSFORMATION: Number after: $var(transformated) (applied rule: '$avp(appliedrule)')\n");
+    xinfo("[$dlg_var(cidhash)] APPLY-TRANSFORMATION: Number after: $var(transformated) (applied rule: '$avp(appliedrule)')\n");
 }
 
 route[REQINIT] {
     # Easy dropping for scanners
     if($ua =~ "friendly-scanner|sipcli|VaxSIPUserAgent" || search("sipvicious")) {
-        xlog("L_WARN", "REQINIT: Dropping scanner request ----> $rm from $si\n");
+        xwarn("REQINIT: Dropping scanner request ----> $rm from $si\n");
         exit;
     }
 
     # Malformed SIP message?
     if(!sanity_check("1511", "7")) {
-        xlog("L_ERR", "REQINIT: Dropping malformed SIP message from $si:$sp\n");
+        xerr("REQINIT: Dropping malformed SIP message from $si:$sp\n");
         exit;
     }
 
     # Max forwards?
     if (!mf_process_maxfwd_header("10")) {
-        xlog("L_ERR", "REQINIT: Too many hops for SIP message from $si:$sp\n");
+        xerr("REQINIT: Too many hops for SIP message from $si:$sp\n");
         send_reply("483","Too Many Hops");
         exit;
     }
@@ -940,15 +940,15 @@ route[GENERATE_PUBLISH] {
 
 route[MAXCALLS_USER] {
     if (!$dlg_var(maxcallsUser)){
-        xlog("L_INFO", "[$dlg_var(cidhash)] MAXCALLS-USER: '$tU@$td' has no call-limit, proceed\n");
+        xinfo("[$dlg_var(cidhash)] MAXCALLS-USER: '$tU@$td' has no call-limit, proceed\n");
         return;
     }
 
     get_profile_size("callsPerAor", "$tU@$td", "$var(currentCalls)");
-    xlog("L_INFO", "[$dlg_var(cidhash)] MAXCALLS-USER: '$tU@$td' has $var(currentCalls) out of $dlg_var(maxcallsUser) active calls\n");
+    xinfo("[$dlg_var(cidhash)] MAXCALLS-USER: '$tU@$td' has $var(currentCalls) out of $dlg_var(maxcallsUser) active calls\n");
 
     if ($var(currentCalls) >= $dlg_var(maxcallsUser)) {
-        xlog("L_WARN", "[$dlg_var(cidhash)] MAXCALLS-USER: Reject call\n");
+        xwarn("[$dlg_var(cidhash)] MAXCALLS-USER: Reject call\n");
         send_reply("486", "Maxcalls exceeded");
         exit;
     } else {
@@ -963,19 +963,19 @@ route[REPLACES] {
     if (! is_present_hf("Replaces")) return;
 
     # AS sending an INVITE with REPLACE header, guess which AS is the proper destination
-    xlog("L_INFO", "[$dlg_var(cidhash)] REPLACES: AS sending a INVITE with Replaces header, forward to proper AS\n");
+    xinfo("[$dlg_var(cidhash)] REPLACES: AS sending a INVITE with Replaces header, forward to proper AS\n");
 
     # Extract CallId from Replaces header
     $var(replace_uri) = $(hdr(Replaces){s.select,0,;});
-    xlog("L_INFO", "[$dlg_var(cidhash)] REPLACES: Which AS is handling $(hdr(Replaces){s.select,0,;})?\n");
+    xinfo("[$dlg_var(cidhash)] REPLACES: Which AS is handling $(hdr(Replaces){s.select,0,;})?\n");
 
     if ($sht(dialogs=>$var(replace_uri)::applicationserver) != $null) {
         $du = $sht(dialogs=>$var(replace_uri)::applicationserver);
-        xlog("L_INFO", "[$dlg_var(cidhash)] REPLACES: Forward to '$du'\n");
+        xinfo("[$dlg_var(cidhash)] REPLACES: Forward to '$du'\n");
         $fu = 'sip:replacer@users.ivozprovider.local'; # Change From header too
         route(RELAY);
     } else {
-        xlog("L_ERROR", "[$dlg_var(cidhash)] REPLACES: CallID not found, 500\n");
+        xerr("[$dlg_var(cidhash)] REPLACES: CallID not found, 500\n");
         send_reply("500", "CallID not found");
         exit;
     }
@@ -994,32 +994,32 @@ route[DISPATCH] {
     # Static routing to specific AS?
     if ($avp(distributeMethod) == 'static') {
         $du = "sip:" + $avp(asAddress) + ":6060";
-        xlog("L_INFO", "[$dlg_var(cidhash)] DISPATCH: Company has static routing enabled\n");
+        xinfo("[$dlg_var(cidhash)] DISPATCH: Company has static routing enabled\n");
         t_on_failure("MANAGE_FAILURE");
     } else {
         if ($avp(distributeMethod) == 'hash') {
             $avp(hash) = $dlg_var(companyId);
             # hash over $avp(hash)
-            xlog("L_INFO", "[$dlg_var(cidhash)] DISPATCH: Dispatch hashing '$avp(hash)'\n");
+            xinfo("[$dlg_var(cidhash)] DISPATCH: Dispatch hashing '$avp(hash)'\n");
             $var(alg) = 7;
         } else {
             # round robin dispatching on ASs (distributeMethod == 'rr')
-            xlog("L_INFO", "[$dlg_var(cidhash)] DISPATCH: dispatch to any AS (round robin)\n");
+            xinfo("[$dlg_var(cidhash)] DISPATCH: dispatch to any AS (round robin)\n");
             $var(alg) = 4;
         }
 
         if(!ds_select_dst("1", "$var(alg)")) {
-            xlog("L_ERR", "[$dlg_var(cidhash)] DISPATCH: No destination found\n");
+            xerr("[$dlg_var(cidhash)] DISPATCH: No destination found\n");
             send_reply("404", "No destination");
             exit;
         } else {
-            xlog("L_INFO", "[$dlg_var(cidhash)] DISPATCH: $avp(AVP_CNT) destination(s) found\n");
+            xinfo("[$dlg_var(cidhash)] DISPATCH: $avp(AVP_CNT) destination(s) found\n");
         }
 
         t_on_failure("MANAGE_FAILURE_AS");
     }
 
-    xlog("L_INFO", "[$dlg_var(cidhash)] DISPATCH: going to <$ru> via <$du>\n");
+    xinfo("[$dlg_var(cidhash)] DISPATCH: going to <$ru> via <$du>\n");
 
     # Save CallID <-> AS relationship
     $sht(dialogs=>$ci::applicationserver) = $du;
@@ -1032,31 +1032,31 @@ route[LOOKUP] {
     lookup("kam_users_location");
     switch ($?) {
         case -1:
-            xlog("L_ERR", "[$dlg_var(cidhash)] LOOKUP: Contact not found for $ru, 404\n");
+            xerr("[$dlg_var(cidhash)] LOOKUP: Contact not found for $ru, 404\n");
             send_reply("404", "Not Found");
             exit;
         case -2:
-            xlog("L_ERR", "[$dlg_var(cidhash)] LOOKUP: Contacts found, but method not supported for $ru, 404\n");
+            xerr("[$dlg_var(cidhash)] LOOKUP: Contacts found, but method not supported for $ru, 404\n");
             send_reply("404", "Not Found");
             exit;
         case -3:
-            xlog("L_ERR", "[$dlg_var(cidhash)] LOOKUP: Internal error during processing lookup for $ru, 404\n");
+            xerr("[$dlg_var(cidhash)] LOOKUP: Internal error during processing lookup for $ru, 404\n");
             send_reply("404", "Not Found");
             exit;
     };
 
     # Handle multiple contacts
     if (!t_load_contacts()) {
-        xlog("L_ERR", "[$dlg_var(cidhash)] LOOKUP: Error loading contacts for $rU\n");
+        xerr("[$dlg_var(cidhash)] LOOKUP: Error loading contacts for $rU\n");
         send_reply("500", "Server Internal Error - Cannot load contacts");
         exit;
     }
 
     # Load contact or contacts
     if (!t_next_contacts()) {
-        xlog("L_INFO", "[$dlg_var(cidhash)] LOOKUP: t_next_contacts - One contact found for $tu, calling $ru\n");
+        xinfo("[$dlg_var(cidhash)] LOOKUP: t_next_contacts - One contact found for $tu, calling $ru\n");
     } else {
-        xlog("L_INFO", "[$dlg_var(cidhash)] LOOKUP: t_next_contacts - Multiple contacts found for $tu, parallel forking\n");
+        xinfo("[$dlg_var(cidhash)] LOOKUP: t_next_contacts - Multiple contacts found for $tu, parallel forking\n");
     }
 }
 
@@ -1089,7 +1089,7 @@ route[STATIC_LOCATION] {
         $var(location) = $var(location) + ';transport=' + $xavp(rb=>transport);
     }
 
-    xlog("L_INFO", "[$dlg_var(cidhash)] STATIC-LOCATION: Call for static $xavp(ra=>type), route to '$var(location)'\n");
+    xinfo("[$dlg_var(cidhash)] STATIC-LOCATION: Call for static $xavp(ra=>type), route to '$var(location)'\n");
     $ru = $var(location);
 
     setbflag(FLB_NATB); # Assume behind NAT (port-forwarding direct connectivity)
@@ -1189,14 +1189,14 @@ route[GET_INFO_FROM_FROM] {
 
 route[FILTER_BY_SCR_ADDR] {
     if ($var(ipFilter) == '0') {
-        xlog("L_INFO", "[$dlg_var(cidhash)] FILTER-BY-SCR-ADDR: IP filter is disabled for company '$dlg_var(companyId)'\n");
+        xinfo("[$dlg_var(cidhash)] FILTER-BY-SCR-ADDR: IP filter is disabled for company '$dlg_var(companyId)'\n");
         return;
     }
 
     # Company has IP check enabled
 
     if (allow_source_address($dlg_var(companyId))) {
-        xlog("L_INFO", "[$dlg_var(cidhash)] FILTER-BY-SCR-ADDR: Valid source $si for company '$dlg_var(companyId)'\n");
+        xinfo("[$dlg_var(cidhash)] FILTER-BY-SCR-ADDR: Valid source $si for company '$dlg_var(companyId)'\n");
         return;
     }
 
@@ -1206,17 +1206,17 @@ route[FILTER_BY_SCR_ADDR] {
         $avp(externalIpCalls) = $xavp(rp=>externalIpCalls);
         if ($avp(externalIpCalls) > 0) {
             get_profile_size("outgoingCallsPerAor", "$fU@$fd", "$var(currentOutgoingCalls)");
-            xlog("L_INFO", "[$dlg_var(cidhash)] FILTER-BY-SCR-ADDR: '$fU@$fd' has $var(currentOutgoingCalls) out of $avp(externalIpCalls) outgoing calls\n");
+            xinfo("[$dlg_var(cidhash)] FILTER-BY-SCR-ADDR: '$fU@$fd' has $var(currentOutgoingCalls) out of $avp(externalIpCalls) outgoing calls\n");
 
             if ($var(currentOutgoingCalls) < $avp(externalIpCalls)) {
-                xlog("L_INFO", "[$dlg_var(cidhash)] FILTER-BY-SCR-ADDR: Allow roadwarrior call\n");
+                xinfo("[$dlg_var(cidhash)] FILTER-BY-SCR-ADDR: Allow roadwarrior call\n");
                 set_dlg_profile("outgoingCallsPerAor", "$fU@$fd");
                 return;
             }
         }
     }
 
-    xlog("L_WARN", "[$dlg_var(cidhash)] FILTER-BY-SCR-ADDR: $si is not valid for company '$dlg_var(companyId)'\n");
+    xwarn("[$dlg_var(cidhash)] FILTER-BY-SCR-ADDR: $si is not valid for company '$dlg_var(companyId)'\n");
     if ($dlg_var(type) == "retail") {
         send_reply("403", "Forbidden (invalid IP)");
         exit;
@@ -1236,7 +1236,7 @@ route[PARSE_X_HEADERS] {
     $var(header) = 'X-Call-Id';
     route(PARSE_MANDATORY_X_HEADER);
     $dlg_var(xcallid) = $var(header-value);
-    xlog("L_NOTICE", "[$dlg_var(cidhash)] Related leg: $dlg_var(xcallid)\n");
+    xnotice("[$dlg_var(cidhash)] Related leg: $dlg_var(xcallid)\n");
 }
 
 # Header MUST be present and with not null value
@@ -1245,7 +1245,7 @@ route[PARSE_MANDATORY_X_HEADER] {
         $var(header-value) = $hdr($var(header));
         remove_hf($var(header));
     } else {
-        xlog("L_ERR", "[$dlg_var(cidhash)] PARSE-MANDATORY-X-HEADER: $var(header) not present or not valid, aborting\n");
+        xerr("[$dlg_var(cidhash)] PARSE-MANDATORY-X-HEADER: $var(header) not present or not valid, aborting\n");
         send_reply("500", "Missing $var(header)");
         exit;
     }
@@ -1271,7 +1271,7 @@ route[IS_INTERNAL] {
 
     # Not recognized as internal, must start with '+' if AS talking
     if ($(var(number){s.substr,0,1}) != '+' && $var(is_from_inside)) {
-        xlog("L_ERR", "[$dlg_var(cidhash)] IS-INTERNAL: Not internal number '$var(number)' not starting with '+', this shouldn't happen\n");
+        xerr("[$dlg_var(cidhash)] IS-INTERNAL: Not internal number '$var(number)' not starting with '+', this shouldn't happen\n");
     }
 
     return;
@@ -1286,39 +1286,39 @@ route[AUTH] {
     if (is_method("REGISTER") || from_uri==myself) {
         # authenticate requests
         if (!auth_check("$fd", "kam_users", "1")) {
-            xlog("L_INFO", "[$dlg_var(cidhash)] AUTH: Auth needed\n");
+            xinfo("[$dlg_var(cidhash)] AUTH: Auth needed\n");
             auth_challenge("$fd", "0");
             exit;
         }
 
-        xlog("L_INFO", "[$dlg_var(cidhash)] AUTH: Authentication OK\n");
+        xinfo("[$dlg_var(cidhash)] AUTH: Authentication OK\n");
         # user authenticated - remove auth header
         consume_credentials();
     }
 
     # If caller is not local subscriber, reject (both AS and subscribers use my domain in from-domain)
     if (from_uri!=myself) {
-        xlog("L_ERR", "[$dlg_var(cidhash)] $fd is not my domain, 403 forbidden\n");
+        xerr("[$dlg_var(cidhash)] $fd is not my domain, 403 forbidden\n");
         send_reply("403","Forbidden");
         exit;
     }
 
     # Check R-URI is for my domain
     if (uri!=myself) {
-        xlog("L_ERR", "[$dlg_var(cidhash)] R-URI not for my domain, 404 Not here\n");
+        xerr("[$dlg_var(cidhash)] R-URI not for my domain, 404 Not here\n");
         send_reply("404", "Invalid domain in R-URI");
         exit;
     }
 
     # Domain strict checking
     if ( uri == myself && !is_uri_host_local() ) {
-        xlog("L_WARN", "[$dlg_var(cidhash)] $rd is my IP but domains should be used, reject\n");
+        xwarn("[$dlg_var(cidhash)] $rd is my IP but domains should be used, reject\n");
         send_reply("488", "Domain needed");
         exit;
     }
 
     if ( from_uri == myself && !is_from_local() ) {
-        xlog("L_WARN", "[$dlg_var(cidhash)] $fd is my IP but domains should be used, reject\n");
+        xwarn("[$dlg_var(cidhash)] $fd is my IP but domains should be used, reject\n");
         send_reply("488", "Domain needed");
         exit;
     }
@@ -1379,7 +1379,7 @@ route[WITHINDLG] {
 
 route[REFER] {
     if (is_present_hf("Refer-to") && $(hdr(Refer-to){s.len})) {
-        xlog("L_INFO", "[$dlg_var(cidhash)] REFER: $fU transfers call to $hdr(Refer-to)\n");
+        xinfo("[$dlg_var(cidhash)] REFER: $fU transfers call to $hdr(Refer-to)\n");
         $dlg_var(referee) = $hdr(Refer-to);
 
         if ($(hdr(Refer-to){nameaddr.uri}{uri.user}) =~ '^,?\*[0-9]{1,3}$') {
@@ -1391,11 +1391,11 @@ route[REFER] {
                 route(ONDEMANDRECORD);
             }
 
-            xlog("L_WARN", "[$dlg_var(cidhash)] REFER: That is NOT the code, relay\n");
+            xwarn("[$dlg_var(cidhash)] REFER: That is NOT the code, relay\n");
         }
 
     } else {
-        xlog("L_ERR", "[$dlg_var(cidhash)] REFER: No Refer-To header found, relay\n");
+        xerr("[$dlg_var(cidhash)] REFER: No Refer-To header found, relay\n");
     }
 
     return;
@@ -1403,10 +1403,10 @@ route[REFER] {
 
 route[INFO] {
     if (is_present_hf("Record")) {
-        xlog("L_INFO", "[$dlg_var(cidhash)] INFO: On demand record using INFO, proceed\n");
+        xinfo("[$dlg_var(cidhash)] INFO: On demand record using INFO, proceed\n");
         route(ONDEMANDRECORD);
     } else {
-        xlog("L_INFO", "[$dlg_var(cidhash)] INFO: INFO without Record header, relay\n");
+        xinfo("[$dlg_var(cidhash)] INFO: INFO without Record header, relay\n");
     }
 
     return;
@@ -1416,10 +1416,10 @@ route[MESSAGE] {
     if (!$var(is_from_inside)) return;
 
     if (search_body("on-demand-record")) {
-        xlog("L_INFO", "[$dlg_var(cidhash)] MESSAGE: On demand record using MESSAGE, proceed\n");
+        xinfo("[$dlg_var(cidhash)] MESSAGE: On demand record using MESSAGE, proceed\n");
         route(ONDEMANDRECORD);
     } else {
-        xlog("L_INFO", "[$dlg_var(cidhash)] MESSAGE: MESSAGE without on-demand-record body, relay\n");
+        xinfo("[$dlg_var(cidhash)] MESSAGE: MESSAGE without on-demand-record body, relay\n");
     }
 
     return;
@@ -1427,13 +1427,13 @@ route[MESSAGE] {
 
 route[ONDEMANDRECORD] {
     if (!$dlg_var(onDemandRecordCode)) {
-        xlog("L_WARN", "[$dlg_var(cidhash)] ONDEMANDRECORD: On demand record not enabled, ignore\n");
+        xwarn("[$dlg_var(cidhash)] ONDEMANDRECORD: On demand record not enabled, ignore\n");
         send_reply("403", "Forbidden");
         exit;
     }
 
     if ($dlg_var(recording) != 'yes') {
-        xlog("L_INFO", "[$dlg_var(cidhash)] ONDEMANDRECORD: Start recording call\n");
+        xinfo("[$dlg_var(cidhash)] ONDEMANDRECORD: Start recording call\n");
         start_recording();
         $dlg_var(recording) = 'yes';
 
@@ -1443,7 +1443,7 @@ route[ONDEMANDRECORD] {
             send_reply("200", "Record On");
         }
     } else {
-        xlog("L_INFO", "[$dlg_var(cidhash)] ONDEMANDRECORD: Stop recording call\n");
+        xinfo("[$dlg_var(cidhash)] ONDEMANDRECORD: Stop recording call\n");
         stop_recording();
         $dlg_var(recording) = 'no';
 
@@ -1466,11 +1466,11 @@ route[RURIALIAS] {
     handle_ruri_alias();
     switch ($rc) {
     case -1:
-        xlog("L_ERR", "[$dlg_var(cidhash)] RURIALIAS: Failed to handle alias of R-URI $ru\n");
+        xerr("[$dlg_var(cidhash)] RURIALIAS: Failed to handle alias of R-URI $ru\n");
         send_reply("400", "Bad request");
         exit;
     case 1:
-        xlog("L_INFO", "[$dlg_var(cidhash)] RURIALIAS: Alias parsed, routing $rm from $fu to $du\n");
+        xinfo("[$dlg_var(cidhash)] RURIALIAS: Alias parsed, routing $rm from $fu to $du\n");
         break;
     case 2:
         # ;alias not found
@@ -1511,25 +1511,25 @@ route[ANTIFLOOD] {
 
     # Trusted sources
     if (allow_trusted($si, 'any')) {
-        xlog("L_INFO", "[$dlg_var(cidhash)] ANTIFLOOD: $si is not checked against antiflood (IP added in kam_trusted)\n");
+        xinfo("[$dlg_var(cidhash)] ANTIFLOOD: $si is not checked against antiflood (IP added in kam_trusted)\n");
         return;
     }
 
     # Allowed sources by company
     $var(group) = allow_source_address_group();
     if ($var(group) != -1) {
-        xlog("L_INFO", "[$dlg_var(cidhash)] ANTIFLOOD: $si is not checked against antiflood (allowed source for companyId '$var(group)')\n");
+        xinfo("[$dlg_var(cidhash)] ANTIFLOOD: $si is not checked against antiflood (allowed source for companyId '$var(group)')\n");
         return;
     }
 
     # Evaluate PIKE
     if($sht(ipban=>$si) != $null) {
         # ip is already blocked
-        xlog("L_ERR", "[$dlg_var(cidhash)] ANTIFLOOD: request from blocked IP - $rm from $fu (IP:$si:$sp)\n");
+        xerr("[$dlg_var(cidhash)] ANTIFLOOD: request from blocked IP - $rm from $fu (IP:$si:$sp)\n");
         exit;
     }
     if (!pike_check_req()) {
-        xlog("L_ERR", "[$dlg_var(cidhash)] ANTIFLOOD: ALERT: pike blocking $rm from $fu (IP:$si:$sp)\n");
+        xerr("[$dlg_var(cidhash)] ANTIFLOOD: ALERT: pike blocking $rm from $fu (IP:$si:$sp)\n");
         $sht(ipban=>$si) = 1;
         exit;
     }
@@ -1546,10 +1546,10 @@ route[REGISTER] {
         setbflag(FLB_NATB);
         # Enable SIP NAT pinging
         if ($proto == 'udp') {
-            xlog("L_INFO", "[$dlg_var(cidhash)] REGISTER: Enable UDP SIP OPTIONS pinging\n");
+            xinfo("[$dlg_var(cidhash)] REGISTER: Enable UDP SIP OPTIONS pinging\n");
             setbflag(FLB_NATSIPPING);
         } else {
-            xlog("L_INFO", "[$dlg_var(cidhash)] REGISTER: Enable TCP raw NAT keeper\n");
+            xinfo("[$dlg_var(cidhash)] REGISTER: Enable TCP raw NAT keeper\n");
         }
     }
 
@@ -1560,20 +1560,20 @@ route[REGISTER] {
     save("kam_users_location");
     switch ($?) {
         case -1:
-            xlog("L_WARN", "[$dlg_var(cidhash)] REGISTER: Something went wrong when saving location\n");
+            xwarn("[$dlg_var(cidhash)] REGISTER: Something went wrong when saving location\n");
             sl_reply_error();
             break;
         case 1:
-            xlog("L_INFO", "[$dlg_var(cidhash)] REGISTER: Contacts inserted ($tu: $var(contact_uri))\n");
+            xinfo("[$dlg_var(cidhash)] REGISTER: Contacts inserted ($tu: $var(contact_uri))\n");
             break;
         case 2:
-            xlog("L_INFO", "[$dlg_var(cidhash)] REGISTER: Contacts updated ($tu: $var(contact_uri))\n");
+            xinfo("[$dlg_var(cidhash)] REGISTER: Contacts updated ($tu: $var(contact_uri))\n");
             break;
         case 3:
-            xlog("L_INFO", "[$dlg_var(cidhash)] REGISTER: Contacts deleted ($tu: $var(contact_uri))\n");
+            xinfo("[$dlg_var(cidhash)] REGISTER: Contacts deleted ($tu: $var(contact_uri))\n");
             break;
         case 4:
-            xlog("L_INFO", "[$dlg_var(cidhash)] REGISTER: Contacts returned\n");
+            xinfo("[$dlg_var(cidhash)] REGISTER: Contacts returned\n");
             break;
     };
 
@@ -1591,11 +1591,11 @@ route[NATDETECT] {
 
     if (nat_uac_test("18")) {
         if ($dlg_var(type) == 'wholesale') {
-           xlog("L_ERR", "[$dlg_var(cidhash)] NATDETECT: Wholesale behind NAT not supported\n");
+           xerr("[$dlg_var(cidhash)] NATDETECT: Wholesale behind NAT not supported\n");
            send_reply("400", "Wholesale behind NAT not supported");
            exit;
         }
-        xlog("L_INFO", "[$dlg_var(cidhash)] NATDETECT: NAT detected\n");
+        xinfo("[$dlg_var(cidhash)] NATDETECT: NAT detected\n");
         setflag(FLT_NATS);
 
         if (is_method("REGISTER")) {
@@ -1606,7 +1606,7 @@ route[NATDETECT] {
             if(is_first_hop()) {
                 # Sets ;alias only if received ip and port differ from those in contact URI
                 if (!add_contact_alias()) {
-                   xlog("L_ERR", "[$dlg_var(cidhash)] NATDETECT: Error in aliasing contact $ct\n");
+                   xerr("[$dlg_var(cidhash)] NATDETECT: Error in aliasing contact $ct\n");
                    send_reply("400", "Bad request");
                    exit;
                 }
@@ -1617,11 +1617,11 @@ route[NATDETECT] {
 
 route[WSFIX] {
     if ($dlg_var(type) == 'wholesale') {
-       xlog("L_ERR", "[$dlg_var(cidhash)] WSFIX: Wholesale using WSS\n");
+       xerr("[$dlg_var(cidhash)] WSFIX: Wholesale using WSS\n");
        send_reply("400", "Invalid transport");
        exit;
     }
-    xlog("L_INFO", "[$dlg_var(cidhash)] WSFIX: Websockets detected, fix contact\n");
+    xinfo("[$dlg_var(cidhash)] WSFIX: Websockets detected, fix contact\n");
     # Do NAT traversal stuff for requests from a WebSocket
     # connection - even if it is not behind a NAT!
     # This won't be needed in the future if Kamailio and the
@@ -1630,7 +1630,7 @@ route[WSFIX] {
     if (is_method("REGISTER")) {
         fix_nated_register();
     } else if (!add_contact_alias()) {
-        if($dlg_var(nolog) != "1") xlog("L_ERR", "[$dlg_var(cidhash)] WSFIX: Error aliasing contact <$ct>\n");
+        if($dlg_var(nolog) != "1") xerr("[$dlg_var(cidhash)] WSFIX: Error aliasing contact <$ct>\n");
         send_reply("400", "Bad Request");
         exit;
     }
@@ -1661,7 +1661,7 @@ route[NATMANAGE] {
     if (is_reply() && isbflagset(FLB_NATB) && is_first_hop()) {
         # Sets ;alias only if received ip and port differ from those in contact URI
         if (!add_contact_alias()) {
-           xlog("L_ERR", "[$dlg_var(cidhash)] NATMANAGE: Error in aliasing contact $ct\n");
+           xerr("[$dlg_var(cidhash)] NATMANAGE: Error in aliasing contact $ct\n");
            send_reply("400", "Bad request");
            exit;
         }
@@ -1699,12 +1699,12 @@ route[CLASSIFY] {
     }
 
     if ($dlg_var(type) == 'wholesale' && $var(is_from_inside)) {
-        xlog("L_ERR", "[$dlg_var(cidhash)] CLASSIFY: Wholesale inbound call, 501\n");
+        xerr("[$dlg_var(cidhash)] CLASSIFY: Wholesale inbound call, 501\n");
         send_reply("501", "Not Implemented [WI]");
         exit;
     }
 
-    xlog("L_INFO", "[$dlg_var(cidhash)] CLASSIFY: '$dlg_var(type)' call (b$dlg_var(brandId):c$dlg_var(companyId))");
+    xinfo("[$dlg_var(cidhash)] CLASSIFY: '$dlg_var(type)' call (b$dlg_var(brandId):c$dlg_var(companyId))");
 }
 
 route[ACCOUNTING] {
@@ -1720,7 +1720,7 @@ route[ACCOUNTING] {
         if (is_present_hf("P-Asserted-Identity")) {
             $dlg_var(caller) = $(ai{uri.user});
         } else {
-            xlog("L_ERR", "[$dlg_var(cidhash)] ACCOUNTING: PAI not present in AS call\n");
+            xerr("[$dlg_var(cidhash)] ACCOUNTING: PAI not present in AS call\n");
         }
     } else {
         # External world talking
@@ -1743,7 +1743,7 @@ route[ACCOUNTING] {
 
 # Reply generic route (all replies goes through this route)
 onreply_route {
-    xlog("L_NOTICE", "[$dlg_var(cidhash)] Response: '$rs $rr' to '$cs $rm' from '$fu' ($si:$sp) [$proto]\n");
+    xnotice("[$dlg_var(cidhash)] Response: '$rs $rr' to '$cs $rm' from '$fu' ($si:$sp) [$proto]\n");
     route(IS_FROM_INSIDE);
 }
 
@@ -1753,7 +1753,7 @@ onreply_route[MANAGE_REPLY] {
     if ($avp(AoR) != $null && !is_in_profile("callsPerAor", "$avp(AoR)")) {
         set_dlg_profile("callsPerAor", "$avp(AoR)");
         get_profile_size("callsPerAor", "$avp(AoR)", "$var(currentCalls)");
-        xlog("L_INFO", "[$dlg_var(cidhash)] MANAGE_REPLY: '$avp(AoR)' has $var(currentCalls) calls now\n");
+        xinfo("[$dlg_var(cidhash)] MANAGE_REPLY: '$avp(AoR)' has $var(currentCalls) calls now\n");
     }
 
     # Account user's missed calls if ringing
@@ -1785,25 +1785,25 @@ onreply_route[MANAGE_REPLY] {
 }
 
 failure_route[MANAGE_FAILURE] {
-    xlog("L_ERR", "[$dlg_var(cidhash)] MANAGE-FAILURE: $rm FAILED: '$T_reply_code $T_reply_reason' to '$cs $rm' from '$fu' ($si:$sp) [$proto]\n");
+    xerr("[$dlg_var(cidhash)] MANAGE-FAILURE: $rm FAILED: '$T_reply_code $T_reply_reason' to '$cs $rm' from '$fu' ($si:$sp) [$proto]\n");
 
     route(IS_FROM_INSIDE);
     route(NATMANAGE);
 
     if (t_is_canceled()) {
-        xlog("L_ERR", "[$dlg_var(cidhash)] MANAGE-FAILURE: t_is_canceled, exit here\n");
+        xerr("[$dlg_var(cidhash)] MANAGE-FAILURE: t_is_canceled, exit here\n");
         exit;
     }
 }
 
 failure_route[MANAGE_FAILURE_AS] {
-    xlog("L_ERR", "[$dlg_var(cidhash)] MANAGE-FAILURE-AS: $rm FAILED: '$T_reply_code $T_reply_reason' to '$cs $rm' from '$fu' ($si:$sp) [$proto]\n");
+    xerr("[$dlg_var(cidhash)] MANAGE-FAILURE-AS: $rm FAILED: '$T_reply_code $T_reply_reason' to '$cs $rm' from '$fu' ($si:$sp) [$proto]\n");
 
     route(IS_FROM_INSIDE);
     route(NATMANAGE);
 
     if (t_is_canceled()) {
-        xlog("L_ERR", "[$dlg_var(cidhash)] MANAGE-FAILURE-AS: t_is_canceled, exit here\n");
+        xerr("[$dlg_var(cidhash)] MANAGE-FAILURE-AS: t_is_canceled, exit here\n");
         exit;
     }
 
@@ -1811,22 +1811,22 @@ failure_route[MANAGE_FAILURE_AS] {
     if (t_check_status("404") or (t_branch_timeout() and !t_branch_replied())) {
         # Invalidate AS only if no response received
         if (t_branch_timeout() and !t_branch_replied()) {
-            xlog("L_ERR", "[$dlg_var(cidhash)] MANAGE-FAILURE-AS: Mark AS '$avp(AVP_DST)' as inactive\n");
+            xerr("[$dlg_var(cidhash)] MANAGE-FAILURE-AS: Mark AS '$avp(AVP_DST)' as inactive\n");
             ds_mark_dst("ip");
         }
 
         if(ds_next_dst()) {
             t_on_failure("MANAGE_FAILURE_AS");
-            xlog("L_INFO", "[$dlg_var(cidhash)] MANAGE-FAILURE-AS: going to <$ru> via <$du>\n");
+            xinfo("[$dlg_var(cidhash)] MANAGE-FAILURE-AS: going to <$ru> via <$du>\n");
             route(RELAY);
             exit;
         } else {
-            xlog("L_ERR", "[$dlg_var(cidhash)] MANAGE-FAILURE-AS: No more AS-s available\n");
+            xerr("[$dlg_var(cidhash)] MANAGE-FAILURE-AS: No more AS-s available\n");
             exit;
         }
     }
 
-    xlog("L_ERR", "[$dlg_var(cidhash)] MANAGE-FAILURE-AS: No failover for '$T_reply_code $T_reply_reason', forward reply\n");
+    xerr("[$dlg_var(cidhash)] MANAGE-FAILURE-AS: No failover for '$T_reply_code $T_reply_reason', forward reply\n");
     exit;
 }
 
@@ -1840,14 +1840,14 @@ branch_route[MANAGE_BRANCH] {
 # Executed when dialog is confirmed with 2XX response code
 event_route[dialog:start] {
     if(isbflagset(FLB_WEBSOCKETS)) {
-        xlog("L_WARN", "[$dlg_var(cidhash)] Answered dialog involves websockets\n");
+        xwarn("[$dlg_var(cidhash)] Answered dialog involves websockets\n");
         $dlg_var(ws) = 'yes';
     }
 }
 
 # Executed when dialog is ended with BYE or timeout
 event_route[dialog:end] {
-    xlog("L_NOTICE", "[$dlg_var(cidhash)] Dialog ended, delete keys from dialogs htable starting with $ci\n");
+    xnotice("[$dlg_var(cidhash)] Dialog ended, delete keys from dialogs htable starting with $ci\n");
     sht_rm_name_re("dialogs=>$ci::.*");
 }
 
@@ -1857,12 +1857,12 @@ onsend_route {
 
 route[XMLRPC]{
     if ($Rp != XMLRPC_PORT) {
-        if ($sel(cfg_get.dolog.xmlrpc)) xlog("L_WARN", "XMLRPC: request received on $Rp, forbidden\n");
+        if ($sel(cfg_get.dolog.xmlrpc)) xwarn("XMLRPC: request received on $Rp, forbidden\n");
         xmlrpc_reply("400", "Unauthorized");
         exit;
     }
 
-    if ($sel(cfg_get.dolog.xmlrpc)) xlog("L_NOTICE", "XMLRPC: XMLRPC call from $si:$sp to $Rp, proceed\n");
+    if ($sel(cfg_get.dolog.xmlrpc)) xnotice("XMLRPC: XMLRPC call from $si:$sp to $Rp, proceed\n");
     route(GENERIC_XMLRPC_COMMAND);
 }
 
@@ -1879,7 +1879,7 @@ route[TRANSPORT_DETECT] {
 
     if (is_request() && !has_totag()) {
         if ($rP == 'ws' || $rP == 'wss' || $proto == 'ws' || $proto == 'wss' || $xavp(ulattrs=>transport) == 'ws' || $xavp(ulattrs=>transport) == 'wss') {
-            xlog("L_WARN", "[$dlg_var(cidhash)] TRANSPORT-DETECT: Websockets, set FLB_WEBSOCKETS\n");
+            xwarn("[$dlg_var(cidhash)] TRANSPORT-DETECT: Websockets, set FLB_WEBSOCKETS\n");
             setbflag(FLB_WEBSOCKETS);
         }
     }
@@ -1897,26 +1897,26 @@ route[RTPENGINE] {
     $var(common_opts) = 'replace-session-connection replace-origin';
 
     if (nat_uac_test("18") && !$var(is_from_inside)) {
-        xlog("L_INFO", "[$dlg_var(cidhash)] RTPENGINE: NAT detected, do not trust SDP addresses\n");
+        xinfo("[$dlg_var(cidhash)] RTPENGINE: NAT detected, do not trust SDP addresses\n");
         $var(symmetry) = 'SIP-source-address';
     } else {
-        xlog("L_INFO", "[$dlg_var(cidhash)] RTPENGINE: No NAT detected, trust SDP addresses\n");
+        xinfo("[$dlg_var(cidhash)] RTPENGINE: No NAT detected, trust SDP addresses\n");
         $var(symmetry) = 'asymmetric trust-address';
     }
 
     if ($dlg_var(ws) == 'yes' || isbflagset(FLB_WEBSOCKETS)) {
         if ($proto == 'ws' || $proto == 'wss' ) {
-            xlog("L_INFO", "[$dlg_var(cidhash)] RTPENGINE: Is through $proto, convert to udp\n");
+            xinfo("[$dlg_var(cidhash)] RTPENGINE: Is through $proto, convert to udp\n");
             $var(wsopts) = 'ICE=remove RTP/AVP DTLS=no';
         } else {
-            xlog("L_INFO", "[$dlg_var(cidhash)] RTPENGINE: Is through $proto (non-ws), convert to wss\n");
+            xinfo("[$dlg_var(cidhash)] RTPENGINE: Is through $proto (non-ws), convert to wss\n");
             $var(wsopts) = 'ICE=force RTP/SAVPF DTLS=passive';
         }
     } else {
         $var(wsopts) ='ICE=remove RTP/AVP';
     }
 
-    xlog("L_INFO", "[$dlg_var(cidhash)] RTPENGINE: rtpengine_manage [$var(common_opts) $var(symmetry) $var(wsopts)]\n");
+    xinfo("[$dlg_var(cidhash)] RTPENGINE: rtpengine_manage [$var(common_opts) $var(symmetry) $var(wsopts)]\n");
     rtpengine_manage("$var(common_opts) $var(symmetry) $var(wsopts)");
 }
 
@@ -1945,33 +1945,33 @@ route[PRESENCE] {
 
 route[CONTROL_MAXCALLS] {
     if (get_profile_size("activeCallsCompany", "$dlg_var(companyId)", "$avp(activeCallsCompany)")) {
-        xlog("L_INFO", "[$dlg_var(cidhash)] CONTROL-MAXCALLS: company$dlg_var(companyId) $avp(activeCallsCompany)/$dlg_var(maxCallsCompany) calls\n");
+        xinfo("[$dlg_var(cidhash)] CONTROL-MAXCALLS: company$dlg_var(companyId) $avp(activeCallsCompany)/$dlg_var(maxCallsCompany) calls\n");
     } else {
-        xlog("L_ERR", "[$dlg_var(cidhash)] CONTROL-MAXCALLS: company$dlg_var(companyId) $avp(activeCallsCompany)/$dlg_var(maxCallsCompany) calls (error obtaining value)\n");
+        xerr("[$dlg_var(cidhash)] CONTROL-MAXCALLS: company$dlg_var(companyId) $avp(activeCallsCompany)/$dlg_var(maxCallsCompany) calls (error obtaining value)\n");
         if ($dlg_var(maxCallsCompany) > 0) {
-            xlog("L_ERR", "[$dlg_var(cidhash)] CONTROL-MAXCALLS: Dropping call for security\n");
+            xerr("[$dlg_var(cidhash)] CONTROL-MAXCALLS: Dropping call for security\n");
             send_reply("500", "Internal Server Error [MC]");
             exit;
         }
     }
 
     if (get_profile_size("activeCallsBrand", "$dlg_var(brandId)", "$avp(activeCallsBrand)")) {
-        xlog("L_INFO", "[$dlg_var(cidhash)] CONTROL-MAXCALLS: brand$dlg_var(brandId) $avp(activeCallsBrand)/$dlg_var(maxCallsBrand) calls\n");
+        xinfo("[$dlg_var(cidhash)] CONTROL-MAXCALLS: brand$dlg_var(brandId) $avp(activeCallsBrand)/$dlg_var(maxCallsBrand) calls\n");
     } else {
-        xlog("L_ERR", "[$dlg_var(cidhash)] CONTROL-MAXCALLS: brand$dlg_var(brandId) $avp(activeCallsBrand)/$dlg_var(maxCallsBrand) calls (error obtaining value)\n");
+        xerr("[$dlg_var(cidhash)] CONTROL-MAXCALLS: brand$dlg_var(brandId) $avp(activeCallsBrand)/$dlg_var(maxCallsBrand) calls (error obtaining value)\n");
         if ($dlg_var(maxCallsBrand) > 0) {
-            xlog("L_ERR", "[$dlg_var(cidhash)] CONTROL-MAXCALLS: Dropping call for security\n");
+            xerr("[$dlg_var(cidhash)] CONTROL-MAXCALLS: Dropping call for security\n");
             send_reply("500", "Internal Server Error [MC]");
             exit;
         }
     }
 
     if ($dlg_var(maxCallsBrand) > 0 && $avp(activeCallsBrand) >= $dlg_var(maxCallsBrand)) {
-        xlog("L_WARN", "[$dlg_var(cidhash)] CONTROL-MAXCALLS: Call NOT allowed for brand$dlg_var(brandId), 403 Maxcalls exceeded\n");
+        xwarn("[$dlg_var(cidhash)] CONTROL-MAXCALLS: Call NOT allowed for brand$dlg_var(brandId), 403 Maxcalls exceeded\n");
         send_reply("403", "Maxcalls exceeded");
         exit;
     } else if ($dlg_var(maxCallsCompany) > 0 && $avp(activeCallsCompany) >= $dlg_var(maxCallsCompany)) {
-        xlog("L_WARN", "[$dlg_var(cidhash)] CONTROL-MAXCALLS: Call NOT allowed for company$dlg_var(companyId), 403 Maxcalls exceeded\n");
+        xwarn("[$dlg_var(cidhash)] CONTROL-MAXCALLS: Call NOT allowed for company$dlg_var(companyId), 403 Maxcalls exceeded\n");
         send_reply("403", "Maxcalls exceeded");
         exit;
     } else {
@@ -1985,11 +1985,11 @@ event_route[xhttp:request] {
     set_reply_no_connect();
 
     if ($Rp == WS_PORT) {
-        if ($sel(cfg_get.dolog.websocket)) xlog("L_INFO", "HTTP Request Received from $si:$sp\n");
+        if ($sel(cfg_get.dolog.websocket)) xinfo("HTTP Request Received from $si:$sp\n");
     } else if ($Rp == WSS_PORT) {
-        if ($sel(cfg_get.dolog.websocket)) xlog("L_INFO", "HTTPS Request Received from $si:$sp\n");
+        if ($sel(cfg_get.dolog.websocket)) xinfo("HTTPS Request Received from $si:$sp\n");
     } else {
-        if ($sel(cfg_get.dolog.websocket)) xlog("L_WARN", "HTTP(S) request received on $Rp, port not allowed\n");
+        if ($sel(cfg_get.dolog.websocket)) xwarn("HTTP(S) request received on $Rp, port not allowed\n");
         xhttp_reply("403", "Forbidden", "", "");
         exit;
     }
@@ -1998,7 +1998,7 @@ event_route[xhttp:request] {
         # Validate Host - make sure the client is using the correct
         # alias for WebSockets
         # if ($hdr(Host) == $null || !is_myself("sip:" + $hdr(Host))) {
-        #     if ($sel(cfg_get.dolog.websocket)) xlog("L_WARN", "Bad host $hdr(Host)\n");
+        #     if ($sel(cfg_get.dolog.websocket)) xwarn("Bad host $hdr(Host)\n");
         #     xhttp_reply("403", "Forbidden, bad host", "", "");
         #     exit;
         # }
@@ -2008,7 +2008,7 @@ event_route[xhttp:request] {
         #
         # if ($hdr(Origin) != "http://communicator.MY_DOMAIN"
         #     && $hdr(Origin) != "https://communicator.MY_DOMAIN") {
-        #       if ($sel(cfg_get.dolog.websocket)) xlog("L_WARN", "Unauthorized client $hdr(Origin)\n");
+        #       if ($sel(cfg_get.dolog.websocket)) xwarn("Unauthorized client $hdr(Origin)\n");
         #       xhttp_reply("403", "Forbidden", "", "");
         #       exit;
         # }
@@ -2020,25 +2020,25 @@ event_route[xhttp:request] {
         if (ws_handle_handshake()) {
             # Optional... cache some information about the
             # successful connection
-            if ($sel(cfg_get.dolog.websocket)) xlog("L_INFO", "Connection upgrade to websocket was successful\n");
+            if ($sel(cfg_get.dolog.websocket)) xinfo("Connection upgrade to websocket was successful\n");
             exit;
         }
     }
 
-    if ($sel(cfg_get.dolog.websocket)) xlog("L_WARN", "HTTP(S) request received without Upgrade to Websocket header, 404\n");
+    if ($sel(cfg_get.dolog.websocket)) xwarn("HTTP(S) request received without Upgrade to Websocket header, 404\n");
     xhttp_reply("404", "Not found", "", "");
 }
 
 event_route[websocket:closed] {
-    if ($sel(cfg_get.dolog.websocket)) xlog("L_INFO", "WebSocket connection from $si:$sp has closed\n");
+    if ($sel(cfg_get.dolog.websocket)) xinfo("WebSocket connection from $si:$sp has closed\n");
 }
 
 event_route[htable:mod-init] {
     if (dns_query("trunks.ivozprovider.local", "kamtrunks")) {
         $var(trunksAddress) = $dns(kamtrunks=>addr);
-        xlog("L_INFO", "trunks.ivozprovider.local: $var(trunksAddress)\n");
+        xinfo("trunks.ivozprovider.local: $var(trunksAddress)\n");
     } else {
-        xlog("L_ERR", "Problems resolving trunks.ivozprovider.local, aborting\n");
+        xerr("Problems resolving trunks.ivozprovider.local, aborting\n");
         abort();
     }
 }


### PR DESCRIPTION
Retail and wholesale clients' calls do not traverse any Application Server. This means that a unique SIP dialog is involved.

In these 2 bouncing scenarios:

- Retail calling to another (or same) retail DDI.
- Wholesale calling to a retail DDI.

2 CDR entries must be created in kam_users_cdrs, the same way kam_trunks_cdrs does for bounced calls.

This PR disables [detect_spirals dialog modparam](http://kamailio.org/docs/modules/5.1.x/modules/dialog.html#dialog.p.detect_spirals) and implements a manual mechanism to call [dlg_manage()](http://kamailio.org/docs/modules/5.1.x/modules/dialog.html#dialog.f.dlg_manage) twice for such calls. Prior to that, logic has to be reordered/adapted to avoid using dlg_vars before dlg_manage() call.


This PR tries to fix #724.