### PR TITLE
Add support for calendar events

### DIFF
--- a/asterisk/agi/src/Agi/Action/DdiAction.php
+++ b/asterisk/agi/src/Agi/Action/DdiAction.php
@@ -98,7 +98,7 @@ class DdiAction
                     $this->externalFilterAction
                         ->setDDI($ddi)
                         ->setFilter($externalCallFilter)
-                        ->setLocution($holidayDate->getLocution())
+                        ->setHolidayDate($holidayDate)
                         ->processHoliday();
                     return;
                 }

--- a/doc/sphinx/administration_portal/client/vpbx/routing_tools/calendars.rst
+++ b/doc/sphinx/administration_portal/client/vpbx/routing_tools/calendars.rst
@@ -15,11 +15,33 @@ days will be holidays using the buttons in its row:
 From this moment on, the calendar has the 1st of January of 2016 as holiday
 date with the locution "Happy New Year".
 
+.. glossary::
+
+    Name
+        Unique name to identify this holiday date
+
+    Locution
+        Override default External call filter holiday locution
+
+    Event Date
+        Day of the calendar to be marked as holiday
+
+    Whole day event
+        Enable this to create an event that lasts all the day
+
+    Time In/Time out
+        For not whole day events, specify the time interval the event will be active
+
+    Routing options
+        Override default External call filter holiday routing
+
 .. warning:: Calendars logic is opposite to Schedulers: If a day is not defined
    as holiday in any of the calendars, it will considered a normal day and no
    filtering will be applied.
 
 .. hint:: Holidays without special locutions will apply the external call filter
-   holiday generic locution (see below).
+   holiday locution.
 
-.. rubric:: Create a new External call filter
+.. hint:: Holidays without special routing will apply the external call filter
+   holiday routing.
+

--- a/doc/sphinx/locale/es/LC_MESSAGES/administration_portal.po
+++ b/doc/sphinx/locale/es/LC_MESSAGES/administration_portal.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: IvozProvider 2.7\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-12-27 16:06+0100\n"
+"POT-Creation-Date: 2018-12-31 11:42+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -53,6 +53,7 @@ msgstr ""
 #: ../../administration_portal/client/vpbx/routing_endpoints/hunt_groups.rst:13
 #: ../../administration_portal/client/vpbx/routing_endpoints/ivrs.rst:21
 #: ../../administration_portal/client/vpbx/routing_endpoints/queues.rst:26
+#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:19
 #: ../../administration_portal/client/vpbx/routing_tools/external_call_filters.rst:17
 #: ../../administration_portal/client/vpbx/routing_tools/route_locks.rst:21
 #: ../../administration_portal/client/vpbx/terminals.rst:15
@@ -6526,21 +6527,69 @@ msgid ""
 "holiday date with the locution \"Happy New Year\"."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:18
+#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:21
+msgid "Unique name to identify this holiday date"
+msgstr ""
+
+#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:22
+msgid "Locution"
+msgstr ""
+
+#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:24
+msgid "Override default External call filter holiday locution"
+msgstr ""
+
+#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:25
+msgid "Event Date"
+msgstr ""
+
+#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:27
+msgid "Day of the calendar to be marked as holiday"
+msgstr ""
+
+#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:28
+msgid "Whole day event"
+msgstr ""
+
+#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:30
+msgid "Enable this to create an event that lasts all the day"
+msgstr ""
+
+#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:31
+msgid "Time In/Time out"
+msgstr ""
+
+#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:33
+msgid ""
+"For not whole day events, specify the time interval the event will be "
+"active"
+msgstr ""
+
+#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:34
+msgid "Routing options"
+msgstr ""
+
+#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:36
+msgid "Override default External call filter holiday routing"
+msgstr ""
+
+#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:38
 msgid ""
 "Calendars logic is opposite to Schedulers: If a day is not defined as "
 "holiday in any of the calendars, it will considered a normal day and no "
 "filtering will be applied."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:22
+#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:42
 msgid ""
 "Holidays without special locutions will apply the external call filter "
-"holiday generic locution (see below)."
+"holiday locution."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:25
-msgid "Create a new External call filter"
+#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:45
+msgid ""
+"Holidays without special routing will apply the external call filter "
+"holiday routing."
 msgstr ""
 
 #: ../../administration_portal/client/vpbx/routing_tools/external_call_filters.rst:7
@@ -8503,29 +8552,11 @@ msgstr ""
 #~ msgstr ""
 
 #~ msgid ""
-#~ "Chosen currency will be used in "
-#~ "price calculation, invoices, balance Choosen"
-#~ " currency will be used in price "
-#~ "calculation, invoices, balance movements and"
-#~ " remaining money operations of this "
-#~ "client."
+#~ "Holidays without special locutions will "
+#~ "apply the external call filter holiday"
+#~ " generic locution (see below)."
 #~ msgstr ""
 
-#~ msgid ""
-#~ "Chosen currency will be used in "
-#~ "cost calculation, balance movements and "
-#~ "Choosen currency will be used in "
-#~ "cost calculation, balance movements and "
-#~ "remaining money operations of this "
-#~ "carrier."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Chosen currency will be used in "
-#~ "price calculation, invoices, invoice's Choosen"
-#~ " currency will be used in price "
-#~ "calculation, invoices, invoice's fixed costs,"
-#~ " balance movements and remaining money "
-#~ "operations of this client."
+#~ msgid "Create a new External call filter"
 #~ msgstr ""
 

--- a/library/Ivoz/Provider/Domain/Model/Calendar/Calendar.php
+++ b/library/Ivoz/Provider/Domain/Model/Calendar/Calendar.php
@@ -46,8 +46,20 @@ class Calendar extends CalendarAbstract implements CalendarInterface
             )
         );
 
-        $holidayDates = $this->getHolidayDates($criteria);
+        $eventMatched = false;
 
-        return !empty($holidayDates);
+        $holidayDates = $this->getHolidayDates($criteria);
+        foreach ($holidayDates as $holidayDate) {
+            $eventMatched = $holidayDate
+                ->checkEventOnTime(
+                    $date
+                );
+
+            if ($eventMatched) {
+                break;
+            }
+        }
+
+        return $eventMatched;
     }
 }

--- a/library/Ivoz/Provider/Domain/Model/ExternalCallFilter/ExternalCallFilter.php
+++ b/library/Ivoz/Provider/Domain/Model/ExternalCallFilter/ExternalCallFilter.php
@@ -114,7 +114,9 @@ class ExternalCallFilter extends ExternalCallFilterAbstract implements ExternalC
             return null;
         }
 
