### PR TITLE
kamusers: fix incorrect From username mangling

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -640,7 +640,7 @@ route[ADAPT_CALLER] {
                 remove_hf("P-Asserted-Identity");
                 remove_hf("Remote-Party-ID");
                 return;
-            } else if ($dlg_var(friendId) != $null || $dlg_var(residentialDeviceId) != $null) {
+            } else if ($dlg_var(friendId) != $null) {
                 if (!is_present_hf("P-Asserted-Identity") && !is_present_hf("Remote-Party-ID")) {
                     return;
                 }
@@ -712,10 +712,13 @@ route[GET_CALLER] {
 
 # Sets $var(transformated) in existing origin headers (From + PAI + RPID)
 route[SET_CALLER] {
+    # Mangle From only for initial requests from wholesale clients without PAI nor RPID
     if (is_request() && !has_totag()) {
-        if ($fU != $var(transformated)) {
-            $var(newfromuri) = 'sip:' + $var(transformated) + '@' + $fd;
-            uac_replace_from("","$var(newfromuri)"); # Change From header for GW
+        if ($dlg_var(type) == 'wholesale' && !is_present_hf("P-Asserted-Identity") && !is_present_hf("Remote-Party-ID")) {
+            if ($fU != $var(transformated)) {
+                $var(newfromuri) = 'sip:' + $var(transformated) + '@' + $fd;
+                uac_replace_from("","$var(newfromuri)");
+            }
         }
     }
 
@@ -734,12 +737,12 @@ route[SET_CALLER] {
     }
 }
 
-# Sets $var(transformated) in new PAI or existing PAI
+# Sets $var(transformated) in new PAI or existing PAI (and makes From username equal)
 route[SET_PAI] {
     if (is_request() && !has_totag()) {
         if ($fU != $var(transformated)) {
             $var(newfromuri) = 'sip:' + $var(transformated) + '@' + $fd;
-            uac_replace_from("", "$var(newfromuri)"); # Change From header for GW
+            uac_replace_from("", "$var(newfromuri)");
         }
     }
 


### PR DESCRIPTION
It should only be mangled in initial requests from wholesale clients
that do not use PAI nor RPID. Otherwise, leave it unchanged.