### PR TITLE
core: terminal friend uniqueness

### DIFF
--- a/asterisk/agi/src/Helpers/EndpointResolver.php
+++ b/asterisk/agi/src/Helpers/EndpointResolver.php
@@ -96,9 +96,9 @@ class EndpointResolver
         /** @var \Ivoz\Provider\Domain\Model\Terminal\TerminalRepository $terminalRepository */
         $terminalRepository = $this->em->getRepository(Terminal::class);
         /** @var \Ivoz\Provider\Domain\Model\Terminal\TerminalInterface $terminal */
-        $terminal = $terminalRepository->findOneByNameAndDomainId(
+        $terminal = $terminalRepository->findOneByNameAndDomain(
             $endpointNum,
-            $domain->getId()
+            $domain
         );
 
         Assertion::notNull(

--- a/library/Ivoz/Provider/Domain/Model/Friend/FriendRepository.php
+++ b/library/Ivoz/Provider/Domain/Model/Friend/FriendRepository.php
@@ -4,8 +4,14 @@ namespace Ivoz\Provider\Domain\Model\Friend;
 
 use Doctrine\Common\Persistence\ObjectRepository;
 use Doctrine\Common\Collections\Selectable;
+use Ivoz\Provider\Domain\Model\Domain\DomainInterface;
 
 interface FriendRepository extends ObjectRepository, Selectable
 {
-
+    /**
+     * @inheritdoc
+     * @param DomainInterface $domain
+     * @return FriendInterface | null
+     */
+    public function findOneByNameAndDomain(string $name, DomainInterface $domain);
 }

--- a/library/Ivoz/Provider/Domain/Model/Terminal/TerminalRepository.php
+++ b/library/Ivoz/Provider/Domain/Model/Terminal/TerminalRepository.php
@@ -4,13 +4,14 @@ namespace Ivoz\Provider\Domain\Model\Terminal;
 
 use Doctrine\Common\Persistence\ObjectRepository;
 use Doctrine\Common\Collections\Selectable;
+use Ivoz\Provider\Domain\Model\Domain\DomainInterface;
 
 interface TerminalRepository extends ObjectRepository, Selectable
 {
     /**
      * @param string $name
-     * @param $domainId
+     * @param DomainInterface $domain
      * @return TerminalInterface | null
      */
-    public function findOneByNameAndDomainId(string $name, $domainId);
+    public function findOneByNameAndDomain(string $name, DomainInterface $domain);
 }

--- a/library/Ivoz/Provider/Domain/Service/Friend/CheckUniqueness.php
+++ b/library/Ivoz/Provider/Domain/Service/Friend/CheckUniqueness.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Ivoz\Provider\Domain\Service\Friend;
+
+use Ivoz\Core\Application\Service\EntityTools;
+use Ivoz\Provider\Domain\Model\Friend\FriendInterface;
+use Ivoz\Provider\Domain\Model\Terminal\TerminalRepository;
+use Zend\EventManager\Exception\DomainException;
+
+/**
+ * Class CheckUniqueness
+ * @package Ivoz\Provider\Domain\Service\Friend
+ */
+class CheckUniqueness implements FriendLifecycleEventHandlerInterface
+{
+    const PRE_PERSIST_PRIORITY = self::PRIORITY_NORMAL;
+
+    /**
+     * @var EntityTools
+     */
+    protected $entityTools;
+
+    /**
+     * @var TerminalRepository
+     */
+    protected $terminalRepository;
+
+    public function __construct(
+        TerminalRepository $terminalRepository
+    ) {
+        $this->terminalRepository = $terminalRepository;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            self::EVENT_PRE_PERSIST => self::PRE_PERSIST_PRIORITY
+        ];
+    }
+
+    /**
+     * Check username and domain is unique in the whole platform
+     *
+     * @param FriendInterface $friend
+     * @param $isNew
+     */
+    public function execute(FriendInterface $friend, $isNew)
+    {
+        $terminal = $this->terminalRepository
+            ->findOneByNameAndDomain(
+                $friend->getName(),
+                $friend->getDomain()
+            );
+
+        if ($terminal) {
+            throw new DomainException("There is already a terminal with that name.", 30008);
+        }
+    }
+}

--- a/library/Ivoz/Provider/Domain/Service/Terminal/CheckUniqueness.php
+++ b/library/Ivoz/Provider/Domain/Service/Terminal/CheckUniqueness.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Ivoz\Provider\Domain\Service\Terminal;
+
+use Ivoz\Core\Application\Service\EntityTools;
+use Ivoz\Provider\Domain\Model\Terminal\TerminalInterface;
+use Ivoz\Provider\Domain\Model\Friend\FriendRepository;
+use Zend\EventManager\Exception\DomainException;
+
+/**
+ * Class CheckUniqueness
+ * @package Ivoz\Provider\Domain\Service\Terminal
+ */
+class CheckUniqueness implements TerminalLifecycleEventHandlerInterface
+{
+    const PRE_PERSIST_PRIORITY = self::PRIORITY_NORMAL;
+
+    /**
+     * @var EntityTools
+     */
+    protected $entityTools;
+
+    /**
+     * @var FriendRepository
+     */
+    protected $friendRepository;
+
+    public function __construct(
+        FriendRepository $friendRepository
+    ) {
+        $this->friendRepository = $friendRepository;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            self::EVENT_PRE_PERSIST => self::PRE_PERSIST_PRIORITY
+        ];
+    }
+
+    /**
+     * Check username and domain is unique in the whole platform
+     *
+     * @param TerminalInterface $terminal
+     * @param $isNew
+     */
+    public function execute(TerminalInterface $terminal, $isNew)
+    {
+        $friend = $this->friendRepository
+            ->findOneByNameAndDomain(
+                $terminal->getName(),
+                $terminal->getDomain()
+            );
+
+        if ($friend) {
+            throw new DomainException("There is already a friend with that name.", 30007);
+        }
+    }
+}

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/FriendDoctrineRepository.php
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/FriendDoctrineRepository.php
@@ -3,6 +3,8 @@
 namespace Ivoz\Provider\Infrastructure\Persistence\Doctrine;
 
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Ivoz\Provider\Domain\Model\Domain\DomainInterface;
+use Ivoz\Provider\Domain\Model\Friend\FriendInterface;
 use Ivoz\Provider\Domain\Model\Friend\FriendRepository;
 use Ivoz\Provider\Domain\Model\Friend\Friend;
 use Symfony\Bridge\Doctrine\RegistryInterface;
