### PR TITLE
Add Body MIME type selector to Notification Template Contents

### DIFF
--- a/asterisk/agi/src/Agi/Action/FaxReceiveStatusAction.php
+++ b/asterisk/agi/src/Agi/Action/FaxReceiveStatusAction.php
@@ -172,6 +172,7 @@ class FaxReceiveStatusAction
             // Get data from template
             $fromName = $notificationTemplateContent->getFromName();
             $fromAddress = $notificationTemplateContent->getFromAddress();
+            $bodyType = $notificationTemplateContent->getBodyType();
             $body = $notificationTemplateContent->getBody();
             $subject = $notificationTemplateContent->getSubject();
 
@@ -183,7 +184,7 @@ class FaxReceiveStatusAction
 
             // Create a new mail and attach the PDF file
             $mail = new \Swift_Message();
-            $mail->setBody($body, 'text/html')
+            $mail->setBody($body, $bodyType)
                 ->setSubject($subject)
                 ->setFrom($fromAddress, $fromName)
                 ->setTo($fax->getEmail())

--- a/asterisk/agi/src/Voicemail/Sender.php
+++ b/asterisk/agi/src/Voicemail/Sender.php
@@ -134,6 +134,7 @@ class Sender extends RouteHandlerAbstract
         // Get data from template
         $fromName = $notificationTemplateContent->getFromName();
         $fromAddress = $notificationTemplateContent->getFromAddress();
+        $bodyType = $notificationTemplateContent->getBodyType();
         $body = $notificationTemplateContent->getBody();
         $subject = $notificationTemplateContent->getSubject();
 
@@ -144,7 +145,7 @@ class Sender extends RouteHandlerAbstract
 
         // Create a new mail and attach the PDF file
         $mail = new \Swift_Message();
-        $mail->setBody($body, 'text/html')
+        $mail->setBody($body, $bodyType)
             ->setSubject($subject)
             ->setFrom($fromAddress, $fromName)
             ->setTo($vm->getEmail());

--- a/library/Ivoz/Core/Domain/Model/Mailer/Message.php
+++ b/library/Ivoz/Core/Domain/Model/Mailer/Message.php
@@ -12,6 +12,11 @@ class Message
     /**
      * @var string
      */
+    protected $bodyType;
+
+    /**
+     * @var string
+     */
     protected $subject;
 
     /**
@@ -42,7 +47,7 @@ class Message
     {
         $message = new \Swift_Message();
         $message
-            ->setBody($this->getBody(), 'text/html')
+            ->setBody($this->getBody(), $this->getBodyType())
             ->setSubject($this->getSubject())
             ->setFrom($this->getFromAddress(), $this->getFromName())
             ->setTo($this->getToAddress());
@@ -63,12 +68,22 @@ class Message
     }
 
     /**
+     * @return string
+     */
+    public function getBodyType(): string
+    {
+        return $this->bodyType;
+    }
+
+    /**
      * @param string $body
+     * @param string $bodyType
      * @return Message
      */
-    public function setBody(string $body): Message
+    public function setBody(string $body, string $bodyType = 'text/plain'): Message
     {
         $this->body = $body;
+        $this->bodyType = $bodyType;
         return $this;
     }
 

--- a/library/Ivoz/Provider/Domain/Model/NotificationTemplateContent/NotificationTemplateContentAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/NotificationTemplateContent/NotificationTemplateContentAbstract.php
@@ -34,6 +34,12 @@ abstract class NotificationTemplateContentAbstract
     protected $body;
 
     /**
+     * comment: enum:text/plain|text/html
+     * @var string
+     */
+    protected $bodyType = 'text/plain';
+
+    /**
      * @var \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateInterface
      */
     protected $notificationTemplate;
@@ -49,10 +55,11 @@ abstract class NotificationTemplateContentAbstract
     /**
      * Constructor
      */
-    protected function __construct($subject, $body)
+    protected function __construct($subject, $body, $bodyType)
     {
         $this->setSubject($subject);
         $this->setBody($body);
+        $this->setBodyType($bodyType);
     }
 
     abstract public function getId();
@@ -121,7 +128,8 @@ abstract class NotificationTemplateContentAbstract
 
         $self = new static(
             $dto->getSubject(),
-            $dto->getBody()
+            $dto->getBody(),
+            $dto->getBodyType()
         );
 
         $self
@@ -153,6 +161,7 @@ abstract class NotificationTemplateContentAbstract
             ->setFromAddress($dto->getFromAddress())
             ->setSubject($dto->getSubject())
             ->setBody($dto->getBody())
