### PR TITLE
web/admin: Platform Default Notification Templates section

### DIFF
--- a/doc/sphinx/administration_portal/platform/default_notification_templates.rst
+++ b/doc/sphinx/administration_portal/platform/default_notification_templates.rst
@@ -1,0 +1,21 @@
+.. _default_notification_templates:
+
+##############################
+Default Notification Templates
+##############################
+
+Brand administrators can configure the notifications sent by IvozProvider:
+
+- Email sent when a new voicemail is received
+
+- Email sent when a new fax is received
+
+- Email sent when a balance is below configured threshold
+
+- Email sent when an automatic invoice is generated
+
+- Email sent when scheduled CDR CSVs are generated
+
+This section allows **modifying default templates** that will be **used when no custom notification is configured**.
+
+See :ref:`notification_templates` for further reference.

--- a/doc/sphinx/administration_portal/platform/index.rst
+++ b/doc/sphinx/administration_portal/platform/index.rst
@@ -13,6 +13,7 @@ This section is only shown to *God administrator* and allows modifying global co
     antiflood_trusted_ips
     terminal_manufacturers
     services
+    default_notification_templates
     sip_domains
     billable_calls
     infrastructure/index

--- a/doc/sphinx/locale/es/LC_MESSAGES/administration_portal.po
+++ b/doc/sphinx/locale/es/LC_MESSAGES/administration_portal.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: IvozProvider 2.7\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-20 18:44+0100\n"
+"POT-Creation-Date: 2018-11-21 13:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3202,26 +3202,32 @@ msgid "Notification Templates"
 msgstr ""
 
 #: ../../administration_portal/brand/settings/notification_templates.rst:7
+#: ../../administration_portal/platform/default_notification_templates.rst:7
 msgid "Brand administrators can configure the notifications sent by IvozProvider:"
 msgstr ""
 
 #: ../../administration_portal/brand/settings/notification_templates.rst:9
+#: ../../administration_portal/platform/default_notification_templates.rst:9
 msgid "Email sent when a new voicemail is received"
 msgstr ""
 
 #: ../../administration_portal/brand/settings/notification_templates.rst:11
+#: ../../administration_portal/platform/default_notification_templates.rst:11
 msgid "Email sent when a new fax is received"
 msgstr ""
 
 #: ../../administration_portal/brand/settings/notification_templates.rst:13
+#: ../../administration_portal/platform/default_notification_templates.rst:13
 msgid "Email sent when a balance is below configured threshold"
 msgstr ""
 
 #: ../../administration_portal/brand/settings/notification_templates.rst:15
+#: ../../administration_portal/platform/default_notification_templates.rst:15
 msgid "Email sent when an automatic invoice is generated"
 msgstr ""
 
 #: ../../administration_portal/brand/settings/notification_templates.rst:17
+#: ../../administration_portal/platform/default_notification_templates.rst:17
 msgid "Email sent when scheduled CDR CSVs are generated"
 msgstr ""
 
@@ -7560,6 +7566,20 @@ msgid ""
 "brand can be guessed, but not the client. As a result, username collision"
 " domain will be at brand level (there cannot exist to client "
 "administrators with the same username within a brand)."
+msgstr ""
+
+#: ../../administration_portal/platform/default_notification_templates.rst:5
+msgid "Default Notification Templates"
+msgstr ""
+
+#: ../../administration_portal/platform/default_notification_templates.rst:19
+msgid ""
+"This section allows **modifying default templates** that will be **used "
+"when no custom notification is configured**."
+msgstr ""
+
+#: ../../administration_portal/platform/default_notification_templates.rst:21
+msgid "See :ref:`notification_templates` for further reference."
 msgstr ""
 
 #: ../../administration_portal/platform/index.rst:3

