### PR TITLE
web/admin: do not use development env by default anymore

### DIFF
--- a/web/admin/public/dev.php
+++ b/web/admin/public/dev.php
@@ -8,4 +8,5 @@ Symfony\Component\Debug\Debug::enable();
 $kernel = new AppKernel('dev', true);
 $kernel->boot();
 
+putenv("APPLICATION_ENV=development");
 require 'zf.php';

--- a/web/admin/public/e2e.php
+++ b/web/admin/public/e2e.php
@@ -5,6 +5,7 @@ require_once 'Zend/Registry.php';
 $loader = require __DIR__.'/../../rest/platform/app/autoload.php';
 include_once __DIR__.'/../../rest/platform/var/bootstrap.php.cache';
 
+putenv("APPLICATION_ENV=testing");
 $kernel = new AppKernel('test_e2e', false);
 $kernel->boot();
 

--- a/web/admin/public/zf.php
+++ b/web/admin/public/zf.php
@@ -13,15 +13,13 @@
     $kernel->getContainer()
 );
 
-
-
 // Define path to application directory
 defined('APPLICATION_PATH')
     || define('APPLICATION_PATH', realpath(dirname(__FILE__) . '/../application'));
 
 // Define application environment
 defined('APPLICATION_ENV')
-    || define('APPLICATION_ENV', (getenv('APPLICATION_ENV') ? getenv('APPLICATION_ENV') : 'development'));
+    || define('APPLICATION_ENV', (getenv('APPLICATION_ENV') ? getenv('APPLICATION_ENV') : 'production'));
 
 // Ensure library/ is on include_path
 /** @todo review this carefully */


### PR DESCRIPTION
There is no reason to keep development as default environment anymore. Access through dev.php or look into the journal in order to check error messages out. Notice that dev.php is broken on repository installations due to missing dependencies.

This PR aims to fix https://github.com/irontec/ivozprovider/issues/766