### PR TITLE
Fix shared ip setup

### DIFF
--- a/debian/ivozprovider.postinst
+++ b/debian/ivozprovider.postinst
@@ -98,6 +98,7 @@ function setup_proxies()
         sed -i -e '/#!define SIPS_PORT/c\#!define SIPS_PORT 7061' /etc/kamailio/proxytrunks/kamailio.cfg
         sed -i -e '/contact=sip:trunks.ivozprovider.local/c\contact=sip:trunks.ivozprovider.local:7060' /etc/asterisk/pjsip.conf
     else
+        sed -i -e '/#!define TRUNKS_SIP_PORT/c\#!define TRUNKS_SIP_PORT 5060' /etc/kamailio/proxyusers/kamailio.cfg
         sed -i -e '/#!define SIP_PORT/c\#!define SIP_PORT 5060' /etc/kamailio/proxytrunks/kamailio.cfg
         sed -i -e '/#!define SIPS_PORT/c\#!define SIPS_PORT 5061' /etc/kamailio/proxytrunks/kamailio.cfg
         sed -i -e '/contact=sip:trunks.ivozprovider.local/c\contact=sip:trunks.ivozprovider.local' /etc/asterisk/pjsip.conf

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -462,7 +462,7 @@ request_route {
 #   - 1: request/response comes from the inside
 #   - 0: request/response comes from the outside world
 route[IS_FROM_INSIDE] {
-    if (ds_is_from_list("1") || $si == $var(usersAddress)) {
+    if (ds_is_from_list("1") || ($si == $var(usersAddress) && $sp == "5060")) {
         $var(is_from_inside) = 1;
     } else {
         $var(is_from_inside) = 0;


### PR DESCRIPTION
This PR fixes KamTrunks bouncing in scenarios where KamUsers and KamTrunks share the same IP address.