### PR TITLE
microservices: call recordings in bounced calls

### DIFF
--- a/library/DataFixtures/ORM/KamTrunksCdr.php
+++ b/library/DataFixtures/ORM/KamTrunksCdr.php
@@ -6,10 +6,10 @@ use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Ivoz\Kam\Domain\Model\UsersCdr\UsersCdr;
-use Ivoz\Kam\Domain\Model\UsersCdr\UsersCdrInterface;
+use Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdr;
+use Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdrInterface;
 
-class KamUsersCdr extends Fixture implements DependentFixtureInterface
+class KamTrunksCdr extends Fixture implements DependentFixtureInterface
 {
     use \DataFixtures\FixtureHelperTrait;
 
@@ -19,24 +19,27 @@ class KamUsersCdr extends Fixture implements DependentFixtureInterface
     public function load(ObjectManager $manager)
     {
         $this->disableLifecycleEvents($manager);
-        $manager->getClassMetadata(UsersCdr::class)->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_NONE);
+        $manager->getClassMetadata(TrunksCdr::class)->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_NONE);
 
-        /** @var UsersCdrInterface $item1 */
-        $item1 = $this->createEntityInstanceWithPublicMethods(UsersCdr::class);
+        /** @var TrunksCdrInterface $item1 */
+        $item1 = $this->createEntityInstanceWithPublicMethods(TrunksCdr::class);
         $item1->setStartTime(new \DateTime('2018-11-22 16:54:49'));
         $item1->setEndTime(new \DateTime('2018-11-22 16:54:54'));
-        $item1->setDuration(4.539);
+        $item1->setDuration(4.765);
         $item1->setDirection('outbound');
-        $item1->setCaller('102');
-        $item1->setCallee('+34676896561');
-        $item1->setCallid('9297bdde-309cd48f@10.10.1.123');
-        $item1->setCallidHash('517fa1eb');
+
+        $item1->setCaller('+3494696823899');
+        $item1->setCallee('+34676238611');
+        $item1->setCallid('1262640e-18d5-4641-880d-e4f411786711');
+        $item1->setCallidHash('2789d532');
+        $item1->setXcallid('9297bdde-309cd48f@10.10.1.123');
+        $item1->setMetered(0);
 
         $item1->setBrand($this->getReference('_reference_ProviderBrand1'));
         $item1->setCompany($this->getReference('_reference_ProviderCompany1'));
-        $item1->setUser($this->getReference('_reference_ProviderUser1'));
+        $item1->setCarrier($this->getReference('_reference_ProviderCarrier1'));
 
-        $this->addReference('_reference_KamUsersCdr1', $item1);
+        $this->addReference('_reference_KamTrunksCdr1', $item1);
         $this->sanitizeEntityValues($item1);
         $manager->persist($item1);
 
@@ -48,7 +51,7 @@ class KamUsersCdr extends Fixture implements DependentFixtureInterface
         return array(
             ProviderBrand::class,
             ProviderCompany::class,
-            ProviderUser::class,
+            ProviderCarrier::class,
         );
     }
 }

--- a/library/Ivoz/Kam/Domain/Model/TrunksCdr/TrunksCdrRepository.php
+++ b/library/Ivoz/Kam/Domain/Model/TrunksCdr/TrunksCdrRepository.php
@@ -25,6 +25,12 @@ interface TrunksCdrRepository extends ObjectRepository, Selectable
 
     /**
      * @param $callid
+     * @return TrunksCdrInterface[]
+     */
+    public function findByCallid($callid);
+
+    /**
+     * @param $callid
      * @return TrunksCdrInterface | null
      */
     public function findOneByCallid($callid);

--- a/library/Ivoz/Kam/Domain/Model/UsersCdr/UsersCdrRepository.php
+++ b/library/Ivoz/Kam/Domain/Model/UsersCdr/UsersCdrRepository.php
@@ -12,4 +12,16 @@ interface UsersCdrRepository extends ObjectRepository, Selectable
      * @return int
      */
     public function countByUserId($userId) :int;
