### PR TITLE
Residential cfw voicemail

### DIFF
--- a/asterisk/agi/app/MicroKernel.php
+++ b/asterisk/agi/app/MicroKernel.php
@@ -60,6 +60,7 @@ class MicroKernel extends Kernel
         $routes->add('/dialplan/userstatus', 'kernel:handleRequestAction');
         $routes->add('/dialplan/trunks', 'kernel:handleRequestAction');
         $routes->add('/dialplan/residentials', 'kernel:handleRequestAction');
+        $routes->add('/dialplan/residentialstatus', 'kernel:handleRequestAction');
         $routes->add('/dialplan/friends', 'kernel:handleRequestAction');
         $routes->add('/dialplan/headers', 'kernel:handleRequestAction');
         $routes->add('/dialplan/huntgroups', 'kernel:handleRequestAction');

--- a/asterisk/agi/app/config/services.yml
+++ b/asterisk/agi/app/config/services.yml
@@ -64,6 +64,9 @@ services:
   Dialplan\UserStatus:
     arguments: ~
 
+  Dialplan\ResidentialStatus:
+    arguments: ~
+
   Dialplan\HuntGroups:
     arguments: ~
 
@@ -169,6 +172,10 @@ services:
     arguments: ~
 
   Agi\Action\ResidentialCallAction:
+    lazy: true
+    arguments: ~
+
+  Agi\Action\ResidentialStatusAction:
     lazy: true
     arguments: ~
 

--- a/asterisk/agi/src/Agi/Action/CallForwardResidentialAction.php
+++ b/asterisk/agi/src/Agi/Action/CallForwardResidentialAction.php
@@ -1,0 +1,135 @@
+<?php
+namespace Agi\Action;
+
+use Agi\ChannelInfo;
+use Agi\Wrapper;
+use Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSettingInterface;
+
+
+class CallForwardResidentialAction
+{
+    /**
+     * @var Wrapper
+     */
+    protected $agi;
+
+    /**
+     * @var ChannelInfo
+     */
+    protected $channelInfo;
+
+    /**
+     * Max allowed Call forwards from a channel
+     *
+     * @var int
+     */
+    protected $_maxRedirections = 5;
+
+    /**
+     * @var CallForwardSettingInterface
+     */
+    protected $cfw;
+
+    /**
+     * @var ExternalResidentialCallAction
+     */
+    protected $externalResidentialCallAction;
+
+    /**
+     * @var VoiceMailAction
+     */
+    protected $voiceMailAction;
+
+    /**
+     * CallForwardAction constructor.
+     *
+     * @param Wrapper $agi
+     * @param ChannelInfo $channelInfo
+     * @param RouterAction $routerAction
+     * @param VoiceMailAction $voiceMailAction
+     */
+    public function __construct(
+        Wrapper $agi,
+        ChannelInfo $channelInfo,
+        ExternalResidentialCallAction $externalResidentialCallAction,
+        VoiceMailAction $voiceMailAction
+    )
+    {
+        $this->agi = $agi;
+        $this->channelInfo = $channelInfo;
+        $this->externalResidentialCallAction = $externalResidentialCallAction;
+        $this->voiceMailAction = $voiceMailAction;
+    }
+
+    /**
+     * @param CallForwardSettingInterface $cfw
+     * @return $this
+     */
+    public function setCallForward(CallForwardSettingInterface $cfw)
+    {
+        $this->cfw = $cfw;
+        return $this;
+    }
+
+    public function process()
+    {
+        if (is_null($this->cfw)) {
+            $this->agi->error("CallForward is not properly defined. Check configuration.");
+            return;
+        }
+
+        // Some CLI information
+        $this->agi->notice("Processing %s call forward", $this->cfw->getCallForwardType());
+
+        /**
+         * Set Diversion reason based on current Call Forward settings
+         *
+         * https://wiki.asterisk.org/wiki/display/AST/Function_REDIRECTING
+         */
+        switch ($this->cfw->getCallForwardType()) {
+            case 'inconditional':
+                $this->agi->setRedirecting('reason,i', 'cfu');
+                break;
+            case 'noAnswer':
+                $this->agi->setRedirecting('reason,i', 'cfnr');
+                break;
+            case 'busy':
+                $this->agi->setRedirecting('reason,i', 'cfb');
+                break;
+            case 'userNotRegistered':
+                $this->agi->setRedirecting('reason,i', 'unavailable');
+                break;
+        }
+
+        // Avoid Redirection loops
+        $count = $this->agi->getRedirecting('count');
+        if ($count < $this->_maxRedirections) {
+            $this->agi->setRedirecting('count,i', ++$count);
+        } else {
+            $this->agi->error("Max %d redirection reached. Leaving.", $count);
+            $this->agi->hangup(44);
+            return;
+        }
+
+        // Use Redirecting user as caller on following routes
+        $caller = $this->cfw->getResidentialDevice();
+        $this->channelInfo->setChannelCaller($caller);
+
+        if ($this->cfw->getTargetType() == RouterAction::Voicemail) {
+            // Set as diversion number the user extension
+            $this->voiceMailAction
+                ->setPlayBanner(true)
+                ->setVoiceMail($caller)
+                ->processResidential();
+
+        } else if ($this->cfw->getTargetType() == RouterAction::External) {
+            // Set as diversion number the user extension
+            $this->agi->setRedirecting('from-num', $caller->getOutgoingDDINumber());
+
+            // Route to destination
+            $this->externalResidentialCallAction
+                ->setDestination($this->cfw->getNumberValueE164())
+                ->process();
+        }
+    }
+}

