### PR TITLE
kamtrunks: remove media liberation delay mechanism

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -29,9 +29,6 @@
 # - options
 #!define WITH_ANTIFLOOD
 
-##!define DELAY_MEDIALIBERATION
-# Note: If defined, Kamailio delays Asterisk initial media liberation for 1 second (only on outbound calls)
-
 #!define DBURL "mysql://kamailio:ironsecret@data/ivozprovider"
 
 # Maximum call duration: 3 hours
@@ -412,12 +409,6 @@ request_route {
         route(GET_INFO_FROM_COMPANY);
         route(CONTROL_MAXCALLS);
         route(SAVE_CONTACT);
-
-        #!ifdef DELAY_MEDIALIBERATION
-        if ($dlg_var(type) == 'vpbx' || $dlg_var(type) == 'residential') {
-            $dlg_var(initial_reinvite) = 'pending';
-        }
-        #!endif
 
         # Check if this call is to one of our DDIs
         route(CHECK_BOUNCE);
@@ -1145,17 +1136,6 @@ route[WITHINDLG] {
 
     route(TRANSFORMATE_WITHINDLG);
 
-    #!ifdef DELAY_MEDIALIBERATION
-    if (is_method("INVITE")) {
-        if ($dlg_var(initial_reinvite) == 'pending') {
-            xinfo("[$dlg_var(cidhash)] WITHINDLG: Initial reinvite from call initiated by AS\n");
-            $dlg_var(initial_reinvite) = 'yes';
-        } else {
-            $dlg_var(initial_reinvite) = 'no';
-        }
-    }
-    #!endif
-
     # Fix overridden R-URI if needed
     if (!$var(is_from_inside) && $dlg_var(contact) != $null && uri != $dlg_var(contact) && $dlg_var(bounced) != '1') {
         xwarn("[$dlg_var(cidhash)] WITHINDLG: Fix overridden contact ($ru -> $dlg_var(contact))\n");
@@ -1552,13 +1532,6 @@ event_route[tm:local-request] {
 
 onsend_route {
     if (is_method("ACK")) $dlg_var(confirmed) = '1';
-
-    #!ifdef DELAY_MEDIALIBERATION
-    if (is_request() && is_method("INVITE") && $dlg_var(initial_reinvite) == 'yes') {
-        xinfo("[$dlg_var(cidhash)] Initial reinvite from call initiated by AS, delay 1 second\n");
-        sleep(1);
-    }
-    #!endif
 }
 
 route[XMLRPC]{


### PR DESCRIPTION
Asterisk trunks endpoint has direct_media to 'no', so this is no longer used.