### PR TITLE
Update Xmlrpc.php

### DIFF
--- a/microservices/workers/src/Worker/Xmlrpc.php
+++ b/microservices/workers/src/Worker/Xmlrpc.php
@@ -156,7 +156,6 @@ class Xmlrpc
                 $this->logger->error(sprintf("[XMLRPC] Unable to send request %s to server %s [%s:%d]",
                     $method, $server->getName(), $server->getIp(), $port
                 ));
-                return false;
             }
         }
         return true;


### PR DESCRIPTION
This change allows all worker iterations on all reachable servers to complete.

Without the change, any unreachable servers will cause worker jobs to not completed in an unpredictable way. It may not do anything on any servers if the unreachable server is the first iteration, or it may get part way through before it hits the unreachable server and exits, or it may only miss the worker jobs on the last server if that is the unreachable server.

To reproduce, add multiple proxytrunks and/or proxyusers in ivozprovider.ProxyTrunks, ivozprovider.ProxyUsers tables and make one of those servers unreachable. Make changes/adds/removes to Global Config > Infrastructure > Application Servers which causes this worker to try reload dispatcher on all the kamailio servers.

The progress and error logging can be seen at `systemctl status supervisor`.