--- a/asterisk/agi/src/Agi/Action/ExternalResidentialCallAction.php
+++ b/asterisk/agi/src/Agi/Action/ExternalResidentialCallAction.php
@@ -94,6 +94,6 @@ class ExternalResidentialCallAction extends ExternalCallAction
         $this->agi->setVariable("DIAL_DST", "PJSIP/" . $number . '@proxytrunks');
         $this->agi->setVariable("DIAL_OPTS", "");
         $this->agi->setVariable("DIAL_TIMEOUT", "");
-        $this->agi->redirect('call-residential', $number);
+        $this->agi->redirect('call-world', $number);
     }
 }

--- a/asterisk/agi/src/Agi/Action/ResidentialCallAction.php
+++ b/asterisk/agi/src/Agi/Action/ResidentialCallAction.php
@@ -3,6 +3,8 @@
 namespace Agi\Action;
 
 use Agi\Wrapper;
+use Ivoz\Core\Infrastructure\Persistence\Doctrine\Model\Helper\CriteriaHelper;
+use Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSettingInterface;
 use Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDeviceInterface;
 
 
@@ -19,14 +21,22 @@ class ResidentialCallAction
     protected $residentialDevice;
 
     /**
+     * @var ResidentialStatusAction
+     */
+    protected $residentialStatusAction;
+
+    /**
      * ResidentialCallAction constructor.
      * @param Wrapper $agi
+     * @param ResidentialStatusAction $residentialStatusAction
      */
     public function __construct(
-        Wrapper $agi
+        Wrapper $agi,
+        ResidentialStatusAction $residentialStatusAction
     )
     {
         $this->agi = $agi;
+        $this->residentialStatusAction = $residentialStatusAction;
     }
 
     /**
@@ -55,21 +65,105 @@ class ResidentialCallAction
         // Some verbose dolan pls
         $this->agi->notice("Preparing call to %s through account %s", $number, $residentialDevice);
 
+        // Check if user has call forwarding enabled
+        $forwarded = $this->residentialStatusAction
+            ->setResidentialDevice($residentialDevice)
+            ->setDialStatus(ResidentialStatusAction::Forwarded)
+            ->process();
+
+        if ($forwarded) {
+            return;
+        }
+
         // Get device endpoint
         $endpointName = $residentialDevice->getSorcery();
 
         // Configure Dial options
+        $timeout = $this->getDialTimeout();
         $options = "";
+
+        if ($this->getResidentialStatusRequired()) {
+            $options .= "g";
+        }
 
         // Call the PSJIP endpoint
         $this->agi->setVariable("DIAL_EXT", $number);
         $this->agi->setVariable("DIAL_DST", "PJSIP/$endpointName");
         $this->agi->setVariable("__DIAL_ENDPOINT", $endpointName);
-        $this->agi->setVariable("DIAL_TIMEOUT", "");
+        $this->agi->setVariable("DIAL_TIMEOUT", $timeout);
         $this->agi->setVariable("DIAL_OPTS", $options);
 
         // Redirect to the calling dialplan context
-        $this->agi->redirect('call-friend', $number);
+        $this->agi->redirect('call-residential', $number);
+    }
+
+    /**
+     * If Device has NoAnswer Call forward setting, return the dial timeout
+     *
+     * @return string
+     */
+    private function getDialTimeout()
+    {
+        $timeout = null;
+
+        // Get active NoAnswer call forwards
+        $criteria = [
+            array('callForwardType', 'eq', 'noAnswer'),
+            array('enabled', 'eq', '1'),
+        ];
+
+        /**
+         * @var CallForwardSettingInterface[] $cfwSettings
+         */
+        $cfwSettings = $this->residentialDevice
+            ->getCallForwardSettings(
+                CriteriaHelper::fromArray($criteria)
+            );
+
+        foreach ($cfwSettings as $cfwSetting) {
+            $cfwType = $cfwSetting->getCallTypeFilter();
+            if ($cfwType == "both" || $cfwType == $this->agi->getCallType()) {
+                $this->agi->verbose("Call Forward No answer enabled [%s]. Setting call timeout.", $cfwSetting);
+                $timeout = $cfwSetting->getNoAnswerTimeout();
+            }
+        }
+
+        return ($timeout)?:"";
+    }
+
+    /**
+     * Determine if we must check call status after dialing the residential device
+     *
+     * @return boolean
+     */
+    private function getResidentialStatusRequired()
+    {
+        // internal or external call
+        $callType = $this->agi->getCallType();
+
+        // Build the criteria to look for call forward settings
+        $criteria = [
+            'or' => array(
+                array('callForwardType', 'eq', 'noAnswer'),
+                array('callForwardType', 'eq', 'busy'),
+                array('callForwardType', 'eq', 'userNotRegistered'),
+            ),
+            'or' => array(
+                array('callTypeFilter', 'eq', 'both'),
+                array('callTypeFilter', 'eq', $callType),
+            ),
+            array('enabled', 'eq', '1')
+        ];
+
+        /** @var CallForwardSettingInterface[] $cfwSettings */
+        $cfwSettings = $this->residentialDevice
+            ->getCallForwardSettings(
+                CriteriaHelper::fromArray($criteria)
+            );
+
+        // Return true if any of the requested Call forwards exist
+        $settingNotEmpty = !empty($cfwSettings);
+        return $settingNotEmpty;
     }
 
 }

