### PR TITLE
core: use parameter instead of request on smtp identification

### DIFF
--- a/library/CoreBundle/Resources/config/config.yml
+++ b/library/CoreBundle/Resources/config/config.yml
@@ -42,6 +42,7 @@ lexik_jwt_authentication:
 
 swiftmailer:
     transport: '%mailer_transport%'
+    local_domain: '%mailer_local_domain%'
     host:      '%mailer_host%'
     username:  '%mailer_user%'
     password:  '%mailer_password%'

--- a/library/CoreBundle/Resources/config/parameters.yml.dist
+++ b/library/CoreBundle/Resources/config/parameters.yml.dist
@@ -15,6 +15,7 @@ parameters:
     jwt_public_key_path: '/opt/irontec/ivozprovider/web/rest/platform/var/jwt/public.pem' # ssh public key path
     jwt_key_pass_phrase: 'changeme' # ssh key pass phrase
     jwt_token_ttl: 3600
+    mailer_local_domain: localhost
     mailer_transport: smtp
     mailer_host: jobs.ivozprovider.local
     mailer_user: ~


### PR DESCRIPTION
Do not resolve SMTP identification through the request object, read it from parameters instead