--- a/web/admin/application/configs/klear/DefaultNotificationTemplatesList.yaml
+++ b/web/admin/application/configs/klear/DefaultNotificationTemplatesList.yaml
@@ -1,0 +1,202 @@
+#include conf.d/mapperList.yaml
+#include conf.d/actions.yaml
+#include conf.d/documentationLink.yaml
+#include NotificationTemplatesList.yaml
+#include NotificationTemplatesContentsList.yaml
+
+production:
+  main:
+    module: klearMatrix
+    defaultScreen: notificationTemplatesList_screen
+
+  screens:
+    <<: *notificationTemplates_screensLink
+    notificationTemplatesList_screen:
+      <<: *notificationTemplatesList_screenLink
+      info:
+        <<: *documentationLink
+        href: "/doc/en/administration_portal/platform/default_notification_templates.html"
+      forcedValues:
+        "self::brand": null
+      fields:
+        options:
+          title: _("Options")
+          screens:
+            notificationTemplatesEdit_screen: false
+            notificationTemplatesContentsVoicemailList_screen: true
+            notificationTemplatesContentsFaxList_screen: true
+            notificationTemplatesContentsLowBalanceList_screen: true
+            notificationTemplatesContentsInvoiceList_screen: true
+            notificationTemplatesContentsCallCsvList_screen: true
+          dialogs:
+            notificationTemplatesDel_dialog: false
+          default: notificationTemplatesContentsVoicemailList_screen
+      options:
+        title: _("Options")
+        screens:
+          notificationTemplatesNew_screen: false
+        dialogs:
+          notificationTemplatesDel_dialog: false
+
+    # notificationTemplatesVoicemailContents screens:
+    notificationTemplatesContentsVoicemailList_screen:
+      <<: *notificationTemplatesContentsVoicemailList_screenLink
+      fields:
+        <<: *notificationTemplatesContents_fieldsLink
+        options:
+          title: _("Options")
+          screens:
+            notificationTemplatesContentsVoicemailEdit_screen: true
+          default: notificationTemplatesContentsVoicemailEdit_screen
+      options:
+        title: _("Options")
+      filterField: notificationTemplate
+      parentOptionCustomizer:
+        - IvozProvider_Klear_Options_OptionsCustomizerFilterForNotificationVoicemail
+        - recordCount
+    notificationTemplatesContentsVoicemailEdit_screen: &notificationTemplatesContentsVoicemailEdit_screenLink
+      <<: *notificationTemplatesContentsEdit_screenLink
+      fields:
+        order:
+          <<: *notificationTemplatesContentsFieldsOrderPositions_Link
+        blacklist:
+          faxVariables: true
+          invoiceVariables: true
+          lowBalanceVariables: true
+          callCsvVariables: true
+        readOnly:
+          language: true
+      filterField: notificationTemplate
+
+    # notificationTemplatesFaxContents screens:
+    notificationTemplatesContentsFaxList_screen:
+      <<: *notificationTemplatesContentsFaxList_screenLink
+      fields:
+        <<: *notificationTemplatesContents_fieldsLink
+        options:
+          title: _("Options")
+          screens:
+            notificationTemplatesContentsFaxEdit_screen: true
+          default: notificationTemplatesContentsFaxEdit_screen
+      options:
+        title: _("Options")
+      filterField: notificationTemplate
+      parentOptionCustomizer:
+        - IvozProvider_Klear_Options_OptionsCustomizerFilterForNotificationFax
+        - recordCount
+    notificationTemplatesContentsFaxEdit_screen: &notificationTemplatesContentsFaxEdit_screenLink
+      <<: *notificationTemplatesContentsEdit_screenLink
+      fields:
+        order:
+          <<: *notificationTemplatesContentsFieldsOrderPositions_Link
+        blacklist:
+          voicemailVariables: true
+          invoiceVariables: true
+          lowBalanceVariables: true
+          callCsvVariables: true
+        readOnly:
+          language: true
+      filterField: notificationTemplate
+
+    # notificationTemplatesInvoiceContents screens:
+    notificationTemplatesContentsInvoiceList_screen:
+      <<: *notificationTemplatesContentsInvoiceList_screenLink
+      fields:
+        <<: *notificationTemplatesContents_fieldsLink
+        options:
+          title: _("Options")
+          screens:
+            notificationTemplatesContentsInvoiceEdit_screen: true
+          default: notificationTemplatesContentsInvoiceEdit_screen
+      options:
+        title: _("Options")
+      filterField: notificationTemplate
+      parentOptionCustomizer:
+        - IvozProvider_Klear_Options_OptionsCustomizerFilterForNotificationInvoice
+        - recordCount
+    notificationTemplatesContentsInvoiceEdit_screen: &notificationTemplatesContentsInvoiceEdit_screenLink
+      <<: *notificationTemplatesContentsEdit_screenLink
+      fields:
+        order:
+          <<: *notificationTemplatesContentsFieldsOrderPositions_Link
+        blacklist:
+          voicemailVariables: true
+          faxVariables: true
+          lowBalanceVariables: true
+          callCsvVariables: true
+        readOnly:
+          language: true
+      filterField: notificationTemplate
+
+    # notificationTemplatesLowBalanceContents screens:
+    notificationTemplatesContentsLowBalanceList_screen:
+      <<: *notificationTemplatesContentsLowBalanceList_screenLink
+      fields:
+        <<: *notificationTemplatesContents_fieldsLink
+        options:
+          title: _("Options")
+          screens:
+            notificationTemplatesContentsLowBalanceEdit_screen: true
+          default: notificationTemplatesContentsLowBalanceEdit_screen
+      options:
+        title: _("Options")
+      filterField: notificationTemplate
+      parentOptionCustomizer:
+        - IvozProvider_Klear_Options_OptionsCustomizerFilterForNotificationLowBalance
+        - recordCount
+    notificationTemplatesContentsLowBalanceEdit_screen: &notificationTemplatesContentsLowBalanceEdit_screenLink
+      <<: *notificationTemplatesContentsEdit_screenLink
+      fields:
+        order:
+          <<: *notificationTemplatesContentsFieldsOrderPositions_Link
+        blacklist:
+          voicemailVariables: true
+          faxVariables: true
+          invoiceVariables: true
+          callCsvVariables: true
+        readOnly:
+          language: true
+      filterField: notificationTemplate
+      
+    # notificationTemplatesCallCsvContents screens:
+    notificationTemplatesContentsCallCsvList_screen:
+      <<: *notificationTemplatesContentsCallCsvList_screenLink
+      fields:
+        <<: *notificationTemplatesContents_fieldsLink
+        options:
+          title: _("Options")
+          screens:
+            notificationTemplatesContentsCallCsvEdit_screen: true
+          default: notificationTemplatesContentsCallCsvEdit_screen
+      options:
+        title: _("Options")
+      filterField: notificationTemplate
+      parentOptionCustomizer:
+        - IvozProvider_Klear_Options_OptionsCustomizerFilterForNotificationCallCsv
+        - recordCount
+    notificationTemplatesContentsCallCsvEdit_screen: &notificationTemplatesContentsCallCsvEdit_screenLink
+      <<: *notificationTemplatesContentsEdit_screenLink
+      fields:
+        order:
+          <<: *notificationTemplatesContentsFieldsOrderPositions_Link
+        blacklist:
+          voicemailVariables: true
+          faxVariables: true
+          invoiceVariables: true
+          lowBalanceVariables: true
+        readOnly:
+          language: true
+      filterField: notificationTemplate      
+
+  dialogs:
+    # notificationTemplatesContents dialogs:
+    <<: *notificationTemplatesContents_dialogsLink
+
+staging:
+  _extends: production
+testing:
+  _extends: production
+development:
+  _extends: production
+localdev:
+  _extends: production