--- a/asterisk/agi/src/Agi/Action/ResidentialStatusAction.php
+++ b/asterisk/agi/src/Agi/Action/ResidentialStatusAction.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Agi\Action;
+
+use Agi\Wrapper;
+use Ivoz\Core\Infrastructure\Persistence\Doctrine\Model\Helper\CriteriaHelper;
+use Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSettingInterface;
+use Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDeviceInterface;
+
+
+class ResidentialStatusAction
+{
+    const InvalidArgs           = 'INVALIDARGS';
+    const ChanUnavailable       = 'CHANUNAVAIL';
+    const Busy                  = 'BUSY';
+    const Congestion            = 'CONGESTION';
+    const NoAnswer              = 'NOANSWER';
+    const Cancel                = 'CANCEL';
+    const Forwarded             = 'FORWARDED';
+
+    /**
+     * @var Wrapper
+     */
+    protected $agi;
+
+    /**
+     * @var ResidentialDeviceInterface
+     */
+    protected $residentialDevice;
+
+    /**
+     * @var string
+     */
+    protected $dialStatus = null;
+
+    /**
+     * @var CallForwardResidentialAction
+     */
+    protected $callForwardAction;
+
+    /**
+     * ResidentialStatusAction constructor.
+     *
+     * @param Wrapper $agi
+     * @param CallForwardResidentialAction $callForwardAction
+     */
+    public function __construct(
+        Wrapper $agi,
+        CallForwardResidentialAction $callForwardAction
+    )
+    {
+        $this->agi = $agi;
+        $this->callForwardAction = $callForwardAction;
+    }
+
+    public function setResidentialDevice($residentialDevice)
+    {
+        $this->residentialDevice = $residentialDevice;
+        return $this;
+    }
+
+    public function setDialStatus(string $dialStatus)
+    {
+        $this->dialStatus = $dialStatus;
+        return $this;
+    }
+
+    public function process()
+    {
+        if (empty($this->residentialDevice)) {
+            $this->agi->error("Residential Device is not properly defined. Check configuration.");
+            return false;
+        }
+
+        // If no dialstatus has been provided, try to get Dial output
+        if (empty($this->dialStatus)) {
+            $this->dialStatus = $this->agi->getVariable("DIALSTATUS");
+        }
+
+        $forwarded = false;
+
+        // Check Call Forward configuration configured with dialstatus
+        switch ($this->dialStatus) {
+            case ResidentialStatusAction::ChanUnavailable;
+                $forwarded = $this->processCallForward('userNotRegistered');
+                break;
+            case ResidentialStatusAction::Busy:
+            case ResidentialStatusAction::Congestion:
+                $forwarded = $this->processCallForward('busy');
+                if (!$forwarded) {
+                    // No busy handler, send response
+                    $this->agi->busy();
+                }
+                break;
+            case ResidentialStatusAction::NoAnswer:
+                $forwarded = $this->processCallForward('noAnswer');
+                break;
+            case ResidentialStatusAction::Cancel:
+                $this->agi->hangup(16);
+                break;
+            case ResidentialStatusAction::Forwarded:
+                $forwarded = $this->processCallForward('inconditional');
+                break;
+            default:
+                break;
+        }
+
+        return $forwarded;
+    }
+
+    /**
+     * @param $type
+     * @return bool
+     */
+    private function processCallForward($type)
+    {
+        // Get active call forwards
+        $criteria = [
+            array('callForwardType', 'eq', $type),
+            array('enabled', 'eq', '1'),
+        ];
+
+        /**
+         * @var CallForwardSettingInterface[] $cfwSettings
+         */
+        $cfwSettings = $this->residentialDevice
+            ->getCallForwardSettings(
+                CriteriaHelper::fromArray(
+                    $criteria
+                )
+            );
+
+        // Process busy Call Forwards
+        foreach ($cfwSettings as $cfwSetting) {
+            $cfwType = $cfwSetting->getCallTypeFilter();
+            if ($cfwType == "both" || $cfwType == $this->agi->getCallType()) {
+                // Some output for the asterisk cli
+                $this->agi->verbose("Call ended with status %s. Processing CallForward.", $this->dialStatus);
+
+                $this->callForwardAction
+                    ->setCallForward($cfwSetting)
+                    ->process();
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+}

--- a/asterisk/agi/src/Agi/Action/VoiceMailAction.php
+++ b/asterisk/agi/src/Agi/Action/VoiceMailAction.php
@@ -3,6 +3,7 @@
 namespace Agi\Action;
 
 use Agi\Wrapper;
+use Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDeviceInterface;
 use Ivoz\Provider\Domain\Model\User\UserInterface;
 
 class VoiceMailAction
@@ -13,7 +14,7 @@ class VoiceMailAction
     protected $agi;
 
     /**
-     * @var UserInterface
+     * @var UserInterface|ResidentialDeviceInterface
      */
     protected $voicemail;
 
@@ -45,10 +46,10 @@ class VoiceMailAction
     }
 
     /**
-     * @param UserInterface|null $voicemail
+     * @param UserInterface|ResidentialDeviceInterface|null $voicemail
      * @return $this
      */
-    public function setVoiceMail(UserInterface $voicemail = null)
+    public function setVoiceMail($voicemail = null)
     {
         $this->voicemail = $voicemail;
         return $this;
@@ -56,9 +57,7 @@ class VoiceMailAction
 
     public function process()
     {
-        // Check extension is defined
         $voicemail = $this->voicemail;
-
         if (is_null($voicemail)) {
             $this->agi->error("Voicemail is not properly defined. Check configuration.");
         }
@@ -83,6 +82,15 @@ class VoiceMailAction
             $this->agi->error("User %s has voicemail disabled.", $voicemail->getFullName());
             $this->agi->busy();
         }
+    }
+
+    public function processResidential()
+    {
+        $voicemail = $this->voicemail;
+
+        $this->agi->voicemail(
+            $voicemail->getVoiceMail()
+        );
     }
 
 }

--- a/asterisk/agi/src/Agi/Wrapper.php
+++ b/asterisk/agi/src/Agi/Wrapper.php
@@ -311,7 +311,7 @@ class Wrapper
         return $this->getVariable("CONFBRIDGE($setting)");
     }
 
