### PR TITLE
core: fixed CallCsvReport/CreateByScheduler service

### DIFF
--- a/library/DataFixtures/ORM/ProviderCallCsvScheduler.php
+++ b/library/DataFixtures/ORM/ProviderCallCsvScheduler.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace DataFixtures\ORM;
+
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Common\DataFixtures\DependentFixtureInterface;
+use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Ivoz\Provider\Domain\Model\CallCsvScheduler\CallCsvScheduler;
+
+class ProviderCallCsvScheduler extends Fixture implements DependentFixtureInterface
+{
+    use \DataFixtures\FixtureHelperTrait;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function load(ObjectManager $manager)
+    {
+        $this->disableLifecycleEvents($manager);
+        $manager
+            ->getClassMetadata(CallCsvScheduler::class)
+            ->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_NONE);
+
+        $item1 = $this->createEntityInstance(CallCsvScheduler::class);
+        (function () {
+            $this->setName('SchedulerName');
+            $this->setUnit('day');
+            $this->setFrequency(1);
+            $this->setEmail('something@domain.net');
+            $this->setLastExecution(new \DateTime('2018-12-01 08:00:00'));
+            $this->setLastExecutionError('');
+            $this->setNextExecution('2018-12-02 08:00:00');
+        })->call($item1);
+
+        $item1->setBrand(
+            $this->getReference('_reference_ProviderBrand1')
+        );
+        $item1->setCompany(
+            $this->getReference('_reference_ProviderCompany1')
+        );
+
+        $this->addReference('_reference_ProviderCallCsvScheduler1', $item1);
+        $this->sanitizeEntityValues($item1);
+        $manager->persist($item1);
+
+        $manager->flush();
+    }
+
+    public function getDependencies()
+    {
+        return array(
+            ProviderCompany::class
+        );
+    }
+}

--- a/library/DataFixtures/ORM/ProviderInvoiceScheduler.php
+++ b/library/DataFixtures/ORM/ProviderInvoiceScheduler.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace DataFixtures\ORM;
+
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Common\DataFixtures\DependentFixtureInterface;
+use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Ivoz\Provider\Domain\Model\InvoiceScheduler\InvoiceScheduler;
+
+class ProviderInvoiceScheduler extends Fixture implements DependentFixtureInterface
+{
+    use \DataFixtures\FixtureHelperTrait;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function load(ObjectManager $manager)
+    {
+        $this->disableLifecycleEvents($manager);
+        $manager
+            ->getClassMetadata(InvoiceScheduler::class)
+            ->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_NONE);
+
+        $item1 = $this->createEntityInstance(InvoiceScheduler::class);
+        (function () {
+            $this->setName('SchedulerName');
+            $this->setUnit('week');
+            $this->setFrequency(1);
+            $this->setEmail('something@domain.net');
+            $this->setLastExecution(new \DateTime('2018-12-01 08:00:00'));
+            $this->setLastExecutionError('');
+            $this->setNextExecution('2018-12-02 08:00:00');
+        })->call($item1);
+
+        $item1->setBrand(
+            $this->getReference('_reference_ProviderBrand1')
+        );
+        $item1->setCompany(
+            $this->getReference('_reference_ProviderCompany1')
+        );
+
+        $this->addReference('_reference_ProviderInvoiceScheduler1', $item1);
+        $this->sanitizeEntityValues($item1);
+        $manager->persist($item1);
+
+        $manager->flush();
+    }
+
+    public function getDependencies()
+    {
+        return array(
+            ProviderCompany::class
+        );
+    }
+}

--- a/library/DataFixtures/ORM/ProviderNotificationTemplate.php
+++ b/library/DataFixtures/ORM/ProviderNotificationTemplate.php
@@ -33,6 +33,18 @@ class ProviderNotificationTemplate extends Fixture implements DependentFixtureIn
         $this->sanitizeEntityValues($item1);
         $manager->persist($item1);
 
+
+        /** @var NotificationTemplateInterface $item1 */
+        $item2 = $this->createEntityInstance(NotificationTemplate::class);
+        (function () {
+            $this->setName("CallCsv notification");
+            $this->setType("callCsv");
+        })->call($item2);
+
+        $this->addReference('_reference_ProviderNotificationTemplate2', $item2);
+        $this->sanitizeEntityValues($item2);
+        $manager->persist($item2);
+
         $manager->flush();
     }
 