-        $datetime = new \DateTime('now');
+        $company = $this->getCompany();
+        $timezone = $company->getDefaultTimezone();
+        $time = new \DateTime('now', $timezone);
 
         /**
          * @var ExternalCallFilterRelCalendar $externalCallFilterRelCalendar
@@ -131,13 +133,20 @@ class ExternalCallFilter extends ExternalCallFilterAbstract implements ExternalC
                 ->where(
                     $expressionBuilder->eq(
                         'eventDate',
-                        $datetime
+                        $time
                     )
                 );
 
             $holidayDates = $calendar->getHolidayDates($holidayDateCriteria);
-            if (!empty($holidayDates)) {
-                return $holidayDates[0];
+            foreach ($holidayDates as $holidayDate) {
+                $eventMatched = $holidayDate
+                    ->checkEventOnTime(
+                        $time
+                    );
+
+                if ($eventMatched) {
+                    return $holidayDate;
+                }
             }
         }
 

--- a/library/Ivoz/Provider/Domain/Model/HolidayDate/HolidayDate.php
+++ b/library/Ivoz/Provider/Domain/Model/HolidayDate/HolidayDate.php
@@ -2,12 +2,15 @@
 
 namespace Ivoz\Provider\Domain\Model\HolidayDate;
 
+use Ivoz\Provider\Domain\Traits\RoutableTrait;
+
 /**
  * HolidayDate
  */
 class HolidayDate extends HolidayDateAbstract implements HolidayDateInterface
 {
     use HolidayDateTrait;
+    use RoutableTrait;
 
     /**
      * @codeCoverageIgnore
@@ -26,5 +29,66 @@ class HolidayDate extends HolidayDateAbstract implements HolidayDateInterface
     public function getId()
     {
         return $this->id;
+    }
+
+    protected function sanitizeValues()
+    {
+        if (!$this->getWholeDayEvent()) {
+            $timeIn = $this->getTimeIn();
+            $timeOut = $this->getTimeOut();
+
+            if ($timeOut < $timeIn) {
+                throw new \DomainException('Time out must be later than time in.');
+            }
+        } else {
+            $this->setTimeIn(null);
+            $this->setTimeOut(null);
+        }
+
+        $this->sanitizeRouteValues();
+    }
+
+    /**
+     * Get the numberValue in E.164 format when routing to 'number'
+     *
+     * @return string
+     */
+    public function getNumberValueE164()
+    {
+        if (!$this->getNumberCountry()) {
+            return "";
+        }
+
+        return
+            $this->getNumberCountry()->getCountryCode() .
+            $this->getNumberValue();
+    }
+
+    /**
+     * Check if the given time matches this HolidayDate events
+     *
+     * @param \DateTime $time
+     * @return bool
+     */
+    public function checkEventOnTime(\DateTime $time)
+    {
+        if ($this->getWholeDayEvent()) {
+            return true;
+        }
+
+        // Check if time is between in and out
+        $timezone = $time->getTimezone();
+        $timeIn = new \DateTime(
+            $this->getTimeIn()->format('H:i:s'),
+            $timezone
+        );
+        $timeOut = new \DateTime(
+            $this->getTimeOut()->format('H:i:s'),
+            $timezone
+        );
+
+        $eventOnTime = ($time >= $timeIn && $time <= $timeOut);
+
+        return $eventOnTime;
     }
 }

--- a/library/Ivoz/Provider/Domain/Model/HolidayDate/HolidayDateAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/HolidayDate/HolidayDateAbstract.php
@@ -24,6 +24,32 @@ abstract class HolidayDateAbstract
     protected $eventDate;
 
     /**
+     * @var boolean
+     */
+    protected $wholeDayEvent = '1';
+
+    /**
+     * @var \DateTime | null
+     */
+    protected $timeIn;
+
+    /**
+     * @var \DateTime | null
+     */
+    protected $timeOut;
+
+    /**
+     * comment: enum:number|extension|voicemail
+     * @var string | null
+     */
+    protected $routeType;
+
+    /**
+     * @var string | null
+     */
+    protected $numberValue;
+
+    /**
      * @var \Ivoz\Provider\Domain\Model\Calendar\CalendarInterface
      */
     protected $calendar;
@@ -33,16 +59,32 @@ abstract class HolidayDateAbstract
      */
     protected $locution;
 
+    /**
+     * @var \Ivoz\Provider\Domain\Model\Extension\ExtensionInterface
+     */
+    protected $extension;
+
+    /**
+     * @var \Ivoz\Provider\Domain\Model\User\UserInterface
+     */
+    protected $voiceMailUser;
+
+    /**
+     * @var \Ivoz\Provider\Domain\Model\Country\CountryInterface
+     */
+    protected $numberCountry;
+
 
     use ChangelogTrait;
 
     /**
      * Constructor
      */
-    protected function __construct($name, $eventDate)
+    protected function __construct($name, $eventDate, $wholeDayEvent)
     {
         $this->setName($name);
         $this->setEventDate($eventDate);
+        $this->setWholeDayEvent($wholeDayEvent);
     }
 
     abstract public function getId();
@@ -113,12 +155,20 @@ abstract class HolidayDateAbstract
 
         $self = new static(
             $dto->getName(),
-            $dto->getEventDate()
+            $dto->getEventDate(),
+            $dto->getWholeDayEvent()
         );
 
         $self
+            ->setTimeIn($dto->getTimeIn())
+            ->setTimeOut($dto->getTimeOut())
+            ->setRouteType($dto->getRouteType())
+            ->setNumberValue($dto->getNumberValue())
             ->setCalendar($dto->getCalendar())
             ->setLocution($dto->getLocution())
+            ->setExtension($dto->getExtension())
+            ->setVoiceMailUser($dto->getVoiceMailUser())
+            ->setNumberCountry($dto->getNumberCountry())
         ;
 
         $self->sanitizeValues();
@@ -142,8 +192,16 @@ abstract class HolidayDateAbstract
         $this
             ->setName($dto->getName())
             ->setEventDate($dto->getEventDate())
+            ->setWholeDayEvent($dto->getWholeDayEvent())
+            ->setTimeIn($dto->getTimeIn())
+            ->setTimeOut($dto->getTimeOut())
+            ->setRouteType($dto->getRouteType())
+            ->setNumberValue($dto->getNumberValue())
             ->setCalendar($dto->getCalendar())
-            ->setLocution($dto->getLocution());
+            ->setLocution($dto->getLocution())
+            ->setExtension($dto->getExtension())
+            ->setVoiceMailUser($dto->getVoiceMailUser())
+            ->setNumberCountry($dto->getNumberCountry());
 
 
 
@@ -161,8 +219,16 @@ abstract class HolidayDateAbstract
         return self::createDto()
             ->setName(self::getName())
             ->setEventDate(self::getEventDate())
+            ->setWholeDayEvent(self::getWholeDayEvent())
+            ->setTimeIn(self::getTimeIn())
+            ->setTimeOut(self::getTimeOut())
+            ->setRouteType(self::getRouteType())
+            ->setNumberValue(self::getNumberValue())
             ->setCalendar(\Ivoz\Provider\Domain\Model\Calendar\Calendar::entityToDto(self::getCalendar(), $depth))