+
+    /**
+     * @param $callid
+     * @return UsersCdrInterface[]
+     */
+    public function findByCallid($callid);
+
+    /**
+     * @param $callid
+     * @return UsersCdrInterface | null
+     */
+    public function findOneByCallid($callid);
 }

--- a/library/Ivoz/Kam/Infrastructure/Persistence/Doctrine/TrunksCdrDoctrineRepository.php
+++ b/library/Ivoz/Kam/Infrastructure/Persistence/Doctrine/TrunksCdrDoctrineRepository.php
@@ -9,7 +9,6 @@ use Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdr;
 use Ivoz\Core\Infrastructure\Persistence\Doctrine\Model\Helper\CriteriaHelper;
 use Ivoz\Core\Infrastructure\Persistence\Doctrine\Traits\GetGeneratorByConditionsTrait;
 use Symfony\Bridge\Doctrine\RegistryInterface;
-use Symfony\Component\Validator\Constraints\DateTime;
 
 /**
  * TrunksCdrDoctrineRepository
@@ -24,6 +23,20 @@ class TrunksCdrDoctrineRepository extends ServiceEntityRepository implements Tru
     public function __construct(RegistryInterface $registry)
     {
         parent::__construct($registry, TrunksCdr::class);
+    }
+
+    /**
+     * @param $callid
+     * @return TrunksCdrInterface[]
+     */
+    public function findByCallid($callid)
+    {
+        /** @var TrunksCdrInterface[] $response */
+        $response = $this->findBy([
+            'callid' => $callid
+        ]);
+
+        return $response;
     }
 
     /**

--- a/library/Ivoz/Kam/Infrastructure/Persistence/Doctrine/UsersCdrDoctrineRepository.php
+++ b/library/Ivoz/Kam/Infrastructure/Persistence/Doctrine/UsersCdrDoctrineRepository.php
@@ -4,6 +4,7 @@ namespace Ivoz\Kam\Infrastructure\Persistence\Doctrine;
 
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Ivoz\Kam\Domain\Model\UsersCdr\UsersCdr;
+use Ivoz\Kam\Domain\Model\UsersCdr\UsersCdrInterface;
 use Ivoz\Kam\Domain\Model\UsersCdr\UsersCdrRepository;
 use Symfony\Bridge\Doctrine\RegistryInterface;
 
@@ -33,5 +34,33 @@ class UsersCdrDoctrineRepository extends ServiceEntityRepository implements User
             ->where($qb->expr()->eq('self.user', $userId))
             ->getQuery()
             ->getSingleScalarResult();
+    }
+
+    /**
+     * @param $callid
+     * @return UsersCdrInterface[]
+     */
+    public function findByCallid($callid)
+    {
+        /** @var UsersCdrInterface[] $response */
+        $response = $this->findBy([
+            'callid' => $callid
+        ]);
+
+        return $response;
+    }
+
+    /**
+     * @param $callid
+     * @return UsersCdrInterface | null
+     */
+    public function findOneByCallid($callid)
+    {
+        /** @var UsersCdrInterface $response */
+        $response = $this->findOneBy([
+            'callid' => $callid
+        ]);
+
+        return $response;
     }
 }

--- a/microservices/recordings/src/Recording/Encoder.php
+++ b/microservices/recordings/src/Recording/Encoder.php
@@ -5,7 +5,9 @@ namespace Recording;
 use Ivoz\Core\Domain\Service\EntityPersisterInterface;
 use Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdrInterface;
 use Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdrRepository;
+use Ivoz\Kam\Domain\Model\UsersCdr\UsersCdrInterface;
 use Ivoz\Kam\Domain\Model\UsersCdr\UsersCdrRepository;
+use Ivoz\Provider\Domain\Model\Ddi\DdiRepository;
 use Ivoz\Provider\Domain\Model\Recording\RecordingDto;
 use Symfony\Bridge\Monolog\Logger;
 use Symfony\Component\Process\Process;
