### PR TITLE
core: residential retail uniqueness

### DIFF
--- a/library/Ivoz/Provider/Domain/Model/ResidentialDevice/ResidentialDeviceRepository.php
+++ b/library/Ivoz/Provider/Domain/Model/ResidentialDevice/ResidentialDeviceRepository.php
@@ -4,8 +4,14 @@ namespace Ivoz\Provider\Domain\Model\ResidentialDevice;
 
 use Doctrine\Common\Persistence\ObjectRepository;
 use Doctrine\Common\Collections\Selectable;
+use Ivoz\Provider\Domain\Model\Domain\DomainInterface;
 
 interface ResidentialDeviceRepository extends ObjectRepository, Selectable
 {
-
+    /**
+     * @inheritdoc
+     * @param DomainInterface $domain
+     * @return mixed
+     */
+    public function findOneByNameAndDomain(string $name, DomainInterface $domain);
 }

--- a/library/Ivoz/Provider/Domain/Model/RetailAccount/RetailAccountRepository.php
+++ b/library/Ivoz/Provider/Domain/Model/RetailAccount/RetailAccountRepository.php
@@ -4,8 +4,14 @@ namespace Ivoz\Provider\Domain\Model\RetailAccount;
 
 use Doctrine\Common\Persistence\ObjectRepository;
 use Doctrine\Common\Collections\Selectable;
+use Ivoz\Provider\Domain\Model\Domain\DomainInterface;
 
 interface RetailAccountRepository extends ObjectRepository, Selectable
 {
-
+    /**
+     * @inheritdoc
+     * @param DomainInterface $domain
+     * @return mixed
+     */
+    public function findOneByNameAndDomain(string $name, DomainInterface $domain);
 }

--- a/library/Ivoz/Provider/Domain/Service/ResidentialDevice/CheckUniqueness.php
+++ b/library/Ivoz/Provider/Domain/Service/ResidentialDevice/CheckUniqueness.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Ivoz\Provider\Domain\Service\ResidentialDevice;
+
+use Ivoz\Core\Application\Service\EntityTools;
+use Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDeviceInterface;
+use Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountRepository;
+use Zend\EventManager\Exception\DomainException;
+
+/**
+ * Class CheckUniqueness
+ * @package Ivoz\Provider\Domain\Service\ResidentialDevice
+ */
+class CheckUniqueness implements ResidentialDeviceLifecycleEventHandlerInterface
+{
+    const PRE_PERSIST_PRIORITY = self::PRIORITY_NORMAL;
+
+    /**
+     * @var EntityTools
+     */
+    protected $entityTools;
+
+    /**
+     * @var RetailAccountRepository
+     */
+    protected $retailAccountRepository;
+
+    public function __construct(
+        RetailAccountRepository $retailAccountRepository
+    ) {
+        $this->retailAccountRepository = $retailAccountRepository;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            self::EVENT_PRE_PERSIST => self::PRE_PERSIST_PRIORITY
+        ];
+    }
+
+    /**
+     * Check username and domain is unique in the whole platform
+     *
+     * @param ResidentialDeviceInterface $residentialDevice
+     * @param $isNew
+     */
+    public function execute(ResidentialDeviceInterface $residentialDevice, $isNew)
+    {
+        $retailAccount = $this->retailAccountRepository
+            ->findOneByNameAndDomain(
+                $residentialDevice->getName(),
+                $residentialDevice->getDomain()
+            );
+
+        if ($retailAccount) {
+            throw new DomainException("There is already a retail account with that name.", 30005);
+        }
+    }
+}

--- a/library/Ivoz/Provider/Domain/Service/RetailAccount/CheckUniqueness.php
+++ b/library/Ivoz/Provider/Domain/Service/RetailAccount/CheckUniqueness.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Ivoz\Provider\Domain\Service\RetailAccount;
+
+use Ivoz\Core\Application\Service\EntityTools;
+use Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDeviceRepository;
+use Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface;
+use Zend\EventManager\Exception\DomainException;
+
+/**
+ * Class CheckUniqueness
+ * @package Ivoz\Provider\Domain\Service\RetailAccount
+ */
+class CheckUniqueness implements RetailAccountLifecycleEventHandlerInterface
+{
+    const PRE_PERSIST_PRIORITY = self::PRIORITY_NORMAL;
+
+    /**
+     * @var EntityTools
+     */
+    protected $entityTools;
+
+    /**
+     * @var ResidentialDeviceRepository
+     */
+    protected $residentialDeviceRepository;
+
+    public function __construct(
+        ResidentialDeviceRepository $residentialDeviceRepository
+    ) {
+        $this->residentialDeviceRepository = $residentialDeviceRepository;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            self::EVENT_PRE_PERSIST => self::PRE_PERSIST_PRIORITY
+        ];
+    }
+
+    /**
+     * Check username and domain is unique in the whole platform
+     *
+     * @param RetailAccountInterface $retailAccount
+     * @param $isNew
+     */
+    public function execute(RetailAccountInterface $retailAccount, $isNew)
+    {
+        $retailAccount = $this->residentialDeviceRepository
+            ->findOneByNameAndDomain(
+                $retailAccount->getName(),
+                $retailAccount->getDomain()
+            );
+
+        if ($retailAccount) {
+            throw new DomainException("There is already a residential device with that name.", 30006);
+        }
+    }
+}

