### PR TITLE
Entity datetime error prevention

### DIFF
--- a/library/Ivoz/Ast/Domain/Model/Voicemail/VoicemailAbstract.php
+++ b/library/Ivoz/Ast/Domain/Model/Voicemail/VoicemailAbstract.php
@@ -1383,7 +1383,7 @@ abstract class VoicemailAbstract
      */
     public function getStamp()
     {
-        return $this->stamp;
+        return !is_null($this->stamp) ? clone $this->stamp : null;
     }
 
     /**

--- a/library/Ivoz/Cgr/Domain/Model/TpAccountAction/TpAccountActionAbstract.php
+++ b/library/Ivoz/Cgr/Domain/Model/TpAccountAction/TpAccountActionAbstract.php
@@ -507,7 +507,7 @@ abstract class TpAccountActionAbstract
      */
     public function getCreatedAt()
     {
-        return $this->createdAt;
+        return clone $this->createdAt;
     }
 
     /**

--- a/library/Ivoz/Cgr/Domain/Model/TpCdr/TpCdrAbstract.php
+++ b/library/Ivoz/Cgr/Domain/Model/TpCdr/TpCdrAbstract.php
@@ -756,7 +756,7 @@ abstract class TpCdrAbstract
      */
     public function getSetupTime()
     {
-        return $this->setupTime;
+        return clone $this->setupTime;
     }
 
     /**
@@ -786,7 +786,7 @@ abstract class TpCdrAbstract
      */
     public function getAnswerTime()
     {
-        return $this->answerTime;
+        return clone $this->answerTime;
     }
 
     /**
@@ -977,7 +977,7 @@ abstract class TpCdrAbstract
      */
     public function getCreatedAt()
     {
-        return $this->createdAt;
+        return !is_null($this->createdAt) ? clone $this->createdAt : null;
     }
 
     /**
@@ -1008,7 +1008,7 @@ abstract class TpCdrAbstract
      */
     public function getUpdatedAt()
     {
-        return $this->updatedAt;
+        return !is_null($this->updatedAt) ? clone $this->updatedAt : null;
     }
 
     /**
@@ -1039,7 +1039,7 @@ abstract class TpCdrAbstract
      */
     public function getDeletedAt()
     {
-        return $this->deletedAt;
+        return !is_null($this->deletedAt) ? clone $this->deletedAt : null;
     }
 
     // @codeCoverageIgnoreEnd

