### PR TITLE
web/admin: hide Rest API private administrator from lists

### DIFF
--- a/web/admin/application/configs/klear/AdministratorsList.yaml
+++ b/web/admin/application/configs/klear/AdministratorsList.yaml
@@ -14,6 +14,7 @@ production:
       <<: *Administrators
       class: fa fa-users red
       title: _("List of %s %2s", ngettext('Main operator', 'Main operators', 0), "[format| (%parent%)]")
+      rawCondition: "Administrator.id != 0"
       info:
         <<: *documentationLink
         href: "/doc/en/administration_portal/platform/main_operators.html"


### PR DESCRIPTION
Private administrator (Administrator with id = 0) is an internal user used for Rest API requests (afaik).
This administrator should not be visible in Main operators list.