### PR TITLE
Fix userportal logo when filename has spaces

### DIFF
--- a/web/rest/client/src/Controller/My/WebThemeAction.php
+++ b/web/rest/client/src/Controller/My/WebThemeAction.php
@@ -60,7 +60,7 @@ class WebThemeAction
             . '/fso/brandUrl/'
             . $brandUrlDto->getId()
             . '-'
-            . $brandUrlDto->getLogoBaseName();
+            . urlencode($brandUrlDto->getLogoBaseName());
 
         return new WebTheme(
             $brandUrlDto->getName(),


### PR DESCRIPTION
User's portal download the company logo to be displayed from an URL provider in the /web_theme request. When the filename to be download contained spaces, the URL provided was not properly encoded.

This PR urlencodes the filename to return valid Logo URLs.

By the way: I found WebThemeAction twice: one in platform API and another one in client API. I've only changed the client one. Not sure if the other one is deprecated or something.