--- a/library/Ivoz/Cgr/Domain/Model/TpCdrStat/TpCdrStatAbstract.php
+++ b/library/Ivoz/Cgr/Domain/Model/TpCdrStat/TpCdrStatAbstract.php
@@ -1197,7 +1197,7 @@ abstract class TpCdrStatAbstract
      */
     public function getCreatedAt()
     {
-        return $this->createdAt;
+        return clone $this->createdAt;
     }
 
     /**

--- a/library/Ivoz/Cgr/Domain/Model/TpDerivedCharger/TpDerivedChargerAbstract.php
+++ b/library/Ivoz/Cgr/Domain/Model/TpDerivedCharger/TpDerivedChargerAbstract.php
@@ -1158,7 +1158,7 @@ abstract class TpDerivedChargerAbstract
      */
     public function getCreatedAt()
     {
-        return $this->createdAt;
+        return clone $this->createdAt;
     }
 
     /**

--- a/library/Ivoz/Cgr/Domain/Model/TpDestination/TpDestinationAbstract.php
+++ b/library/Ivoz/Cgr/Domain/Model/TpDestination/TpDestinationAbstract.php
@@ -303,7 +303,7 @@ abstract class TpDestinationAbstract
      */
     public function getCreatedAt()
     {
-        return $this->createdAt;
+        return clone $this->createdAt;
     }
 
     /**

--- a/library/Ivoz/Cgr/Domain/Model/TpDestinationRate/TpDestinationRateAbstract.php
+++ b/library/Ivoz/Cgr/Domain/Model/TpDestinationRate/TpDestinationRateAbstract.php
@@ -501,7 +501,7 @@ abstract class TpDestinationRateAbstract
      */
     public function getCreatedAt()
     {
-        return $this->createdAt;
+        return clone $this->createdAt;
     }
 
     /**

--- a/library/Ivoz/Cgr/Domain/Model/TpLcrRule/TpLcrRuleAbstract.php
+++ b/library/Ivoz/Cgr/Domain/Model/TpLcrRule/TpLcrRuleAbstract.php
@@ -596,7 +596,7 @@ abstract class TpLcrRuleAbstract
      */
     public function getActivationTime()
     {
-        return $this->activationTime;
+        return clone $this->activationTime;
     }
 
     /**
@@ -654,7 +654,7 @@ abstract class TpLcrRuleAbstract
      */
     public function getCreatedAt()
     {
-        return $this->createdAt;
+        return clone $this->createdAt;
     }
 
     /**

--- a/library/Ivoz/Cgr/Domain/Model/TpRate/TpRateAbstract.php
+++ b/library/Ivoz/Cgr/Domain/Model/TpRate/TpRateAbstract.php
@@ -465,7 +465,7 @@ abstract class TpRateAbstract
      */
     public function getCreatedAt()
     {
-        return $this->createdAt;
+        return clone $this->createdAt;
     }
 
     /**

--- a/library/Ivoz/Cgr/Domain/Model/TpRatingPlan/TpRatingPlanAbstract.php
+++ b/library/Ivoz/Cgr/Domain/Model/TpRatingPlan/TpRatingPlanAbstract.php
@@ -380,7 +380,7 @@ abstract class TpRatingPlanAbstract
      */
     public function getCreatedAt()
     {
-        return $this->createdAt;
+        return clone $this->createdAt;
     }
 
     /**

--- a/library/Ivoz/Cgr/Domain/Model/TpRatingProfile/TpRatingProfileAbstract.php
+++ b/library/Ivoz/Cgr/Domain/Model/TpRatingProfile/TpRatingProfileAbstract.php
@@ -581,7 +581,7 @@ abstract class TpRatingProfileAbstract
      */
     public function getCreatedAt()
     {
-        return $this->createdAt;
+        return clone $this->createdAt;
     }
 
     /**

--- a/library/Ivoz/Cgr/Domain/Model/TpTiming/TpTimingAbstract.php
+++ b/library/Ivoz/Cgr/Domain/Model/TpTiming/TpTimingAbstract.php
@@ -460,7 +460,7 @@ abstract class TpTimingAbstract
      */
     public function getCreatedAt()
     {
-        return $this->createdAt;
+        return clone $this->createdAt;
     }
 
     /**

--- a/library/Ivoz/Kam/Domain/Model/Rtpengine/RtpengineAbstract.php
+++ b/library/Ivoz/Kam/Domain/Model/Rtpengine/RtpengineAbstract.php
@@ -349,7 +349,7 @@ abstract class RtpengineAbstract
      */
     public function getStamp()
     {
-        return $this->stamp;
+        return clone $this->stamp;
     }
 
     /**

--- a/library/Ivoz/Kam/Domain/Model/TrunksCdr/TrunksCdrAbstract.php
+++ b/library/Ivoz/Kam/Domain/Model/TrunksCdr/TrunksCdrAbstract.php
@@ -330,7 +330,7 @@ abstract class TrunksCdrAbstract
      */
     public function getStartTime()
     {
-        return $this->startTime;
+        return clone $this->startTime;
     }
 
     /**
@@ -360,7 +360,7 @@ abstract class TrunksCdrAbstract
      */
     public function getEndTime()
     {
-        return $this->endTime;
+        return clone $this->endTime;
     }
 
     /**

--- a/library/Ivoz/Kam/Domain/Model/TrunksDomainAttr/TrunksDomainAttrAbstract.php
+++ b/library/Ivoz/Kam/Domain/Model/TrunksDomainAttr/TrunksDomainAttrAbstract.php
@@ -334,7 +334,7 @@ abstract class TrunksDomainAttrAbstract
      */
     public function getLastModified()
     {
-        return $this->lastModified;
+        return clone $this->lastModified;
     }
 
     // @codeCoverageIgnoreEnd

--- a/library/Ivoz/Kam/Domain/Model/UsersCdr/UsersCdrAbstract.php
+++ b/library/Ivoz/Kam/Domain/Model/UsersCdr/UsersCdrAbstract.php
@@ -339,7 +339,7 @@ abstract class UsersCdrAbstract
      */
     public function getStartTime()
     {
-        return $this->startTime;
+        return clone $this->startTime;
     }
 
     /**
@@ -369,7 +369,7 @@ abstract class UsersCdrAbstract
      */
     public function getEndTime()
     {
-        return $this->endTime;
+        return clone $this->endTime;
     }
 
     /**

--- a/library/Ivoz/Kam/Domain/Model/UsersLocation/UsersLocationAbstract.php
+++ b/library/Ivoz/Kam/Domain/Model/UsersLocation/UsersLocationAbstract.php
@@ -572,7 +572,7 @@ abstract class UsersLocationAbstract
      */
     public function getExpires()
     {
-        return $this->expires;
+        return clone $this->expires;
     }
 
     /**
@@ -684,7 +684,7 @@ abstract class UsersLocationAbstract
      */
     public function getLastModified()
     {
-        return $this->lastModified;
+        return clone $this->lastModified;
     }
 
     /**

--- a/library/Ivoz/Kam/Domain/Model/UsersLocationAttr/UsersLocationAttrAbstract.php
+++ b/library/Ivoz/Kam/Domain/Model/UsersLocationAttr/UsersLocationAttrAbstract.php
@@ -411,7 +411,7 @@ abstract class UsersLocationAttrAbstract
      */
     public function getLastModified()
     {
-        return $this->lastModified;
+        return clone $this->lastModified;
     }
 
     // @codeCoverageIgnoreEnd

