### PR TITLE
Force Carrier externally rated when Billing feature is disabled 

### DIFF
--- a/library/Ivoz/Provider/Domain/Model/Carrier/Carrier.php
+++ b/library/Ivoz/Provider/Domain/Model/Carrier/Carrier.php
@@ -28,6 +28,21 @@ class Carrier extends CarrierAbstract implements CarrierInterface
         return $this->id;
     }
 
+
+    /**
+     * @inheritdoc
+     */
+    protected function sanitizeValues()
+    {
+        if ($this->getExternallyRated()) {
+            $this->setCalculateCost(false);
+        }
+
+        if (!$this->getCalculateCost()) {
+            $this->setCurrency(null);
+        }
+    }
+
     /**
      * @return string
      */

--- a/library/Ivoz/Provider/Domain/Service/Carrier/ForceExternallyRated.php
+++ b/library/Ivoz/Provider/Domain/Service/Carrier/ForceExternallyRated.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Ivoz\Provider\Domain\Service\Carrier;
+
+use Ivoz\Core\Application\Service\EntityTools;
+use Ivoz\Provider\Domain\Model\Carrier\CarrierDto;
+use Ivoz\Provider\Domain\Model\Carrier\CarrierInterface;
+use Ivoz\Provider\Domain\Model\Feature\Feature;
+
+/**
+ * Class ForceExternallyRated
+ * @package Ivoz\Provider\Domain\Service\Carrier
+ * @lifecycle pre_persist
+ */
+class ForceExternallyRated implements CarrierLifecycleEventHandlerInterface
+{
+    const PRE_PERSIST_PRIORITY = self::PRIORITY_NORMAL;
+
+    /**
+     * @var EntityTools
+     */
+    protected $entityTools;
+
+    public function __construct(
+        EntityTools $entityTools
+    ) {
+        $this->entityTools = $entityTools;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            self::EVENT_PRE_PERSIST => self::PRE_PERSIST_PRIORITY
+        ];
+    }
+
+    /**
+     * Enables externally rated on carrier when Brand has no Billing feature enabled
+     *
+     * @param CarrierInterface $carrier
+     */
+    public function execute(CarrierInterface $carrier)
+    {
+        // Only apply to carriers with externally rated disabled
+        if ($carrier->getExternallyRated()) {
+            return;
+        }
+
+        $brand = $carrier->getBrand();
+
+        // Check if brand has billing feature enabled
+        if (!$brand->hasFeature(Feature::BILLING)) {
+            /** @var CarrierDto $carrierDto */
+            $carrierDto = $this->entityTools->entityToDto(
+                $carrier
+            );
+
+            // Force externally rated on carrier
+            $carrierDto->setExternallyRated(true);
+
+            $this->entityTools->updateEntityByDto(
+                $carrier,
+                $carrierDto
+            );
+        }
+    }
+}

--- a/web/admin/application/configs/klear/CarriersList.yaml
+++ b/web/admin/application/configs/klear/CarriersList.yaml
@@ -73,6 +73,8 @@ production:
           <<: *carrierOrder_Link
         blacklist:
           externallyRated: ${auth.brandFeatures.billing.disabled}
+          calculateCos: ${auth.brandFeatures.billing.disabled}
+          currency: ${auth.brandFeatures.billing.disabled}
           balance: true
           acd: true
           asr: true
@@ -111,6 +113,8 @@ production:
           <<: *carrierOrder_Link
         blacklist:
           externallyRated: ${auth.brandFeatures.billing.disabled}
+          calculateCost: ${auth.brandFeatures.billing.disabled}
+          currency: ${auth.brandFeatures.billing.disabled}
           balance: true
       fixedPositions:
         <<: *carriersNew_fixedPositionsLink

--- a/web/admin/application/configs/klear/model/Carriers.yaml
+++ b/web/admin/application/configs/klear/model/Carriers.yaml
@@ -65,13 +65,13 @@ production:
           '0':
             title: _("No")
             visualFilter:
-              show: [balance, calculateCost]
+              show: [balance, calculateCost, currency]
               hide: []
           '1':
             title: _("Yes")
             visualFilter:
               show: []
-              hide: [balance, calculateCost]
+              hide: [balance, calculateCost, currency]
     calculateCost:
       title: _('Calculate cost?')
       type: select


### PR DESCRIPTION
This PR adds a service to force Carrier.externallyRated field when Brand has no billing feature enabled.

Additionally, it updates Carrier screens to hide fields based on that feature and includes a Carrier sanitize method to ensure hidden fields have default values.