### PR TITLE
Update ivozprovider-profile-portal.postinst

### DIFF
--- a/debian/ivozprovider-profile-portal.postinst
+++ b/debian/ivozprovider-profile-portal.postinst
@@ -51,7 +51,7 @@ function setup_apache_config()
 
 function setup_gearman_job_server()
 {
-    sed -i -r 's/"(--listen=).*"/"\10.0.0.0"/' /etc/default/gearman-job-server
+    sed -i -r 's/"(--listen=).*"/"\10.0.0.0 --log-file=stderr"/' /etc/default/gearman-job-server
 }
 
 function setup_klear()


### PR DESCRIPTION
Fix a problem with gearman log file not being created.  You can see the error in gearman log when running `systemctl status gearman-job-server` after gearman is started.

`gearmand[7735]: /usr/sbin/gearmand: Could not open log file "/var/log/gearmand.log", from "/", switching to stderr. (Permission denied)`