### PR TITLE
devops: added systemd timer to clear expired API refresh tokens

### DIFF
--- a/debian/ivozprovider-web-rest.install
+++ b/debian/ivozprovider-web-rest.install
@@ -1,1 +1,2 @@
 web/rest	/opt/irontec/ivozprovider/web/
+debian/systemd/ivozprovider-jwt.timer /lib/systemd/system

--- a/debian/ivozprovider-web-rest.ivozprovider-jwt.service
+++ b/debian/ivozprovider-web-rest.ivozprovider-jwt.service
@@ -1,0 +1,1 @@
+systemd/ivozprovider-jwt.service

--- a/debian/ivozprovider.postinst
+++ b/debian/ivozprovider.postinst
@@ -156,6 +156,7 @@ function enable_services()
     /bin/systemctl enable kamailio@users
     /bin/systemctl enable kamailio@trunks
     /bin/systemctl enable asterisk
+    /bin/systemctl enable ivozprovider-jwt.timer
     /bin/systemctl enable ivozprovider-recordings.timer
     /bin/systemctl enable ivozprovider-balances.timer
     /bin/systemctl enable ivozprovider-scheduler.timer

--- a/debian/rules
+++ b/debian/rules
@@ -58,6 +58,7 @@ override_dh_systemd_enable:
 	dh_systemd_enable -p ivozprovider-asterisk-agi	  --name=fastagi@      fastagi@.service
 	dh_systemd_enable -p ivozprovider-asterisk-agi	  --name=fastagi       fastagi.socket
 	dh_systemd_enable -p ivozprovider-profile-proxy   --name=kamailio@     kamailio@.service --no-enable
+	dh_systemd_enable -p ivozprovider-web-rest        --name=ivozprovider-jwt                --no-enable
 	dh_systemd_enable -p ivozprovider-recordings      --name=ivozprovider-recordings         --no-enable
 	dh_systemd_enable -p ivozprovider-balances        --name=ivozprovider-balances           --no-enable
 	dh_systemd_enable -p ivozprovider-scheduler       --name=ivozprovider-scheduler          --no-enable
@@ -67,6 +68,7 @@ override_dh_systemd_start:
 	dh_systemd_start  -p ivozprovider-asterisk-agi     --name=fastagi@     fastagi@.service   --no-restart-on-upgrade --no-start
 	dh_systemd_start  -p ivozprovider-asterisk-agi     --name=fastagi      fastagi.socket     --no-restart-on-upgrade --no-start
 	dh_systemd_start  -p ivozprovider-profile-proxy    --name=kamailio@    kamailio@.service  --no-restart-on-upgrade --no-start
+	dh_systemd_start  -p ivozprovider-web-rest	       --name=ivozprovider-jwt                --no-restart-on-upgrade --no-start
 	dh_systemd_start  -p ivozprovider-recordings	   --name=ivozprovider-recordings         --no-restart-on-upgrade --no-start
 	dh_systemd_start  -p ivozprovider-balances	       --name=ivozprovider-balances           --no-restart-on-upgrade --no-start
 	dh_systemd_start  -p ivozprovider-scheduler	       --name=ivozprovider-scheduler          --no-restart-on-upgrade --no-start

--- a/debian/systemd/ivozprovider-jwt.service
+++ b/debian/systemd/ivozprovider-jwt.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Run Ivozprovider JWT tasks
+
+[Service]
+Type=oneshot
+ExecStart=/opt/irontec/ivozprovider/web/rest/platform/bin/console gesdinet:jwt:clear

--- a/debian/systemd/ivozprovider-jwt.timer
+++ b/debian/systemd/ivozprovider-jwt.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Ivozprovider JWT tasks runner
+
+[Timer]
+OnBootSec=1h
+OnUnitActiveSec=1d
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Remove expired JWT refresh tokens from refresh_tokens table in database