-    public function voicemail($mailbox, $opts)
+    public function voicemail($mailbox, $opts = "")
     {
         return $this->fastagi->exec('VoiceMail', "$mailbox,$opts");
     }

--- a/asterisk/agi/src/Dialplan/ResidentialStatus.php
+++ b/asterisk/agi/src/Dialplan/ResidentialStatus.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Dialplan;
+
+use Agi\Action\ResidentialStatusAction;
+use Agi\Wrapper;
+use Helpers\EndpointResolver;
+use RouteHandlerAbstract;
+
+class ResidentialStatus extends RouteHandlerAbstract
+{
+    /**
+     * @var Wrapper
+     */
+    protected $agi;
+
+    /**
+     * @var EndpointResolver
+     */
+    protected $endpointResolver;
+
+    /**
+     * @var ResidentialStatusAction
+     */
+    protected $residentialStatusAction;
+
+    /**
+     * ResidentialStatus constructor.
+     *
+     * @param Wrapper $agi
+     * @param EndpointResolver $endpointResolver
+     * @param ResidentialStatusAction $residentialStatusAction
+     */
+    public function __construct(
+        Wrapper $agi,
+        EndpointResolver $endpointResolver,
+        ResidentialStatusAction $residentialStatusAction
+    ) {
+        $this->agi = $agi;
+        $this->endpointResolver = $endpointResolver;
+        $this->residentialStatusAction = $residentialStatusAction;
+    }
+
+
+    /**
+     * Outgoing calls from terminals to Extensions, Services or World
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public function process()
+    {
+        // Get the called endpoint to check postcall actions
+        $endpointName = $this->agi->getVariable("DIAL_ENDPOINT");
+
+        // Get device from the endpoint.
+        $residentialDevice = $this->endpointResolver->getResidentialFromEndpoint($endpointName);
+
+        // ProcessDialStatus
+        $this->residentialStatusAction
+            ->setResidentialDevice($residentialDevice)
+            ->process();
+    }
+}

--- a/asterisk/config/dialplan/default.conf
+++ b/asterisk/config/dialplan/default.conf
@@ -89,6 +89,7 @@ exten => _[+*0-9]!,1,NoOp(Calling to ${QUEUE})
 [call-residential]
 exten => _[+*0-9]!,1,NoOp(Calling ${EXTEN} through ${DIAL_ENDPOINT})
     same => n,Dial(${DIAL_DST},${DIAL_TIMEOUT},${DIAL_OPTS}b(add-headers^${EXTEN}^1))
+    same => n,AGI(agi://127.0.0.1:4573/fastagi-runner.php?command=dialplan/residentialstatus)
 
 ;;---------------------------------------------------------------------------------------------------
 ;;------------------------------------[      Subroutines      ]--------------------------------------

--- a/library/Ivoz/Ast/Domain/Service/Voicemail/UpdateByResidentialDevice.php
+++ b/library/Ivoz/Ast/Domain/Service/Voicemail/UpdateByResidentialDevice.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Ivoz\Ast\Domain\Service\Voicemail;
+
+use Ivoz\Ast\Domain\Model\Voicemail\Voicemail;
+use Ivoz\Ast\Domain\Model\Voicemail\VoicemailDto;
+use Ivoz\Ast\Domain\Model\Voicemail\VoicemailRepository;
+use Ivoz\Core\Application\Service\EntityTools;
+use Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDeviceInterface;
+use Ivoz\Provider\Domain\Service\ResidentialDevice\ResidentialDeviceLifecycleEventHandlerInterface;
+
+class UpdateByResidentialDevice implements ResidentialDeviceLifecycleEventHandlerInterface
+{
+    const POST_PERSIST_PRIORITY = self::PRIORITY_NORMAL;
+
+    /**
+     * @var EntityTools
+     */
+    protected $entityTools;
+
+    /**
+     * @var VoicemailRepository
+     */
+    protected $voicemailRepository;
+
+    public function __construct(
+        EntityTools $entityTools,
+        VoicemailRepository $voicemailRepository
+    ) {
+        $this->entityTools = $entityTools;
+        $this->voicemailRepository = $voicemailRepository;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            self::EVENT_POST_PERSIST => self::POST_PERSIST_PRIORITY
+        ];
+    }
+
+    public function execute(ResidentialDeviceInterface $residentialDevice, $isNew)
+    {
+        /** @var Voicemail $voicemail */
+        $voicemail = $this->voicemailRepository->findOneBy([
+            'residentialDevice' => $residentialDevice->getId()
+        ]);
+
+        $voicemailDto = is_null($voicemail)
+            ? new VoicemailDto()
+            : $this->entityTools->entityToDto($voicemail);
+
+        $company = $residentialDevice->getCompany();
+
+        // Update/Insert voicemail data
+        $voicemailDto
+            ->setResidentialDeviceId($residentialDevice->getId())
+            ->setContext($residentialDevice->getVoiceMailContext())
+            ->setMailbox($residentialDevice->getVoiceMailUser())
+            ->setTz($company->getDefaultTimezone()->getTz());
+
+        $this->entityTools->persistDto(
+            $voicemailDto,
+            $voicemail
+        );
+    }
+}

--- a/library/Ivoz/Provider/Domain/Model/Brand/Brand.php
+++ b/library/Ivoz/Provider/Domain/Model/Brand/Brand.php
@@ -4,6 +4,7 @@ namespace Ivoz\Provider\Domain\Model\Brand;
 
 use Ivoz\Core\Domain\Model\TempFileContainnerTrait;
 use Ivoz\Core\Domain\Service\FileContainerInterface;