--- a/library/DataFixtures/ORM/ProviderNotificationTemplateContent.php
+++ b/library/DataFixtures/ORM/ProviderNotificationTemplateContent.php
@@ -36,7 +36,21 @@ class ProviderNotificationTemplateContent extends Fixture implements DependentFi
         $this->sanitizeEntityValues($item1);
         $manager->persist($item1);
 
-    
+        /** @var NotificationTemplateContentInterface $item2 */
+        $item2 = $this->createEntityInstance(NotificationTemplateContent::class);
+        (function () {
+            $this->setFromName("IvozProvider Notification");
+            $this->setFromAddress("no-reply@ivozprovider.com");
+            $this->setSubject("test subject");
+            $this->setBody("test body");
+        })->call($item2);
+
+        $item2->setNotificationTemplate($this->getReference('_reference_ProviderNotificationTemplate2'));
+        $item2->setLanguage($this->getReference('_reference_ProviderLanguage1'));
+        $this->addReference('_reference_ProviderNotificationTemplateContent2', $item2);
+        $this->sanitizeEntityValues($item2);
+
+        $manager->persist($item2);
         $manager->flush();
     }
 

--- a/library/Ivoz/Provider/Application/Service/CallCsvReport/CallCsvReportDtoAssembler.php
+++ b/library/Ivoz/Provider/Application/Service/CallCsvReport/CallCsvReportDtoAssembler.php
@@ -40,7 +40,7 @@ class CallCsvReportDtoAssembler implements CustomDtoAssemblerInterface
             return $dto;
         }
 