-            ->setLocution(\Ivoz\Provider\Domain\Model\Locution\Locution::entityToDto(self::getLocution(), $depth));
+            ->setLocution(\Ivoz\Provider\Domain\Model\Locution\Locution::entityToDto(self::getLocution(), $depth))
+            ->setExtension(\Ivoz\Provider\Domain\Model\Extension\Extension::entityToDto(self::getExtension(), $depth))
+            ->setVoiceMailUser(\Ivoz\Provider\Domain\Model\User\User::entityToDto(self::getVoiceMailUser(), $depth))
+            ->setNumberCountry(\Ivoz\Provider\Domain\Model\Country\Country::entityToDto(self::getNumberCountry(), $depth));
     }
 
     /**
@@ -173,8 +239,16 @@ abstract class HolidayDateAbstract
         return [
             'name' => self::getName(),
             'eventDate' => self::getEventDate(),
+            'wholeDayEvent' => self::getWholeDayEvent(),
+            'timeIn' => self::getTimeIn(),
+            'timeOut' => self::getTimeOut(),
+            'routeType' => self::getRouteType(),
+            'numberValue' => self::getNumberValue(),
             'calendarId' => self::getCalendar() ? self::getCalendar()->getId() : null,
-            'locutionId' => self::getLocution() ? self::getLocution()->getId() : null
+            'locutionId' => self::getLocution() ? self::getLocution()->getId() : null,
+            'extensionId' => self::getExtension() ? self::getExtension()->getId() : null,
+            'voiceMailUserId' => self::getVoiceMailUser() ? self::getVoiceMailUser()->getId() : null,
+            'numberCountryId' => self::getNumberCountry() ? self::getNumberCountry()->getId() : null
         ];
     }
     // @codeCoverageIgnoreStart
@@ -233,6 +307,148 @@ abstract class HolidayDateAbstract
     }
 
     /**
+     * Set wholeDayEvent
+     *
+     * @param boolean $wholeDayEvent
+     *
+     * @return self
+     */
+    protected function setWholeDayEvent($wholeDayEvent)
+    {
+        Assertion::notNull($wholeDayEvent, 'wholeDayEvent value "%s" is null, but non null value was expected.');
+        Assertion::between(intval($wholeDayEvent), 0, 1, 'wholeDayEvent provided "%s" is not a valid boolean value.');
+
+        $this->wholeDayEvent = $wholeDayEvent;
+
+        return $this;
+    }
+
+    /**
+     * Get wholeDayEvent
+     *
+     * @return boolean
+     */
+    public function getWholeDayEvent()
+    {
+        return $this->wholeDayEvent;
+    }
+
+    /**
+     * Set timeIn
+     *
+     * @param \DateTime $timeIn
+     *
+     * @return self
+     */
+    protected function setTimeIn($timeIn = null)
+    {
+        if (!is_null($timeIn)) {
+        }
+
+        $this->timeIn = $timeIn;
+
+        return $this;
+    }
+
+    /**
+     * Get timeIn
+     *
+     * @return \DateTime | null
+     */
+    public function getTimeIn()
+    {
+        return $this->timeIn;
+    }
+
+    /**
+     * Set timeOut
+     *
+     * @param \DateTime $timeOut
+     *
+     * @return self
+     */
+    protected function setTimeOut($timeOut = null)
+    {
+        if (!is_null($timeOut)) {
+        }
+
+        $this->timeOut = $timeOut;
+
+        return $this;
+    }
+
+    /**
+     * Get timeOut
+     *
+     * @return \DateTime | null
+     */
+    public function getTimeOut()
+    {
+        return $this->timeOut;
+    }
+
+    /**
+     * Set routeType
+     *
+     * @param string $routeType
+     *
+     * @return self
+     */
+    protected function setRouteType($routeType = null)
+    {
+        if (!is_null($routeType)) {
+            Assertion::maxLength($routeType, 25, 'routeType value "%s" is too long, it should have no more than %d characters, but has %d characters.');
+            Assertion::choice($routeType, array (
+              0 => 'number',
+              1 => 'extension',
+              2 => 'voicemail',
+            ), 'routeTypevalue "%s" is not an element of the valid values: %s');
+        }
+
+        $this->routeType = $routeType;
+
+        return $this;
+    }
+
+    /**
+     * Get routeType
+     *
+     * @return string | null
+     */
+    public function getRouteType()
+    {
+        return $this->routeType;
+    }
+
+    /**
+     * Set numberValue
+     *
+     * @param string $numberValue
+     *
+     * @return self
+     */
+    protected function setNumberValue($numberValue = null)
+    {
+        if (!is_null($numberValue)) {
+            Assertion::maxLength($numberValue, 25, 'numberValue value "%s" is too long, it should have no more than %d characters, but has %d characters.');
+        }
+
+        $this->numberValue = $numberValue;
+
+        return $this;
+    }
+
+    /**
+     * Get numberValue
+     *
+     * @return string | null
+     */
+    public function getNumberValue()
+    {
+        return $this->numberValue;
+    }
+
+    /**
      * Set calendar
      *
      * @param \Ivoz\Provider\Domain\Model\Calendar\CalendarInterface $calendar
@@ -278,6 +494,78 @@ abstract class HolidayDateAbstract
     public function getLocution()
     {
         return $this->locution;
+    }
+
+    /**
+     * Set extension
+     *
+     * @param \Ivoz\Provider\Domain\Model\Extension\ExtensionInterface $extension
+     *
+     * @return self
+     */
+    public function setExtension(\Ivoz\Provider\Domain\Model\Extension\ExtensionInterface $extension = null)
+    {
+        $this->extension = $extension;
+
+        return $this;
+    }
+
+    /**
+     * Get extension
+     *
+     * @return \Ivoz\Provider\Domain\Model\Extension\ExtensionInterface
+     */
+    public function getExtension()
+    {
+        return $this->extension;
+    }
+
+    /**
+     * Set voiceMailUser
+     *
+     * @param \Ivoz\Provider\Domain\Model\User\UserInterface $voiceMailUser
+     *
+     * @return self
+     */
+    public function setVoiceMailUser(\Ivoz\Provider\Domain\Model\User\UserInterface $voiceMailUser = null)
+    {
+        $this->voiceMailUser = $voiceMailUser;
+
+        return $this;
+    }
+
+    /**
+     * Get voiceMailUser
+     *
+     * @return \Ivoz\Provider\Domain\Model\User\UserInterface
+     */
+    public function getVoiceMailUser()
+    {
+        return $this->voiceMailUser;
+    }
+
+    /**
+     * Set numberCountry
+     *
+     * @param \Ivoz\Provider\Domain\Model\Country\CountryInterface $numberCountry
+     *
+     * @return self
+     */
+    public function setNumberCountry(\Ivoz\Provider\Domain\Model\Country\CountryInterface $numberCountry = null)
+    {
+        $this->numberCountry = $numberCountry;
+
+        return $this;
+    }
+
+    /**
+     * Get numberCountry
+     *
+     * @return \Ivoz\Provider\Domain\Model\Country\CountryInterface
+     */
+    public function getNumberCountry()
+    {
+        return $this->numberCountry;
     }
 
     // @codeCoverageIgnoreEnd

