### PR TITLE
web/admin: Access API through localhost instead of server name

### DIFF
--- a/web/admin/application/library/IvozProvider/Service/RestClient.php
+++ b/web/admin/application/library/IvozProvider/Service/RestClient.php
@@ -89,9 +89,7 @@ class RestClient
 
     protected static function getBaseUrl($api = 'platform')
     {
-        return 'https://'
-            . $_SERVER['SERVER_NAME']
-            . '/api/'
+        return 'https://127.0.0.1/api/'
             . $api
             . '/'
             . basename($_SERVER['SCRIPT_FILENAME']);


### PR DESCRIPTION
Avoid unnecessary point of failure 