-        if ($entity->getCsv()->getFileSize()) {
+        if (!is_null($entity->getCsv()->getFileSize())) {
             $pathResolver = $this
                 ->storagePathResolver
                 ->getPathResolver('Csv');

--- a/library/spec/Ivoz/Provider/Domain/Service/CallCsvReport/CreateBySchedulerSpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Service/CallCsvReport/CreateBySchedulerSpec.php
@@ -101,7 +101,36 @@ class CreateBySchedulerSpec extends ObjectBehavior
         $this->execute($scheduler);
     }
 
+    public function it_updates_scheduler_last_execution_even_if_a_exception_is_thrown(
+        CallCsvSchedulerInterface $scheduler,
+        CallCsvSchedulerDto $schedulerDto,
+        TimezoneInterface $timezone,
+        CompanyInterface $company,
+        CallCsvReportInterface $callCsvReport
+    ) {
+        $this->prepareExecution(
+            $scheduler,
+            $schedulerDto,
+            $timezone,
+            $company,
+            $callCsvReport
+        );
 
+        $schedulerDto
+            ->setLastExecution(
+                Argument::type(\DateTime::class)
+            )
+            ->shouldBeCalled();
+
+        $scheduler
+            ->getNextExecution()
+            ->willThrow(new \Exception('Some error'))
+            ->shouldBeCalled();
+
+        $this
+            ->shouldThrow(\Exception::class)
+            ->during('execute', [$scheduler]);
+    }
 
     public function it_accepts_no_company(
         CallCsvSchedulerInterface $scheduler,

--- a/scheme/app/config/config_test.yml
+++ b/scheme/app/config/config_test.yml
@@ -1,6 +1,7 @@
 imports:
     - { resource: config_dev.yml }
     - { resource: fixtures.yml }
+    - { resource: services_test.yml }
 
 framework:
     test: ~
@@ -14,3 +15,5 @@ doctrine:
     driver: 'pdo_sqlite'
     path: '%kernel.cache_dir%/db.sqlite'
     charset: 'UTF8'
+
+

--- a/scheme/app/config/services_test.yml
+++ b/scheme/app/config/services_test.yml
@@ -1,0 +1,9 @@
+
+services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+    public: true
+
+  Ivoz\Provider\Domain\Service\CallCsvReport\CreateByScheduler: ~
+  Ivoz\Provider\Domain\Service\Invoice\CreateByScheduler: ~

--- a/scheme/tests/DbIntegrationTestHelperTrait.php
+++ b/scheme/tests/DbIntegrationTestHelperTrait.php
@@ -9,6 +9,7 @@ use Ivoz\Core\Domain\Service\DomainEventPublisher;
 use Ivoz\Core\Domain\Service\EntityEventSubscriber;
 use Ivoz\Provider\Domain\Model\Changelog\Changelog;
 use Ivoz\Provider\Domain\Model\Changelog\ChangelogRepository;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Ivoz\Core\Application\Service\EntityTools;
@@ -19,6 +20,11 @@ trait DbIntegrationTestHelperTrait
      * @var KernelInterface
      */
     protected static $kernel;
+
+    /**
+     * @var ContainerInterface
+     */
+    protected $serviceContainer;
 
     /**
      * @var EntityManager
@@ -56,19 +62,23 @@ trait DbIntegrationTestHelperTrait
     protected function setUp()
     {
         $kernel = self::bootKernel();
-        $serviceContainer = $kernel->getContainer();
+        $this->serviceContainer = $kernel->getContainer();
 
-        $this->em = $serviceContainer
+        $this->em = $this
+            ->serviceContainer
             ->get('doctrine')
             ->getManager();
 
-        $this->eventPublisher = $serviceContainer
+        $this->eventPublisher = $this
+            ->serviceContainer
             ->get(DomainEventPublisher::class);
 
-        $this->entityTools = $serviceContainer
+        $this->entityTools = $this
+            ->serviceContainer
             ->get(EntityTools::class);
 
-        $this->entityEventSubscriber = $serviceContainer
+        $this->entityEventSubscriber = $this
+            ->serviceContainer
             ->get(EntityEventSubscriber::class);
 
         $this->resetDatabase();

--- a/scheme/tests/Provider/CallCsvReport/CreateBySchedulerServiceTest.php
+++ b/scheme/tests/Provider/CallCsvReport/CreateBySchedulerServiceTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Tests\Provider\CallCsvReport;
+
+use Ivoz\Provider\Domain\Model\CallCsvScheduler\CallCsvScheduler;
+use Ivoz\Provider\Domain\Model\CallCsvScheduler\CallCsvSchedulerDto;
+use Ivoz\Provider\Domain\Service\CallCsvReport\CreateByScheduler;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\DbIntegrationTestHelperTrait;
+use Ivoz\Provider\Domain\Model\CallCsvReport\CallCsvReport;
+use Ivoz\Provider\Domain\Model\CallCsvReport\CallCsvReportDto;
+
+class CreateBySchedulerServiceTest extends KernelTestCase
+{
+    use DbIntegrationTestHelperTrait;
+
+    /**
+     * @test
+     */
+    public function it_creates_callCsvReports()
+    {
+        $callCsvSchedulerRepository = $this->em
+            ->getRepository(CallCsvScheduler::class);
+
+        $fixtureCallCsvReport = $callCsvSchedulerRepository
+            ->find(1);
+
+        $service = $this
+            ->serviceContainer
+            ->get(
+                CreateByScheduler::class
+            );
+
+        $service
+            ->execute($fixtureCallCsvReport);
+
+        ///////////////////////
+
+        $changelogEntries = $this->getChangelogByClass(
+            CallCsvReport::class
+        );
+
+        $this->assertCount(1, $changelogEntries);
+    }
+
+    /**
+     * @test
+     */
+    public function date_ranges_are_lower_than_next_execution_day()
+    {
+        $callCsvScheduler = $this->createScheduler('2018-12-10 08:00:00');
+
+        $service = $this
+            ->serviceContainer
+            ->get(
+                CreateByScheduler::class
+            );
+
+        $service
+            ->execute($callCsvScheduler);
+
+        ///////////////////////
+
+        $changelogEntries = $this->getChangelogByClass(
+            CallCsvReport::class
+        );
+
+        $this->assertCount(1, $changelogEntries);
+        $changelog = $changelogEntries[0];
+
+        $diff = $changelog->getData();
+        $this->assertArraySubset(
+            [
+                'inDate' => '2018-12-08 23:00:00',
+                'outDate' => '2018-12-09 22:59:59'
+            ],
+            $diff
+        );
+    }
+
+
+    /**
+     * @test
+     */
+    public function next_execution_is_properly_updated()
+    {
+        $callCsvScheduler = $this->createScheduler('2018-12-10 08:00:00');
+
+        $service = $this
+            ->serviceContainer
+            ->get(
+                CreateByScheduler::class
+            );
+
+        $service
+            ->execute($callCsvScheduler);
+
+        $changelogEntries = $this->getChangelogByClass(
+            CallCsvScheduler::class
+        );
+
+        $this->assertCount(1, $changelogEntries);
+        $changelog = $changelogEntries[0];
+
+        $diff = $changelog->getData();
+        $this->assertArraySubset(
+            [
+                'nextExecution' => '2018-12-11 08:00:00'
+            ],
+            $diff
+        );
+    }
+
+
+    private function createScheduler($nextExecution): CallCsvScheduler
+    {
+        $callCsvSchedulerDto = new CallCsvSchedulerDto();
+        $callCsvSchedulerDto
+            ->setName('')
+            ->setUnit('day')
+            ->setFrequency(1)
+            ->setEmail('')
+            ->setNextExecution($nextExecution)
+            ->setCompanyId(1);
+
+        /** @var CallCsvScheduler $callCsvScheduler */
+        $callCsvScheduler = $this->entityTools
+            ->persistDto($callCsvSchedulerDto, null, true);
+
+        $this->resetChangelog();
+
+        return $callCsvScheduler;
+    }
+}

--- a/scheme/tests/Provider/CallCsvScheduler/CallCsvSchedulerLifeCycleTest.php
+++ b/scheme/tests/Provider/CallCsvScheduler/CallCsvSchedulerLifeCycleTest.php
@@ -152,7 +152,7 @@ class CallCsvSchedulerLifeCycleTest extends KernelTestCase
                 'frequency' => 1,
                 'email' => 'mikel+test-report@irontec.com',
                 'companyId' => 1,
-                'id' => 1
+                'id' => 2
             ],
             $diff
         );

