### PR TITLE
Update TpRatingProfile.TpRatingProfileAbstract.orm.yml

### DIFF
--- a/library/Ivoz/Cgr/Infrastructure/Persistence/Doctrine/Mapping/TpRatingProfile.TpRatingProfileAbstract.orm.yml
+++ b/library/Ivoz/Cgr/Infrastructure/Persistence/Doctrine/Mapping/TpRatingProfile.TpRatingProfileAbstract.orm.yml
@@ -60,8 +60,9 @@ Ivoz\Cgr\Domain\Model\TpRatingProfile\TpRatingProfileAbstract:
       options:
         fixed: false
     activationTime:
-      type: datetime
+      type: string
       nullable: false
+      length: 24
       options:
         default: CURRENT_TIMESTAMP
       column: activation_time


### PR DESCRIPTION
Fix `activation_time` data type to match cgrates schema.  
https://github.com/cgrates/cgrates/blob/48e10f9201ff1b2fe3047c8f3e5d78086b87fc1e/data/storage/mysql/create_tariffplan_tables.sql#L113

Helps prevents some strange things from happening.
https://github.com/irontec/ivozprovider/issues/801