--- a/web/admin/application/configs/klear/NotificationTemplatesContentsList.yaml
+++ b/web/admin/application/configs/klear/NotificationTemplatesContentsList.yaml
@@ -23,6 +23,7 @@ production:
           faxVariables: true
           invoiceVariables: true
           lowBalanceVariables: true
+          callCsvVariables: true
         options:
           title: _("Options")
           screens:
@@ -53,6 +54,7 @@ production:
           faxVariables: true
           invoiceVariables: true
           lowBalanceVariables: true
+          callCsvVariables: true
           subject: true
           bodyType: true
           body: true
@@ -91,7 +93,7 @@ production:
 
     ###################################################################################################################
     # Screens for Voicemail Notification templates
-    # This screens is like the generic one but hidding the other substitution variables helpers
+    # This screens is like the generic one but hiding the other substitution variables helpers
     ###################################################################################################################
     notificationTemplatesContentsVoicemailList_screen: &notificationTemplatesContentsVoicemailList_screenLink
       <<: *notificationTemplatesContentsList_screenLink
@@ -119,6 +121,7 @@ production:
           faxVariables: true
           invoiceVariables: true
           lowBalanceVariables: true
+          callCsvVariables: true
     notificationTemplatesContentsVoicemailEdit_screen: &notificationTemplatesContentsVoicemailEdit_screenLink
       <<: *notificationTemplatesContentsEdit_screenLink
       fields:
@@ -128,10 +131,11 @@ production:
           faxVariables: true
           invoiceVariables: true
           lowBalanceVariables: true
+          callCsvVariables: true
 
     ###################################################################################################################
     # Screens for Fax Notification templates
-    # This screens is like the generic one but hidding the other substitution variables helpers
+    # This screens is like the generic one but hiding the other substitution variables helpers
     ###################################################################################################################
     notificationTemplatesContentsFaxList_screen: &notificationTemplatesContentsFaxList_screenLink
       <<: *notificationTemplatesContentsList_screenLink
@@ -159,6 +163,7 @@ production:
           voicemailVariables: true
           invoiceVariables: true
           lowBalanceVariables: true
+          callCsvVariables: true
     notificationTemplatesContentsFaxEdit_screen: &notificationTemplatesContentsFaxEdit_screenLink
       <<: *notificationTemplatesContentsEdit_screenLink
       fields:
@@ -168,10 +173,11 @@ production:
           voicemailVariables: true
           lowBalanceVariables: true
           invoiceVariables: true
+          callCsvVariables: true
 
     ###################################################################################################################
     # Screens for Invoice Notification templates
-    # This screens is like the generic one but hidding the other substitution variables helpers
+    # This screens is like the generic one but hiding the other substitution variables helpers
     ###################################################################################################################
     notificationTemplatesContentsInvoiceList_screen: &notificationTemplatesContentsInvoiceList_screenLink
       <<: *notificationTemplatesContentsList_screenLink
@@ -199,6 +205,7 @@ production:
           voicemailVariables: true
           lowBalanceVariables: true
           faxVariables: true
+          callCsvVariables: true
     notificationTemplatesContentsInvoiceEdit_screen: &notificationTemplatesContentsInvoiceEdit_screenLink
       <<: *notificationTemplatesContentsEdit_screenLink
       fields:
@@ -208,10 +215,11 @@ production:
           voicemailVariables: true
           lowBalanceVariables: true
           faxVariables: true
+          callCsvVariables: true
 
     ###################################################################################################################
     # Screens for LowBalance Notification templates
-    # This screens is like the generic one but hidding the other substitution variables helpers
+    # This screens is like the generic one but hiding the other substitution variables helpers
     ###################################################################################################################
     notificationTemplatesContentsLowBalanceList_screen: &notificationTemplatesContentsLowBalanceList_screenLink
       <<: *notificationTemplatesContentsList_screenLink
@@ -239,6 +247,7 @@ production:
           voicemailVariables: true
           faxVariables: true
           invoiceVariables: true
+          callCsvVariables: true
     notificationTemplatesContentsLowBalanceEdit_screen: &notificationTemplatesContentsLowBalanceEdit_screenLink
       <<: *notificationTemplatesContentsEdit_screenLink
       fields:
@@ -246,6 +255,49 @@ production:
           <<: *notificationTemplatesContentsFieldsOrderPositions_Link
         blacklist:
           voicemailVariables: true
+          faxVariables: true
+          invoiceVariables: true
+          callCsvVariables: true
+
+    ###################################################################################################################
+    # Screens for CallCsv Notification templates
+    # This screens is like the generic one but hiding the other substitution variables helpers
+    ###################################################################################################################
+    notificationTemplatesContentsCallCsvList_screen: &notificationTemplatesContentsCallCsvList_screenLink
+      <<: *notificationTemplatesContentsList_screenLink
+      fields:
+        <<: *notificationTemplatesContents_fieldsLink
+        options:
+          title: _("Options")
+          screens:
+            notificationTemplatesContentsCallCsvEdit_screen: true
+          dialogs:
+            notificationTemplatesContentsDel_dialog: true
+          default: notificationTemplatesContentsCallCsvEdit_screen
+      options:
+        title: _("Options")
+        screens:
+          notificationTemplatesContentsCallCsvNew_screen: true
+        dialogs:
+          notificationTemplatesContentsDel_dialog: true
+    notificationTemplatesContentsCallCsvNew_screen: &notificationTemplatesContentsCallCsvNew_screenLink
+      <<: *notificationTemplatesContentsNew_screenLink
+      fields:
+        order:
+          <<: *notificationTemplatesContentsFieldsOrderPositions_Link
+        blacklist:
+          voicemailVariables: true
+          lowBalanceVariables: true
+          faxVariables: true
+          invoiceVariables: true
+    notificationTemplatesContentsCallCsvEdit_screen: &notificationTemplatesContentsCallCsvEdit_screenLink
+      <<: *notificationTemplatesContentsEdit_screenLink
+      fields:
+        order:
+          <<: *notificationTemplatesContentsFieldsOrderPositions_Link
+        blacklist:
+          voicemailVariables: true
+          lowBalanceVariables: true
           faxVariables: true
           invoiceVariables: true
 
@@ -260,7 +312,6 @@ production:
       message: _("%s successfully deleted.", ngettext('Notification content', 'Notification contents', 1))
       multiItem: 1
       labelOnList: 1
-
 
 staging:
   _extends: production

--- a/web/admin/application/configs/klear/NotificationTemplatesList.yaml
+++ b/web/admin/application/configs/klear/NotificationTemplatesList.yaml
@@ -30,6 +30,7 @@ production:
             notificationTemplatesContentsFaxList_screen: true
             notificationTemplatesContentsLowBalanceList_screen: true
             notificationTemplatesContentsInvoiceList_screen: true
+            notificationTemplatesContentsCallCsvList_screen: true
           dialogs:
             notificationTemplatesDel_dialog: true
           default: notificationTemplatesEdit_screen
@@ -122,6 +123,20 @@ production:
       filterField: notificationTemplate
     notificationTemplatesContentsLowBalanceEdit_screen:
       <<: *notificationTemplatesContentsLowBalanceEdit_screenLink
+      filterField: notificationTemplate
+
+    # notificationTemplatesCallCsvContents screens:
+    notificationTemplatesContentsCallCsvList_screen:
+      <<: *notificationTemplatesContentsCallCsvList_screenLink
+      filterField: notificationTemplate
+      parentOptionCustomizer:
+        - IvozProvider_Klear_Options_OptionsCustomizerFilterForNotificationCallCsv
+        - recordCount
+    notificationTemplatesContentsCallCsvNew_screen:
+      <<: *notificationTemplatesContentsCallCsvNew_screenLink
+      filterField: notificationTemplate
+    notificationTemplatesContentsCallCsvEdit_screen:
+      <<: *notificationTemplatesContentsCallCsvEdit_screenLink
       filterField: notificationTemplate
 
   dialogs: &notificationTemplates_dialogsLink

