### PR TITLE
kamtrunks: allow outgoing calls if CGRateS is unreachable

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -34,6 +34,19 @@
 # Maximum call duration: 3 hours
 #!define MAX_DIALOG_TIMEOUT 10800
 
+# Allow calls when billing engine is down
+#
+# By default (after service restart) it is off. To enable, execute:
+# kamcmd-proxytrunks cfg.set config.allow_calls_without_cgrates 1
+#
+# To disable again:
+# kamcmd-proxytrunks cfg.set config.allow_calls_without_cgrates 0
+#
+# To see current value:
+# kamcmd-proxytrunks cfg.get config.allow_calls_without_cgrates
+
+config.allow_calls_without_cgrates = 0
+
 ####### Global Parameters #########
 
 listen=udp:IP:SIP_PORT
@@ -424,10 +437,19 @@ request_route {
 
         if ($var(needsRater) == 1) {
             route(CGRATES_AUTH_REQUEST);
-        } else {
-            route(SELECT_NEXT_GW);
-            route(RELAY);
+
+            # From now on, only executed if CGRateS is DOWN
+            if ($sel(cfg_get.config.allow_calls_without_cgrates) == 1) {
+                xwarn("[$dlg_var(cidhash)] Allow call despite CGRateS being down");
+            } else {
+                xerr("[$dlg_var(cidhash)] Drop call as CGRateS is down");
+                send_reply("503","Charging controller unreachable");
+                exit;
+            }
         }
+
+        route(SELECT_NEXT_GW);
+        route(RELAY);
     } else {
         if (uri == myself) {
             xinfo("[$dlg_var(cidhash)] Someone calling to my domain, dispatch to next hop\n");
@@ -690,6 +712,10 @@ route[SELECT_NEXT_GW] {
 
     if ($xavp(ra=>externallyRated) == '1') {
         # Externally rating GW
+        $dlg_var(cgrid) = $null;
+        dlg_set_timeout(MAX_DIALOG_TIMEOUT);
+    } else if ($sht(cgrconn=>cgr) == $null) {
+        xwarn("[$dlg_var(cidhash)] SELECT-NEXT-GW: Charging controller unreachable, treat as externally rated");
         $dlg_var(cgrid) = $null;
         dlg_set_timeout(MAX_DIALOG_TIMEOUT);
     } else {
@@ -1659,8 +1685,7 @@ route[CGRATES_AUTH_REQUEST] {
     # Auth INVITEs with CGRateS
     if $sht(cgrconn=>cgr) == $null {
         xerr("[$dlg_var(cidhash)] CGRATES-AUTH-REQUEST: Charging controller unreachable");
-        send_reply("503","Charging controller unreachable");
-        exit;
+        return;
     }
 
     $dlg_var(cgrTenant) = 'b' + $dlg_var(brandId);
@@ -1744,8 +1769,7 @@ route[CGRATES_AUTH_REPLY] {
 route[CGR_CALL_START] {
     if $sht(cgrconn=>cgr) == $null {
         xerr("[$dlg_var(cidhash)] CGR-CALL-START: Charging controller unreachable");
-        send_reply("503","Charging controller unreachable");
-        exit;
+        return;
     }
 
     xnotice("[$dlg_var(cidhash)] CGR-CALL-START: Warn CGRates that call is started");
@@ -1768,7 +1792,7 @@ route[CGR_CALL_START] {
 route[CGR_CALL_END] {
     if $sht(cgrconn=>cgr) == $null {
         xerr("[$dlg_var(cidhash)] CGR-CALL-END: Charging controller unreachable");
-        exit;
+        return;
     }
 
     $var(callDur) = $TS - $dlg(start_ts);
@@ -1802,7 +1826,7 @@ route[CGR_CALL_END] {
 route[CGR_CALL_FAILED] {
     if $sht(cgrconn=>cgr) == $null {
         xerr("[$dlg_var(cidhash)] CGR-CALL-FAILED: Charging controller unreachable");
-        exit;
+        return;
     }
 
     $var(cgrCarrier) = 'cr' + $dlg_var(carrierId);

--- a/library/CoreBundle/Resources/config/services/infraestructure/cgrates.yml
+++ b/library/CoreBundle/Resources/config/services/infraestructure/cgrates.yml
@@ -45,3 +45,6 @@ services:
   Ivoz\Cgr\Domain\Service\TpCdrStat\FetchCallStatsServiceInterface:
     alias: Ivoz\Core\Infrastructure\Domain\Service\Cgrates\FetchCallStatsService
     public: true
+
+
+  Ivoz\Core\Infrastructure\Domain\Service\Cgrates\ProcessExternalCdr: ~

--- a/library/DataFixtures/ORM/KamTrunksCdr.php
+++ b/library/DataFixtures/ORM/KamTrunksCdr.php
@@ -34,7 +34,8 @@ class KamTrunksCdr extends Fixture implements DependentFixtureInterface
             $this->setCallid('1262640e-18d5-4641-880d-e4f411786711');
             $this->setCallidHash('2789d532');
             $this->setXcallid('9297bdde-309cd48f@10.10.1.123');
-            $this->setMetered(0);
+            $this->setParsed(0);
+            $this->setParserScheduledAt(new \DateTime('2018-11-22 16:54:54'));
         })->call($item1);
         $item1->setBrand($this->getReference('_reference_ProviderBrand1'));
         $item1->setCompany($this->getReference('_reference_ProviderCompany1'));

--- a/library/Ivoz/Cgr/Domain/Model/TpCdr/TpCdrRepository.php
+++ b/library/Ivoz/Cgr/Domain/Model/TpCdr/TpCdrRepository.php
@@ -8,6 +8,13 @@ use Doctrine\Common\Collections\Selectable;
 interface TpCdrRepository extends ObjectRepository, Selectable
 {
     /**
+     * @param string $originId
+     * @return TpCdrInterface | null
+     */
+    public function getByOriginId(string $originId);
+
+
+    /**
      * @param string $cgrid
      * @return int
      */

--- a/library/Ivoz/Cgr/Infrastructure/Persistence/Doctrine/TpCdrDoctrineRepository.php
+++ b/library/Ivoz/Cgr/Infrastructure/Persistence/Doctrine/TpCdrDoctrineRepository.php
@@ -4,6 +4,7 @@ namespace Ivoz\Cgr\Infrastructure\Persistence\Doctrine;
 
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\ORM\NoResultException;
+use Ivoz\Cgr\Domain\Model\TpCdr\TpCdrInterface;
 use Ivoz\Cgr\Domain\Model\TpCdr\TpCdrRepository;
 use Ivoz\Cgr\Domain\Model\TpCdr\TpCdr;
 use Ivoz\Core\Infrastructure\Persistence\Doctrine\Model\Helper\CriteriaHelper;
@@ -20,6 +21,17 @@ class TpCdrDoctrineRepository extends ServiceEntityRepository implements TpCdrRe
     public function __construct(RegistryInterface $registry)
     {
         parent::__construct($registry, TpCdr::class);
+    }
+
+    /**
+     * @inheritdoc
+     * @see TpCdrRepository::getByOriginId
+     */
+    public function getByOriginId(string $originId)
+    {
+        return $this->findOneBy([
+            'originId' => $originId
+        ]);
     }
 
     /**

--- a/library/Ivoz/Core/Infrastructure/Domain/Service/Cgrates/ApiClient.php
+++ b/library/Ivoz/Core/Infrastructure/Domain/Service/Cgrates/ApiClient.php
@@ -4,10 +4,7 @@ namespace Ivoz\Core\Infrastructure\Domain\Service\Cgrates;
 
 use Graze\GuzzleHttp\JsonRpc\ClientInterface;
 
-/**
- * @deprecated Use ApiClient as a collaborator instead
- */
-abstract class AbstractApiBasedService
+class ApiClient
 {
     /**
      * @var ClientInterface
@@ -23,9 +20,9 @@ abstract class AbstractApiBasedService
     /**
      * @param $payload
      * @throws \DomainException
-     * @return void
+     * @return \stdClass
      */
-    protected function sendRequest($method, array $payload)
+    public function sendRequest($method, array $payload)
     {
         /** @var \Graze\GuzzleHttp\JsonRpc\Message\Request $request */
         $request = $this->jsonRpcClient
@@ -47,5 +44,7 @@ abstract class AbstractApiBasedService
             );
             throw new \RuntimeException($errorMsg);
         }
+
+        return $objectResponse;
     }
 }

--- a/library/Ivoz/Core/Infrastructure/Domain/Service/Cgrates/ProcessExternalCdr.php
+++ b/library/Ivoz/Core/Infrastructure/Domain/Service/Cgrates/ProcessExternalCdr.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Ivoz\Core\Infrastructure\Domain\Service\Cgrates;
+
+use Ivoz\Cgr\Domain\Model\TpCdr\TpCdrInterface;
+use Ivoz\Cgr\Domain\Model\TpCdr\TpCdrRepository;
+use Ivoz\Core\Application\Service\EntityTools;
+use Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdrDto;
+use Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdrInterface;
+use Graze\GuzzleHttp\JsonRpc\ClientInterface;
+use Psr\Log\LoggerInterface;
+use Zend\EventManager\Exception\DomainException;
+
+class ProcessExternalCdr
+{
+    const DATE_FORMAT = 'Y-m-d\TH:i:s\Z';
+
+    /**
+     * @var ApiClient
+     */
+    protected $apiClient;
+
+    /**
+     * @var EntityTools
+     */
+    protected $entityTools;
+
+    /**
+     * @var TpCdrRepository
+     */
+    protected $tpCdrRepository;
+
+    /**
+     * @var LoggerInterface
+     */
+    protected $logger;
+
+    public function __construct(
+        ApiClient $apiClient,
+        EntityTools $entityTools,
+        TpCdrRepository $tpCdrRepository,
+        LoggerInterface $logger
+    ) {
+        $this->entityTools = $entityTools;
+        $this->logger = $logger;
+        $this->tpCdrRepository = $tpCdrRepository;
+        $this->apiClient = $apiClient;
+    }
+
+    /**
+     * @param TrunksCdrInterface $trunksCdr
+     * @return bool
+     * @throws \DomainException
+     */
+    public function execute(TrunksCdrInterface $trunksCdr)
+    {
+        $carrier = $trunksCdr->getCarrier();
+        if ($carrier && $carrier->getExternallyRated()) {
+            return false;
+        }
+
+        $brand = $trunksCdr->getBrand();
+        $company = $trunksCdr->getCompany();
+        $time = $trunksCdr
+            ->getStartTime()
+            ->format(self::DATE_FORMAT);
+
+        $callId = $trunksCdr->getCallid();
+
+        $payload = [
+            'OriginHost' => '127.0.0.1',
+            'Source' => 'offline',
+            'OriginID' => $callId,
+            'ToR' => '*voice',
+            'RequestType' => '*' . $company->getBillingMethod(),
+            'Tenant' => 'b' . $brand->getId(),
+            'Account' => 'c' . $company->getId(),
+            'Destination' => $trunksCdr->getCallee(),
+            'SetupTime' => $time,
+            'AnswerTime' => $time,
+            'Usage' => round($trunksCdr->getDuration()) . 's'
+        ];
+
+        if ($carrier) {
+            $payload['ExtraFields'] = [
+                'carrierId' => 'cr' . $carrier->getId(),
+                'carrierReqtype' => '*postpaid'
+            ];
+        }
+
+        try {
+            $response = $this->apiClient->sendRequest(
+                'CdrsV1.ProcessExternalCDR',
+                $payload
+            );
+
+            /** @var TpCdrInterface $tpCdr */
+            $tpCdr = $this->tpCdrRepository->getByOriginId($callId);
+            if (!$tpCdr) {
+                throw new \DomainException('TpCdr not found');
+            }
+
+            /** @var TrunksCdrDto $trunksCdrDto */
+            $trunksCdrDto = $this->entityTools->entityToDto($trunksCdr);
+            $trunksCdrDto->setCgrid($tpCdr->getCgrid());
+
+            $this->entityTools->persistDto(
+                $trunksCdrDto,
+                $trunksCdr,
+                false
+            );
+        } catch (\Exception $e) {
+            $errorMsg = sprintf(
+                'Unable to process external cdr for #%s: %s',
+                $trunksCdr->getId(),
+                $e->getMessage()
+            );
+            $this->logger->error($errorMsg);
+
+            throw new \DomainException('There was a error on external CDR processing');
+        }
+
+        return true;
+    }
+}

--- a/library/Ivoz/Core/Infrastructure/Domain/Service/Cgrates/ReloadService.php
+++ b/library/Ivoz/Core/Infrastructure/Domain/Service/Cgrates/ReloadService.php
@@ -19,10 +19,6 @@ class ReloadService extends AbstractApiBasedService
         );
     }
 
-    /**
-     * @inheritdoc
-     * @see RerateCallServiceInterface::execute()
-     */
     public function execute(string $tpid)
     {
         $payload = [

--- a/library/Ivoz/Core/Infrastructure/Domain/Service/Cgrates/RerateCallService.php
+++ b/library/Ivoz/Core/Infrastructure/Domain/Service/Cgrates/RerateCallService.php
@@ -85,14 +85,14 @@ class RerateCallService extends AbstractApiBasedService implements RerateCallSer
         // shared
         $this
             ->billableCallRepository
-            ->resetPrices($pks);
+            ->resetPricingData($pks);
 
         $trunkCdrIds = $this
             ->billableCallRepository
             ->idsToTrunkCdrId($pks);
 
         $this->trunksCdrRepository
-            ->resetMetered($trunkCdrIds);
+            ->resetParsed($trunkCdrIds);
 
         if ($error) {
             throw new \DomainException(

--- a/library/Ivoz/Core/Infrastructure/Domain/Service/Cgrates/RerateCallService.php
+++ b/library/Ivoz/Core/Infrastructure/Domain/Service/Cgrates/RerateCallService.php
@@ -21,6 +21,11 @@ class RerateCallService extends AbstractApiBasedService implements RerateCallSer
     protected $billableCallRepository;
 
     /**
+     * @var ProcessExternalCdr
+     */
+    protected $processExternalCdr;
+
+    /**
      * @var LoggerInterface
      */
     protected $logger;
@@ -29,10 +34,12 @@ class RerateCallService extends AbstractApiBasedService implements RerateCallSer
         ClientInterface $jsonRpcClient,
         BillableCallRepository $billableCallRepository,
         TrunksCdrRepository $trunksCdrRepository,
+        ProcessExternalCdr $processExternalCdr,
         LoggerInterface $logger
     ) {
         $this->billableCallRepository = $billableCallRepository;
         $this->trunksCdrRepository = $trunksCdrRepository;
+        $this->processExternalCdr = $processExternalCdr;
         $this->logger = $logger;
 
         return parent::__construct(
@@ -46,10 +53,60 @@ class RerateCallService extends AbstractApiBasedService implements RerateCallSer
      */
     public function execute(array $pks)
     {
+        $error = false;
         $cgrIds = $this
             ->billableCallRepository
-            ->idsToCgrid($pks);
+            ->findRerateableCgridsInGroup($pks);
 
+        if (!empty($cgrIds)) {
+            try {
+                $this->rerate($cgrIds);
+            } catch (\Exception $e) {
+                $this->logger->error($e->getMessage());
+                $error = true;
+            }
+        }
+
+        $unrated = $this->billableCallRepository->findUnratedInGroup($pks);
+        if (!empty($unrated)) {
+            foreach ($unrated as $billableCall) {
+                try {
+                    $this->processExternalCdr->execute(
+                        $billableCall->getTrunksCdr()
+                    );
+                } catch (\Exception $e) {
+                    $this->logger->error($e->getMessage());
+                    $error = true;
+                    continue;
+                }
+            }
+        }
+
+        // shared
+        $this
+            ->billableCallRepository
+            ->resetPrices($pks);
+
+        $trunkCdrIds = $this
+            ->billableCallRepository
+            ->idsToTrunkCdrId($pks);
+
+        $this->trunksCdrRepository
+            ->resetMetered($trunkCdrIds);
+
+        if ($error) {
+            throw new \DomainException(
+                'Some calls could not be rerated'
+            );
+        }
+    }
+
+    /**
+     * @param array $cgrIds
+     * @return void
+     */
+    private function rerate(array $cgrIds)
+    {
         $payload = [
             "CgrIds" => $cgrIds,
             "MediationRunIds" => null,
@@ -71,30 +128,9 @@ class RerateCallService extends AbstractApiBasedService implements RerateCallSer
             "SendToStats" => false
         ];
 
-        try {
-            $this->sendRequest(
-                'CdrsV1.RateCDRs',
-                $payload
-            );
-        } catch (\Exception $e) {
-            $this->logger->error($e->getMessage());
-
-            throw new \DomainException(
-                'There was an error during API request',
-                $e->getCode(),
-                $e
-            );
-        }
-
-        $this
-            ->billableCallRepository
-            ->resetPrices($pks);
-
-        $trunkCdrIds = $this
-            ->billableCallRepository
-            ->idsToTrunkCdrId($pks);
-
-        $this->trunksCdrRepository
-            ->resetMetered($trunkCdrIds);
+        $this->sendRequest(
+            'CdrsV1.RateCDRs',
+            $payload
+        );
     }
 }

--- a/library/Ivoz/Kam/Domain/Model/TrunksCdr/TrunksCdrAbstract.php
+++ b/library/Ivoz/Kam/Domain/Model/TrunksCdr/TrunksCdrAbstract.php
@@ -68,7 +68,12 @@ abstract class TrunksCdrAbstract
     /**
      * @var boolean | null
      */
-    protected $metered = '0';
+    protected $parsed = '0';
+
+    /**
+     * @var \DateTime
+     */
+    protected $parserScheduledAt;
 
     /**
      * @var string | null
@@ -106,11 +111,16 @@ abstract class TrunksCdrAbstract
     /**
      * Constructor
      */
-    protected function __construct($startTime, $endTime, $duration)
-    {
+    protected function __construct(
+        $startTime,
+        $endTime,
+        $duration,
+        $parserScheduledAt
+    ) {
         $this->setStartTime($startTime);
         $this->setEndTime($endTime);
         $this->setDuration($duration);
+        $this->setParserScheduledAt($parserScheduledAt);
     }
 
     abstract public function getId();
@@ -184,7 +194,8 @@ abstract class TrunksCdrAbstract
         $self = new static(
             $dto->getStartTime(),
             $dto->getEndTime(),
-            $dto->getDuration()
+            $dto->getDuration(),
+            $dto->getParserScheduledAt()
         );
 
         $self
@@ -195,7 +206,7 @@ abstract class TrunksCdrAbstract
             ->setXcallid($dto->getXcallid())
             ->setDiversion($dto->getDiversion())
             ->setBounced($dto->getBounced())
-            ->setMetered($dto->getMetered())
+            ->setParsed($dto->getParsed())
             ->setDirection($dto->getDirection())
             ->setCgrid($dto->getCgrid())
             ->setBrand($fkTransformer->transform($dto->getBrand()))
@@ -235,7 +246,8 @@ abstract class TrunksCdrAbstract
             ->setXcallid($dto->getXcallid())
             ->setDiversion($dto->getDiversion())
             ->setBounced($dto->getBounced())
-            ->setMetered($dto->getMetered())
+            ->setParsed($dto->getParsed())
+            ->setParserScheduledAt($dto->getParserScheduledAt())
             ->setDirection($dto->getDirection())
             ->setCgrid($dto->getCgrid())
             ->setBrand($fkTransformer->transform($dto->getBrand()))
@@ -267,7 +279,8 @@ abstract class TrunksCdrAbstract
             ->setXcallid(self::getXcallid())
             ->setDiversion(self::getDiversion())
             ->setBounced(self::getBounced())
-            ->setMetered(self::getMetered())
+            ->setParsed(self::getParsed())
+            ->setParserScheduledAt(self::getParserScheduledAt())
             ->setDirection(self::getDirection())
             ->setCgrid(self::getCgrid())
             ->setBrand(\Ivoz\Provider\Domain\Model\Brand\Brand::entityToDto(self::getBrand(), $depth))
@@ -292,7 +305,8 @@ abstract class TrunksCdrAbstract
             'xcallid' => self::getXcallid(),
             'diversion' => self::getDiversion(),
             'bounced' => self::getBounced(),
-            'metered' => self::getMetered(),
+            'parsed' => self::getParsed(),
+            'parserScheduledAt' => self::getParserScheduledAt(),
             'direction' => self::getDirection(),
             'cgrid' => self::getCgrid(),
             'brandId' => self::getBrand() ? self::getBrand()->getId() : null,
@@ -588,31 +602,61 @@ abstract class TrunksCdrAbstract
     }
 
     /**
-     * Set metered
+     * Set parsed
      *
-     * @param boolean $metered
+     * @param boolean $parsed
      *
      * @return self
      */
-    protected function setMetered($metered = null)
+    protected function setParsed($parsed = null)
     {
-        if (!is_null($metered)) {
-            Assertion::between(intval($metered), 0, 1, 'metered provided "%s" is not a valid boolean value.');
+        if (!is_null($parsed)) {
+            Assertion::between(intval($parsed), 0, 1, 'parsed provided "%s" is not a valid boolean value.');
         }
 
-        $this->metered = $metered;
+        $this->parsed = $parsed;
 
         return $this;
     }
 
     /**
-     * Get metered
+     * Get parsed
      *
      * @return boolean | null
      */
-    public function getMetered()
+    public function getParsed()
     {
-        return $this->metered;
+        return $this->parsed;
+    }
+
+    /**
+     * Set parserScheduledAt
+     *
+     * @param \DateTime $parserScheduledAt
+     *
+     * @return self
+     */
+    protected function setParserScheduledAt($parserScheduledAt)
+    {
+        Assertion::notNull($parserScheduledAt, 'parserScheduledAt value "%s" is null, but non null value was expected.');
+        $parserScheduledAt = \Ivoz\Core\Domain\Model\Helper\DateTimeHelper::createOrFix(
+            $parserScheduledAt,
+            'CURRENT_TIMESTAMP'
+        );
+
+        $this->parserScheduledAt = $parserScheduledAt;
+
+        return $this;
+    }
+
+    /**
+     * Get parserScheduledAt
+     *
+     * @return \DateTime
+     */
+    public function getParserScheduledAt()
+    {
+        return clone $this->parserScheduledAt;
     }
 
     /**

--- a/library/Ivoz/Kam/Domain/Model/TrunksCdr/TrunksCdrDtoAbstract.php
+++ b/library/Ivoz/Kam/Domain/Model/TrunksCdr/TrunksCdrDtoAbstract.php
@@ -63,7 +63,12 @@ abstract class TrunksCdrDtoAbstract implements DataTransferObjectInterface
     /**
      * @var boolean
      */
-    private $metered = '0';
+    private $parsed = '0';
+
+    /**
+     * @var \DateTime
+     */
+    private $parserScheduledAt = 'CURRENT_TIMESTAMP';
 
     /**
      * @var string
@@ -128,7 +133,8 @@ abstract class TrunksCdrDtoAbstract implements DataTransferObjectInterface
             'xcallid' => 'xcallid',
             'diversion' => 'diversion',
             'bounced' => 'bounced',
-            'metered' => 'metered',
+            'parsed' => 'parsed',
+            'parserScheduledAt' => 'parserScheduledAt',
             'direction' => 'direction',
             'cgrid' => 'cgrid',
             'id' => 'id',
@@ -155,7 +161,8 @@ abstract class TrunksCdrDtoAbstract implements DataTransferObjectInterface
             'xcallid' => $this->getXcallid(),
             'diversion' => $this->getDiversion(),
             'bounced' => $this->getBounced(),
-            'metered' => $this->getMetered(),
+            'parsed' => $this->getParsed(),
+            'parserScheduledAt' => $this->getParserScheduledAt(),
             'direction' => $this->getDirection(),
             'cgrid' => $this->getCgrid(),
             'id' => $this->getId(),
@@ -367,13 +374,13 @@ abstract class TrunksCdrDtoAbstract implements DataTransferObjectInterface
     }
 
     /**
-     * @param boolean $metered
+     * @param boolean $parsed
      *
      * @return static
      */
-    public function setMetered($metered = null)
+    public function setParsed($parsed = null)
     {
-        $this->metered = $metered;
+        $this->parsed = $parsed;
 
         return $this;
     }
@@ -381,9 +388,29 @@ abstract class TrunksCdrDtoAbstract implements DataTransferObjectInterface
     /**
      * @return boolean
      */
-    public function getMetered()
+    public function getParsed()
     {
-        return $this->metered;
+        return $this->parsed;
+    }
+
+    /**
+     * @param \DateTime $parserScheduledAt
+     *
+     * @return static
+     */
+    public function setParserScheduledAt($parserScheduledAt = null)
+    {
+        $this->parserScheduledAt = $parserScheduledAt;
+
+        return $this;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getParserScheduledAt()
+    {
+        return $this->parserScheduledAt;
     }
 
     /**

--- a/library/Ivoz/Kam/Domain/Model/TrunksCdr/TrunksCdrInterface.php
+++ b/library/Ivoz/Kam/Domain/Model/TrunksCdr/TrunksCdrInterface.php
@@ -77,11 +77,18 @@ interface TrunksCdrInterface extends EntityInterface
     public function getBounced();
 
     /**
-     * Get metered
+     * Get parsed
      *
      * @return boolean | null
      */
-    public function getMetered();
+    public function getParsed();
+
+    /**
+     * Get parserScheduledAt
+     *
+     * @return \DateTime
+     */
+    public function getParserScheduledAt();
 
     /**
      * Get direction

--- a/library/Ivoz/Kam/Domain/Model/TrunksCdr/TrunksCdrRepository.php
+++ b/library/Ivoz/Kam/Domain/Model/TrunksCdr/TrunksCdrRepository.php
@@ -8,20 +8,20 @@ use Doctrine\Common\Collections\Selectable;
 interface TrunksCdrRepository extends ObjectRepository, Selectable
 {
     /**
-     * This method expects results to be marked as metered as soon as they're used:
+     * This method expects results to be marked as parsed as soon as they're used:
      * a.k.a it does not apply any query offset, just a limit
      *
      * @param int $batchSize
      * @param array|null $order
      * @return \Generator
      */
-    public function getUnmeteredCallsGeneratorWithoutOffset(int $batchSize, array $order = null);
+    public function getUnparsedCallsGeneratorWithoutOffset(int $batchSize, array $order = null);
 
     /**
      * @param array $ids
      * @return mixed
      */
-    public function resetMetered(array $ids);
+    public function resetParsed(array $ids);
 
     /**
      * @param $callid

--- a/library/Ivoz/Kam/Infrastructure/Persistence/Doctrine/Mapping/TrunksCdr.TrunksCdrAbstract.orm.yml
+++ b/library/Ivoz/Kam/Infrastructure/Persistence/Doctrine/Mapping/TrunksCdr.TrunksCdrAbstract.orm.yml
@@ -16,6 +16,9 @@ Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdrAbstract:
     trunksCdr_direction_idx:
       columns:
         - direction
+    trunksCdr_parsed_idx:
+      columns:
+        - parsed
     trunksCdr_cgrid_idx:
       columns:
         - cgrid
@@ -79,11 +82,17 @@ Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdrAbstract:
     bounced:
       type: boolean
       nullable: true
-    metered:
+    parsed:
       type: boolean
       nullable: true
       options:
         default: '0'
+    parserScheduledAt:
+      type: datetime
+      nullable: false
+      options:
+        default: CURRENT_TIMESTAMP
+      column: parserScheduledAt
     direction:
       type: string
       nullable: true

--- a/library/Ivoz/Provider/Domain/Model/BillableCall/BillableCallRepository.php
+++ b/library/Ivoz/Provider/Domain/Model/BillableCall/BillableCallRepository.php
@@ -44,7 +44,7 @@ interface BillableCallRepository extends ObjectRepository, Selectable
      * @param array $ids
      * @return void
      */
-    public function resetPrices(array $ids);
+    public function resetPricingData(array $ids);
 
     /**
      * @param int $invoiceId

--- a/library/Ivoz/Provider/Domain/Model/BillableCall/BillableCallRepository.php
+++ b/library/Ivoz/Provider/Domain/Model/BillableCall/BillableCallRepository.php
@@ -19,15 +19,24 @@ interface BillableCallRepository extends ObjectRepository, Selectable
      */
     public function areRetarificable(array $pks);
 
+
     /**
-     * @param array $ids
-     * @return array
+     * Return non externally rated calls without cgrid
+     * @param array $pks
+     * @return BillableCallInterface[]
      */
-    public function idsToCgrid(array $ids);
+    public function findUnratedInGroup(array $pks);
 
     /**
      * @param array $ids
      * @return array
+     */
+    public function findRerateableCgridsInGroup(array $ids);
+
+    /**
+     * @param array $ids
+     * @return array
+     * @throws \Exception | \DomainException
      */
     public function idsToTrunkCdrId(array $ids);
 

--- a/library/Ivoz/Provider/Domain/Service/BillableCall/CreateOrUpdateByTrunksCdr.php
+++ b/library/Ivoz/Provider/Domain/Service/BillableCall/CreateOrUpdateByTrunksCdr.php
@@ -44,7 +44,7 @@ class CreateOrUpdateByTrunksCdr
 
         $carrierName = $carrier
             ? $carrier->getName()
-            : '';
+            : $billableCallDto->getCarrierName();
 
         /**
          * @var TrunksCdrDto $trunksCdrDto

--- a/library/Ivoz/Provider/Domain/Service/BillableCall/CreateOrUpdateByTrunksCdr.php
+++ b/library/Ivoz/Provider/Domain/Service/BillableCall/CreateOrUpdateByTrunksCdr.php
@@ -72,13 +72,23 @@ class CreateOrUpdateByTrunksCdr
                 $trunksCdrDto->getCallid()
             )->setCaller(
                 $caller
-            )->setCallee(
-                $trunksCdrDto->getCallee()
-            )->setStartTime(
-                $trunksCdrDto->getStartTime()
-            )->setDuration(
+            );
+
+        $isNew = is_null($billableCall);
+        if ($isNew) {
+            $durantion = round(
                 $trunksCdrDto->getDuration()
             );
+
+            $billableCallDto
+                ->setCallee(
+                    $trunksCdrDto->getCallee()
+                )->setStartTime(
+                    $trunksCdrDto->getStartTime()
+                )->setDuration(
+                    $durantion
+                );
+        }
 
         if ($trunksCdrDto->getRetailAccountId()) {
             $billableCallDto

--- a/library/Ivoz/Provider/Domain/Service/BillableCall/MigrateFromTrunksCdr.php
+++ b/library/Ivoz/Provider/Domain/Service/BillableCall/MigrateFromTrunksCdr.php
@@ -67,7 +67,7 @@ class MigrateFromTrunksCdr
         /**
          * @var \Generator
          */
-        $trunksGenerator = $this->trunksCdrRepository->getUnmeteredCallsGeneratorWithoutOffset(self::BATCH_SIZE);
+        $trunksGenerator = $this->trunksCdrRepository->getUnparsedCallsGeneratorWithoutOffset(self::BATCH_SIZE);
 
         $cdrCount = 0;
         foreach ($trunksGenerator as $trunks) {
@@ -118,7 +118,7 @@ class MigrateFromTrunksCdr
         $trunksCdrDto = $this->entityTools->entityToDto(
             $trunksCdr
         );
-        $trunksCdrDto->setMetered(true);
+        $trunksCdrDto->setParsed(true);
         $this->entityTools->persistDto(
             $trunksCdrDto,
             $trunksCdr,

--- a/library/Ivoz/Provider/Domain/Service/BillableCall/UpdateDtoByDefaultRunTpCdr.php
+++ b/library/Ivoz/Provider/Domain/Service/BillableCall/UpdateDtoByDefaultRunTpCdr.php
@@ -102,7 +102,6 @@ class UpdateDtoByDefaultRunTpCdr
         );
 
         if (is_null($cost) || $cost < 0 || !$tpRatingPlan) {
-
             $errorMsg = empty($tpRatingPlan)
                 ? 'Rating plan not found'
                 : 'Rating price error';

--- a/library/Ivoz/Provider/Domain/Service/BillableCall/UpdateDtoByDefaultRunTpCdr.php
+++ b/library/Ivoz/Provider/Domain/Service/BillableCall/UpdateDtoByDefaultRunTpCdr.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace Ivoz\Provider\Domain\Service\BillableCall;
+
+use Ivoz\Cgr\Domain\Model\TpCdr\TpCdrInterface;
+use Ivoz\Cgr\Domain\Model\TpCdr\TpCdrRepository;
+use Ivoz\Cgr\Domain\Model\TpDestination\TpDestinationInterface;
+use Ivoz\Cgr\Domain\Model\TpDestination\TpDestinationRepository;
+use Ivoz\Cgr\Domain\Model\TpRatingPlan\TpRatingPlanInterface;
+use Ivoz\Cgr\Domain\Model\TpRatingPlan\TpRatingPlanRepository;
+use Ivoz\Core\Application\Service\EntityTools;
+use Ivoz\Core\Domain\Service\DomainEventSubscriberInterface;
+use Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdrInterface;
+use Ivoz\Provider\Domain\Model\BillableCall\BillableCallDto;
+use Ivoz\Provider\Domain\Model\BillableCall\BillableCallInterface;
+use Ivoz\Provider\Domain\Model\Destination\DestinationInterface;
+use Ivoz\Kam\Domain\Model\TrunksCdr\Event\TrunksCdrWasMigrated;
+use Ivoz\Core\Domain\Event\DomainEventInterface;
+use Ivoz\Provider\Domain\Model\RatingPlan\RatingPlanInterface;
+use Ivoz\Provider\Domain\Model\RatingPlanGroup\RatingPlanGroupInterface;
+use Psr\Log\LoggerInterface;
+
+class UpdateDtoByDefaultRunTpCdr
+{
+    /**
+     * @var TpRatingPlanRepository
+     */
+    protected $tpRatingPlanRepository;
+
+    /**
+     * @var TpDestinationRepository
+     */
+    protected $tpDestinationRepository;
+
+    /**
+     * @var LoggerInterface
+     */
+    protected $logger;
+
+    public function __construct(
+        TpRatingPlanRepository $tpRatingPlanRepository,
+        TpDestinationRepository $tpDestinationRepository,
+        LoggerInterface $logger
+    ) {
+        $this->tpRatingPlanRepository = $tpRatingPlanRepository;
+        $this->tpDestinationRepository = $tpDestinationRepository;
+        $this->logger = $logger;
+    }
+
+    /**
+     * @param BillableCallDto $billableCallDto
+     * @param TrunksCdrInterface $trunksCdr
+     * @param TpCdrInterface $defaultRunTpCdr
+     * @returns BillableCallDto
+     */
+    public function execute(
+        BillableCallDto $billableCallDto,
+        TrunksCdrInterface $trunksCdr,
+        TpCdrInterface $defaultRunTpCdr
+    ) :BillableCallDto {
+        if (!$defaultRunTpCdr->getCostDetailsFirstTimespan()) {
+            $errorMsg = sprintf(
+                'Empty cost details. Skipping'
+            );
+            $this->logger->error($errorMsg);
+
+            return $billableCallDto;
+        }
+
+        $cost = $defaultRunTpCdr->getCost();
+        $callee = $defaultRunTpCdr->getDestination()
+            ? $defaultRunTpCdr->getDestination()
+            : $billableCallDto->getCallee();
+
+        $startTime = $defaultRunTpCdr->getStartTime()
+            ? $defaultRunTpCdr->getStartTime()
+            : $billableCallDto->getStartTime();
+
+        $duration = $defaultRunTpCdr->getDuration()
+            ? $defaultRunTpCdr->getDuration()
+            : $billableCallDto->getDuration();
+
+        $billableCallDto
+            ->setStartTime(
+                $startTime
+            )
+            ->setDuration(
+                $duration
+            )
+            ->setCallee(
+                $callee
+            )
+            ->setPrice(
+                $cost
+            );
+
+        /**
+         * @var TpRatingPlanInterface $tpRatingPlan
+         */
+        $tpRatingPlan = $this->tpRatingPlanRepository->findOneByTag(
+            $defaultRunTpCdr->getRatingPlanTag()
+        );
+
+        if (is_null($cost) || $cost < 0 || !$tpRatingPlan) {
+
+            $errorMsg = empty($tpRatingPlan)
+                ? 'Rating plan not found'
+                : 'Rating price error';
+
+            $this->logger->error(
+                $errorMsg . '. Setting some Destination/RatingPlan save values and skipping'
+            );
+
+            $billableCallDto
+                ->setDestinationId(
+                    null
+                )
+                ->setDestinationName(
+                    null
+                )
+                ->setRatingPlanGroupId(
+                    null
+                )
+                ->setRatingPlanName(
+                    null
+                );
+
+            return $billableCallDto;
+        }
+
+        /** @var RatingPlanInterface $ratingPlan */
+        $ratingPlan = $tpRatingPlan->getRatingPlan();
+
+        /** @var RatingPlanGroupInterface $ratingPlanGroup */
+        $ratingPlanGroup = $ratingPlan->getRatingPlanGroup();
+
+        $ratingPlanGroupId = $ratingPlanGroup
+            ? $ratingPlanGroup->getId()
+            : null;
+
+        $languageCode = ucfirst($trunksCdr->getBrand()->getLanguageCode());
+        $brandLangGetter = 'get' . $languageCode;
+        $ratingPlanGroupName = $ratingPlanGroup
+            ? $ratingPlanGroup->getName()->{$brandLangGetter}()
+            : '';
+
+        /** @var TpDestinationInterface $tpDestination */
+        $tpDestination = $this->tpDestinationRepository->findOneByTag(
+            $defaultRunTpCdr->getMatchedDestinationTag()
+        );
+        /** @var DestinationInterface $destination */
+        $destination = $tpDestination
+            ? $tpDestination->getDestination()
+            : null;
+
+        $destinationId = $destination
+            ? $destination->getId()
+            : null;
+
+        $brandLangGetter = 'get' . $languageCode;
+        $destinationName = $destination
+            ? $destination->getName()->{$brandLangGetter}()
+            : '';
+
+        $billableCallDto
+            ->setDestinationId(
+                $destinationId
+            )
+            ->setDestinationName(
+                $destinationName
+            )
+            ->setRatingPlanGroupId(
+                $ratingPlanGroupId
+            )
+            ->setRatingPlanName(
+                $ratingPlanGroupName
+            );
+
+        return $billableCallDto;
+    }
+}

--- a/library/Ivoz/Provider/Domain/Service/Invoice/CheckValidity.php
+++ b/library/Ivoz/Provider/Domain/Service/Invoice/CheckValidity.php
@@ -6,7 +6,6 @@ use Ivoz\Provider\Domain\Model\BillableCall\BillableCallRepository;
 use Ivoz\Provider\Domain\Model\Invoice\Invoice;
 use Ivoz\Provider\Domain\Model\Invoice\InvoiceInterface;
 use Ivoz\Provider\Domain\Model\Invoice\InvoiceRepository;
-use Ivoz\Kam\Domain\Model\TrunksCdr\AccCdrRepository;
 
 class CheckValidity implements InvoiceLifecycleEventHandlerInterface
 {
@@ -95,7 +94,7 @@ class CheckValidity implements InvoiceLifecycleEventHandlerInterface
 
     /**
      * @param InvoiceInterface $invoice
-     * @param $utcOutDate
+     * @param \DateTime $utcOutDate
      * @throws \Doctrine\ORM\NoResultException
      * @throws \Doctrine\ORM\NonUniqueResultException
      * @throws \Doctrine\ORM\Query\QueryException

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/BillableCallDoctrineRepository.php
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/BillableCallDoctrineRepository.php
@@ -65,36 +65,68 @@ class BillableCallDoctrineRepository extends ServiceEntityRepository implements 
     }
 
     /**
+     * Return non externally rated calls without cgrid
      * @inheritdoc
-     * @see BillableCallRepository::idsToCgrid
+     * @see BillableCallRepository::findUnratedInGroup
      */
-    public function idsToCgrid(array $ids)
+    public function findUnratedInGroup(array $pks)
     {
         $qb = $this->createQueryBuilder('self');
 
         $conditions = [
-            ['id', 'in', $ids]
+            ['self.id', 'in', $pks],
+            ['trunksCdr.cgrid', 'isNull'],
+            'or' => [
+                ['carrier.externallyRated', 'eq', 0],
+                ['self.carrier', 'isNUll']
+            ]
         ];
 
         $qb
-            ->select('self')
+            ->select('self, trunksCdr')
+            ->innerJoin('self.trunksCdr', 'trunksCdr')
+            ->leftJoin('self.carrier', 'carrier')
             ->addCriteria(
                 CriteriaHelper::fromArray($conditions)
             );
+        $query = $qb->getQuery();
+
+        return $query->getResult();
+    }
+
+    /**
+     * @inheritdoc
+     * @see BillableCallRepository::findRerateableCgridsInGroup
+     */
+    public function findRerateableCgridsInGroup(array $ids)
+    {
+        $qb = $this->createQueryBuilder('self');
+
+        $conditions = [
+            ['id', 'in', $ids],
+            ['trunksCdr.cgrid', 'isNotNull'],
+            'or' => [
+                ['carrier.externallyRated', 'eq', 0],
+                ['self.carrier', 'isNull']
+            ]
+        ];
+
+        $qb
+            ->select('self, trunksCdr')
+            ->innerJoin('self.trunksCdr', 'trunksCdr')
+            ->leftJoin('self.carrier', 'carrier')
+            ->addCriteria(
+                CriteriaHelper::fromArray($conditions)
+            );
+
+        $query = $qb->getQuery();
+
         /** @var BillableCallInterface[] $billableCalls */
-        $billableCalls = $qb
-            ->getQuery()
-            ->getResult();
+        $billableCalls = $query->getResult();
 
         $cgrids = [];
         foreach ($billableCalls as $billableCall) {
-            if (!is_null($billableCall->getTrunksCdr())) {
-                $cgrids[] = $billableCall->getTrunksCdr()->getCgrid();
-            }
-        }
-
-        if (count($ids) !== count($cgrids)) {
-            throw new \DomainException('Some id were not found');
+            $cgrids[] = $billableCall->getTrunksCdr()->getCgrid();
         }
 
         return $cgrids;
@@ -147,6 +179,10 @@ class BillableCallDoctrineRepository extends ServiceEntityRepository implements 
             ->update($this->_entityName, 'self')
             ->set('self.price', ':nullValue')
             ->set('self.cost', ':nullValue')
+            ->set('self.destination', ':nullValue')
+            ->set('self.destinationName', ':nullValue')
+            ->set('self.ratingPlanGroup', ':nullValue')
+            ->set('self.ratingPlanName', ':nullValue')
             ->setParameter(':nullValue', null)
             ->where('self.id in (:ids)')
             ->setParameter(':ids', $ids);
@@ -206,7 +242,6 @@ class BillableCallDoctrineRepository extends ServiceEntityRepository implements 
                 ['price', 'isNull'],
                 ['price', 'lt', 0],
             ]
-
         ];
 
         $qb
@@ -232,7 +267,10 @@ class BillableCallDoctrineRepository extends ServiceEntityRepository implements 
             ['startTime', 'gt', $startTime],
             ['carrier', 'neq', null],
             ['carrier', 'neq', ''],
-            ['price', 'isNull']
+            'or' => [
+                ['price', 'isNull'],
+                ['price', 'lt', 0],
+            ]
         ];
 
         $qb

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/BillableCallDoctrineRepository.php
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/BillableCallDoctrineRepository.php
@@ -170,9 +170,9 @@ class BillableCallDoctrineRepository extends ServiceEntityRepository implements 
 
     /**
      * @inheritdoc
-     * @see BillableCallRepository::resetPrices
+     * @see BillableCallRepository::resetPricingData
      */
-    public function resetPrices(array $ids)
+    public function resetPricingData(array $ids)
     {
         $qb = $this
             ->createQueryBuilder('self')

--- a/library/spec/Ivoz/Core/Infrastructure/Domain/Service/Cgrates/ProcessExternalCdrSpec.php
+++ b/library/spec/Ivoz/Core/Infrastructure/Domain/Service/Cgrates/ProcessExternalCdrSpec.php
@@ -1,0 +1,332 @@
+<?php
+
+namespace spec\Ivoz\Core\Infrastructure\Domain\Service\Cgrates;
+
+use Ivoz\Cgr\Domain\Model\TpCdr\TpCdrInterface;
+use Ivoz\Cgr\Domain\Model\TpCdr\TpCdrRepository;
+use Ivoz\Cgr\Infrastructure\Persistence\Doctrine\TpCdrDoctrineRepository;
+use Ivoz\Core\Application\Service\EntityTools;
+use Ivoz\Core\Infrastructure\Domain\Service\Cgrates\ProcessExternalCdr;
+use Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdrDto;
+use Ivoz\Provider\Domain\Model\Brand\BrandInterface;
+use Ivoz\Provider\Domain\Model\Carrier\CarrierInterface;
+use Ivoz\Provider\Domain\Model\Company\CompanyInterface;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdrInterface;
+use Graze\GuzzleHttp\JsonRpc\ClientInterface;
+use Prophecy\Prophet;
+use Psr\Log\LoggerInterface;
+use spec\HelperTrait;
+use Ivoz\Core\Infrastructure\Domain\Service\Cgrates\ApiClient;
+
+class ProcessExternalCdrSpec extends ObjectBehavior
+{
+    use HelperTrait;
+
+    /**
+     * @var ApiClient
+     */
+    protected $apiClient;
+
+    /**
+     * @var EntityTools
+     */
+    protected $entityTools;
+
+    /**
+     * @var TpCdrRepository
+     */
+    protected $tpCdrRepository;
+
+    /**
+     * @var LoggerInterface
+     */
+    protected $logger;
+
+    public function let(
+        ApiClient $apiClient,
+        EntityTools $entityTools,
+        TpCdrRepository $tpCdrRepository,
+        LoggerInterface $logger
+    ) {
+        $this->apiClient = $apiClient;
+        $this->entityTools = $entityTools;
+        $this->tpCdrRepository = $tpCdrRepository;
+        $this->logger = $logger;
+
+        $this->beConstructedWith(
+            $apiClient,
+            $entityTools,
+            $tpCdrRepository,
+            $logger
+        );
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ProcessExternalCdr::class);
+    }
+
+    function it_calls_cgrates_api(
+        TrunksCdrInterface $trunksCdr,
+        BrandInterface $brand,
+        CompanyInterface $company,
+        TpCdrInterface $tpCdr
+    ) {
+        $this->prepareExecution(
+            $trunksCdr,
+            $brand,
+            $company,
+            $tpCdr
+        );
+
+        $this
+            ->apiClient
+            ->sendRequest(
+                'CdrsV1.ProcessExternalCDR',
+                Argument::any()
+            )
+            ->shouldBeCalled();
+
+        $this->execute($trunksCdr);
+    }
+
+    function it_does_nothing_with_externallyRated_carrier(
+        TrunksCdrInterface $trunksCdr,
+        CarrierInterface $carrier
+    ) {
+        $trunksCdr
+            ->getCarrier()
+            ->willReturn($carrier)
+            ->shouldBeCalled();
+
+        $carrier
+            ->getExternallyRated()
+            ->willReturn(true);
+
+        $this
+            ->execute($trunksCdr)
+            ->shouldReturn(false);
+    }
+
+    function it_returns_true_when_external_CDR_processing_is_succeeded(
+        TrunksCdrInterface $trunksCdr,
+        BrandInterface $brand,
+        CompanyInterface $company,
+        TpCdrInterface $tpCdr
+    ) {
+        $this->prepareExecution(
+            $trunksCdr,
+            $brand,
+            $company,
+            $tpCdr
+        );
+
+        $this
+            ->execute($trunksCdr)
+            ->shouldReturn(true);
+    }
+
+    function it_constructs_api_payload(
+        TrunksCdrInterface $trunksCdr,
+        BrandInterface $brand,
+        CompanyInterface $company,
+        TpCdrInterface $tpCdr
+    ) {
+        $this->prepareExecution(
+            $trunksCdr,
+            $brand,
+            $company,
+            $tpCdr
+        );
+
+        $trunksCdr
+            ->getCallid()
+            ->willReturn('4567');
+
+        $trunksCdr
+            ->getCallee()
+            ->willReturn('+346002050');
+
+        $trunksCdr
+            ->getStartTime()
+            ->willReturn(
+                new \DateTime(
+                    '2019-01-15 12:00:00',
+                    new \DateTimeZone('UTC')
+                )
+            );
+
+        $trunksCdr
+            ->getDuration()
+            ->willReturn(4.26);
+
+        $brand
+            ->getId()
+            ->willReturn(1);
+
+        $company
+            ->getId()
+            ->willReturn(1);
+
+        $company
+            ->getBillingMethod()
+            ->willReturn('prepaid');
+
+        $expectedArgument = [
+            'OriginHost' => '127.0.0.1',
+            'Source' => 'offline',
+            'OriginID' => '4567',
+            'ToR' => '*voice',
+            'RequestType' => '*prepaid',
+            'Tenant' => 'b1',
+            'Account' => 'c1',
+            'Destination' => '+346002050',
+            'SetupTime' => '2019-01-15T12:00:00Z',
+            'AnswerTime' => '2019-01-15T12:00:00Z',
+            'Usage' => '4s'
+        ];
+
+        $this
+            ->apiClient
+            ->sendRequest(
+                'CdrsV1.ProcessExternalCDR',
+                Argument::exact($expectedArgument)
+            )
+            ->shouldBeCalled();
+
+        $this
+            ->execute($trunksCdr);
+    }
+
+    function it_sets_payload_extra_fields_if_carrier_is_not_null(
+        TrunksCdrInterface $trunksCdr,
+        BrandInterface $brand,
+        CompanyInterface $company,
+        TpCdrInterface $tpCdr,
+        CarrierInterface $carrier
+    ) {
+        $this->prepareExecution(
+            $trunksCdr,
+            $brand,
+            $company,
+            $tpCdr
+        );
+
+        $trunksCdr
+            ->getCarrier()
+            ->willReturn($carrier)
+            ->shouldBeCalled();
+
+        $carrier
+            ->getExternallyRated()
+            ->willReturn(false);
+
+        $carrier
+            ->getId()
+            ->willReturn(2);
+
+        $this
+            ->apiClient
+            ->sendRequest(
+                'CdrsV1.ProcessExternalCDR',
+                Argument::that(function ($payload) {
+                    return array_key_exists('ExtraFields', $payload);
+                })
+            )
+            ->shouldBeCalled();
+
+        $this
+            ->execute($trunksCdr);
+    }
+
+    function it_logs_exceptions(
+        TrunksCdrInterface $trunksCdr,
+        BrandInterface $brand,
+        CompanyInterface $company
+    ) {
+        $this->prepareExecution(
+            $trunksCdr,
+            $brand,
+            $company
+        );
+
+        $this
+            ->apiClient
+            ->sendRequest(
+                'CdrsV1.ProcessExternalCDR',
+                Argument::any()
+            )
+            ->willThrow(\DomainException::class);
+
+        $this
+            ->logger
+            ->error(Argument::type('string'))
+            ->shouldBeCalled();
+
+        $this
+            ->shouldThrow(\DomainException::class)
+            ->duringExecute($trunksCdr);
+    }
+
+    protected function prepareExecution(
+        TrunksCdrInterface $trunksCdr,
+        BrandInterface $brand,
+        CompanyInterface $company,
+        TpCdrInterface $tpCdr = null
+    ) {
+        $startTime = new \DateTime(
+            '2019-01-15 12:00:00',
+            new \DateTimeZone('UTC')
+        );
+
+        $this->getterProphecy(
+            $trunksCdr,
+            [
+                'getId' => 1,
+                'getBrand' => $brand,
+                'getCompany' => $company,
+                'getCarrier' => null,
+                'getCallid' => '',
+                'getCallee' => '',
+                'getDuration' => '',
+                'getStartTime' => $startTime
+            ],
+            false
+        );
+
+        $this
+            ->apiClient
+            ->sendRequest(
+                Argument::type('string'),
+                Argument::type('array')
+            )
+            ->willReturn(null);
+
+        $this
+            ->tpCdrRepository
+            ->getByOriginId(
+                Argument::any()
+            )
+            ->willReturn($tpCdr);
+
+        $this
+            ->entityTools
+            ->entityToDto(
+                Argument::type(TrunksCdrInterface::class)
+            )
+            ->willReturn(
+                new TrunksCdrDto()
+            );
+
+        $this
+            ->entityTools
+            ->persistDto(
+                Argument::type(TrunksCdrDto::class),
+                Argument::type(TrunksCdrInterface::class),
+                false
+            )
+            ->willReturn(null);
+    }
+}

--- a/library/spec/Ivoz/Provider/Domain/Service/BillableCall/MigrateFromTrunksCdrSpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Service/BillableCall/MigrateFromTrunksCdrSpec.php
@@ -86,7 +86,7 @@ class MigrateFromTrunksCdrSpec extends ObjectBehavior
     function it_logs_success_message()
     {
         $this->trunksCdrRepository
-            ->getUnmeteredCallsGeneratorWithoutOffset(MigrateFromTrunksCdr::BATCH_SIZE)
+            ->getUnparsedCallsGeneratorWithoutOffset(MigrateFromTrunksCdr::BATCH_SIZE)
             ->willReturn([]);
 
         $this
@@ -199,7 +199,7 @@ class MigrateFromTrunksCdrSpec extends ObjectBehavior
 
         $this
             ->trunksCdrRepository
-            ->getUnmeteredCallsGeneratorWithoutOffset(MigrateFromTrunksCdr::BATCH_SIZE)
+            ->getUnparsedCallsGeneratorWithoutOffset(MigrateFromTrunksCdr::BATCH_SIZE)
             ->willReturn([[$trunksCdr]]);
 
         $this

--- a/library/spec/Ivoz/Provider/Domain/Service/BillableCall/UpdateByTpCdrSpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Service/BillableCall/UpdateByTpCdrSpec.php
@@ -2,13 +2,17 @@
 
 namespace spec\Ivoz\Provider\Domain\Service\BillableCall;
 
+use Ivoz\Core\Domain\Service\DomainEventSubscriberInterface;
 use Ivoz\Kam\Domain\Model\TrunksCdr\Event\TrunksCdrWasMigrated;
 use Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdrInterface;
+use Ivoz\Provider\Domain\Model\BillableCall\BillableCall;
 use Ivoz\Provider\Domain\Model\BillableCall\BillableCallInterface;
 use Ivoz\Provider\Domain\Model\Brand\BrandInterface;
+use Ivoz\Provider\Domain\Model\Carrier\CarrierInterface;
 use Ivoz\Provider\Domain\Model\RatingPlan\RatingPlanInterface;
 use Ivoz\Provider\Domain\Model\RatingPlanGroup\RatingPlanGroupInterface;
 use Ivoz\Provider\Domain\Service\BillableCall\UpdateByTpCdr;
+use Ivoz\Provider\Domain\Service\BillableCall\UpdateDtoByDefaultRunTpCdr;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Ivoz\Cgr\Domain\Model\TpCdr\TpCdrInterface;
@@ -20,6 +24,7 @@ use Ivoz\Provider\Domain\Model\BillableCall\BillableCallDto;
 use Ivoz\Provider\Domain\Model\Destination\DestinationInterface;
 use Ivoz\Provider\Domain\Model\RatingPlanGroup\Name;
 use Ivoz\Core\Application\Service\EntityTools;
+use Psr\Log\LoggerInterface;
 use spec\HelperTrait;
 
 class UpdateByTpCdrSpec extends ObjectBehavior
@@ -32,36 +37,158 @@ class UpdateByTpCdrSpec extends ObjectBehavior
     protected $tpCdrRepository;
 
     /**
-     * @var TpRatingPlanRepository
+     * @var UpdateDtoByDefaultRunTpCdr
      */
-    protected $tpRatingPlanRepository;
-
-    /**
-     * @var TpDestinationRepository
-     */
-    protected $tpDestinationRepository;
+    protected $updateDtoByDefaultRunTpCdr;
 
     /**
      * @var EntityTools
      */
     protected $entityTools;
 
-    public function let(
-        TpCdrRepository $tpCdrRepository,
-        TpRatingPlanRepository $tpRatingPlanRepository,
-        TpDestinationRepository $tpDestinationRepository,
-        EntityTools $entityTools
-    ) {
-        $this->tpCdrRepository = $tpCdrRepository;
-        $this->tpRatingPlanRepository = $tpRatingPlanRepository;
-        $this->tpDestinationRepository = $tpDestinationRepository;
-        $this->entityTools = $entityTools;
+    /**
+     * @var LoggerInterface
+     */
+    protected $logger;
+
+    /////////////////////////////////////////////7
+    ///
+    /////////////////////////////////////////////7
+
+    /**
+     * @var TrunksCdrInterface
+     */
+    protected $trunksCdr;
+
+    /**
+     * @var BillableCallInterface
+     */
+    protected $billableCall;
+
+    /**
+     * @var CarrierInterface
+     */
+    protected $carrier;
+
+    /**
+     * @var TpCdrInterface
+     */
+    protected $defaultRunTpCdr;
+
+    /**
+     * @var BillableCallDto
+     */
+    protected $billableCallDto;
+
+    /**
+     * @var TpCdrInterface
+     */
+    protected $carrierRunTpCdr;
+
+    /**
+     * @var TrunksCdrWasMigrated
+     */
+    protected $event;
+
+    public function let()
+    {
+        $this->tpCdrRepository = $this->getTestDouble(
+            TpCdrRepository::class
+        );
+        $this->updateDtoByDefaultRunTpCdr = $this->getTestDouble(
+            UpdateDtoByDefaultRunTpCdr::class
+        );
+        $this->entityTools = $this->getTestDouble(
+            EntityTools::class
+        );
+        $this->logger = $this->getTestDouble(
+            LoggerInterface::class
+        );
 
         $this->beConstructedWith(
             $this->tpCdrRepository,
-            $this->tpRatingPlanRepository,
-            $this->tpDestinationRepository,
-            $this->entityTools
+            $this->updateDtoByDefaultRunTpCdr,
+            $this->entityTools,
+            $this->logger
+        );
+
+        $this->prepareExecution();
+    }
+
+    function prepareExecution()
+    {
+        $this->trunksCdr = $this->getTestDouble(
+            TrunksCdrInterface::class
+        );
+        $this->billableCall = $this->getTestDouble(
+            BillableCallInterface::class
+        );
+        $this->billableCallDto = $this->getTestDouble(
+            BillableCallDto::class
+        );
+        $this->carrier = $this->getTestDouble(
+            CarrierInterface::class
+        );
+        $this->defaultRunTpCdr = $this->getTestDouble(
+            TpCdrInterface::class
+        );
+        $this->carrierRunTpCdr = $this->getTestDouble(
+            TpCdrInterface::class
+        );
+
+        $this
+            ->trunksCdr
+            ->getCgrid()
+            ->willReturn(1);
+
+        $this
+            ->billableCall
+            ->getCarrier()
+            ->willReturn($this->carrier);
+
+        $this->getterProphecy(
+            $this->carrier,
+            [
+                'getExternallyRated' => false,
+                'getId' => 1
+            ],
+            false
+        );
+
+        $this
+            ->tpCdrRepository
+            ->getDefaultRunByCgrid(
+                Argument::any()
+            )
+            ->willReturn($this->defaultRunTpCdr);
+
+        $this
+            ->entityTools
+            ->entityToDto(
+                Argument::type(BillableCallInterface::class)
+            )
+            ->willReturn($this->billableCallDto);
+
+        $this
+            ->updateDtoByDefaultRunTpCdr
+            ->execute(
+                Argument::type(BillableCallDto::class),
+                Argument::type(TrunksCdrInterface::class),
+                Argument::type(TpCdrInterface::class)
+            )
+            ->willReturn($this->billableCallDto);
+
+        $this
+            ->entityTools
+            ->persistDto(
+                Argument::type(BillableCallDto::class),
+                Argument::type(BillableCallInterface::class),
+                false
+            );
+
+        $this->event = new TrunksCdrWasMigrated(
+            $this->trunksCdr->reveal(),
+            $this->billableCall->reveal()
         );
     }
 
@@ -70,11 +197,44 @@ class UpdateByTpCdrSpec extends ObjectBehavior
         $this->shouldHaveType(UpdateByTpCdr::class);
     }
 
-    function it_returns_on_empty_cgrid(
-        TrunksCdrInterface $trunksCdr,
-        BillableCallInterface $billableCall
-    ) {
-        $cgrid = null;
+    function it_implements_domainEventSubscriberInterface()
+    {
+        $this->shouldHaveType(DomainEventSubscriberInterface::class);
+    }
+
+    function it_logs_an_error_and_returns_on_empty_cgrid()
+    {
+        $this
+            ->trunksCdr
+            ->getCgrid()
+            ->willReturn(null);
+
+        $this
+            ->logger
+            ->error(Argument::type('string'))
+            ->shouldBeCalled();
+
+        $this
+            ->billableCall
+            ->getCarrier()
+            ->shouldNotBeCalled();
+
+        $this->handle(
+            $this->event
+        );
+    }
+
+    function it_returns_on_externally_rated_carriers()
+    {
+        $this
+            ->carrier
+            ->getExternallyRated()
+            ->willReturn(true);
+
+        $this
+            ->logger
+            ->info(Argument::type('string'))
+            ->shouldBeCalled();
 
         $this
             ->tpCdrRepository
@@ -82,151 +242,32 @@ class UpdateByTpCdrSpec extends ObjectBehavior
             ->shouldNotBeCalled();
 
         $this->handle(
-            new TrunksCdrWasMigrated(
-                $trunksCdr->getWrappedObject(),
-                $billableCall->getWrappedObject()
-            )
+            $this->event
         );
     }
 
-    function it_returns_on_empty_defaultRunTpCdr(
-        TrunksCdrInterface $trunksCdr,
-        BillableCallInterface $billableCall
-    ) {
-        $trunksCdr
-            ->getCgrid()
-            ->willReturn(1);
-
+    function it_calls_updateDtoByDefaultRunTpCdr_collaborator_service()
+    {
         $this
-            ->tpCdrRepository
-            ->getDefaultRunByCgrid(
-                Argument::any()
+            ->updateDtoByDefaultRunTpCdr
+            ->execute(
+                Argument::type(BillableCallDto::class),
+                Argument::type(TrunksCdrInterface::class),
+                Argument::type(TpCdrInterface::class)
             )
+            ->willReturn($this->billableCallDto)
             ->shouldBeCalled();
 
-        $this
-            ->tpRatingPlanRepository
-            ->findOneByTag(
-                Argument::any()
-            )
-            ->shouldNotBeCalled();
-
         $this->handle(
-            new TrunksCdrWasMigrated(
-                $trunksCdr->getWrappedObject(),
-                $billableCall->getWrappedObject()
-            )
+            $this->event
         );
     }
 
-    function it_updates_billableCallDto(
-        TrunksCdrInterface $trunksCdr,
-        BillableCallInterface $billableCall,
-        BillableCallDto $billableCallDto,
-        TpCdrInterface $tpCdr,
-        TpRatingPlanInterface $tpRatingPlan,
-        RatingPlanInterface $ratingPlan,
-        RatingPlanGroupInterface $ratingPlanGroup,
-        BrandInterface $brand,
-        DestinationInterface $destination
-    ) {
-        $this->prepareExecution(
-            $trunksCdr,
-            $billableCall,
-            $billableCallDto,
-            $tpCdr,
-            $tpRatingPlan,
-            $ratingPlan,
-            $ratingPlanGroup,
-            $brand,
-            $destination
-        );
+    function it_set_cost_when_carrierRunTpCdr_is_found()
+    {
 
-        $this->prepareBillableCallDtoSetters(
-            $billableCallDto
-        );
-
-        $this->handle(
-            new TrunksCdrWasMigrated(
-                $trunksCdr->getWrappedObject(),
-                $billableCall->getWrappedObject()
-            )
-        );
-    }
-
-    protected function prepareExecution(
-        TrunksCdrInterface $trunksCdr,
-        BillableCallInterface $billableCall,
-        BillableCallDto $billableCallDto,
-        TpCdrInterface $defaultRunTpCdr,
-        TpRatingPlanInterface $tpRatingPlan,
-        RatingPlanInterface $ratingPlan,
-        RatingPlanGroupInterface $ratingPlanGroup,
-        BrandInterface $brand,
-        DestinationInterface $destination
-    ) {
-        $trunksCdr
-            ->getCgrid()
-            ->willReturn(1);
-
-        $trunksCdr
-            ->getBrand()
-            ->willReturn($brand);
-
-        $this
-            ->entityTools
-            ->entityToDto($billableCall)
-            ->willReturn($billableCallDto);
-
-        $this
-            ->entityTools
-            ->persistDto(
-                $billableCallDto,
-                $billableCall,
-                false
-            )
-            ->willReturn($billableCall);
-
-        $brand
-            ->getLanguageCode()
-            ->willReturn('es');
-
-        $this
-            ->tpCdrRepository
-            ->getDefaultRunByCgrid(
-                Argument::any()
-            )
-            ->willReturn($defaultRunTpCdr);
-
-        $this
-            ->tpRatingPlanRepository
-            ->findOneByTag(
-                Argument::any()
-            )
-            ->willReturn($tpRatingPlan);
-
-        $tpRatingPlan
-            ->getRatingPlan()
-            ->willReturn($ratingPlan);
-
-        $ratingPlan
-            ->getRatingPlanGroup()
-            ->willReturn($ratingPlanGroup);
-
-        $ratingPlanGroup
-            ->getId()
-            ->willReturn(null);
-
-        $ratingPlanGroup
-            ->getName()
-            ->willReturn(
-                new Name('', '')
-            );
-
-        $this->prepareDefaultRunTpCdrGetters(
-            $defaultRunTpCdr,
-            $destination,
-            false
+        $carrierRunTpCdr = $this->getTestDouble(
+            TpCdrInterface::class
         );
 
         $this
@@ -234,55 +275,36 @@ class UpdateByTpCdrSpec extends ObjectBehavior
             ->getCarrierRunByCgrid(
                 Argument::any()
             )
-            ->willReturn($defaultRunTpCdr);
-    }
+            ->willReturn($carrierRunTpCdr)
+            ->shouldBeCalled();
 
-    protected function prepareBillableCallDtoSetters(
-        BillableCallDto $billableCallDto
-    ) {
-        $any = Argument::any();
-        $this->fluentSetterProphecy(
-            $billableCallDto,
-            [
-                'setStartTime' => $any,
-                'setDuration' => $any,
-                'setCallee' => $any,
-                'setDestinationId' => $any,
-                'setDestinationName' => $any,
-                'setRatingPlanGroupId' => $any,
-                'setRatingPlanName' => $any,
-                'setPrice' => $any
-            ]
+        $carrierRunTpCdr
+            ->getCost()
+            ->willReturn(1)
+            ->shouldBeCalled();
+
+        $this->billableCallDto
+            ->setCost(1)
+            ->shouldBeCalled();
+
+        $this->handle(
+            $this->event
         );
-
-        // Conditional
-        $billableCallDto
-            ->setCost($any)
-            ->willReturn($billableCallDto);
     }
 
-    /**
-     * @param TpCdrInterface $defaultRunTpCdr
-     * @param DestinationInterface $destination
-     * @param bool $shouldBeCalled
-     */
-    protected function prepareDefaultRunTpCdrGetters(
-        TpCdrInterface $defaultRunTpCdr,
-        DestinationInterface $destination,
-        $shouldBeCalled = false
-    ) {
-        $this->getterProphecy(
-            $defaultRunTpCdr,
-            [
-                'getCostDetailsFirstTimespan' => ['something'],
-                'getDestination' => $destination,
-                'getRatingPlanTag' => 'rpt',
-                'getMatchedDestinationTag' => 'destinationtag',
-                'getStartTime' => new  \DateTime('2015-01-01 01:01:01'),
-                'getDuration' => 120,
-                'getCost' => 3
-            ],
-            $shouldBeCalled
+    function it_persists_billableCall()
+    {
+        $this
+            ->entityTools
+            ->persistDto(
+                Argument::type(BillableCallDto::class),
+                Argument::type(BillableCallInterface::class),
+                false
+            )
+            ->shouldBeCalled();
+
+        $this->handle(
+            $this->event
         );
     }
 }

--- a/library/spec/Ivoz/Provider/Domain/Service/BillableCall/UpdateDtoByDefaultRunTpCdrSpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Service/BillableCall/UpdateDtoByDefaultRunTpCdrSpec.php
@@ -1,0 +1,328 @@
+<?php
+
+namespace spec\Ivoz\Provider\Domain\Service\BillableCall;
+
+use Ivoz\Cgr\Domain\Model\TpCdr\TpCdrInterface;
+use Ivoz\Cgr\Domain\Model\TpDestination\TpDestinationInterface;
+use Ivoz\Cgr\Domain\Model\TpDestination\TpDestinationRepository;
+use Ivoz\Cgr\Domain\Model\TpRatingPlan\TpRatingPlanInterface;
+use Ivoz\Cgr\Domain\Model\TpRatingPlan\TpRatingPlanRepository;
+use Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdrInterface;
+use Ivoz\Provider\Domain\Model\Brand\BrandInterface;
+use Ivoz\Provider\Domain\Model\Destination\DestinationInterface;
+use Ivoz\Provider\Domain\Model\RatingPlan\RatingPlanInterface;
+use Ivoz\Provider\Domain\Model\RatingPlanGroup\RatingPlanGroupInterface;
+use Ivoz\Provider\Domain\Model\BillableCall\BillableCallDto;
+use Ivoz\Provider\Domain\Service\BillableCall\UpdateDtoByDefaultRunTpCdr;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Psr\Log\LoggerInterface;
+use spec\HelperTrait;
+
+class UpdateDtoByDefaultRunTpCdrSpec extends ObjectBehavior
+{
+    use HelperTrait;
+
+    /**
+     * @var TpRatingPlanRepository
+     */
+    protected $tpRatingPlanRepository;
+
+    /**
+     * @var TpDestinationRepository
+     */
+    protected $tpDestinationRepository;
+
+    /**
+     * @var LoggerInterface
+     */
+    protected $logger;
+
+    /////////////////////////////////////////
+    ///
+    /////////////////////////////////////////
+
+    /**
+     * @var BillableCallDto
+     */
+    protected $billableCallDto;
+
+    /**
+     * @var TrunksCdrInterface
+     */
+    protected $trunksCdr;
+
+    /**
+     * @var BrandInterface
+     */
+    protected $brand;
+
+    /**
+     * @var TpCdrInterface
+     */
+    protected $defaultRunTpCdr;
+
+    /**
+     * @var TpRatingPlanInterface
+     */
+    protected $tpRatingPlan;
+
+    /**
+     * @var RatingPlanInterface
+     */
+    protected $ratingPlan;
+
+    /**
+     * @var RatingPlanGroupInterface
+     */
+    protected $ratingPlanGroup;
+
+    /**
+     * @var TpDestinationInterface
+     */
+    protected $tpDestination;
+
+    /**
+     * @var DestinationInterface
+     */
+    protected $destination;
+
+    public function let(
+        TpRatingPlanRepository $tpRatingPlanRepository,
+        TpDestinationRepository $tpDestinationRepository,
+        LoggerInterface $logger
+    ) {
+        $this->tpRatingPlanRepository = $tpRatingPlanRepository;
+        $this->tpDestinationRepository = $tpDestinationRepository;
+        $this->logger = $logger;
+
+        $this->beConstructedWith(
+            ...func_get_args()
+        );
+
+        /////////////////////////////////////////
+        ///
+        /////////////////////////////////////////
+
+        $this->billableCallDto = $this->getTestDouble(
+            BillableCallDto::class
+        );
+        $this->trunksCdr = $this->getTestDouble(
+            TrunksCdrInterface::class
+        );
+        $this->brand = $this->getTestDouble(
+            BrandInterface::class
+        );
+        $this->defaultRunTpCdr = $this->getTestDouble(
+            TpCdrInterface::class
+        );
+        $this->tpRatingPlan = $this->getTestDouble(
+            TpRatingPlanInterface::class
+        );
+        $this->ratingPlan = $this->getTestDouble(
+            RatingPlanInterface::class
+        );
+        $this->ratingPlanGroup = $this->getTestDouble(
+            RatingPlanGroupInterface::class
+        );
+        $this->tpDestination = $this->getTestDouble(
+            TpDestinationInterface::class
+        );
+        $this->destination = $this->getTestDouble(
+            DestinationInterface::class
+        );
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(UpdateDtoByDefaultRunTpCdr::class);
+    }
+
+    function it_returns_on_empty_cost_details()
+    {
+        $this
+            ->defaultRunTpCdr
+            ->getCostDetailsFirstTimespan()
+            ->willReturn(null)
+            ->shouldBeCalled();
+
+        $this
+            ->logger
+            ->error(Argument::type('string'))
+            ->shouldBeCalled();
+
+        $this->execute(
+            $this->billableCallDto,
+            $this->trunksCdr,
+            $this->defaultRunTpCdr
+        );
+    }
+
+    function it_sets_save_values_on_negative_cost()
+    {
+        $this->prepareExecution();
+
+        $this
+            ->defaultRunTpCdr
+            ->getCost()
+            ->willReturn(-1)
+            ->shouldBeCalled();
+
+        $this
+            ->logger
+            ->error(Argument::type('string'))
+            ->shouldbeCalled();
+
+        $this->fluentSetterProphecy(
+            $this->billableCallDto,
+            [
+                'setPrice' => -1,
+                'setDestinationId' => null,
+                'setDestinationName' => null,
+                'setRatingPlanGroupId' => null,
+                'setRatingPlanName' => null,
+            ],
+            true
+        );
+
+        $this->execute(
+            $this->billableCallDto,
+            $this->trunksCdr,
+            $this->defaultRunTpCdr
+        );
+    }
+
+    function it_sets_save_values_on_null_cost()
+    {
+        $this->prepareExecution();
+
+        $this
+            ->defaultRunTpCdr
+            ->getCost()
+            ->willReturn(null)
+            ->shouldBeCalled();
+
+        $this
+            ->logger
+            ->error(Argument::type('string'))
+            ->shouldbeCalled();
+
+        $this->fluentSetterProphecy(
+            $this->billableCallDto,
+            [
+                'setPrice' => null,
+                'setDestinationId' => null,
+                'setDestinationName' => null,
+                'setRatingPlanGroupId' => null,
+                'setRatingPlanName' => null,
+            ],
+            true
+        );
+
+        $this->execute(
+            $this->billableCallDto,
+            $this->trunksCdr,
+            $this->defaultRunTpCdr
+        );
+    }
+
+    function it_sets_destination_id_and_name()
+    {
+        $this->prepareExecution();
+
+        $this->fluentSetterProphecy(
+            $this->billableCallDto,
+            [
+                'setDestinationId' => 1,
+                'setDestinationName' => 'DestinationEn',
+                'setRatingPlanGroupId' => 1,
+                'setRatingPlanName' => 'RatingPlanGroupEn',
+            ],
+            true
+        );
+
+        $this->execute(
+            $this->billableCallDto,
+            $this->trunksCdr,
+            $this->defaultRunTpCdr
+        );
+    }
+
+    private function prepareExecution()
+    {
+        $this->getterProphecy(
+            $this->defaultRunTpCdr,
+            [
+                'getCostDetailsFirstTimespan' => ['SomeValue'],
+                'getCost' => 1,
+                'getRatingPlanTag' => 'tag',
+                'getMatchedDestinationTag' => 'destTag'
+            ],
+            false
+        );
+
+        $this
+            ->tpRatingPlanRepository
+            ->findOneByTag(Argument::type('string'))
+            ->willReturn($this->tpRatingPlan);
+
+        $this->tpRatingPlan
+            ->getRatingPlan()
+            ->willReturn($this->ratingPlan);
+
+        $this
+            ->ratingPlan
+            ->getRatingPlanGroup()
+            ->willReturn($this->ratingPlanGroup);
+
+        $this
+            ->trunksCdr
+            ->getBrand()
+            ->willReturn($this->brand);
+
+        $this
+            ->brand
+            ->getLanguageCode()
+            ->willReturn('en');
+
+        $this->getterProphecy(
+            $this->ratingPlanGroup,
+            [
+                'getId' => 1,
+                'getName' => new \Ivoz\Provider\Domain\Model\RatingPlanGroup\Name(
+                    'RatingPlanGroupEn',
+                    'RatingPlanGroupEs'
+                ),
+            ],
+            false
+        );
+
+        $this
+            ->tpDestinationRepository
+            ->findOneByTag(
+                Argument::type('string')
+            )
+            ->willReturn(
+                $this->tpDestination
+            );
+
+        $this
+            ->tpDestination
+            ->getDestination()
+            ->willReturn(
+                $this->destination
+            );
+
+        $this->getterProphecy(
+            $this->destination,
+            [
+                'getId' => '1',
+                'getName' => new \Ivoz\Provider\Domain\Model\Destination\Name(
+                    'DestinationEn',
+                    'DestinationEs'
+                ),
+            ],
+            false
+        );
+    }
+}

--- a/scheme/app/DoctrineMigrations/Version20190122092017.php
+++ b/scheme/app/DoctrineMigrations/Version20190122092017.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20190122092017 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE kam_trunks_cdrs CHANGE metered parsed TINYINT(1) DEFAULT \'0\'');
+        $this->addSql('ALTER TABLE kam_trunks_cdrs ADD parserScheduledAt DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL COMMENT \'(DC2Type:datetime)\' AFTER `parsed`');
+
+        $this->addSql('CREATE INDEX trunksCdr_parsed_idx ON kam_trunks_cdrs (parsed)');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+
+        $this->addSql('DROP INDEX trunksCdr_parsed_idx ON kam_trunks_cdrs');
+        $this->addSql('ALTER TABLE kam_trunks_cdrs DROP parserScheduledAt, CHANGE parsed metered TINYINT(1) DEFAULT \'0\'');
+    }
+}

--- a/scheme/tests/Kam/TrunksCdr/TrunksCdrRepositoryTest.php
+++ b/scheme/tests/Kam/TrunksCdr/TrunksCdrRepositoryTest.php
@@ -74,7 +74,7 @@ class TrunksCdrRepositoryTest extends KernelTestCase
     /**
      * @test
      */
-    public function it_finds_unmeteredCalls()
+    public function it_finds_unparsedCalls()
     {
         /** @var TrunksCdrRepository $repository */
         $repository = $this
@@ -82,7 +82,7 @@ class TrunksCdrRepositoryTest extends KernelTestCase
             ->getRepository(TrunksCdr::class);
 
         $result = $repository
-            ->getUnmeteredCallsGeneratorWithoutOffset(1000);
+            ->getUnparsedCallsGeneratorWithoutOffset(1000);
 
         $this->assertInstanceOf(
             \Generator::class,
@@ -100,7 +100,7 @@ class TrunksCdrRepositoryTest extends KernelTestCase
     /**
      * @test
      */
-    public function it_resets_metered_calls()
+    public function it_resets_parsed_calls()
     {
         /** @var TrunksCdrRepository $repository */
         $repository = $this
@@ -108,7 +108,7 @@ class TrunksCdrRepositoryTest extends KernelTestCase
             ->getRepository(TrunksCdr::class);
 
         $result = $repository
-            ->resetMetered([1,2,3]);
+            ->resetParsed([1,2,3]);
 
         $this->assertNotEmpty($result);
     }

--- a/scheme/tests/Provider/BillableCall/BillableCallRepositoryTest.php
+++ b/scheme/tests/Provider/BillableCall/BillableCallRepositoryTest.php
@@ -13,8 +13,8 @@ class BillableCallRepositoryTest extends KernelTestCase
     use DbIntegrationTestHelperTrait;
 
     /**
-     * @inheritdoc
      * @test
+     * @see BillableCallRepository::areRetarificable
      */
     public function it_checks_retarificable_calls()
     {
@@ -33,10 +33,10 @@ class BillableCallRepositoryTest extends KernelTestCase
     }
 
     /**
-     * @inheritdoc
      * @test
+     * @see BillableCallRepository::findUnratedInGroup
      */
-    public function it_transforms_ids_to_cgrid()
+    public function it_finds_unrated_calls_in_group()
     {
         /** @var BillableCallRepository $billableCallRepository */
         $billableCallRepository = $this->em
@@ -44,7 +44,7 @@ class BillableCallRepositoryTest extends KernelTestCase
 
         /** @var BillableCallInterface $billableCalls */
         $cgrids = $billableCallRepository
-            ->idsToCgrid([]);
+            ->findUnratedInGroup([]);
 
         $this->assertInternalType(
             'array',
@@ -53,7 +53,26 @@ class BillableCallRepositoryTest extends KernelTestCase
     }
 
     /**
-     * @inheritdoc
+     * @test
+     * @see BillableCallRepository::findRerateableCgridsInGroup
+     */
+    public function it_finds_rerateable_cgrids_in_group()
+    {
+        /** @var BillableCallRepository $billableCallRepository */
+        $billableCallRepository = $this->em
+            ->getRepository(BillableCall::class);
+
+        /** @var BillableCallInterface $billableCalls */
+        $cgrids = $billableCallRepository
+            ->findRerateableCgridsInGroup([]);
+
+        $this->assertInternalType(
+            'array',
+            $cgrids
+        );
+    }
+
+    /**
      * @test
      */
     public function it_transforms_ids_to_trunkCdrId()
@@ -73,10 +92,9 @@ class BillableCallRepositoryTest extends KernelTestCase
     }
 
     /**
-     * @inheritdoc
      * @test
      */
-    public function it_resets_prices()
+    public function it_resets_pricing_data()
     {
         /** @var BillableCallRepository $billableCallRepository */
         $billableCallRepository = $this->em
@@ -84,7 +102,7 @@ class BillableCallRepositoryTest extends KernelTestCase
 
         /** @var BillableCallInterface $billableCalls */
         $response = $billableCallRepository
-            ->resetPrices([1]);
+            ->resetPricingData([1]);
 
         $this->assertInternalType(
             'null',
@@ -93,7 +111,6 @@ class BillableCallRepositoryTest extends KernelTestCase
     }
 
     /**
-     * @inheritdoc
      * @test
      */
     public function it_resets_invoice_id()
@@ -113,7 +130,6 @@ class BillableCallRepositoryTest extends KernelTestCase
     }
 
     /**
-     * @inheritdoc
      * @test
      */
     public function it_sets_invoice_id()
@@ -138,7 +154,6 @@ class BillableCallRepositoryTest extends KernelTestCase
     }
 
     /**
-     * @inheritdoc
      * @test
      */
     public function it_counts_untarificatted_calls_before_date()
@@ -162,7 +177,6 @@ class BillableCallRepositoryTest extends KernelTestCase
     }
 
     /**
-     * @inheritdoc
      * @test
      */
     public function it_counts_untarificatted_calls_in_range()


### PR DESCRIPTION
Before this PR calls where dropped if CGRateS connection was down.

This could lead to long duration service failure.

This PR:

- Skips CGRateS call grant if CGRateS is down.

- Treats GWs as externally rated (no CGRateS involved) when CGRateS is down.

After this PR, BillableCalls table will allow entries without price and cost
through non-externally-rated gateways.

Rerating logic will be modified too to allow retarification of these calls, implementing
offline billing using CGRateS CdrsV1.ProcessExternalCDR method.