--- a/library/Ivoz/Provider/Domain/Model/HolidayDate/HolidayDateDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/HolidayDate/HolidayDateDtoAbstract.php
@@ -23,6 +23,31 @@ abstract class HolidayDateDtoAbstract implements DataTransferObjectInterface
     private $eventDate;
 
     /**
+     * @var boolean
+     */
+    private $wholeDayEvent = '1';
+
+    /**
+     * @var \DateTime
+     */
+    private $timeIn;
+
+    /**
+     * @var \DateTime
+     */
+    private $timeOut;
+
+    /**
+     * @var string
+     */
+    private $routeType;
+
+    /**
+     * @var string
+     */
+    private $numberValue;
+
+    /**
      * @var integer
      */
     private $id;
@@ -36,6 +61,21 @@ abstract class HolidayDateDtoAbstract implements DataTransferObjectInterface
      * @var \Ivoz\Provider\Domain\Model\Locution\LocutionDto | null
      */
     private $locution;
+
+    /**
+     * @var \Ivoz\Provider\Domain\Model\Extension\ExtensionDto | null
+     */
+    private $extension;
+
+    /**
+     * @var \Ivoz\Provider\Domain\Model\User\UserDto | null
+     */
+    private $voiceMailUser;
+
+    /**
+     * @var \Ivoz\Provider\Domain\Model\Country\CountryDto | null
+     */
+    private $numberCountry;
 
 
     use DtoNormalizer;
@@ -57,9 +97,17 @@ abstract class HolidayDateDtoAbstract implements DataTransferObjectInterface
         return [
             'name' => 'name',
             'eventDate' => 'eventDate',
+            'wholeDayEvent' => 'wholeDayEvent',
+            'timeIn' => 'timeIn',
+            'timeOut' => 'timeOut',
+            'routeType' => 'routeType',
+            'numberValue' => 'numberValue',
             'id' => 'id',
             'calendarId' => 'calendar',
-            'locutionId' => 'locution'
+            'locutionId' => 'locution',
+            'extensionId' => 'extension',
+            'voiceMailUserId' => 'voiceMailUser',
+            'numberCountryId' => 'numberCountry'
         ];
     }
 
@@ -71,9 +119,17 @@ abstract class HolidayDateDtoAbstract implements DataTransferObjectInterface
         return [
             'name' => $this->getName(),
             'eventDate' => $this->getEventDate(),
+            'wholeDayEvent' => $this->getWholeDayEvent(),
+            'timeIn' => $this->getTimeIn(),
+            'timeOut' => $this->getTimeOut(),
+            'routeType' => $this->getRouteType(),
+            'numberValue' => $this->getNumberValue(),
             'id' => $this->getId(),
             'calendar' => $this->getCalendar(),
-            'locution' => $this->getLocution()
+            'locution' => $this->getLocution(),
+            'extension' => $this->getExtension(),
+            'voiceMailUser' => $this->getVoiceMailUser(),
+            'numberCountry' => $this->getNumberCountry()
         ];
     }
 