--- a/web/admin/application/configs/klear/conf.d/notificationTemplateHelp.yaml
+++ b/web/admin/application/configs/klear/conf.d/notificationTemplateHelp.yaml
@@ -56,3 +56,16 @@ lowBalanceVariablesHelp: &lowBalanceVariablesHelp
                <b>&#36;{BALANCE_NAME}</b> <i>Company or carrier name</i><br/>
                <b>&#36;{BALANCE_AMOUNT}</b>  <i>Current balance amount</i><br/>
             </pre>'
+
+callCsvVariablesHelp: &callCsvVariablesHelp
+    info:
+      type: box
+      position: left
+      icon: help
+      label: _("Need help?")
+      text: 'You can use these balance variables in subject and body:<br/>
+            <pre>
+               <b>&#36;{CALLCSV_COMPANY}</b>  <i>Company name</i><br/>
+               <b>&#36;{CALLCSV_DATE_IN}</b> <i>Start date</i><br/>
+               <b>&#36;{CALLCSV_DATE_OUT}</b> <i>End date</i><br/>
+            </pre>'

--- a/web/admin/application/configs/klear/klear.yaml
+++ b/web/admin/application/configs/klear/klear.yaml
@@ -69,6 +69,10 @@ production:
           title: ngettext('Service', 'Services', 0)
           class: ui-silk-page-white-wrench
           description: _("List of %s", ngettext('Service', 'Services', 0))
+        DefaultNotificationTemplatesList:
+          title: ngettext('Default notification template', 'Default notification templates', 0)
+          class: ui-silk-email
+          description: _("List of %s", ngettext('Notification template', 'Notification templates', 0))
         DomainsList:
           title: ngettext('SIP Domain', 'SIP Domains', 0)
           class: ui-silk-link

--- a/web/admin/application/configs/klear/model/NotificationTemplates.yaml
+++ b/web/admin/application/configs/klear/model/NotificationTemplates.yaml
@@ -30,6 +30,7 @@ production:
           'fax': ngettext('Fax', 'Faxes', 1)
           'lowbalance': _('Low balance')
           'invoice': ngettext('Invoice', 'Invoices', 1)
+          'callCsv': ngettext('Call CSV', 'Call CSVs', 1)
 staging:
   _extends: production
 testing:

--- a/web/admin/application/configs/klear/model/NotificationTemplatesContents.yaml
+++ b/web/admin/application/configs/klear/model/NotificationTemplatesContents.yaml
@@ -19,6 +19,7 @@ production:
       title: _('Language')
       type: select
       required: true
+      default: true
       source:
         data: mapper
         config:
@@ -88,6 +89,15 @@ production:
         class: IvozProvider_Klear_Ghost_NotificationTemplate
         method: getVariables
       <<: *lowBalanceVariablesHelp
+    callCsvVariables:
+      title: _('Substitution variables')
+      type: ghost
+      maxLength: 255
+      readonly: true
+      source:
+        class: IvozProvider_Klear_Ghost_NotificationTemplate
+        method: getVariables
+      <<: *callCsvVariablesHelp
     subject:
       title: _('Subject')
       trim: both

--- a/web/admin/application/languages/en_US/en_US.po
+++ b/web/admin/application/languages/en_US/en_US.po
@@ -563,6 +563,11 @@ msgstr[1] "DDI Provider Registrations"
 msgid "Default Action"
 msgstr "Default Action"
 
+msgid "Default notification template"
+msgid_plural "Default notification templates"
+msgstr[0] "Default Notification template"
+msgstr[1] "Default Notification templates"
+
 msgid "Default outgoing DDI. This can be overriden in accounts's edit screen."
 msgstr "Default outgoing DDI. This can be overriden in accounts's edit screen."
 

--- a/web/admin/application/languages/en_US/en_US.po
+++ b/web/admin/application/languages/en_US/en_US.po
@@ -322,6 +322,11 @@ msgid_plural "Call ACL Patterns"
 msgstr[0] "Call ACL Pattern"
 msgstr[1] "Call ACL Patterns"
 
