### PR TITLE
Fix client simulation answer time

### DIFF
--- a/library/Ivoz/Core/Infrastructure/Domain/Service/Cgrates/BillingService.php
+++ b/library/Ivoz/Core/Infrastructure/Domain/Service/Cgrates/BillingService.php
@@ -42,7 +42,7 @@ class BillingService implements BillingServiceInterface
     {
         $answerDateTime = new \DateTime();
         $answerDateTime->setTimestamp(time());
-        $answerDateTime->setTimezone(new \DateTimeZone(date_default_timezone_get()));
+        $answerDateTime->setTimezone(new \DateTimeZone('UTC'));
 
         $payload = [
             'Tenant' => $tenant,


### PR DESCRIPTION
Should be UTC instead of operator timezone.

**Before fix running VirtualPBX Rating Plan call simulation:**

`ngrep -t -W byline port 2080 -d lo`

```
{"jsonrpc":"2.0","method":"ApierV1.GetCost","params":[{"Tenant":"b4","RatingPlanId":"b4rp4","Category":"call","AnswerTime":"2018-12-01T13:14:29Z","Destination":"+1","Usage":"60s"}],"id":1}
```
The above `AnswerTime`  is the logged in operators timezone, not UTC time.

**After fix and server reboot:**

`ngrep -t -W byline port 2080 -d lo`

```
{"jsonrpc":"2.0","method":"ApierV1.GetCost","params":[{"Tenant":"b4","Subject":"c3","Category":"call","AnswerTime":"2018-12-01T21:17:07Z","Destination":"+1","Usage":"60s"}],"id":1}
```
AnswerTime is now UTC time.