@@ -21,6 +23,11 @@ class Encoder
      * @var UsersCdrRepository
      */
     protected $usersCdrRepository;
+
+    /**
+     * @var DdiRepository
+     */
+    protected $ddiRepository;
 
     /**
      * @var EntityPersisterInterface
@@ -40,6 +47,7 @@ class Encoder
     public function __construct(
         TrunksCdrRepository $trunksCdrRepository,
         UsersCdrRepository $usersCdrRepository,
+        DdiRepository $ddiRepository,
         EntityPersisterInterface $entityPersister,
         string $rawRecordingsDir,
         Logger $logger
@@ -48,6 +56,7 @@ class Encoder
         $this->usersCdrRepository = $usersCdrRepository;
         $this->entityPersister = $entityPersister;
         $this->rawRecordingsDir = $rawRecordingsDir;
+        $this->ddiRepository = $ddiRepository;
         $this->logger = $logger;
     }
 
@@ -58,7 +67,7 @@ class Encoder
             'deleted' => 0,
             'skipped' => 0,
             'encoded' => 0,
-            'error'   => 0
+            'error' => 0
         );
 
         // Ignore process when recordings folder does not exist
@@ -74,8 +83,9 @@ class Encoder
                 $filenameabs = $this->rawRecordingsDir . $filename;
 
                 // Only handle files
-                if (!is_file($filenameabs))
+                if (!is_file($filenameabs)) {
                     continue;
+                }
 
                 // Delete empty files
                 if (filesize($filenameabs) === 0) {
@@ -89,7 +99,7 @@ class Encoder
                 if (substr($filename, -8) == "-mix.wav") {
                     array_push($files, $filename);
                 }
-           }
+            }
         }
 
         $this->logger->info(
@@ -109,26 +119,70 @@ class Encoder
             }
 
             // Get Call-Id hash id
-            $hashid = substr(md5($callid),0,8);
+            $hashid = substr(md5($callid), 0, 8);
 
             // Get callid from file
             $this->logger->info(sprintf("[Recordings][%s] Checking file %s\n", $hashid, $file));
 
-            // Look if the converstation with that id has ended
-            /** @var TrunksCdrInterface $kamAccCdr */
-            $kamAccCdr = $this->trunksCdrRepository->findOneByCallid($callid);
-            if ($kamAccCdr) {
-                $type = 'ddi';
-                if ($kamAccCdr->getXcallid()) {
-                    // If call first leg, caller is who activated the recording
-                    $recorder = $kamAccCdr->getCaller();
-                } else {
-                    // If call second leg, callee is who activated the recording
-                    $recorder = $kamAccCdr->getCallee();
-                }
-            } else {
-                $kamAccCdr = $this->usersCdrRepository->findOneByCallid($callid);
-                if ($kamAccCdr) {
+            // Look if the conversation with that id has ended
+            $kamAccCdrs = [];
+            $kamAccCdrs = array_merge(
+                $kamAccCdrs,
+                $this->trunksCdrRepository->findByCallid($callid)
+            );
+            if (empty($kamAccCdrs)) {
+                $kamAccCdrs = array_merge(
+                    $kamAccCdrs,
+                    $this->usersCdrRepository->findByCallid($callid)
+                );
+            }
+
+            if (empty($kamAccCdrs)) {
+                $stats['skipped']++;
+                $this->logger->info(sprintf(
+                    "[Recordings][%s] Call with id = %s has not yet finished!\n",
+                    $hashid,
+                    $callid
+                ));
+                continue;
+            }
+
+            // Set recording filenames
+            $convertWav = $this->rawRecordingsDir . $filename;
+            $convertMp3 = $this->rawRecordingsDir . $callid . ".mp3";
+            $metadata = 'artist="' . $callid . '"';
+
+            foreach ($kamAccCdrs as $kamAccCdr) {
+
+                if ($kamAccCdr instanceof TrunksCdrInterface) {
+                    $type = 'ddi';
+                    $direction = $kamAccCdr->getDirection();
+
+                    if ($direction == 'outbound') {
+                        // If call first leg, caller is who activated the recording
+                        $recorder = $kamAccCdr->getCaller();
+                    } else {
+                        // If call second leg, callee is who activated the recording
+                        $recorder = $kamAccCdr->getCallee();
+                    }
+
+                    // Check this ddi has recording enabled
+                    $ddi = $this->ddiRepository->findOneByDdiE164($recorder);
+                    if (!$ddi) {
+                        $this->logger->error(
+                            sprintf("[Recordings][%s] Unable to find DDI for %s\n", $hashid, $recorder)
+                        );
+                        continue;
+                    }
+
+                    if (!in_array($ddi->getRecordCalls(), array('all', $direction), true)) {
+                        $this->logger->info(
+                            sprintf("[Recordings][%s] %s has no %s recording enabled. Skipping.\n",
+                                $hashid, $ddi, $recorder)
+                        );
+                        continue;
+                    }
+                } elseif ($kamAccCdr instanceof UsersCdrInterface) {
                     $type = 'ondemand';
                     if ($kamAccCdr->getXcallid()) {
                         // If call second leg, callee is who activated the recording
@@ -138,88 +192,85 @@ class Encoder
                         $recorder = $kamAccCdr->getCaller();
                     }
                 } else {
-                    $stats['skipped']++;
-                    $this->logger->info(sprintf("[Recordings][%s] Call with id = %s has not yet finished!\n", $hashid, $callid));
+                    // This should not even be possible
+                    $this->logger->error(sprintf("[Recordings][ERROR] Invalid CDR entries for %s\n", $callid));
                     continue;
                 }
-            }
 
-            // Convert .wav to .mp3
-            $convertWav = $this->rawRecordingsDir . $filename;
-            $convertMp3 = $this->rawRecordingsDir . $callid . ".mp3";
-            $metadata = 'artist="'. $callid .'"';
-            $this->logger->info(sprintf("[Recordings][%s] Encoding to %s\n", $hashid, basename($convertMp3)));
+                // Convert .wav to .mp3
+                $this->logger->info(sprintf("[Recordings][%s] Encoding to %s\n", $hashid, basename($convertMp3)));
 
-            $convertProcess = new Process([
-                "/usr/bin/avconv",
-                "-y",
-                "-i",
-                $convertWav,
-                "-metadata",
-                $metadata,
-                $convertMp3
-            ]);
-            $convertProcess->mustRun();
+                $convertProcess = new Process([
+                    "/usr/bin/avconv",
+                    "-y",
+                    "-i",
+                    $convertWav,
+                    "-metadata",
+                    $metadata,
+                    $convertMp3
+                ]);
+                $convertProcess->mustRun();
 
-            if ($convertProcess->getExitCode() != 0) {
-                $stats['error']++;
-                $this->logger->error(
-                    sprintf(
-                        "[Recordings][%s] Failed to convert audio: Command was %s\n",
-                        $hashid,
-                        $convertProcess->getCommandLine()
-                    )
+                if ($convertProcess->getExitCode() != 0) {
+                    $stats['error']++;
+                    $this->logger->error(
+                        sprintf(
+                            "[Recordings][%s] Failed to convert audio: Command was %s\n",
+                            $hashid,
+                            $convertProcess->getCommandLine()
+                        )
+                    );
+                    continue;
+                }
+
+                // Get created mp3 information
+                $mp3info = new \Zend_Media_Mpeg_Abs($convertMp3);
+                $duration = $mp3info->getLengthEstimate();
+
+                // Create an entry in Recordings table with the file
+                $recordingDto = new RecordingDto();
+
+                // Get company and brand for this recording
+                $company = $kamAccCdr->getCompany();
+
+                $callDate = $kamAccCdr->getStartTime();
+                $caller = $kamAccCdr->getCaller();
+                $callee = $kamAccCdr->getCallee();
+
+                $baseName =
+                    $callDate->format('YmdHis')
+                    . '_'
+                    . $type
+                    . '-'
+                    . str_replace('+', '', $recorder)
+                    . '_'
+                    . str_replace('+', '', $caller)
+                    . '_'
+                    . str_replace('+', '', $callee)
+                    . '.mp3';
+
+                $recordingDto->setCompanyId($company->getId())
+                    ->setCalldate($callDate)
+                    ->setType($type)
+                    ->setRecorder($recorder)
+                    ->setCallid($kamAccCdr->getCallid())
+                    ->setDuration($duration)
+                    ->setCaller($kamAccCdr->getCaller())
+                    ->setCallee($kamAccCdr->getCallee())
+                    ->setRecordedFileBaseName($baseName)
+                    ->setRecordedFilePath($convertMp3);
+
+                // Store this Recording
+                $recording = $this->entityPersister->persistDto($recordingDto, null, true);
+                $this->logger->info(
+                    sprintf("[Recordings][%s] Create Recordings entry with id %s\n", $hashid, $recording->getId())
                 );
-                continue;
+                $stats['encoded']++;
             }
-
-            // Get created mp3 information
-            $mp3info = new \Zend_Media_Mpeg_Abs($convertMp3);
-            $duration = $mp3info->getLengthEstimate();
-
-            // Create an entry in Recordings table with the file
-            $recordingDto = new RecordingDto();
-
-            // Get company and brand for this recording
-            $company = $kamAccCdr->getCompany();
-
-            $callDate = $kamAccCdr->getStartTime();
-            $caller = $kamAccCdr->getCaller();
-            $callee = $kamAccCdr->getCallee();
-
-            $baseName =
-                $callDate->format('YmdHis')
-                . '_'
-                . $type
-                . '-'
-                . $recorder
-                . '_'
-                . str_replace('+', '', $caller)
-                . '_'
-                . str_replace('+', '', $callee)
-                . '.mp3';
-
-            $recordingDto->setCompanyId($company->getId())
-                ->setCalldate($callDate)
-                ->setType($type)
-                ->setRecorder($recorder)
-                ->setCallid($kamAccCdr->getCallid())
-                ->setDuration($duration)
-                ->setCaller($kamAccCdr->getCaller())
-                ->setCallee($kamAccCdr->getCallee())
-                ->setRecordedFileBaseName($baseName)
-                ->setRecordedFilePath($convertMp3);
-
-            // Store this Recording
-            $recording = $this->entityPersister->persistDto($recordingDto, null, true);
-            $this->logger->info(
-                sprintf("[Recordings][%s] Create Recordings entry with id %s\n", $hashid, $recording->getId())
-            );
 
             // Remove encoded files
             unlink($convertWav);
-            $stats['encoded']++;
-       }
+        }
 
         // Total processed calls
         $total = $stats['encoded'] + $stats['error'] + $stats['deleted'] + $stats['skipped'];

--- a/scheme/tests/Kam/TrunksCdr/TrunksCdrRepositoryTest.php
+++ b/scheme/tests/Kam/TrunksCdr/TrunksCdrRepositoryTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Tests\Provider\TrunksCdr;
+
+use Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdrInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\DbIntegrationTestHelperTrait;
+use Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdr;
+use Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdrRepository;
+
+class TrunksCdrRepositoryTest extends KernelTestCase
+{
+    use DbIntegrationTestHelperTrait;
+
+    /**
+     * @test
+     */
+    public function its_instantiable()
+    {
+        /** @var TrunksCdrRepository $repository */
+        $repository = $this
+            ->em
+            ->getRepository(TrunksCdr::class);
+
+        $this->assertInstanceOf(
+            TrunksCdrRepository::class,
+            $repository
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_finds_by_callid()
+    {
+        /** @var TrunksCdrRepository $repository */
+        $repository = $this
+            ->em
+            ->getRepository(TrunksCdr::class);
+
+        $result = $repository
+            ->findByCallid('1262640e-18d5-4641-880d-e4f411786711');
+
+        $this->assertCount(
+            1,
+            $result
+        );
+
+        $this->assertInstanceOf(
+            TrunksCdrInterface::class,
+            $result[0]
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_finds_one_by_callid()
+    {
+        /** @var TrunksCdrRepository $repository */
+        $repository = $this
+            ->em
+            ->getRepository(TrunksCdr::class);
+
+        $result = $repository
+            ->findOneByCallid('1262640e-18d5-4641-880d-e4f411786711');
+
+        $this->assertInstanceOf(
+            TrunksCdrInterface::class,
+            $result
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_finds_unmeteredCalls()
+    {
+        /** @var TrunksCdrRepository $repository */
+        $repository = $this
+            ->em
+            ->getRepository(TrunksCdr::class);
+
+        $result = $repository
+            ->getUnmeteredCallsGeneratorWithoutOffset(1000);
+
+        $this->assertInstanceOf(
+            \Generator::class,
+            $result
+        );
+
+        foreach ($result as $item) {
+            $this->assertInstanceOf(
+                TrunksCdrInterface::class,
+                $item[0]
+            );
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function it_resets_metered_calls()
+    {
+        /** @var TrunksCdrRepository $repository */
+        $repository = $this
+            ->em
+            ->getRepository(TrunksCdr::class);
+
+        $result = $repository
+            ->resetMetered([1,2,3]);
+
+        $this->assertNotEmpty($result);
+    }
+
+
+}

--- a/scheme/tests/Kam/UsersCdr/UsersCdrRepositoryTest.php
+++ b/scheme/tests/Kam/UsersCdr/UsersCdrRepositoryTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Tests\Provider\UsersCdr;
+
+use Ivoz\Kam\Domain\Model\UsersCdr\UsersCdrInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\DbIntegrationTestHelperTrait;
+use Ivoz\Kam\Domain\Model\UsersCdr\UsersCdr;
+use Ivoz\Kam\Domain\Model\UsersCdr\UsersCdrRepository;
+
+class UsersCdrRepositoryTest extends KernelTestCase
+{
+    use DbIntegrationTestHelperTrait;
+
+    /**
+     * @test
+     */
+    public function its_instantiable()
+    {
+        /** @var UsersCdrRepository $repository */
+        $repository = $this
+            ->em
+            ->getRepository(UsersCdr::class);
+
+        $this->assertInstanceOf(
+            UsersCdrRepository::class,
+            $repository
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_counts_by_userId()
+    {
+        /** @var UsersCdrRepository $repository */
+        $repository = $this
+            ->em
+            ->getRepository(UsersCdr::class);
+
+        $result = $repository
+            ->countByUserId(1);
+
+        $this->AssertEquals(
+            1,
+            $result
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_finds_by_callid()
+    {
+        /** @var UsersCdrRepository $repository */
+        $repository = $this
+            ->em
+            ->getRepository(UsersCdr::class);
+
+        $result = $repository
+            ->findByCallid('9297bdde-309cd48f@10.10.1.123');
+
+        $this->assertCount(
+            1,
+            $result
+        );
+
+        $this->assertInstanceOf(
+            UsersCdrInterface::class,
+            $result[0]
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_finds_one_by_callid()
+    {
+        /** @var UsersCdrRepository $repository */
+        $repository = $this
+            ->em
+            ->getRepository(UsersCdr::class);
+
+        $result = $repository
+            ->findOneByCallid('9297bdde-309cd48f@10.10.1.123');
+
+        $this->assertInstanceOf(
+            UsersCdrInterface::class,
+            $result
+        );
+    }
+
+}


### PR DESCRIPTION
Improve Recordings encoder to handle multiple Cdrs entries for each Call-Id (like in bounced calls). The core tagged commit is not necessary if #734 is merged before this.

This PR fixes #549