--- a/library/Ivoz/Provider/Domain/Model/BalanceMovement/BalanceMovementAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/BalanceMovement/BalanceMovementAbstract.php
@@ -279,7 +279,7 @@ abstract class BalanceMovementAbstract
      */
     public function getCreatedOn()
     {
-        return $this->createdOn;
+        return !is_null($this->createdOn) ? clone $this->createdOn : null;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/BalanceNotification/BalanceNotificationAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/BalanceNotification/BalanceNotificationAbstract.php
@@ -285,7 +285,7 @@ abstract class BalanceNotificationAbstract
      */
     public function getLastSent()
     {
-        return $this->lastSent;
+        return !is_null($this->lastSent) ? clone $this->lastSent : null;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/BillableCall/BillableCallAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/BillableCall/BillableCallAbstract.php
@@ -382,7 +382,7 @@ abstract class BillableCallAbstract
      */
     public function getStartTime()
     {
-        return $this->startTime;
+        return !is_null($this->startTime) ? clone $this->startTime : null;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/CallCsvReport/CallCsvReportAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/CallCsvReport/CallCsvReportAbstract.php
@@ -297,7 +297,7 @@ abstract class CallCsvReportAbstract
      */
     public function getInDate()
     {
-        return $this->inDate;
+        return clone $this->inDate;
     }
 
     /**
@@ -327,7 +327,7 @@ abstract class CallCsvReportAbstract
      */
     public function getOutDate()
     {
-        return $this->outDate;
+        return clone $this->outDate;
     }
 
     /**
@@ -357,7 +357,7 @@ abstract class CallCsvReportAbstract
      */
     public function getCreatedOn()
     {
-        return $this->createdOn;
+        return clone $this->createdOn;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/CallCsvScheduler/CallCsvSchedulerAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/CallCsvScheduler/CallCsvSchedulerAbstract.php
@@ -373,7 +373,7 @@ abstract class CallCsvSchedulerAbstract
      */
     public function getLastExecution()
     {
-        return $this->lastExecution;
+        return !is_null($this->lastExecution) ? clone $this->lastExecution : null;
     }
 
     /**
@@ -432,7 +432,7 @@ abstract class CallCsvSchedulerAbstract
      */
     public function getNextExecution()
     {
-        return $this->nextExecution;
+        return !is_null($this->nextExecution) ? clone $this->nextExecution : null;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/Changelog/ChangelogAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Changelog/ChangelogAbstract.php
@@ -315,7 +315,7 @@ abstract class ChangelogAbstract
      */
     public function getCreatedOn()
     {
-        return $this->createdOn;
+        return clone $this->createdOn;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/Commandlog/CommandlogAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Commandlog/CommandlogAbstract.php
@@ -342,7 +342,7 @@ abstract class CommandlogAbstract
      */
     public function getCreatedOn()
     {
-        return $this->createdOn;
+        return clone $this->createdOn;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/FaxesInOut/FaxesInOutAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/FaxesInOut/FaxesInOutAbstract.php
@@ -272,7 +272,7 @@ abstract class FaxesInOutAbstract
      */
     public function getCalldate()
     {
-        return $this->calldate;
+        return clone $this->calldate;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/Invoice/InvoiceAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Invoice/InvoiceAbstract.php
@@ -345,7 +345,7 @@ abstract class InvoiceAbstract
      */
     public function getInDate()
     {
-        return $this->inDate;
+        return !is_null($this->inDate) ? clone $this->inDate : null;
     }
 
     /**
@@ -376,7 +376,7 @@ abstract class InvoiceAbstract
      */
     public function getOutDate()
     {
-        return $this->outDate;
+        return !is_null($this->outDate) ? clone $this->outDate : null;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/InvoiceScheduler/InvoiceSchedulerAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/InvoiceScheduler/InvoiceSchedulerAbstract.php
@@ -400,7 +400,7 @@ abstract class InvoiceSchedulerAbstract
      */
     public function getLastExecution()
     {
-        return $this->lastExecution;
+        return !is_null($this->lastExecution) ? clone $this->lastExecution : null;
     }
 
     /**
@@ -459,7 +459,7 @@ abstract class InvoiceSchedulerAbstract
      */
     public function getNextExecution()
     {
-        return $this->nextExecution;
+        return !is_null($this->nextExecution) ? clone $this->nextExecution : null;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/RatingProfile/RatingProfileAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/RatingProfile/RatingProfileAbstract.php
@@ -218,7 +218,7 @@ abstract class RatingProfileAbstract
      */
     public function getActivationTime()
     {
-        return $this->activationTime;
+        return clone $this->activationTime;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/Recording/RecordingAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Recording/RecordingAbstract.php
@@ -306,7 +306,7 @@ abstract class RecordingAbstract
      */
     public function getCalldate()
     {
-        return $this->calldate;
+        return clone $this->calldate;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/Terminal/TerminalAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Terminal/TerminalAbstract.php
@@ -481,7 +481,7 @@ abstract class TerminalAbstract
      */
     public function getLastProvisionDate()
     {
-        return $this->lastProvisionDate;
+        return !is_null($this->lastProvisionDate) ? clone $this->lastProvisionDate : null;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Service/CallCsvReport/CreateByScheduler.php
+++ b/library/Ivoz/Provider/Domain/Service/CallCsvReport/CreateByScheduler.php
@@ -57,7 +57,7 @@ class CreateByScheduler
      */
     private function createCallCsvReport(CallCsvSchedulerInterface $scheduler)
     {
-        $outDate = clone $scheduler->getNextExecution();
+        $outDate = $scheduler->getNextExecution();
         $outDate->setTimezone(
             new \DateTimeZone(
                 $scheduler->getTimezone()->getTz()

--- a/library/Ivoz/Provider/Domain/Service/Invoice/CheckValidity.php
+++ b/library/Ivoz/Provider/Domain/Service/Invoice/CheckValidity.php
@@ -65,7 +65,7 @@ class CheckValidity implements InvoiceLifecycleEventHandlerInterface
         /**
          * @var \Datetime $outDate
          */
-        $outDate = clone $invoice->getOutDate();
+        $outDate = $invoice->getOutDate();
         $utcOutDate = $outDate->setTimezone($utcTz);
 
         $this->assertNoFutureDates($invoiceTz, $inDate, $outDate);

--- a/library/Ivoz/Provider/Domain/Service/Invoice/CreateByScheduler.php
+++ b/library/Ivoz/Provider/Domain/Service/Invoice/CreateByScheduler.php
@@ -61,7 +61,7 @@ class CreateByScheduler
     private function createInvoice(InvoiceSchedulerInterface $scheduler)
     {
         $brand = $scheduler->getBrand();
-        $outDate = clone $scheduler->getNextExecution();
+        $outDate = $scheduler->getNextExecution();
         $outDate->setTimezone(
             new \DateTimeZone(
                 $brand->getDefaultTimezone()->getTz()

--- a/library/Ivoz/Provider/Domain/Service/Invoice/Generator.php
+++ b/library/Ivoz/Provider/Domain/Service/Invoice/Generator.php
@@ -123,10 +123,10 @@ class Generator
         $invoiceDate = new \DateTime();
         $invoiceDate->setTimezone($invoiceTz);
 
-        $inDate = clone $invoice->getInDate();
+        $inDate = $invoice->getInDate();
         $inDate->setTimezone($invoiceTz);
 
-        $outDate = clone $invoice->getOutDate();
+        $outDate = $invoice->getOutDate();
         $outDate->setTimezone($invoiceTz);
 
         $invoiceDto = $this->entityTools->entityToDto($invoice);
@@ -189,10 +189,10 @@ class Generator
 
         $currencySymbol = $company->getCurrencySymbol();
 
-        $inDate = clone $invoice->getInDate();
+        $inDate = $invoice->getInDate();
         $utcInDate = $inDate->setTimezone($utcTz);
 
-        $outDate = clone $invoice->getOutDate();
+        $outDate = $invoice->getOutDate();
         $utcOutDate = $outDate->setTimezone($utcTz);
 
         $callsPerType = [];

--- a/library/Ivoz/Provider/Domain/Service/InvoiceScheduler/NextExecutionResolverTrait.php
+++ b/library/Ivoz/Provider/Domain/Service/InvoiceScheduler/NextExecutionResolverTrait.php
@@ -71,7 +71,7 @@ trait NextExecutionResolverTrait
             return;
         }
 
-        $nextExecution = clone $scheduler->getNextExecution();
+        $nextExecution = $scheduler->getNextExecution();
         if (!$nextExecution) {
             return;
         }


### PR DESCRIPTION
Return cloned instances of entity datetime attributes in order to avoid side effects and invalid object state