### PR TITLE
scheme: change rp.activation_time type

### DIFF
--- a/library/DataFixtures/ORM/CgrTpRatingProfile.php
+++ b/library/DataFixtures/ORM/CgrTpRatingProfile.php
@@ -31,9 +31,7 @@ class CgrTpRatingProfile extends Fixture implements DependentFixtureInterface
             $this->setTenant('b1');
             $this->setCategory('call');
             $this->setSubject('c1');
-            $this->setActivationTime(
-                new \DateTime('2018-01-01 10:10:10')
-            );
+            $this->setActivationTime('2018-01-01 10:10:10');
             $this->setRatingPlanTag('b1rp1');
             $this->setCreatedAt(
                 new \DateTime('2018-01-01 10:10:10')
@@ -55,9 +53,7 @@ class CgrTpRatingProfile extends Fixture implements DependentFixtureInterface
             $this->setTenant('b1');
             $this->setCategory('call');
             $this->setSubject('c1rt1');
-            $this->setActivationTime(
-                new \DateTime('2018-02-02 20:20:20')
-            );
+            $this->setActivationTime('2018-02-02 20:20:20');
             $this->setRatingPlanTag('b1rp2');
             $this->setCreatedAt(
                 new \DateTime('2018-02-02 20:20:20')

--- a/library/Ivoz/Cgr/Domain/Model/TpRatingProfile/TpRatingProfileAbstract.php
+++ b/library/Ivoz/Cgr/Domain/Model/TpRatingProfile/TpRatingProfileAbstract.php
@@ -45,9 +45,9 @@ abstract class TpRatingProfileAbstract
 
     /**
      * column: activation_time
-     * @var \DateTime
+     * @var string
      */
-    protected $activationTime;
+    protected $activationTime = '1970-01-01 00:00:00';
 
     /**
      * column: rating_plan_tag
@@ -442,17 +442,14 @@ abstract class TpRatingProfileAbstract
     /**
      * Set activationTime
      *
-     * @param \DateTime $activationTime
+     * @param string $activationTime
      *
      * @return self
      */
     protected function setActivationTime($activationTime)
     {
         Assertion::notNull($activationTime, 'activationTime value "%s" is null, but non null value was expected.');
-        $activationTime = \Ivoz\Core\Domain\Model\Helper\DateTimeHelper::createOrFix(
-            $activationTime,
-            'CURRENT_TIMESTAMP'
-        );
+        Assertion::maxLength($activationTime, 32, 'activationTime value "%s" is too long, it should have no more than %d characters, but has %d characters.');
 
         $this->activationTime = $activationTime;
 
@@ -462,7 +459,7 @@ abstract class TpRatingProfileAbstract
     /**
      * Get activationTime
      *
-     * @return \DateTime
+     * @return string
      */
     public function getActivationTime()
     {

--- a/library/Ivoz/Cgr/Domain/Model/TpRatingProfile/TpRatingProfileDtoAbstract.php
+++ b/library/Ivoz/Cgr/Domain/Model/TpRatingProfile/TpRatingProfileDtoAbstract.php
@@ -43,9 +43,9 @@ abstract class TpRatingProfileDtoAbstract implements DataTransferObjectInterface
     private $subject;
 
     /**
-     * @var \DateTime
+     * @var string
      */
-    private $activationTime = 'CURRENT_TIMESTAMP';
+    private $activationTime = '1970-01-01 00:00:00';
 
     /**
      * @var string
@@ -277,7 +277,7 @@ abstract class TpRatingProfileDtoAbstract implements DataTransferObjectInterface
     }
 
     /**
-     * @param \DateTime $activationTime
+     * @param string $activationTime
      *
      * @return static
      */
@@ -289,7 +289,7 @@ abstract class TpRatingProfileDtoAbstract implements DataTransferObjectInterface
     }
 
     /**
-     * @return \DateTime
+     * @return string
      */
     public function getActivationTime()
     {

--- a/library/Ivoz/Cgr/Domain/Model/TpRatingProfile/TpRatingProfileInterface.php
+++ b/library/Ivoz/Cgr/Domain/Model/TpRatingProfile/TpRatingProfileInterface.php
@@ -57,7 +57,7 @@ interface TpRatingProfileInterface extends LoggableEntityInterface
     /**
      * Get activationTime
      *
-     * @return \DateTime
+     * @return string
      */
     public function getActivationTime();
 

--- a/library/Ivoz/Cgr/Domain/Service/TpRatingProfile/UpdateByRatingProfile.php
+++ b/library/Ivoz/Cgr/Domain/Service/TpRatingProfile/UpdateByRatingProfile.php
@@ -55,7 +55,7 @@ class UpdateByRatingProfile implements RatingProfileLifecycleEventHandlerInterfa
         // Update/Create TpRatingPorfile for this RatingProfile
         $tpRatingProfileDto
             ->setTpid($brand->getCgrTenant())
-            ->setActivationTime($ratingProfile->getActivationTime())
+            ->setActivationTime($ratingProfile->getActivationTime()->format("Y-m-d H:i:s"))
             ->setTenant($brand->getCgrTenant())
             ->setRatingPlanTag($ratingPlanGroup->getCgrTag())
             ->setRatingProfileId($ratingProfile->getId());

--- a/library/Ivoz/Cgr/Infrastructure/Persistence/Doctrine/Mapping/TpRatingProfile.TpRatingProfileAbstract.orm.yml
+++ b/library/Ivoz/Cgr/Infrastructure/Persistence/Doctrine/Mapping/TpRatingProfile.TpRatingProfileAbstract.orm.yml
@@ -60,10 +60,11 @@ Ivoz\Cgr\Domain\Model\TpRatingProfile\TpRatingProfileAbstract:
       options:
         fixed: false
     activationTime:
-      type: datetime
+      type: string
       nullable: false
+      length: 32
       options:
-        default: CURRENT_TIMESTAMP
+        default: "1970-01-01 00:00:00"
       column: activation_time
     ratingPlanTag:
       type: string

--- a/scheme/app/DoctrineMigrations/Version20181221113443.php
+++ b/scheme/app/DoctrineMigrations/Version20181221113443.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20181221113443 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql("ALTER TABLE tp_rating_profiles CHANGE activation_time activation_time VARCHAR(32) DEFAULT '1970-01-01 00:00:00' NOT NULL");
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql("ALTER TABLE tp_rating_profiles CHANGE activation_time activation_time DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL COMMENT '(DC2Type:datetime)'");
+    }
+}


### PR DESCRIPTION
As reported by @powerpbx in https://github.com/irontec/ivozprovider/pull/807#issue-234711702, CGRateS does not handle properly rating profiles activation_time if this field has datetime type.

This PR changes type to varchar (as CGRateS original field) and needs https://github.com/irontec/cgrates/commit/72fa43d91251d413591665f20ed1b3239a9f59bf to work properly.

This issue closes #801 and #807.

Thanks @powerpbx  for your report.