--- a/scheme/tests/Provider/Invoice/CreateBySchedulerServiceTest.php
+++ b/scheme/tests/Provider/Invoice/CreateBySchedulerServiceTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Tests\Provider\Invoice;
+
+use Ivoz\Provider\Domain\Model\InvoiceScheduler\InvoiceScheduler;
+use Ivoz\Provider\Domain\Model\InvoiceScheduler\InvoiceSchedulerDto;
+use Ivoz\Provider\Domain\Service\Invoice\CreateByScheduler;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\DbIntegrationTestHelperTrait;
+use Ivoz\Provider\Domain\Model\Invoice\Invoice;
+use Ivoz\Provider\Domain\Model\Invoice\InvoiceDto;
+
+class CreateBySchedulerServiceTest extends KernelTestCase
+{
+    use DbIntegrationTestHelperTrait;
+
+    /**
+     * @test
+     */
+    public function it_creates_invoices()
+    {
+        $invoiceSchedulerRepository = $this->em
+            ->getRepository(InvoiceScheduler::class);
+
+        $fixtureInvoice = $invoiceSchedulerRepository
+            ->find(1);
+
+        $service = $this
+            ->serviceContainer
+            ->get(
+                CreateByScheduler::class
+            );
+
+        $service
+            ->execute($fixtureInvoice);
+
+        ///////////////////////
+
+        $changelogEntries = $this->getChangelogByClass(
+            Invoice::class
+        );
+
+        $this->assertCount(1, $changelogEntries);
+    }
+
+    /**
+     * @test
+     */
+    public function date_ranges_are_lower_than_next_execution_day()
+    {
+        $invoiceScheduler = $this->createScheduler('2018-12-10 08:00:00');
+
+        $service = $this
+            ->serviceContainer
+            ->get(
+                CreateByScheduler::class
+            );
+
+        $service
+            ->execute($invoiceScheduler);
+
+        ///////////////////////
+
+        $changelogEntries = $this->getChangelogByClass(
+            Invoice::class
+        );
+
+        $this->assertCount(1, $changelogEntries);
+        $changelog = $changelogEntries[0];
+
+        $diff = $changelog->getData();
+        $this->assertArraySubset(
+            [
+                'inDate' => '2018-12-02 23:00:00',
+                'outDate' => '2018-12-09 22:59:59'
+            ],
+            $diff
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function next_execution_is_properly_updated()
+    {
+        $invoiceScheduler = $this->createScheduler('2018-11-10 08:00:00');
+
+        $service = $this
+            ->serviceContainer
+            ->get(
+                CreateByScheduler::class
+            );
+
+        $service
+            ->execute($invoiceScheduler);
+
+        $changelogEntries = $this->getChangelogByClass(
+            InvoiceScheduler::class
+        );
+
+        $this->assertCount(1, $changelogEntries);
+        $changelog = $changelogEntries[0];
+
+        $diff = $changelog->getData();
+        $this->assertArraySubset(
+            [
+                'nextExecution' => '2018-11-17 08:00:00'
+            ],
+            $diff
+        );
+    }
+
+    private function createScheduler($nextExecution): InvoiceScheduler
+    {
+        $schedulerDto = new InvoiceSchedulerDto();
+        $schedulerDto
+            ->setName('')
+            ->setUnit('week')
+            ->setFrequency(1)
+            ->setEmail('')
+            ->setNextExecution($nextExecution)
+            ->setCompanyId(2)
+            ->setBrandId(1);
+
+        /** @var InvoiceScheduler $invoiceScheduler */
+        $invoiceScheduler = $this->entityTools
+            ->persistDto($schedulerDto, null, true);
+
+        $this->resetChangelog();
+
+        return $invoiceScheduler;
+    }
+}

--- a/scheme/tests/Provider/InvoiceScheduler/InvoiceSchedulerSchedulerLifeCycleTest.php
+++ b/scheme/tests/Provider/InvoiceScheduler/InvoiceSchedulerSchedulerLifeCycleTest.php
@@ -24,7 +24,7 @@ class InvoiceSchedulerLifeCycleTest extends KernelTestCase
             ->setEmail('mikel+test-invoice@irontec.com')
             ->setTaxRate(3)
             ->setBrandId(1)
-            ->setCompanyId(1);
+            ->setCompanyId(2);
 
         return $invoiceSchedulerDto;
     }
@@ -154,10 +154,10 @@ class InvoiceSchedulerLifeCycleTest extends KernelTestCase
                 'unit' => 'week',
                 'frequency' => 1,
                 'email' => 'mikel+test-invoice@irontec.com',
-                'taxRate' => 3.0,
+                'taxRate' => 3,
                 'brandId' => 1,
-                'companyId' => 1,
-                'id' => 1,
+                'companyId' => 2,
+                'id' => 2,
             ],
             $diff
         );

