### PR TITLE
devops: disable http2

### DIFF
--- a/debian/ivozprovider-profile-portal.postinst
+++ b/debian/ivozprovider-profile-portal.postinst
@@ -35,7 +35,7 @@ function setup_apache_config()
     [ ! -L /etc/apache2/mods-enabled/php7.0.load ] && /usr/sbin/a2enmod php7.0
     [ ! -L /etc/apache2/mods-enabled/headers.load ] && /usr/sbin/a2enmod headers
     [ ! -L /etc/apache2/mods-enabled/rewrite.load ] && /usr/sbin/a2enmod rewrite
-    [ ! -L /etc/apache2/mods-enabled/http2.load ] && /usr/sbin/a2enmod http2
+    [   -L /etc/apache2/mods-enabled/http2.load ] && /usr/sbin/a2dismod http2 #requires mpm_event or mpm_worker
     [ ! -L /etc/apache2/mods-enabled/ssl.load ] && /usr/sbin/a2enmod ssl
     [ ! -L /etc/apache2/mods-enabled/mpm_prefork.load ] && /usr/sbin/a2enmod mpm_prefork
     [   -L /etc/apache2/mods-enabled/mpm_event.load ] && /usr/sbin/a2dismod mpm_event

--- a/profiles/portal/etc/apache2/sites-available/020-ivozprovider-portals.conf
+++ b/profiles/portal/etc/apache2/sites-available/020-ivozprovider-portals.conf
@@ -48,7 +48,6 @@ DocumentRoot /opt/irontec/ivozprovider/web/admin/public
 ### SSL Apache Site
 ################################################################################
 <VirtualHost *:443>
-    Protocols h2 http/1.1
     # Portal certificates
     SSLEngine on
     SSLCertificateFile    /etc/ssl/certs/ivozprovider-portals.pem


### PR DESCRIPTION
Apache is logging a lot of warnings since a recent apache2 update. From now on, php-fpm is required for http2 connections:

apache2 (2.4.25-3+deb9u5) removes the support for using
HTTP/2 when running with mpm_prefork. HTTP/2 supportis
only provided when running with mpm_event or mpm_worker.