+use Ivoz\Core\Infrastructure\Persistence\Doctrine\Model\Helper\CriteriaHelper;
 use Ivoz\Provider\Domain\Model\Company\CompanyInterface;
 use Ivoz\Provider\Domain\Model\Feature\FeatureInterface;
 
@@ -129,5 +130,18 @@ class Brand extends BrandAbstract implements FileContainerInterface, BrandInterf
             "b%d",
             $this->getId()
         );
+    }
+
+    public function getServiceByIden(string $iden)
+    {
+        $service = $this->serviceRepsitory->getByIden($iden);
+
+        $services = $this->getServices(
+            CriteriaHelper::fromArray([
+                'service' => $service
+            ])
+        );
+
+        return array_shift($services);
     }
 }

--- a/library/Ivoz/Provider/Domain/Model/Brand/BrandInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/Brand/BrandInterface.php
@@ -59,6 +59,8 @@ interface BrandInterface extends FileContainerInterface, LoggableEntityInterface
      */
     public function getCgrTenant();
 
+    public function getServiceByIden(string $iden);
+
     /**
      * @deprecated
      * Set name

--- a/library/Ivoz/Provider/Domain/Model/BrandService/BrandServiceRepository.php
+++ b/library/Ivoz/Provider/Domain/Model/BrandService/BrandServiceRepository.php
@@ -4,8 +4,11 @@ namespace Ivoz\Provider\Domain\Model\BrandService;
 
 use Doctrine\Common\Persistence\ObjectRepository;
 use Doctrine\Common\Collections\Selectable;
+use Ivoz\Provider\Domain\Model\Brand\Brand;
+use Ivoz\Provider\Domain\Model\Brand\BrandInterface;
 
 interface BrandServiceRepository extends ObjectRepository, Selectable
 {
 
+    public function findByIden(BrandInterface $brand, string $iden);
 }

--- a/library/Ivoz/Provider/Domain/Model/ResidentialDevice/ResidentialDevice.php
+++ b/library/Ivoz/Provider/Domain/Model/ResidentialDevice/ResidentialDevice.php
@@ -140,6 +140,19 @@ class ResidentialDevice extends ResidentialDeviceAbstract implements Residential
     }
 
     /**
+     * @return string
+     */
+    public function getOutgoingDdiNumber()
+    {
+        $ddi = $this->getOutgoingDdi();
+        if ($ddi) {
+            return $ddi->getDdiE164();
+        }
+
+        return null;
+    }
+
+    /**
      * Get Residential Device outgoingDdi
      * If no Ddi is assigned, retrieve company's default Ddi
      * @return \Ivoz\Provider\Domain\Model\Ddi\DdiInterface or NULL
@@ -178,5 +191,31 @@ class ResidentialDevice extends ResidentialDeviceAbstract implements Residential
 
 
         return array_shift($ddis);
+    }
+
+    /**
+     * @return string with the voicemail
+     */
+    public function getVoiceMail()
+    {
+        return $this->getVoiceMailUser() . '@' . $this->getVoiceMailContext();
+    }
+
+    /**
+     * @return string with the voicemail user
+     */
+    public function getVoiceMailUser()
+    {
+        return "residential" . $this->getId();
+    }
+
+    /**
+     * @return string with the voicemail context
+     */
+    public function getVoiceMailContext()
+    {
+        return
+            'company'
+            . $this->getCompany()->getId();
     }
 }

--- a/library/Ivoz/Provider/Domain/Model/ResidentialDevice/ResidentialDeviceDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/ResidentialDevice/ResidentialDeviceDtoAbstract.php
@@ -127,6 +127,11 @@ abstract class ResidentialDeviceDtoAbstract implements DataTransferObjectInterfa
      */
     private $ddis = null;
 
+    /**
+     * @var \Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSettingDto[] | null
+     */
+    private $callForwardSettings = null;
+
 
     use DtoNormalizer;
 
@@ -197,7 +202,8 @@ abstract class ResidentialDeviceDtoAbstract implements DataTransferObjectInterfa
             'outgoingDdi' => $this->getOutgoingDdi(),
             'language' => $this->getLanguage(),
             'psEndpoints' => $this->getPsEndpoints(),
-            'ddis' => $this->getDdis()
+            'ddis' => $this->getDdis(),
+            'callForwardSettings' => $this->getCallForwardSettings()
         ];
     }
 
@@ -232,6 +238,16 @@ abstract class ResidentialDeviceDtoAbstract implements DataTransferObjectInterfa
                 );
             }
         }
+        if (!is_null($this->callForwardSettings)) {
+            $items = $this->getCallForwardSettings();
+            $this->callForwardSettings = [];
+            foreach ($items as $item) {
+                $this->callForwardSettings[] = $transformer->transform(
+                    'Ivoz\\Provider\\Domain\\Model\\CallForwardSetting\\CallForwardSetting',
+                    $item->getId() ?? $item
+                );
+            }
+        }
     }
 
     /**
@@ -246,6 +262,10 @@ abstract class ResidentialDeviceDtoAbstract implements DataTransferObjectInterfa
         $this->ddis = $transformer->transform(
             'Ivoz\\Provider\\Domain\\Model\\Ddi\\Ddi',
             $this->ddis
+        );
+        $this->callForwardSettings = $transformer->transform(
+            'Ivoz\\Provider\\Domain\\Model\\CallForwardSetting\\CallForwardSetting',
+            $this->callForwardSettings
         );
     }
 
@@ -863,5 +883,25 @@ abstract class ResidentialDeviceDtoAbstract implements DataTransferObjectInterfa
     public function getDdis()
     {
         return $this->ddis;
+    }
+
+    /**
+     * @param array $callForwardSettings
+     *
+     * @return static
+     */
+    public function setCallForwardSettings($callForwardSettings = null)
+    {
+        $this->callForwardSettings = $callForwardSettings;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getCallForwardSettings()
+    {
+        return $this->callForwardSettings;
     }
 }

