### PR TITLE
web/admin: show terminal register status in Users

### DIFF
--- a/web/admin/application/configs/klear/UsersList.yaml
+++ b/web/admin/application/configs/klear/UsersList.yaml
@@ -48,6 +48,7 @@ production:
           timezone: true
           extension: true
           terminal: true
+          statusIcon: true
           outgoingDDI: true
           callACL: true
           voicemailEnabled: true
@@ -122,6 +123,7 @@ production:
           language: true
           transformationRuleSet: true
           externalIpCalls: true
+          statusIcon: true
       fixedPositions: &UsersFixedPositions_link
         group0:
           label: _("Personal data")
@@ -149,6 +151,7 @@ production:
       fields:
         blacklist:
           tokenKey: true
+          statusIcon: true
         order:
           <<: *Users_orderLink
       fixedPositions: &UsersFixedPositions_link

--- a/web/admin/application/configs/klear/model/Users.yaml
+++ b/web/admin/application/configs/klear/model/Users.yaml
@@ -104,6 +104,13 @@ production:
           order:
             Terminal.name: asc
         'null': _("Unassigned")
+    statusIcon:
+      title: _('Status')
+      type: ghost
+      dirty: true
+      source:
+        class: IvozProvider_Klear_Ghost_RegisterStatus
+        method: getUserTerminalStatusIcon
     extension:
       title: _('Screen Extension')
       type: select

--- a/web/admin/application/library/IvozProvider/Klear/Ghost/RegisterStatus.php
+++ b/web/admin/application/library/IvozProvider/Klear/Ghost/RegisterStatus.php
@@ -7,6 +7,7 @@ use Ivoz\Provider\Domain\Model\Domain\Domain;
 use Ivoz\Provider\Domain\Model\Domain\DomainDto;
 use Ivoz\Provider\Domain\Model\Friend\FriendDto;
 use Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDeviceDto;
+use Ivoz\Provider\Domain\Model\Terminal\Terminal;
 use Ivoz\Provider\Domain\Model\Terminal\TerminalDto;
 
 class IvozProvider_Klear_Ghost_RegisterStatus extends KlearMatrix_Model_Field_Ghost_Abstract
@@ -20,6 +21,30 @@ class IvozProvider_Klear_Ghost_RegisterStatus extends KlearMatrix_Model_Field_Gh
     public function getTerminalStatusIcon($model)
     {
         return $this->getLocationStatusIcon($model);
+    }
+
+    /**
+     * Get Register Status for Users Terminals
+     * @param UserDto $model
+     * @return string HTML code to display SIP register status
+     * @throws Zend_Exception
+     */
+    public function getUserTerminalStatusIcon($model)
+    {
+        if (!$model->getTerminalId()) {
+            return '<span class="ui-silk inline ui-silk-error" title="No terminal assigned"></span>';
+        }
+
+        /** @var DataGateway $dataGateway */
+        $dataGateway = \Zend_Registry::get('data_gateway');
+
+        /** @var TerminalDto $terminal */
+        $terminal = $dataGateway->find(
+            Terminal::class,
+            $model->getTerminalId()
+        );
+
+        return $this->getLocationStatusIcon($terminal);
     }
 
     /**
@@ -178,7 +203,7 @@ class IvozProvider_Klear_Ghost_RegisterStatus extends KlearMatrix_Model_Field_Gh
         }
 
         // Draw a red cross if not found
-        return '<span class="ui-silk inline ui-silk-exclamation"></span>';
+        return '<span class="ui-silk inline ui-silk-exclamation" title="Not registered"></span>';
     }
 
     /**


### PR DESCRIPTION
It may be handy to see terminal register status icon directly in Users section.

This PR fixes #794 