@@ -84,6 +140,9 @@ abstract class HolidayDateDtoAbstract implements DataTransferObjectInterface
     {
         $this->calendar = $transformer->transform('Ivoz\\Provider\\Domain\\Model\\Calendar\\Calendar', $this->getCalendarId());
         $this->locution = $transformer->transform('Ivoz\\Provider\\Domain\\Model\\Locution\\Locution', $this->getLocutionId());
+        $this->extension = $transformer->transform('Ivoz\\Provider\\Domain\\Model\\Extension\\Extension', $this->getExtensionId());
+        $this->voiceMailUser = $transformer->transform('Ivoz\\Provider\\Domain\\Model\\User\\User', $this->getVoiceMailUserId());
+        $this->numberCountry = $transformer->transform('Ivoz\\Provider\\Domain\\Model\\Country\\Country', $this->getNumberCountryId());
     }
 
     /**
@@ -131,6 +190,106 @@ abstract class HolidayDateDtoAbstract implements DataTransferObjectInterface
     public function getEventDate()
     {
         return $this->eventDate;
+    }
+
+    /**
+     * @param boolean $wholeDayEvent
+     *
+     * @return static
+     */
+    public function setWholeDayEvent($wholeDayEvent = null)
+    {
+        $this->wholeDayEvent = $wholeDayEvent;
+
+        return $this;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getWholeDayEvent()
+    {
+        return $this->wholeDayEvent;
+    }
+
+    /**
+     * @param \DateTime $timeIn
+     *
+     * @return static
+     */
+    public function setTimeIn($timeIn = null)
+    {
+        $this->timeIn = $timeIn;
+
+        return $this;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getTimeIn()
+    {
+        return $this->timeIn;
+    }
+
+    /**
+     * @param \DateTime $timeOut
+     *
+     * @return static
+     */
+    public function setTimeOut($timeOut = null)
+    {
+        $this->timeOut = $timeOut;
+
+        return $this;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getTimeOut()
+    {
+        return $this->timeOut;
+    }
+
+    /**
+     * @param string $routeType
+     *
+     * @return static
+     */
+    public function setRouteType($routeType = null)
+    {
+        $this->routeType = $routeType;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRouteType()
+    {
+        return $this->routeType;
+    }
+
+    /**
+     * @param string $numberValue
+     *
+     * @return static
+     */
+    public function setNumberValue($numberValue = null)
+    {
+        $this->numberValue = $numberValue;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getNumberValue()
+    {
+        return $this->numberValue;
     }
 
     /**
@@ -239,6 +398,144 @@ abstract class HolidayDateDtoAbstract implements DataTransferObjectInterface
     public function getLocutionId()
     {
         if ($dto = $this->getLocution()) {
+            return $dto->getId();
+        }
+
+        return null;
+    }
+
+    /**
+     * @param \Ivoz\Provider\Domain\Model\Extension\ExtensionDto $extension
+     *
+     * @return static
+     */
+    public function setExtension(\Ivoz\Provider\Domain\Model\Extension\ExtensionDto $extension = null)
+    {
+        $this->extension = $extension;
+
+        return $this;
+    }
+
+    /**
+     * @return \Ivoz\Provider\Domain\Model\Extension\ExtensionDto
+     */
+    public function getExtension()
+    {
+        return $this->extension;
+    }
+
+    /**
+     * @param integer $id | null
+     *
+     * @return static
+     */
+    public function setExtensionId($id)
+    {
+        $value = !is_null($id)
+            ? new \Ivoz\Provider\Domain\Model\Extension\ExtensionDto($id)
+            : null;
+
+        return $this->setExtension($value);
+    }
+
+    /**
+     * @return integer | null
+     */
+    public function getExtensionId()
+    {
+        if ($dto = $this->getExtension()) {
+            return $dto->getId();
+        }
+
+        return null;
+    }
+
+    /**
+     * @param \Ivoz\Provider\Domain\Model\User\UserDto $voiceMailUser
+     *
+     * @return static
+     */
+    public function setVoiceMailUser(\Ivoz\Provider\Domain\Model\User\UserDto $voiceMailUser = null)
+    {
+        $this->voiceMailUser = $voiceMailUser;
+
+        return $this;
+    }
+
+    /**
+     * @return \Ivoz\Provider\Domain\Model\User\UserDto
+     */
+    public function getVoiceMailUser()
+    {
+        return $this->voiceMailUser;
+    }
+
+    /**
+     * @param integer $id | null
+     *
+     * @return static
+     */
+    public function setVoiceMailUserId($id)
+    {
+        $value = !is_null($id)
+            ? new \Ivoz\Provider\Domain\Model\User\UserDto($id)
+            : null;
+
+        return $this->setVoiceMailUser($value);
+    }
+
+    /**
+     * @return integer | null
+     */
+    public function getVoiceMailUserId()
+    {
+        if ($dto = $this->getVoiceMailUser()) {
+            return $dto->getId();
+        }
+
+        return null;
+    }
+
+    /**
+     * @param \Ivoz\Provider\Domain\Model\Country\CountryDto $numberCountry
+     *
+     * @return static
+     */
+    public function setNumberCountry(\Ivoz\Provider\Domain\Model\Country\CountryDto $numberCountry = null)
+    {
+        $this->numberCountry = $numberCountry;
+
+        return $this;
+    }
+
+    /**
+     * @return \Ivoz\Provider\Domain\Model\Country\CountryDto
+     */
+    public function getNumberCountry()
+    {
+        return $this->numberCountry;
+    }
+
+    /**
+     * @param integer $id | null
+     *
+     * @return static
+     */
+    public function setNumberCountryId($id)
+    {
+        $value = !is_null($id)
+            ? new \Ivoz\Provider\Domain\Model\Country\CountryDto($id)
+            : null;
+
+        return $this->setNumberCountry($value);
+    }
+
+    /**
+     * @return integer | null
+     */
+    public function getNumberCountryId()
+    {
+        if ($dto = $this->getNumberCountry()) {
             return $dto->getId();
         }
 

--- a/library/Ivoz/Provider/Domain/Model/HolidayDate/HolidayDateInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/HolidayDate/HolidayDateInterface.php
@@ -13,6 +13,21 @@ interface HolidayDateInterface extends LoggableEntityInterface
     public function getChangeSet();
 
     /**
+     * Get the numberValue in E.164 format when routing to 'number'
+     *
+     * @return string
+     */
+    public function getNumberValueE164();
+
+    /**
+     * Check if the given time matches this HolidayDate events
+     *
+     * @param \DateTime $time
+     * @return bool
+     */
+    public function checkEventOnTime(\DateTime $time);
+
+    /**
      * Get name
      *
      * @return string
@@ -25,6 +40,41 @@ interface HolidayDateInterface extends LoggableEntityInterface
      * @return \DateTime
      */
     public function getEventDate();
+
+    /**
+     * Get wholeDayEvent
+     *
+     * @return boolean
+     */
+    public function getWholeDayEvent();
+
+    /**
+     * Get timeIn
+     *
+     * @return \DateTime | null
+     */
+    public function getTimeIn();
+
+    /**
+     * Get timeOut
+     *
+     * @return \DateTime | null
+     */
+    public function getTimeOut();
+
+    /**
+     * Get routeType
+     *
+     * @return string | null
+     */
+    public function getRouteType();
+
+    /**
+     * Get numberValue
+     *
+     * @return string | null
+     */
+    public function getNumberValue();
 
     /**
      * Set calendar
@@ -57,4 +107,58 @@ interface HolidayDateInterface extends LoggableEntityInterface
      * @return \Ivoz\Provider\Domain\Model\Locution\LocutionInterface
      */
     public function getLocution();
+
+    /**
+     * Set extension
+     *
+     * @param \Ivoz\Provider\Domain\Model\Extension\ExtensionInterface $extension
+     *
+     * @return self
+     */
+    public function setExtension(\Ivoz\Provider\Domain\Model\Extension\ExtensionInterface $extension = null);
+
+    /**
+     * Get extension
+     *
+     * @return \Ivoz\Provider\Domain\Model\Extension\ExtensionInterface
+     */
+    public function getExtension();
+
+    /**
+     * Set voiceMailUser
+     *
+     * @param \Ivoz\Provider\Domain\Model\User\UserInterface $voiceMailUser
+     *
+     * @return self
+     */
+    public function setVoiceMailUser(\Ivoz\Provider\Domain\Model\User\UserInterface $voiceMailUser = null);
+
+    /**
+     * Get voiceMailUser
+     *
+     * @return \Ivoz\Provider\Domain\Model\User\UserInterface
+     */
+    public function getVoiceMailUser();
+
+    /**
+     * Set numberCountry
+     *
+     * @param \Ivoz\Provider\Domain\Model\Country\CountryInterface $numberCountry
+     *
+     * @return self
+     */
+    public function setNumberCountry(\Ivoz\Provider\Domain\Model\Country\CountryInterface $numberCountry = null);
+
+    /**
+     * Get numberCountry
+     *
+     * @return \Ivoz\Provider\Domain\Model\Country\CountryInterface
+     */
+    public function getNumberCountry();
+
+    /**
+     * @param string $prefix
+     * @return null|string
+     */
+    public function getTarget(string $prefix = '');
 }

--- a/library/Ivoz/Provider/Domain/Service/HolidayDate/CheckEventDateCollision.php
+++ b/library/Ivoz/Provider/Domain/Service/HolidayDate/CheckEventDateCollision.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Ivoz\Provider\Domain\Service\HolidayDate;
+
+use Ivoz\Core\Infrastructure\Persistence\Doctrine\Model\Helper\CriteriaHelper;
+use Ivoz\Provider\Domain\Model\HolidayDate\HolidayDate;
+use Ivoz\Provider\Domain\Model\HolidayDate\HolidayDateDto;
+use Ivoz\Provider\Domain\Model\HolidayDate\HolidayDateInterface;
+
+/**
+ * Class CheckEventDateCollision
+ * @package Ivoz\Provider\Domain\Service\HolidayDate
+ */
+class CheckEventDateCollision implements HolidayDateLifecycleEventHandlerInterface
+{
+    const PRE_PERSIST_PRIORITY = self::PRIORITY_NORMAL;
+
+    public function __construct()
+    {
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            self::EVENT_PRE_PERSIST => self::PRE_PERSIST_PRIORITY,
+        ];
+    }
+
+    public function execute(HolidayDateInterface $holidayDate)
+    {
+        $eventsCriteria = CriteriaHelper::fromArray(
+            [
+                array('id', 'neq', $holidayDate->getId()),
+                array('eventDate', 'eq', $holidayDate->getEventDate()),
+            ]
+        );
+
+        $calendar = $holidayDate->getCalendar();
+        $calendarHolidays = $calendar->getHolidayDates($eventsCriteria);
+
+        foreach ($calendarHolidays as $calendarHoliday) {
+            // Only one whole day event allowed per day
+            if ($calendarHoliday->getWholeDayEvent() || $holidayDate->getWholeDayEvent()) {
+                throw new \DomainException("Another event already exists for this day.");
+            }
+
+            $calendarHolidayTimeIn = $calendarHoliday
+                ->getTimeIn()
+                ->format('H:i:s');
+
+            $calendarHolidayTimeOut = $calendarHoliday
+                ->getTimeOut()
+                ->format('H:i:s');
+
+            // Validate TimeIn collisions
+            $timeIn = $holidayDate
+                ->getTimeIn()
+                ->format('H:i:s');
+
+            if ($timeIn >= $calendarHolidayTimeIn && $timeIn <=  $calendarHolidayTimeOut) {
+                throw new \DomainException("Time In conflicts with existing calendar event.");
+            }
+
+            // Validate TimeOut collisions
+            $timeOut = $holidayDate
+                ->getTimeOut()
+                ->format('H:i:s');
+
+            if ($timeOut >= $calendarHolidayTimeIn && $timeOut <=  $calendarHolidayTimeOut) {
+                throw new \DomainException("Time Out conflicts with existing calendar event.");
+            }
+        }
+    }
+}

--- a/library/Ivoz/Provider/Domain/Service/HolidayDate/HolidayDateLifecycleEventHandlerInterface.php
+++ b/library/Ivoz/Provider/Domain/Service/HolidayDate/HolidayDateLifecycleEventHandlerInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Ivoz\Provider\Domain\Service\HolidayDate;
+
+use Ivoz\Core\Domain\Service\LifecycleEventHandlerInterface;
+use Ivoz\Provider\Domain\Model\HolidayDate\HolidayDateInterface;
+
+interface HolidayDateLifecycleEventHandlerInterface extends LifecycleEventHandlerInterface
+{
+    public function execute(HolidayDateInterface $holidayDate);
+}

--- a/library/Ivoz/Provider/Domain/Service/HolidayDate/HolidayDateLifecycleServiceCollection.php
+++ b/library/Ivoz/Provider/Domain/Service/HolidayDate/HolidayDateLifecycleServiceCollection.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Ivoz\Provider\Domain\Service\HolidayDate;
+
+use Ivoz\Core\Domain\Service\LifecycleServiceCollectionInterface;
+use Ivoz\Core\Domain\Service\LifecycleServiceCollectionTrait;
+
+/**
+ * @codeCoverageIgnore
+ */
+class HolidayDateLifecycleServiceCollection implements LifecycleServiceCollectionInterface
+{
+    use LifecycleServiceCollectionTrait;
+
+    protected function addService(HolidayDateLifecycleEventHandlerInterface $service)
+    {
+        $this->services[] = $service;
+    }
+}

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/HolidayDate.HolidayDateAbstract.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/HolidayDate.HolidayDateAbstract.orm.yml
@@ -1,10 +1,5 @@
 Ivoz\Provider\Domain\Model\HolidayDate\HolidayDateAbstract:
   type: mappedSuperclass
-  uniqueConstraints:
-    dateCalendar:
-      columns:
-        - eventDate
-        - calendarId
   fields:
     name:
       column: name
@@ -17,6 +12,35 @@ Ivoz\Provider\Domain\Model\HolidayDate\HolidayDateAbstract:
       type: date
       nullable: false
       column: eventDate
+    wholeDayEvent:
+      type: boolean
+      nullable: false
+      options:
+        default: '1'
+      column: wholeDayEvent
+    timeIn:
+      type: time
+      nullable: true
+      column: timeIn
+    timeOut:
+      type: time
+      nullable: true
+      column: timeOut
+    routeType:
+      type: string
+      nullable: true
+      length: 25
+      options:
+        fixed: false
+        comment: '[enum:number|extension|voicemail]'
+      column: routeType
+    numberValue:
+      type: string
+      nullable: true
+      length: 25
+      options:
+        fixed: false
+      column: numberValue
   manyToOne:
     calendar:
       targetEntity: \Ivoz\Provider\Domain\Model\Calendar\CalendarInterface
@@ -38,6 +62,39 @@ Ivoz\Provider\Domain\Model\HolidayDate\HolidayDateAbstract:
       inversedBy: null
       joinColumns:
         locutionId:
+          referencedColumnName: id
+          onDelete: set null
+      orphanRemoval: false
+    extension:
+      targetEntity: \Ivoz\Provider\Domain\Model\Extension\ExtensionInterface
+      cascade: {  }
+      fetch: LAZY
+      mappedBy: null
+      inversedBy: null
+      joinColumns:
+        extensionId:
+          referencedColumnName: id
+          onDelete: set null
+      orphanRemoval: false
+    voiceMailUser:
+      targetEntity: \Ivoz\Provider\Domain\Model\User\UserInterface
+      cascade: {  }
+      fetch: LAZY
+      mappedBy: null
+      inversedBy: null
+      joinColumns:
+        voiceMailUserId:
+          referencedColumnName: id
+          onDelete: cascade
+      orphanRemoval: false
+    numberCountry:
+      targetEntity: \Ivoz\Provider\Domain\Model\Country\CountryInterface
+      cascade: {  }
+      fetch: LAZY
+      mappedBy: null
+      inversedBy: null
+      joinColumns:
+        numberCountryId:
           referencedColumnName: id
           onDelete: set null
       orphanRemoval: false

--- a/scheme/app/DoctrineMigrations/Version20181227122711.php
+++ b/scheme/app/DoctrineMigrations/Version20181227122711.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20181227122711 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP INDEX dateCalendar ON HolidayDates');
+        $this->addSql('ALTER TABLE HolidayDates ADD wholeDayEvent TINYINT(1) DEFAULT \'1\' NOT NULL, ADD timeIn TIME DEFAULT NULL, ADD timeOut TIME DEFAULT NULL, ADD routeType VARCHAR(25) DEFAULT NULL COMMENT \'[enum:number|extension|voicemail]\', ADD numberValue VARCHAR(25) DEFAULT NULL, ADD extensionId INT UNSIGNED DEFAULT NULL, ADD voiceMailUserId INT UNSIGNED DEFAULT NULL, ADD numberCountryId INT UNSIGNED DEFAULT NULL');
+        $this->addSql('ALTER TABLE HolidayDates ADD CONSTRAINT FK_4C57128012AB7F65 FOREIGN KEY (extensionId) REFERENCES Extensions (id) ON DELETE SET NULL');
+        $this->addSql('ALTER TABLE HolidayDates ADD CONSTRAINT FK_4C571280AF230FFD FOREIGN KEY (voiceMailUserId) REFERENCES Users (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE HolidayDates ADD CONSTRAINT FK_4C571280D7819488 FOREIGN KEY (numberCountryId) REFERENCES Countries (id) ON DELETE SET NULL');
+        $this->addSql('CREATE INDEX IDX_4C57128012AB7F65 ON HolidayDates (extensionId)');
+        $this->addSql('CREATE INDEX IDX_4C571280AF230FFD ON HolidayDates (voiceMailUserId)');
+        $this->addSql('CREATE INDEX IDX_4C571280D7819488 ON HolidayDates (numberCountryId)');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE HolidayDates DROP FOREIGN KEY FK_4C57128012AB7F65');
+        $this->addSql('ALTER TABLE HolidayDates DROP FOREIGN KEY FK_4C571280AF230FFD');
+        $this->addSql('ALTER TABLE HolidayDates DROP FOREIGN KEY FK_4C571280D7819488');
+        $this->addSql('DROP INDEX IDX_4C57128012AB7F65 ON HolidayDates');
+        $this->addSql('DROP INDEX IDX_4C571280AF230FFD ON HolidayDates');
+        $this->addSql('DROP INDEX IDX_4C571280D7819488 ON HolidayDates');
+        $this->addSql('ALTER TABLE HolidayDates DROP wholeDayEvent, DROP timeIn, DROP timeOut, DROP routeType, DROP numberValue, DROP extensionId, DROP voiceMailUserId, DROP numberCountryId');
+        $this->addSql('CREATE UNIQUE INDEX dateCalendar ON HolidayDates (eventDate, calendarId)');
+    }
+}

--- a/web/admin/application/configs/klear/CalendarsList.yaml
+++ b/web/admin/application/configs/klear/CalendarsList.yaml
@@ -66,9 +66,6 @@ production:
       filterField: Calendar
     holidayDatesEdit_screen:
       <<: *holidayDatesEdit_screenLink
-      fields:
-        readOnly:
-          calendar: true
 
   dialogs: &calendars_dialogsLink
     calendarsDel_dialog: &calendarsDel_dialogLink

--- a/web/admin/application/configs/klear/HolidayDatesList.yaml
+++ b/web/admin/application/configs/klear/HolidayDatesList.yaml
@@ -14,6 +14,20 @@ production:
       class: ui-silk-calendar-view-day
       title: _("List of %s %2s", ngettext('Holiday date', 'Holiday dates', 0), "[format| (%parent%)]")
       fields:
+        blacklist:
+          numberCountry: true
+          numberValue: true
+          extension: true
+          voiceMailUser: true
+        order:
+          name: true
+          eventDate: true
+          locution: true
+          wholeDayEvent: true
+          timeIn: true
+          timeOut: true
+          routeType: true
+          target: true
         options:
           title: _("Options")
           screens:
@@ -36,12 +50,47 @@ production:
       multiInstance: true
       title: _("Add %s %2s", ngettext('Holiday date', 'Holiday dates', 1), "[format| (%parent%)]")
       shortcutOption: N
+      defaultValues:
+        numberCountry: ${auth.companyCountryId}
+      fields:
+        blacklist:
+          target: true
+      fixedPositions: &holidayDates_fixedPosLink
+        group0:
+          colsPerRow: 2
+          fields:
+            name: 1
+            locution: 1
+        group1:
+          colsPerRow: 2
+          fields:
+            eventDate: 1
+            wholeDayEvent: 1
+            timeIn: 1
+            timeOut: 1
+        group2:
+          colsPerRow: 7
+          fields:
+            routeType: 4
+            numberCountry: 4
+            numberValue: 3
+            extension: 3
+            voiceMailUser: 3
     holidayDatesEdit_screen: &holidayDatesEdit_screenLink
       <<: *HolidayDates
       controller: edit
       class: ui-silk-pencil
       label: false
       title: _("Edit %s %2s", ngettext('Holiday date', 'Holiday dates', 1), "[format| (%item%)]")
+      defaultValues:
+        numberCountry: ${auth.companyCountryId}
+      fields:
+        readOnly:
+          calendar: true
+        blacklist:
+          target: true
+      fixedPositions:
+        <<: *holidayDates_fixedPosLink
   dialogs: &holidayDates_dialogsLink
     holidayDatesDel_dialog: &holidayDatesDel_dialogLink
       <<: *HolidayDates

--- a/web/admin/application/configs/klear/model/HolidayDates.yaml
+++ b/web/admin/application/configs/klear/model/HolidayDates.yaml
@@ -42,6 +42,137 @@ production:
               - name
             template: '%name%'
         'null': _("Unassigned")
+    wholeDayEvent:
+      title: _('Whole day event')
+      type: select
+      defaultValue: 1
+      source:
+        data: inline
+        values:
+          '0':
+            title: _("No")
+            visualFilter:
+              show: [ timeIn, timeOut ]
+              hide: []
+          '1':
+            title: _("Yes")
+            visualFilter:
+              show: []
+              hide: [ timeIn, timeOut ]
+    timeIn:
+      title: _('Time in')
+      type: picker
+      required: true
+      source:
+        control: time
+        settings:
+          disabled: 'false'
+    timeOut:
+      title: _('Time out')
+      type: picker
+      required: true
+      source:
+        control: time
+        settings:
+          disabled: 'false'
+    routeType:
+      title: _('Route type')
+      type: select
+      source:
+        data: inline
+        filterClass: IvozProvider_Klear_Filter_RouteTypes
+        values:
+          '__null__':
+            title: _("Default holiday routing")
+            visualFilter:
+              show: [ ]
+              hide: &routableFields
+                - numberCountry
+                - numberValue
+                - extension
+                - voiceMailUser
+          'voicemail':
+            title: ngettext('Voicemail', 'Voicemails', 1)
+            visualFilter:
+              show: [ voiceMailUser ]
+              hide:
+                <<: *routableFields
+          'extension':
+            title: ngettext('Extension', 'Extension', 1)
+            visualFilter:
+              show: [ extension ]
+              hide:
+                <<: *routableFields
+          'number':
+            title: _('Number')
+            visualFilter:
+              show: [ numberCountry, numberValue ]
+              hide:
+                <<: *routableFields
+    numberCountry:
+      title: _('Country')
+      type: select
+      required: true
+      source:
+        data: mapper
+        config:
+          entity: \Ivoz\Provider\Domain\Model\Country\Country
+          fieldName:
+            fields:
+              - name${lang}
+              - countryCode
+            template: '%name${lang}% (%countryCode%)'
+          order:
+            Country.name.${lang}: asc
+    numberValue:
+      title: _('Number')
+      type: text
+      pattern: "^\\+?[0-9]+$"
+      required: true
+      maxLength: 25
+      trim: both
+    voiceMailUser:
+      title: ngettext('Voicemail', 'Voicemails', 1)
+      type: select
+      required: true
+      source:
+        data: mapper
+        config:
+          entity: \Ivoz\Provider\Domain\Model\User\User
+          filterClass: IvozProvider_Klear_Filter_Voicemail
+          fieldName:
+            fields:
+              - name
+              - lastname
+            template: '%name% %lastname%'
+          order:
+            User.name: asc
+        'null': _("Unassigned")
+    extension:
+      title: ngettext('Extension', 'Extension', 1)
+      type: select
+      required: true
+      source:
+        data: mapper
+        config:
+          entity: \Ivoz\Provider\Domain\Model\Extension\Extension
+          filterClass: IvozProvider_Klear_Filter_Company
+          fieldName:
+            fields:
+              - number
+            template: '%number%'
+          order:
+            Extension.number: asc
+          extraDataAttributes:
+            iden: companyId
+        'null': _("Unassigned")
+    target:
+      title: _('Target')
+      type: ghost
+      source:
+        class: IvozProvider_Klear_Ghost_RouteTarget
+        method: getTarget
+
 staging:
   _extends: production
 testing:

--- a/web/admin/application/languages/en_US/en_US.po
+++ b/web/admin/application/languages/en_US/en_US.po
@@ -582,6 +582,9 @@ msgstr "Default Action"
 msgid "Default currency"
 msgstr "Default currency"
 
+msgid "Default holiday routing"
+msgstr "Default holiday routing"
+
 msgid "Default notification template"
 msgid_plural "Default notification templates"
 msgstr[0] "Default Notification template"
@@ -2714,6 +2717,9 @@ msgstr ""
 
 msgid "White Lists"
 msgstr "White Lists"
+
+msgid "Whole day event"
+msgstr "Whole day event"
 
 msgid "Wholesale"
 msgid_plural "Wholesales"

--- a/web/admin/application/languages/es_ES/es_ES.po
+++ b/web/admin/application/languages/es_ES/es_ES.po
@@ -589,6 +589,9 @@ msgstr "Acción por defecto"
 msgid "Default currency"
 msgstr "Divisa por defecto"
 
+msgid "Default holiday routing"
+msgstr "Enrutado festivo por defecto"
+
 msgid "Default notification template"
 msgid_plural "Default notification templates"
 msgstr[0] "Plantilla de notificación por defecto"
@@ -2747,6 +2750,9 @@ msgstr ""
 
 msgid "White Lists"
 msgstr "Listas blancas"
+
+msgid "Whole day event"
+msgstr "Todo el día"
 
 msgid "Wholesale"
 msgid_plural "Wholesales"

--- a/web/rest/client/features/provider/holidayDate/getHolidayDate.feature
+++ b/web/rest/client/features/provider/holidayDate/getHolidayDate.feature
@@ -34,12 +34,20 @@ Feature: Retrieve holiday dates
       {
           "name": "Name",
           "eventDate": "2021-12-21",
+          "wholeDayEvent": true,
+          "timeIn": null,
+          "timeOut": null,
+          "routeType": null,
+          "numberValue": null,
           "id": 1,
           "calendar": {
               "name": "testCalendar",
               "id": 1,
               "company": 1
           },
-          "locution": null
+          "locution": null,
+          "extension": null,
+          "voiceMailUser": null,
+          "numberCountry": null
       }
     """

--- a/web/rest/client/features/provider/holidayDate/postHolidayDate.feature
+++ b/web/rest/client/features/provider/holidayDate/postHolidayDate.feature
@@ -41,6 +41,11 @@ Feature: Create holiday dates
       {
           "name": "New",
           "eventDate": "2017-12-21",
+          "wholeDayEvent": true,
+          "timeIn": null,
+          "timeOut": null,
+          "routeType": null,
+          "numberValue": null,
           "id": 2,
           "calendar": {
               "name": "testCalendar",
@@ -53,15 +58,18 @@ Feature: Create holiday dates
               "id": 1,
               "encodedFile": {
                   "fileSize": 1,
-                  "mimeType": "audio/x-wav; charset=binary",
+                  "mimeType": "audio\/x-wav; charset=binary",
                   "baseName": "locution.wav"
               },
               "originalFile": {
                   "fileSize": 1,
-                  "mimeType": "audio/mpeg; charset=binary",
+                  "mimeType": "audio\/mpeg; charset=binary",
                   "baseName": "locution.mp3"
               },
               "company": 1
-          }
+          },
+          "extension": null,
+          "voiceMailUser": null,
+          "numberCountry": null
       }
     """

--- a/web/rest/client/features/provider/holidayDate/putHolidayDate.feature
+++ b/web/rest/client/features/provider/holidayDate/putHolidayDate.feature
@@ -25,6 +25,11 @@ Feature: Update holiday dates
       {
           "name": "UpdatedName",
           "eventDate": "2021-12-22",
+          "wholeDayEvent": true,
+          "timeIn": null,
+          "timeOut": null,
+          "routeType": null,
+          "numberValue": null,
           "id": 1,
           "calendar": {
               "name": "testCalendar2",
@@ -37,15 +42,18 @@ Feature: Update holiday dates
               "id": 1,
               "encodedFile": {
                   "fileSize": 1,
-                  "mimeType": "audio/x-wav; charset=binary",
+                  "mimeType": "audio\/x-wav; charset=binary",
                   "baseName": "locution.wav"
               },
               "originalFile": {
                   "fileSize": 1,
-                  "mimeType": "audio/mpeg; charset=binary",
+                  "mimeType": "audio\/mpeg; charset=binary",
                   "baseName": "locution.mp3"
               },
               "company": 1
-          }
+          },
+          "extension": null,
+          "voiceMailUser": null,
+          "numberCountry": null
       }
     """


### PR DESCRIPTION
This PR add extra fields to Holiday dates to allow entering a start and end time and specific routing options.

Holiday Dates can now be a whole day event or just during a Time Period.
Optionally, it can override both locution and treatment. If this fields are left empty, the external call filter locutions and handlers will be used.


Fixes #22 