+            ->setBodyType($dto->getBodyType())
             ->setNotificationTemplate($dto->getNotificationTemplate())
             ->setLanguage($dto->getLanguage());
 
@@ -173,6 +182,7 @@ abstract class NotificationTemplateContentAbstract
             ->setFromAddress(self::getFromAddress())
             ->setSubject(self::getSubject())
             ->setBody(self::getBody())
+            ->setBodyType(self::getBodyType())
             ->setNotificationTemplate(\Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplate::entityToDto(self::getNotificationTemplate(), $depth))
             ->setLanguage(\Ivoz\Provider\Domain\Model\Language\Language::entityToDto(self::getLanguage(), $depth));
     }
@@ -187,6 +197,7 @@ abstract class NotificationTemplateContentAbstract
             'fromAddress' => self::getFromAddress(),
             'subject' => self::getSubject(),
             'body' => self::getBody(),
+            'bodyType' => self::getBodyType(),
             'notificationTemplateId' => self::getNotificationTemplate() ? self::getNotificationTemplate()->getId() : null,
             'languageId' => self::getLanguage() ? self::getLanguage()->getId() : null
         ];
@@ -305,6 +316,38 @@ abstract class NotificationTemplateContentAbstract
     public function getBody()
     {
         return $this->body;
+    }
+
+    /**
+     * @deprecated
+     * Set bodyType
+     *
+     * @param string $bodyType
+     *
+     * @return self
+     */
+    public function setBodyType($bodyType)
+    {
+        Assertion::notNull($bodyType, 'bodyType value "%s" is null, but non null value was expected.');
+        Assertion::maxLength($bodyType, 25, 'bodyType value "%s" is too long, it should have no more than %d characters, but has %d characters.');
+        Assertion::choice($bodyType, array (
+          0 => 'text/plain',
+          1 => 'text/html',
+        ), 'bodyTypevalue "%s" is not an element of the valid values: %s');
+
+        $this->bodyType = $bodyType;
+
+        return $this;
+    }
+
+    /**
+     * Get bodyType
+     *
+     * @return string
+     */
+    public function getBodyType()
+    {
+        return $this->bodyType;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/NotificationTemplateContent/NotificationTemplateContentDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/NotificationTemplateContent/NotificationTemplateContentDtoAbstract.php
@@ -33,6 +33,11 @@ abstract class NotificationTemplateContentDtoAbstract implements DataTransferObj
     private $body;
 
     /**
+     * @var string
+     */
+    private $bodyType = 'text/plain';
+
+    /**
      * @var integer
      */
     private $id;
@@ -69,6 +74,7 @@ abstract class NotificationTemplateContentDtoAbstract implements DataTransferObj
             'fromAddress' => 'fromAddress',
             'subject' => 'subject',
             'body' => 'body',
+            'bodyType' => 'bodyType',
             'id' => 'id',
             'notificationTemplateId' => 'notificationTemplate',
             'languageId' => 'language'
@@ -85,6 +91,7 @@ abstract class NotificationTemplateContentDtoAbstract implements DataTransferObj
             'fromAddress' => $this->getFromAddress(),
             'subject' => $this->getSubject(),
             'body' => $this->getBody(),
+            'bodyType' => $this->getBodyType(),
             'id' => $this->getId(),
             'notificationTemplate' => $this->getNotificationTemplate(),
             'language' => $this->getLanguage()
@@ -185,6 +192,26 @@ abstract class NotificationTemplateContentDtoAbstract implements DataTransferObj
     public function getBody()
     {
         return $this->body;
+    }
+
+    /**
+     * @param string $bodyType
+     *
+     * @return static
+     */
+    public function setBodyType($bodyType = null)
+    {
+        $this->bodyType = $bodyType;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getBodyType()
+    {
+        return $this->bodyType;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/NotificationTemplateContent/NotificationTemplateContentInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/NotificationTemplateContent/NotificationTemplateContentInterface.php
@@ -81,6 +81,23 @@ interface NotificationTemplateContentInterface extends LoggableEntityInterface
     public function getBody();
 
     /**
+     * @deprecated
+     * Set bodyType
+     *
+     * @param string $bodyType
+     *
+     * @return self
+     */
+    public function setBodyType($bodyType);
+
+    /**
+     * Get bodyType
+     *
+     * @return string
+     */
+    public function getBodyType();
+
+    /**
      * Set notificationTemplate
      *
      * @param \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateInterface $notificationTemplate

--- a/library/Ivoz/Provider/Domain/Service/BalanceNotification/NotifyBrokenThreshold.php
+++ b/library/Ivoz/Provider/Domain/Service/BalanceNotification/NotifyBrokenThreshold.php
@@ -83,6 +83,7 @@ class NotifyBrokenThreshold implements DomainEventSubscriberInterface
             $name,
             $event->getCurrentBalance()
         );
+        $bodyType = $notificationContent->getBodyType();
 
         $body = $this->parseNotificationContent(
             $notificationContent->getBody(),
@@ -93,7 +94,7 @@ class NotifyBrokenThreshold implements DomainEventSubscriberInterface
         $email = new Message();
         $email
             ->setSubject($subject)
-            ->setBody($body)
+            ->setBody($body, $bodyType)
             ->setFromAddress(
                 $notificationContent->getFromAddress()
             )

--- a/library/Ivoz/Provider/Domain/Service/CallCsvReport/EmailSender.php
+++ b/library/Ivoz/Provider/Domain/Service/CallCsvReport/EmailSender.php
@@ -73,6 +73,7 @@ class EmailSender implements CallCsvReportLifecycleEventHandlerInterface
         $notificationTemplateContent = $this->getNotificationTemplateContent($callCsvReport);
         $fromName = $notificationTemplateContent->getFromName();
         $fromAddress = $notificationTemplateContent->getFromAddress();
+        $bodyType = $notificationTemplateContent->getBodyType();
         $body = $this->parseVariables(
             $callCsvReport,
             $notificationTemplateContent->getBody()
@@ -88,7 +89,7 @@ class EmailSender implements CallCsvReportLifecycleEventHandlerInterface
         );
 
         $mail = new Message();
-        $mail->setBody($body)
+        $mail->setBody($body, $bodyType)
             ->setSubject($subject)
             ->setFromAddress($fromAddress)
             ->setFromName($fromName)

--- a/library/Ivoz/Provider/Domain/Service/Invoice/EmailSender.php
+++ b/library/Ivoz/Provider/Domain/Service/Invoice/EmailSender.php
@@ -60,6 +60,7 @@ class EmailSender implements InvoiceLifecycleEventHandlerInterface
         // Get data from template
         $fromName = $notificationTemplateContent->getFromName();
         $fromAddress = $notificationTemplateContent->getFromAddress();
+        $bodyType = $notificationTemplateContent->getBodyType();
         $body = $this->parseVariables(
             $invoice,
             $notificationTemplateContent->getBody()
@@ -81,7 +82,7 @@ class EmailSender implements InvoiceLifecycleEventHandlerInterface
 
         // Create a new mail and attach the PDF file
         $mail = new \Swift_Message();
-        $mail->setBody($body, 'text/html')
+        $mail->setBody($body, $bodyType)
             ->setSubject($subject)
             ->setFrom($fromAddress, $fromName)
             ->setTo($targetEmail)

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/NotificationTemplateContent.NotificationTemplateContentAbstract.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/NotificationTemplateContent.NotificationTemplateContentAbstract.orm.yml
@@ -32,6 +32,15 @@ Ivoz\Provider\Domain\Model\NotificationTemplateContent\NotificationTemplateConte
       length: 65535
       options:
         fixed: false
+    bodyType:
+      type: string
+      nullable: false
+      length: 25
+      options:
+        fixed: false
+        default: 'text/plain'
+        comment: '[enum:text/plain|text/html]'
+      column: bodyType
   manyToOne:
     notificationTemplate:
       targetEntity: \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateInterface

--- a/library/spec/Ivoz/Provider/Domain/Service/CallCsvReport/EmailSenderSpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Service/CallCsvReport/EmailSenderSpec.php
@@ -246,6 +246,7 @@ class EmailSenderSpec extends ObjectBehavior
                 'getFromName' => 'Name',
                 'getFromAddress' => 'Address',
                 'getBody' => 'Body',
+                'getBodyType' => 'BodyType',
                 'getSubject' => 'Subject'
             ],
             false

--- a/scheme/app/DoctrineMigrations/Version20181113095345.php
+++ b/scheme/app/DoctrineMigrations/Version20181113095345.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20181113095345 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE NotificationTemplatesContents ADD bodyType VARCHAR(25) DEFAULT \'text/plain\' NOT NULL COMMENT \'[enum:text/plain|text/html]\'');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE NotificationTemplatesContents DROP bodyType');
+    }
+}

--- a/web/admin/application/configs/klear/NotificationTemplatesContentsList.yaml
+++ b/web/admin/application/configs/klear/NotificationTemplatesContentsList.yaml
@@ -18,6 +18,7 @@ production:
         blacklist:
           subject: true
           body: true
+          bodyType: true
           voicemailVariables: true
           faxVariables: true
           invoiceVariables: true
@@ -53,6 +54,7 @@ production:
           invoiceVariables: true
           lowBalanceVariables: true
           subject: true
+          bodyType: true
           body: true
       fixedPositions: &notificationTemplatesContentsFixedPositions_Link
         group0:
@@ -68,14 +70,15 @@ production:
             fromAddress: 1
         group2:
           label: _("Contents configuration")
-          colsPerRow: 1
+          colsPerRow: 12
           fields:
-            voicemailVariables: 1
-            faxVariables: 1
-            invoiceVariables: 1
-            lowBalanceVariables: 1
-            subject: 1
-            body: 1
+            voicemailVariables: 12
+            faxVariables: 12
+            invoiceVariables: 12
+            lowBalanceVariables: 12
+            bodyType: 3
+            subject: 9
+            body: 12
     notificationTemplatesContentsEdit_screen: &notificationTemplatesContentsEdit_screenLink
       <<: *NotificationTemplatesContents
       controller: edit

--- a/web/admin/application/configs/klear/model/NotificationTemplatesContents.yaml
+++ b/web/admin/application/configs/klear/model/NotificationTemplatesContents.yaml
@@ -104,6 +104,14 @@ production:
             - html
           lineNumbers: true
           matchBrackets: true
+    bodyType:
+      title: ngettext('Body type', 'Body types', 1)
+      type: select
+      source:
+        data: inline
+        values:
+          text/plain: "text/plain"
+          text/html: "text/html"
 staging:
   _extends: production
 testing:

--- a/web/admin/application/languages/en_US/en_US.po
+++ b/web/admin/application/languages/en_US/en_US.po
@@ -248,6 +248,11 @@ msgstr "Black Lists"
 msgid "Body"
 msgstr "Body"
 
+msgid "Body type"
+msgid_plural "Body types"
+msgstr[0] "Body type"
+msgstr[1] "Body types"
+
 msgid "Boss Whitelist"
 msgstr "Boss Whitelist"
 

--- a/web/admin/application/languages/es_ES/es_ES.po
+++ b/web/admin/application/languages/es_ES/es_ES.po
@@ -253,6 +253,11 @@ msgstr "Listas negras"
 msgid "Body"
 msgstr "Cuerpo"
 
+msgid "Body type"
+msgid_plural "Body types"
+msgstr[0] "Tipo de cuerpo"
+msgstr[1] "Tipos de cuerpo"
+
 msgid "Boss Whitelist"
 msgstr "Listas blanca jefe"
 

--- a/web/rest/brand/features/provider/notificationTemplateContent/getNotificationTemplateContent.feature
+++ b/web/rest/brand/features/provider/notificationTemplateContent/getNotificationTemplateContent.feature
@@ -36,6 +36,7 @@ Feature: Retrieve notification template contents
           "fromAddress": "no-reply@ivozprovider.com",
           "subject": "test subject",
           "body": "test body",
+          "bodyType": "text\/plain",
           "id": 1,
           "notificationTemplate": {
               "name": "Voicemail notification",

--- a/web/rest/brand/features/provider/notificationTemplateContent/postNotificationTemplateContent.feature
+++ b/web/rest/brand/features/provider/notificationTemplateContent/postNotificationTemplateContent.feature
@@ -43,6 +43,7 @@ Feature: Create notification template contents
           "fromAddress": null,
           "subject": "Test subject",
           "body": "Test body",
+          "bodyType": "text\/plain",
           "id": 2,
           "notificationTemplate": {
               "name": "Voicemail notification",

--- a/web/rest/brand/features/provider/notificationTemplateContent/putNotificationTemplateContent.feature
+++ b/web/rest/brand/features/provider/notificationTemplateContent/putNotificationTemplateContent.feature
@@ -27,6 +27,7 @@ Feature: Update notification template contents
           "fromAddress": "no-reply@ivozprovider.com",
           "subject": "New Test subject",
           "body": "New Test body",
+          "bodyType": "text\/plain",
           "id": 1,
           "notificationTemplate": {
               "name": "Voicemail notification",


### PR DESCRIPTION
>Mail templates newlines are not applying as text/html is used instead of text/plain (for agis tasks).
>
>This issue aims to evaluate this same change for every task that sends an email.

Edit: This PR now includes the required changes to add a new field to Notification Template Contents in order to specify the body MIME type. The supported types are _text/html_ and _text/plain_