@@ -18,5 +20,19 @@ class FriendDoctrineRepository extends ServiceEntityRepository implements Friend
     public function __construct(RegistryInterface $registry)
     {
         parent::__construct($registry, Friend::class);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function findOneByNameAndDomain(string $name, DomainInterface $domain)
+    {
+        /** @var FriendInterface $response */
+        $response = $this->findOneBy([
+            "name" => $name,
+            "domain" => $domain
+        ]);
+
+        return $response;
     }
 }

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/TerminalDoctrineRepository.php
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/TerminalDoctrineRepository.php
@@ -3,6 +3,7 @@
 namespace Ivoz\Provider\Infrastructure\Persistence\Doctrine;
 
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Ivoz\Provider\Domain\Model\Domain\DomainInterface;
 use Ivoz\Provider\Domain\Model\Terminal\TerminalRepository;
 use Ivoz\Provider\Domain\Model\Terminal\TerminalInterface;
 use Ivoz\Provider\Domain\Model\Terminal\Terminal;
@@ -23,15 +24,15 @@ class TerminalDoctrineRepository extends ServiceEntityRepository implements Term
 
     /**
      * @param string $name
-     * @param $domainId
+     * @param DomainInterface $domain
      * @return TerminalInterface | null
      */
-    public function findOneByNameAndDomainId(string $name, $domainId)
+    public function findOneByNameAndDomain(string $name, DomainInterface $domain)
     {
         /** @var TerminalInterface $response */
         $response = $this->findOneBy([
             'name' => $name,
-            'domain' => $domainId
+            'domain' => $domain
         ]);
 
         return $response;

--- a/web/admin/application/configs/klear/errors.yaml
+++ b/web/admin/application/configs/klear/errors.yaml
@@ -7,6 +7,8 @@ production:
     30004: _("There is already a userNotRegistered call forward with that call type.")
     30005: _("There is already a retail account with that name.")
     30006: _("There is already a residential device with that name.")
+    30007: _("There is already a friend with that name.")
+    30008: _("There is already a terminal with that name.")
     30100: _("Error reloading modules. Please reload modules manually.")
     30200: _("There is a call forward with that call type. You can't add this call forward")
     40000: _("'Valid From' must be earlier than 'Valid to'")

--- a/web/admin/application/languages/en_US/en_US.po
+++ b/web/admin/application/languages/en_US/en_US.po
@@ -2367,6 +2367,9 @@ msgstr ""
 msgid "There is already a busy call forward with that call type."
 msgstr "There is already a busy call forward with that call type."
 
+msgid "There is already a friend with that name."
+msgstr "There is already a friend with that name."
+
 msgid "There is already a noAnswer call forward with that call type."
 msgstr "There is already a no answer call forward with that call type."
 
@@ -2375,6 +2378,9 @@ msgstr "There is already a residential device with that name."
 
 msgid "There is already a retail account with that name."
 msgstr "There is already a retail account with that name."
+
+msgid "There is already a terminal with that name."
+msgstr "There is already a terminal with that name."
 
 msgid "There is already a userNotRegistered call forward with that call type."
 msgstr ""

--- a/web/admin/application/languages/es_ES/es_ES.po
+++ b/web/admin/application/languages/es_ES/es_ES.po
@@ -2395,6 +2395,9 @@ msgstr ""
 msgid "There is already a busy call forward with that call type."
 msgstr "Ya existe un desvío si ocupado con ese tipo de llamada."
 
+msgid "There is already a friend with that name."
+msgstr "Ya existe un friend con ese nombre."
+
 msgid "There is already a noAnswer call forward with that call type."
 msgstr "Ya existe un desvío si no contesta con ese tipo de llamada."
 
@@ -2403,6 +2406,9 @@ msgstr "Ya existe un dispositivo residencial con ese nombre."
 
 msgid "There is already a retail account with that name."
 msgstr "Ya existe una cuenta retail con ese nombre."
+
+msgid "There is already a terminal with that name."
+msgstr "Ya existe un terminal con ese nombre."
 
 msgid "There is already a userNotRegistered call forward with that call type."
 msgstr "Ya existe un desvío si usuario no registrado con ese tipo de llamada."


### PR DESCRIPTION
This PR is like #753 for Terminals and Friends.

The added services check Terminal and Friends does't have the same name in the same Company (or, in other words, with the same domain).

The TerminalRepository already had a method to find by name and domain, but I have update its signature so now is like the Residential Device, Friend, Retail Account ones. That's the reason why an agi commit is present in the PR.

This fixes #308