--- a/scheme/tests/Provider/NotificationTemplate/NotificationTemplateRepositoryTest.php
+++ b/scheme/tests/Provider/NotificationTemplate/NotificationTemplateRepositoryTest.php
@@ -42,8 +42,8 @@ class NotificationTemplateRepositoryTest extends KernelTestCase
         $genericCallCsvTemplate = $repository
             ->findGenericCallCsvTemplate();
 
-        $this->assertInternalType(
-            'null', // @todo NotificationTemplateRepository::class (No fixture yet)
+        $this->assertInstanceOf(
+            NotificationTemplate::class,
             $genericCallCsvTemplate
         );
     }

--- a/web/rest/brand/features/provider/notificationTemplate/postNotificationTemplate.feature
+++ b/web/rest/brand/features/provider/notificationTemplate/postNotificationTemplate.feature
@@ -24,14 +24,14 @@ Feature: Create notification templates
       {
           "name": "New fax notification",
           "type": "fax",
-          "id": 2
+          "id": 3
       }
     """
 
   Scenario: Retrieve created notification template
     Given I add Brand Authorization header
     When I add "Accept" header equal to "application/json"
-    And I send a "GET" request to "notification_templates/2"
+    And I send a "GET" request to "notification_templates/3"
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/json; charset=utf-8"
@@ -40,7 +40,7 @@ Feature: Create notification templates
       {
           "name": "New fax notification",
           "type": "fax",
-          "id": 2,
+          "id": 3,
           "brand": {
               "name": "DemoBrand",
               "domainUsers": "",

--- a/web/rest/brand/features/provider/notificationTemplateContent/postNotificationTemplateContent.feature
+++ b/web/rest/brand/features/provider/notificationTemplateContent/postNotificationTemplateContent.feature
@@ -25,14 +25,14 @@ Feature: Create notification template contents
       {
           "fromName": null,
           "fromAddress": null,
-          "id": 2
+          "id": 3
       }
     """
 
   Scenario: Retrieve created notification template content
     Given I add Brand Authorization header
     When I add "Accept" header equal to "application/json"
-    And I send a "GET" request to "notification_template_contents/2"
+    And I send a "GET" request to "notification_template_contents/3"
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/json; charset=utf-8"
@@ -44,7 +44,7 @@ Feature: Create notification template contents
           "subject": "Test subject",
           "body": "Test body",
           "bodyType": "text\/plain",
-          "id": 2,
+          "id": 3,
           "notificationTemplate": {
               "name": "Voicemail notification",
               "type": "voicemail",


### PR DESCRIPTION
Do not modify input argument before service execution, nextExecution was
being updated before report creation.

This PR aims to fix https://github.com/irontec/ivozprovider/issues/821