--- a/library/Ivoz/Provider/Domain/Model/ResidentialDevice/ResidentialDeviceInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/ResidentialDevice/ResidentialDeviceInterface.php
@@ -45,6 +45,11 @@ interface ResidentialDeviceInterface extends LoggableEntityInterface
     public function getLanguageCode();
 
     /**
+     * @return string
+     */
+    public function getOutgoingDdiNumber();
+
+    /**
      * Get Residential Device outgoingDdi
      * If no Ddi is assigned, retrieve company's default Ddi
      * @return \Ivoz\Provider\Domain\Model\Ddi\DdiInterface or NULL
@@ -57,6 +62,21 @@ interface ResidentialDeviceInterface extends LoggableEntityInterface
      * @return DdiInterface
      */
     public function getDdi($ddieE164);
+
+    /**
+     * @return string with the voicemail
+     */
+    public function getVoiceMail();
+
+    /**
+     * @return string with the voicemail user
+     */
+    public function getVoiceMailUser();
+
+    /**
+     * @return string with the voicemail context
+     */
+    public function getVoiceMailContext();
 
     /**
      * Get name
@@ -406,4 +426,35 @@ interface ResidentialDeviceInterface extends LoggableEntityInterface
      * @return \Ivoz\Provider\Domain\Model\Ddi\DdiInterface[]
      */
     public function getDdis(\Doctrine\Common\Collections\Criteria $criteria = null);
+
+    /**
+     * Add callForwardSetting
+     *
+     * @param \Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSettingInterface $callForwardSetting
+     *
+     * @return ResidentialDeviceTrait
+     */
+    public function addCallForwardSetting(\Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSettingInterface $callForwardSetting);
+
+    /**
+     * Remove callForwardSetting
+     *
+     * @param \Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSettingInterface $callForwardSetting
+     */
+    public function removeCallForwardSetting(\Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSettingInterface $callForwardSetting);
+
+    /**
+     * Replace callForwardSettings
+     *
+     * @param \Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSettingInterface[] $callForwardSettings
+     * @return self
+     */
+    public function replaceCallForwardSettings(Collection $callForwardSettings);
+
+    /**
+     * Get callForwardSettings
+     *
+     * @return \Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSettingInterface[]
+     */
+    public function getCallForwardSettings(\Doctrine\Common\Collections\Criteria $criteria = null);
 }

--- a/library/Ivoz/Provider/Domain/Model/ResidentialDevice/ResidentialDeviceTrait.php
+++ b/library/Ivoz/Provider/Domain/Model/ResidentialDevice/ResidentialDeviceTrait.php
@@ -28,6 +28,11 @@ trait ResidentialDeviceTrait
      */
     protected $ddis;
 