+msgid "Call CSV"
+msgid_plural "Call CSVs"
+msgstr[0] "Call CSV"
+msgstr[1] "Call CSVs"
+
 msgid "Call CSV report"
 msgid_plural "Call CSV reports"
 msgstr[0] "Call CSV report"

--- a/web/admin/application/languages/es_ES/es_ES.po
+++ b/web/admin/application/languages/es_ES/es_ES.po
@@ -570,6 +570,11 @@ msgstr[1] "Registros Proveedor"
 msgid "Default Action"
 msgstr "Acción por defecto"
 
+msgid "Default notification template"
+msgid_plural "Default notification templates"
+msgstr[0] "Plantilla de notificación por defecto"
+msgstr[1] "Plantillas de notificación por defecto"
+
 msgid "Default outgoing DDI. This can be overriden in accounts's edit screen."
 msgstr ""
 "DDI saliente por defecto. Esta opción puede ser sobrescrita en la pantalla "

--- a/web/admin/application/languages/es_ES/es_ES.po
+++ b/web/admin/application/languages/es_ES/es_ES.po
@@ -329,6 +329,11 @@ msgid_plural "Call ACL Patterns"
 msgstr[0] "Patrón permisos llamada"
 msgstr[1] "Patrón permisos llamada"
 
+msgid "Call CSV"
+msgid_plural "Call CSVs"
+msgstr[0] "CSV de llamadas"
+msgstr[1] "CSVs de llamadas"
+
 msgid "Call CSV report"
 msgid_plural "Call CSV reports"
 msgstr[0] "CSV de llamadas"

--- a/web/admin/application/library/IvozProvider/Klear/Options/OptionsCustomizerFilterForNotificationCallCsv.php
+++ b/web/admin/application/library/IvozProvider/Klear/Options/OptionsCustomizerFilterForNotificationCallCsv.php
@@ -1,0 +1,58 @@
+<?php
+
+use Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateDto;
+
+class IvozProvider_Klear_Options_OptionsCustomizerFilterForNotificationCallCsv implements \KlearMatrix_Model_Interfaces_ParentOptionCustomizer
+{
+    /**
+     * @var KlearMatrix_Model_RouteDispatcher
+     */
+    protected $_mainRouter = null;
+
+    /**
+     * @var array
+     */
+    protected $_mainRouterOriginalParams = null;
+
+    /**
+     * @var KlearMatrix_Model_AbstractOption
+     */
+    protected $_option = null;
+
+    protected $_resultWrapper = 'div';
+    protected $_cssClass = 'hidden';
+    protected $_parentModel;
+
+
+    public function __construct(\Zend_Config $configuration)
+    {
+        $front = \Zend_Controller_Front::getInstance();
+        $this->_mainRouter = $front->getRequest()->getUserParam("mainRouter");
+        $this->_mainRouterOriginalParams = $this->_mainRouter->getParams();
+    }
+
+    public function setOption (\KlearMatrix_Model_Option_Abstract $option)
+    {
+        $this->_option = $option;
+    }
+
+    /**
+     * @param NotificationTemplateDto $parentModel
+     * @return KlearMatrix_Model_ParentOptionCustomizer_Response|null
+     */
+    public function customize($parentModel)
+    {
+        $optionName = $this->_option->getName();
+        $type = $parentModel->getType();
+
+        if ($optionName == 'notificationTemplatesContentsCallCsvList_screen' && $type != 'callCsv') {
+            $response = new \KlearMatrix_Model_ParentOptionCustomizer_Response();
+            $response->setParentWrapper($this->_resultWrapper)
+                ->setParentCssClass($this->_cssClass);
+
+            return $response;
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
This PR adds a new portal section under Platform menu to allow administrators to edit default Notification templates. This new section is limited to edition, so new and delete have been removed.

The PR also includes the missing screens for Call CSV Notification Templates contents.