--- a/library/Ivoz/Provider/Domain/Service/RetailAccount/RetailAccountLifecycleEventHandlerInterface.php
+++ b/library/Ivoz/Provider/Domain/Service/RetailAccount/RetailAccountLifecycleEventHandlerInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Ivoz\Provider\Domain\Service\RetailAccount;
+
+use Ivoz\Core\Domain\Service\LifecycleEventHandlerInterface;
+use Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface;
+
+interface RetailAccountLifecycleEventHandlerInterface extends LifecycleEventHandlerInterface
+{
+    public function execute(RetailAccountInterface $entity, $isNew);
+}

--- a/library/Ivoz/Provider/Domain/Service/RetailAccount/RetailAccountLifecycleServiceCollection.php
+++ b/library/Ivoz/Provider/Domain/Service/RetailAccount/RetailAccountLifecycleServiceCollection.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Ivoz\Provider\Domain\Service\RetailAccount;
+
+use Ivoz\Core\Domain\Service\LifecycleServiceCollectionInterface;
+use Ivoz\Core\Domain\Service\LifecycleServiceCollectionTrait;
+
+/**
+ * @codeCoverageIgnore
+ */
+class RetailAccountLifecycleServiceCollection implements LifecycleServiceCollectionInterface
+{
+    use LifecycleServiceCollectionTrait;
+
+    protected function addService(RetailAccountLifecycleEventHandlerInterface $service)
+    {
+        $this->services[] = $service;
+    }
+}

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/ResidentialDeviceDoctrineRepository.php
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/ResidentialDeviceDoctrineRepository.php
@@ -3,6 +3,8 @@
 namespace Ivoz\Provider\Infrastructure\Persistence\Doctrine;
 
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Ivoz\Provider\Domain\Model\Domain\DomainInterface;
+use Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDeviceInterface;
 use Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDeviceRepository;
 use Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDevice;
 use Symfony\Bridge\Doctrine\RegistryInterface;
@@ -18,5 +20,18 @@ class ResidentialDeviceDoctrineRepository extends ServiceEntityRepository implem
     public function __construct(RegistryInterface $registry)
     {
         parent::__construct($registry, ResidentialDevice::class);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function findOneByNameAndDomain(string $name, DomainInterface $domain)
+    {
+        /** @var ResidentialDeviceInterface $response */
+        $response = $this->findOneBy([
+            "name" => $name,
+            "domain" => $domain
+        ]);
+        return $response;
     }
 }

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/RetailAccountDoctrineRepository.php
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/RetailAccountDoctrineRepository.php
@@ -3,6 +3,8 @@
 namespace Ivoz\Provider\Infrastructure\Persistence\Doctrine;
 
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Ivoz\Provider\Domain\Model\Domain\DomainInterface;
+use Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface;
 use Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountRepository;
 use Ivoz\Provider\Domain\Model\RetailAccount\RetailAccount;
 use Symfony\Bridge\Doctrine\RegistryInterface;
@@ -18,5 +20,18 @@ class RetailAccountDoctrineRepository extends ServiceEntityRepository implements
     public function __construct(RegistryInterface $registry)
     {
         parent::__construct($registry, RetailAccount::class);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function findOneByNameAndDomain(string $name, DomainInterface $domain)
+    {
+        /** @var RetailAccountInterface $response */
+        $response = $this->findOneBy([
+            "name" => $name,
+            "domain" => $domain
+        ]);
+        return $response;
     }
 }

--- a/web/admin/application/configs/klear/errors.yaml
+++ b/web/admin/application/configs/klear/errors.yaml
@@ -5,6 +5,8 @@ production:
     30002: _("There is already a busy call forward with that call type.")
     30003: _("There is already a noAnswer call forward with that call type.")
     30004: _("There is already a userNotRegistered call forward with that call type.")
+    30005: _("There is already a retail account with that name.")
+    30006: _("There is already a residential device with that name.")
     30100: _("Error reloading modules. Please reload modules manually.")
     30200: _("There is a call forward with that call type. You can't add this call forward")
     40000: _("'Valid From' must be earlier than 'Valid to'")

--- a/web/admin/application/languages/en_US/en_US.po
+++ b/web/admin/application/languages/en_US/en_US.po
@@ -2366,6 +2366,12 @@ msgstr "There is already a busy call forward with that call type."
 msgid "There is already a noAnswer call forward with that call type."
 msgstr "There is already a no answer call forward with that call type."
 
+msgid "There is already a residential device with that name."
+msgstr "There is already a residential device with that name."
+
+msgid "There is already a retail account with that name."
+msgstr "There is already a retail account with that name."
+
 msgid "There is already a userNotRegistered call forward with that call type."
 msgstr ""
 "There is already a user not registered call forward with that call type."

--- a/web/admin/application/languages/es_ES/es_ES.po
+++ b/web/admin/application/languages/es_ES/es_ES.po
@@ -2394,6 +2394,12 @@ msgstr "Ya existe un desvío si ocupado con ese tipo de llamada."
 msgid "There is already a noAnswer call forward with that call type."
 msgstr "Ya existe un desvío si no contesta con ese tipo de llamada."
 
+msgid "There is already a residential device with that name."
+msgstr "Ya existe un dispositivo residencial con ese nombre."
+
+msgid "There is already a retail account with that name."
+msgstr "Ya existe una cuenta retail con ese nombre."
+
 msgid "There is already a userNotRegistered call forward with that call type."
 msgstr "Ya existe un desvío si usuario no registrado con ese tipo de llamada."
 


### PR DESCRIPTION
This PR adds two services to check Retail Accounts and Residential Devices does't have the same name. 

The same behaviour could be implemented in the future for Terminals and Friends for #308