+    /**
+     * @var Collection
+     */
+    protected $callForwardSettings;
+
 
     /**
      * Constructor
@@ -37,6 +42,7 @@ trait ResidentialDeviceTrait
         parent::__construct(...func_get_args());
         $this->psEndpoints = new ArrayCollection();
         $this->ddis = new ArrayCollection();
+        $this->callForwardSettings = new ArrayCollection();
     }
 
     /**
@@ -56,6 +62,10 @@ trait ResidentialDeviceTrait
 
         if ($dto->getDdis()) {
             $self->replaceDdis($dto->getDdis());
+        }
+
+        if ($dto->getCallForwardSettings()) {
+            $self->replaceCallForwardSettings($dto->getCallForwardSettings());
         }
         if ($dto->getId()) {
             $self->id = $dto->getId();
@@ -80,6 +90,9 @@ trait ResidentialDeviceTrait
         }
         if ($dto->getDdis()) {
             $this->replaceDdis($dto->getDdis());
+        }
+        if ($dto->getCallForwardSettings()) {
+            $this->replaceCallForwardSettings($dto->getCallForwardSettings());
         }
         return $this;
     }
@@ -246,5 +259,77 @@ trait ResidentialDeviceTrait
         }
 
         return $this->ddis->toArray();
+    }
+
+    /**
+     * Add callForwardSetting
+     *
+     * @param \Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSettingInterface $callForwardSetting
+     *
+     * @return ResidentialDeviceTrait
+     */
+    public function addCallForwardSetting(\Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSettingInterface $callForwardSetting)
+    {
+        $this->callForwardSettings->add($callForwardSetting);
+
+        return $this;
+    }
+
+    /**
+     * Remove callForwardSetting
+     *
+     * @param \Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSettingInterface $callForwardSetting
+     */
+    public function removeCallForwardSetting(\Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSettingInterface $callForwardSetting)
+    {
+        $this->callForwardSettings->removeElement($callForwardSetting);
+    }
+
+    /**
+     * Replace callForwardSettings
+     *
+     * @param \Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSettingInterface[] $callForwardSettings
+     * @return self
+     */
+    public function replaceCallForwardSettings(Collection $callForwardSettings)
+    {
+        $updatedEntities = [];
+        $fallBackId = -1;
+        foreach ($callForwardSettings as $entity) {
+            $index = $entity->getId() ? $entity->getId() : $fallBackId--;
+            $updatedEntities[$index] = $entity;
+            $entity->setResidentialDevice($this);
+        }
+        $updatedEntityKeys = array_keys($updatedEntities);
+
+        foreach ($this->callForwardSettings as $key => $entity) {
+            $identity = $entity->getId();
+            if (in_array($identity, $updatedEntityKeys)) {
+                $this->callForwardSettings->set($key, $updatedEntities[$identity]);
+            } else {
+                $this->callForwardSettings->remove($key);
+            }
+            unset($updatedEntities[$identity]);
+        }
+
+        foreach ($updatedEntities as $entity) {
+            $this->addCallForwardSetting($entity);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get callForwardSettings
+     *
+     * @return \Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSettingInterface[]
+     */
+    public function getCallForwardSettings(Criteria $criteria = null)
+    {
+        if (!is_null($criteria)) {
+            return $this->callForwardSettings->matching($criteria)->toArray();
+        }
+
+        return $this->callForwardSettings->toArray();
     }
 }

--- a/library/Ivoz/Provider/Domain/Model/Service/Service.php
+++ b/library/Ivoz/Provider/Domain/Model/Service/Service.php
@@ -11,6 +11,21 @@ class Service extends ServiceAbstract implements ServiceInterface
 {
     use ServiceTrait;
 
+    const DIRECT_PICKUP     = "DirectPickUp";
+
+    const GROUP_PICKUP      = "GroupPickUp";
+
+    const VOICEMAIL         = "Voicemail";
+
+    const RECORD_LOCUTION   = "RecordLocution";
+
+    const CLOSE_LOCK        = "CloseLock";
+
+    const OPEN_LOCK         = "OpenLock";
+
+    const TOGGLE_LOCK       = "ToggleLock";
+
+
     /**
      * @codeCoverageIgnore
      * @return array

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/BrandServiceDoctrineRepository.php
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/BrandServiceDoctrineRepository.php
@@ -3,6 +3,8 @@
 namespace Ivoz\Provider\Infrastructure\Persistence\Doctrine;
 
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Ivoz\Provider\Domain\Model\Brand\Brand;
+use Ivoz\Provider\Domain\Model\Brand\BrandInterface;
 use Ivoz\Provider\Domain\Model\BrandService\BrandServiceRepository;
 use Ivoz\Provider\Domain\Model\BrandService\BrandService;
 use Symfony\Bridge\Doctrine\RegistryInterface;
@@ -18,5 +20,23 @@ class BrandServiceDoctrineRepository extends ServiceEntityRepository implements 
     public function __construct(RegistryInterface $registry)
     {
         parent::__construct($registry, BrandService::class);
+    }
+
+    public function findByIden(BrandInterface $brand, string $iden)
+    {
+        $qb = $this->createQueryBuilder('self');
+        $query = $qb
+            ->select('self')
+            ->innerJoin('self.service', 'service')
+            ->where(
+                $qb->expr()->eq('self.brand', $brand->getId())
+            )
+            ->andWhere(
+                $qb->expr()->eq('service.iden', "'$iden'")
+            )
+            ->getQuery();
+
+        $result = $query->getResult();
+        return array_shift($result);
     }
 }

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/CallForwardSetting.CallForwardSettingAbstract.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/CallForwardSetting.CallForwardSettingAbstract.orm.yml
@@ -96,7 +96,7 @@ Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSettingAbstract:
       cascade: {  }
       fetch: LAZY
       mappedBy: null
-      inversedBy: null
+      inversedBy: callForwardSettings
       joinColumns:
         residentialDeviceId:
           referencedColumnName: id

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/ResidentialDevice.ResidentialDevice.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/ResidentialDevice.ResidentialDevice.orm.yml
@@ -19,3 +19,6 @@ Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDevice:
     ddis:
       targetEntity: Ivoz\Provider\Domain\Model\Ddi\DdiInterface
       mappedBy: residentialDevice
+    callForwardSettings:
+      targetEntity: Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSettingInterface
+      mappedBy: residentialDevice

--- a/scheme/app/DoctrineMigrations/Version20181019153700.php
+++ b/scheme/app/DoctrineMigrations/Version20181019153700.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20181019153700 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->addSql(
+          'INSERT IGNORE INTO ast_voicemail (
+                context,
+                mailbox,
+                tz
+            ) SELECT CONCAT("residential", id),
+              CONCAT("company", companyId),
+              "Europe/Madrid"
+              FROM ResidentialDevices'
+        );
+
+        $this->addSql('UPDATE ast_voicemail SET mailbox = CONCAT("residential", residentialDeviceId) WHERE residentialDeviceId IS NOT NULL');
+
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $this->addSql("DELETE FROM ast_voicemail WHERE residentialDeviceId IS NOT NULL");
+    }
+}

--- a/scheme/tests/Provider/ResidentialDevice/ResidentialDeviceLifeCycleTest.php
+++ b/scheme/tests/Provider/ResidentialDevice/ResidentialDeviceLifeCycleTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Provider\ResidentialDevice;
 
 use Ivoz\Ast\Domain\Model\PsEndpoint\PsEndpoint;
+use Ivoz\Ast\Domain\Model\Voicemail\Voicemail;
 use Ivoz\Cgr\Domain\Model\TpResidentialDevice\TpResidentialDevice;
 use Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDeviceDto;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -107,6 +108,7 @@ class ResidentialDeviceLifeCycleTest extends KernelTestCase
         $this->assetChangedEntities([
             ResidentialDevice::class,
             PsEndpoint::class,
+            Voicemail::class
         ]);
     }
 
@@ -118,7 +120,8 @@ class ResidentialDeviceLifeCycleTest extends KernelTestCase
         $this->updateResidentialDevice();
         $this->assetChangedEntities([
             ResidentialDevice::class,
-            PsEndpoint::class,
+            Voicemail::class,
+            PsEndpoint::class
         ]);
     }
 

--- a/web/admin/application/configs/klear/CallForwardSettingsList.yaml
+++ b/web/admin/application/configs/klear/CallForwardSettingsList.yaml
@@ -33,6 +33,8 @@ production:
           extension: true
           voiceMailUser: true
           noAnswerTimeout: true
+          user: true
+          residentialDevice: true
       options:
         title: _("Options")
         screens:
@@ -53,6 +55,9 @@ production:
       fields:
         blacklist:
           targetTypeValue: true
+          user: true
+          residentialDevice: true
+          voiceMailUser: ${auth.companyResidential}
         order: &callForwardSettingsOrder_Link
           enabled: true
           targetType: true
@@ -72,6 +77,7 @@ production:
             numberValue: 2
             extension: 3
             voiceMailUser: 3
+
     callForwardSettingsEdit_screen: &callForwardSettingsEdit_screenLink 
       <<: *CallForwardSettings
       controller: edit
@@ -81,6 +87,9 @@ production:
       fields:
         blacklist:
           targetTypeValue: true
+          user: true
+          residentialDevice: true
+          voiceMailUser: ${auth.companyResidential}
         order:
           <<: *callForwardSettingsOrder_Link
       fixedPositions:

--- a/web/admin/application/configs/klear/ResidentialDevicesList.yaml
+++ b/web/admin/application/configs/klear/ResidentialDevicesList.yaml
@@ -1,6 +1,7 @@
 #include conf.d/mapperList.yaml
 #include conf.d/actions.yaml
 #include conf.d/documentationLink.yaml
+#include CallForwardSettingsList.yaml
 
 production:
   main:
@@ -49,6 +50,7 @@ production:
           title: _("Options")
           screens:
             residentialDevicesEdit_screen: ${auth.canSeeBrand}
+            callForwardSettingsList_screen: true
           dialogs:
             residentialDevicesDel_dialog: ${auth.canSeeBrand}
           default: residentialDevicesEdit_screen
@@ -157,6 +159,26 @@ production:
         <<: *forcedCompany
         <<: *forcedBrand
 
+    # CallForwardSettings:
+    <<: *callForwardSettings_screensLink
+    callForwardSettingsList_screen:
+      <<: *callForwardSettingsList_screenLink
+      filterField: residentialDevice
+      parentOptionCustomizer:
+        - recordCount
+      forcedValues:
+        callTypeFilter: both
+    callForwardSettingsNew_screen:
+      <<: *callForwardSettingsNew_screenLink
+      filterField: residentialDevice
+      forcedValues:
+        callTypeFilter: both
+    callForwardSettingsEdit_screen:
+      <<: *callForwardSettingsEdit_screenLink
+      filterField: residentialDevice
+      forcedValues:
+        callTypeFilter: both
+
   dialogs: &residentialDevices_dialogsLink
     residentialDevicesDel_dialog: &residentialDevicesDel_dialogLink
       <<: *ResidentialDevices
@@ -168,6 +190,10 @@ production:
       message: _("%s successfully deleted.", ngettext('Residential Device', 'Residential Devices', 1))
       multiItem: 1
       labelOnList: 1
+
+    # CallForwardSettings dialogs:
+    <<: *callForwardSettings_dialogsLink
+
 
   commands:
     generatePassword_command:

--- a/web/admin/application/configs/klear/model/CallForwardSettings.yaml
+++ b/web/admin/application/configs/klear/model/CallForwardSettings.yaml
@@ -16,6 +16,21 @@ production:
           order:
             User.name: asc
       default: true
+    residentialDevice:
+      title: ngettext('Residential Device', 'Residential Devices', 1)
+      type: select
+      required: true
+      source:
+        data: mapper
+        config:
+          entity: \Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDevice
+          fieldName:
+            fields:
+              - name
+            template: '%name%'
+          order:
+            ResidentialDevice.name: asc
+      default: true
     callTypeFilter:
       title: _('Call type')
       type: select
@@ -55,6 +70,7 @@ production:
       required: true
       source:
         data: inline
+        filterClass: IvozProvider_Klear_Filter_TargetTypes
         values:
           'number':
             title: _('Number')

--- a/web/admin/application/library/IvozProvider/Klear/Filter/TargetTypes.php
+++ b/web/admin/application/library/IvozProvider/Klear/Filter/TargetTypes.php
@@ -1,0 +1,51 @@
+<?php
+
+use Ivoz\Core\Application\Service\DataGateway;
+use Ivoz\Provider\Domain\Model\Company\Company;
+use Ivoz\Provider\Domain\Model\Company\CompanyDto;
+
+/**
+ * Class IvozProvider_Klear_Filter_TargetTypes
+ *
+ * Filter Call Forward settings based on client type
+ */
+class IvozProvider_Klear_Filter_TargetTypes implements KlearMatrix_Model_Field_Select_Filter_Interface
+{
+
+    public function setRouteDispatcher(KlearMatrix_Model_RouteDispatcher $routeDispatcher)
+    {
+        return true;
+    }
+
+    /**
+     * Get Call forward types based on company type
+     * @return array
+     */
+    public function getCondition()
+    {
+        $auth = Zend_Auth::getInstance();
+        $user = $auth->getIdentity();
+
+        /** @var DataGateway $dataGateway */
+        $dataGateway = \Zend_Registry::get('data_gateway');
+
+        /** @var CompanyDto $companyDto */
+        $companyDto = $dataGateway->find(
+            Company::class,
+            $user->companyId
+        );
+
+        if (is_null($companyDto)) {
+            // No company feature to filter by
+            return [];
+        }
+
+        $excludedRoutes = [];
+
+        if ($companyDto->getType() !== Company::VPBX) {
+            $excludedRoutes[] = "extension";
+        }
+
+        return $excludedRoutes;
+    }
+}


### PR DESCRIPTION
This PR fixes #545 by implementing required logics in AGIs and interface to enable Call Forward Settings for Residential Devices.

This feature already existed in Oasis release and the fields in the tables already existed, so no API changes should occur. Scheme changes only create any missing asterisk voicemails and update their information.