### PR TITLE
Fallback external number for unreachable retail accounts

### DIFF
--- a/asterisk/agi/app/MicroKernel.php
+++ b/asterisk/agi/app/MicroKernel.php
@@ -60,6 +60,7 @@ class MicroKernel extends Kernel
         $routes->add('/dialplan/userstatus', 'kernel:handleRequestAction');
         $routes->add('/dialplan/trunks', 'kernel:handleRequestAction');
         $routes->add('/dialplan/residentials', 'kernel:handleRequestAction');
+        $routes->add('/dialplan/retails', 'kernel:handleRequestAction');
         $routes->add('/dialplan/residentialstatus', 'kernel:handleRequestAction');
         $routes->add('/dialplan/friends', 'kernel:handleRequestAction');
         $routes->add('/dialplan/headers', 'kernel:handleRequestAction');

--- a/asterisk/agi/app/config/services.yml
+++ b/asterisk/agi/app/config/services.yml
@@ -57,6 +57,9 @@ services:
   Dialplan\Residentials:
     arguments: ~
 
+  Dialplan\Retails:
+    arguments: ~
+
   Dialplan\Friends:
     arguments: ~
 

--- a/asterisk/agi/src/Agi/Agents/RetailAgent.php
+++ b/asterisk/agi/src/Agi/Agents/RetailAgent.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Agi\Agents;
+
+use Agi\Wrapper;
+use Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDeviceInterface;
+use Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface;
+
+class RetailAgent implements AgentInterface
+{
+    use AgentTrait;
+
+    /** @var Wrapper */
+    private $agi;
+
+    /** @var RetailAccountInterface */
+    private $retailAccount;
+
+    /**
+     * ResidentialAgent constructor.
+     *
+     * @param Wrapper $agi
+     * @param RetailAccountInterface $retailAccount
+     */
+    public function __construct(
+        Wrapper $agi,
+        RetailAccountInterface $retailAccount
+    ) {
+        $this->retailAccount = $retailAccount;
+        $this->agi = $agi;
+    }
+
+    public function getType()
+    {
+        return "Retail";
+    }
+
+    public function getId()
+    {
+        return $this->retailAccount->getId();
+    }
+
+    public function getCompany()
+    {
+        return $this->retailAccount->getCompany();
+    }
+
+    public function getLanguageCode()
+    {
+        return $this->retailAccount->getCompany()->getLanguageCode();
+    }
+
+    public function getOutgoingDdi($destination)
+    {
+        // Allow identification from any Residential Device DDI
+        $callerIdNum = $this->agi->getCallerIdNum();
+        $ddi = $this->retailAccount->getDDI($callerIdNum);
+
+        if (empty($ddi)) {
+            // Check presented number against company DDIs
+            $companyDDIs = $this->retailAccount->getCompany()->getDDIs();
+            foreach ($companyDDIs as $companyDDI) {
+                if ($callerIdNum === $companyDDI->getDdie164()) {
+                    $this->agi->notice(
+                        "Retail %s presented origin matches company DDI %s",
+                        $this->retailAccount,
+                        $companyDDI
+                    );
+                    $ddi = $companyDDI;
+                    break;
+                }
+            }
+        }
+
+        if (!isset($ddi)) {
+            // Allow diversion from any company DDI
+            $callerIdNum = $this->agi->getRedirecting('from-num');
+
+            foreach ($companyDDIs as $companyDDI) {
+                if ($callerIdNum === $companyDDI->getDdie164()) {
+                    $this->agi->notice("Retail %s presented diversion matches company DDI %s", $this->retailAccount, $companyDDI);
+                    $ddi = $companyDDI;
+                    break;
+                }
+            }
+        }
+
+        // Use fallback outgoing DDI
+        if (empty($ddi)) {
+            $ddi = $this->retailAccount->getOutgoingDDI();
+            if ($ddi) {
+                $this->agi->notice(
+                    "Using fallback DDI %s for friend %s because %s does not match any DDI.",
+                    $ddi,
+                    $this->retailAccount,
+                    $callerIdNum
+                );
+            }
+        }
+
+        return $ddi;
+    }
+
+    /**
+     * @param string $destination
+     * @return boolean
+     */
+    public function isAllowedToCall($destination)
+    {
+        return true;
+    }
+}

--- a/asterisk/agi/src/Agi/ChannelInfo.php
+++ b/asterisk/agi/src/Agi/ChannelInfo.php
@@ -8,6 +8,7 @@ use Agi\Agents\DdiAgent;
 use Agi\Agents\FaxAgent;
 use Agi\Agents\FriendAgent;
 use Agi\Agents\ResidentialAgent;
+use Agi\Agents\RetailAgent;
 use Agi\Agents\UserAgent;
 use Doctrine\ORM\EntityManagerInterface;
 use Ivoz\Provider\Domain\Model\Ddi\Ddi;
@@ -18,6 +19,8 @@ use Ivoz\Provider\Domain\Model\Friend\Friend;
 use Ivoz\Provider\Domain\Model\Friend\FriendInterface;
 use Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDevice;
 use Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDeviceInterface;
+use Ivoz\Provider\Domain\Model\RetailAccount\RetailAccount;
+use Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface;
 use Ivoz\Provider\Domain\Model\User\User;
 use Ivoz\Provider\Domain\Model\User\UserInterface;
 
@@ -140,6 +143,11 @@ class ChannelInfo
                 /** @var ResidentialDeviceInterface $residential */
                 $residential = $repository->find($id);
                 return new ResidentialAgent($this->agi, $residential);
+            case "Retail":
+                $repository = $this->em->getRepository(RetailAccount::class);
+                /** @var RetailAccountInterface $retailAccount */
+                $retailAccount = $repository->find($id);
+                return new RetailAgent($this->agi, $retailAccount);
             case "Fax":
                 $repository = $this->em->getRepository(Fax::class);
                 /** @var FaxInterface $fax */

--- a/asterisk/agi/src/Dialplan/Retails.php
+++ b/asterisk/agi/src/Dialplan/Retails.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Dialplan;
+
+use Agi\Action\ExternalNumberAction;
+use Agi\Action\ServiceAction;
+use Agi\Agents\RetailAgent;
+use Agi\ChannelInfo;
+use Agi\Wrapper;
+use Helpers\EndpointResolver;
+use RouteHandlerAbstract;
+
+class Retails extends RouteHandlerAbstract
+{
+    /**
+     * @var Wrapper
+     */
+    protected $agi;
+
+    /**
+     * @var ChannelInfo
+     */
+    protected $channelInfo;
+
+    /**
+     * @var EndpointResolver
+     */
+    protected $endpointResolver;
+
+    /**
+     * @var ExternalNumberAction
+     */
+    protected $externalNumberAction;
+
+    /**
+     * Retails constructor.
+     *
+     * @param Wrapper $agi
+     * @param ChannelInfo $channelInfo
+     * @param EndpointResolver $endpointResolver
+     * @param ExternalNumberAction $externalNumberAction
+     * @param ServiceAction $serviceAction
+     */
+    public function __construct(
+        Wrapper $agi,
+        ChannelInfo $channelInfo,
+        EndpointResolver $endpointResolver,
+        ExternalNumberAction $externalNumberAction
+    ) {
+        $this->agi = $agi;
+        $this->channelInfo = $channelInfo;
+        $this->endpointResolver = $endpointResolver;
+        $this->externalNumberAction = $externalNumberAction;
+    }
+
+    /**
+     * Outgoing calls from retail accounts
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public function process()
+    {
+        // Get identified Endpoint name
+        $endpointName = $this->agi->getEndpoint();
+
+        // Get retailAccount from the endpoint.
+        $retailAccount = $this->endpointResolver->getRetailFromEndpoint($endpointName);
+
+        // Set Company/Brand/Generic Music class
+        $company = $retailAccount->getCompany();
+        $brand = $company->getBrand();
+        $this->agi->setVariable("__COMPANYID", $company->getId());
+        $this->agi->setVariable("CHANNEL(language)", $company->getLanguageCode());
+
+        // Get call destination
+        $exten = $this->agi->getExtension();
+
+        // Set Outgoing Channels X-CID header variable
+        $this->agi->setVariable("_CALL_ID", $this->agi->getCallId());
+
+        // Set User as the caller
+        $caller = new RetailAgent($this->agi, $retailAccount);
+        $this->channelInfo->setChannelCaller($caller);
+
+        // Only forwarded calls are allowed from retail accounts
+        if ($this->agi->getRedirecting('count') == 0) {
+            $this->agi->error(
+                "Call without Diversion header from <cyan>%s</cyan> to number %s, drop call",
+                $retailAccount,
+                $exten
+            );
+            $this->agi->hangup();
+            return;
+        }
+
+        // Some feedback for asterisk cli
+        $this->agi->notice("Processing outgoing call from \e[0;36m%s\e[0;93m to number %s", $retailAccount, $exten);
+
+        // All retail account calls are handled as external
+        $this->externalNumberAction
+            ->setDestination($exten)
+            ->process();
+    }
+}

--- a/asterisk/agi/src/Helpers/EndpointResolver.php
+++ b/asterisk/agi/src/Helpers/EndpointResolver.php
@@ -168,4 +168,32 @@ class EndpointResolver
 
         return $residential;
     }
+
+    /**
+     * @param $endpointName
+     * @return \Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface
+     * @throws \Assert\AssertionFailedException
+     */
+    public function getRetailFromEndpoint($endpointName)
+    {
+        /** @var \Ivoz\Ast\Domain\Model\PsEndpoint\PsEndpointInterface $endpoint */
+        $endpoint = $this->getEndpointFromName($endpointName);
+
+        Assertion::notNull(
+            $endpoint,
+            sprintf('No endpoint found for "%s".', $endpointName)
+        );
+
+        file_put_contents('/tmp/farsa', var_export($endpoint, true));
+
+        /** @var \Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface $retailAccount */
+        $retailAccount = $endpoint->getRetailAccount();
+
+        Assertion::notNull(
+            $retailAccount,
+            sprintf('Endpoint "%s" has no retail account associated.', $endpointName)
+        );
+
+        return $retailAccount;
+    }
 }

--- a/asterisk/config/dialplan/default.conf
+++ b/asterisk/config/dialplan/default.conf
@@ -36,6 +36,13 @@ exten => _[+*0-9]!,1,NoOp(Outgoing call from residential device ${CALLERID(all)}
 ; Playback specific sounds and leave
 include => sounds
 
+;; Context for retail accounts (CFW calls only)
+[retail]
+exten => _[+*0-9]!,1,NoOp(Outgoing call from retail account ${CALLERID(all)} to ${EXTEN})
+    same => n,AGI(agi://127.0.0.1:4573/fastagi-runner.php?command=dialplan/retails)
+; Playback specific sounds and leave
+include => sounds
+
 ;; Context for calls from queues
 [queues]
 exten => _[+*0-9]!,1,NoOp(Call from queue ${QUEUE} to extension ${EXTEN})

--- a/doc/sphinx/administration_portal/brand/clients/retail.rst
+++ b/doc/sphinx/administration_portal/brand/clients/retail.rst
@@ -14,7 +14,7 @@ They just provide a SIP trunking service that include these features:
 - **Receive external calls** to their DDIs.
 - Record calls.
 
-.. warning:: No users, no extensions, no internal calls, no hunt groups, no IVRs, no voicemail, no call forwards...
+.. warning:: No users, no extensions, no internal calls, no hunt groups, no IVRs, no voicemail...
              just **incoming and outgoing external calls**.
 
 .. error:: Retail clients and their accounts **MUST use Brand's SIP domain in their SIP messages**.
@@ -26,8 +26,6 @@ There is an important key difference between these two clients: **retail client 
 any application server**.
 
 As a result:
-
-- No call forwarding features for retail accounts will be allowed.
 
 - No virtual faxing service for retail clients.
 
@@ -47,7 +45,7 @@ But they also have benefits that make them ideal for some situations:
              Retail clients, on the other hand, can talk in the codecs they offer in their SDP and in the
              codecs selected in IvozProvider: IvozProvider will make transcoding when necessary.
 
-.. tip:: Use retail client type unless you need any of the services provided by application servers (fax, call forward or voicemails).
+.. tip:: Use retail client type unless you need any of the services provided by application servers (fax or voicemails).
 
 Adding/Editing retail clients
 -----------------------------

--- a/doc/sphinx/administration_portal/client/retail/retail_accounts.rst
+++ b/doc/sphinx/administration_portal/client/retail/retail_accounts.rst
@@ -86,7 +86,13 @@ There is no voicemail service for retail clients.
 Call forwarding settings
 ========================
 
-There are no call forwarding settings for retail accounts.
+Each retail account can have a unique enabled call forward setting, pointing to an external number.
+
+This external called will be called whenever the retail account cannot be reached:
+
+- Direct connectivity accounts: when no answer is received from defined address.
+
+- Accounts using SIP register: when no answer is received from last contact address or when no active register is found.
 
 Asterisk as a retail account
 ============================

--- a/doc/sphinx/locale/es/LC_MESSAGES/administration_portal.po
+++ b/doc/sphinx/locale/es/LC_MESSAGES/administration_portal.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: IvozProvider 2.7\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-01-24 16:03+0100\n"
+"POT-Creation-Date: 2019-01-30 17:52+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -33,7 +33,7 @@ msgstr ""
 #: ../../administration_portal/brand/billing/destination_rates.rst:12
 #: ../../administration_portal/brand/billing/rating_plans.rst:17
 #: ../../administration_portal/brand/clients/residential.rst:30
-#: ../../administration_portal/brand/clients/retail.rst:61
+#: ../../administration_portal/brand/clients/retail.rst:59
 #: ../../administration_portal/brand/clients/virtual_pbx.rst:11
 #: ../../administration_portal/brand/clients/wholesale.rst:37
 #: ../../administration_portal/brand/invoicing/invoice_number_sequences.rst:11
@@ -88,7 +88,7 @@ msgstr ""
 #: ../../administration_portal/brand/billing/destination_rates.rst:18
 #: ../../administration_portal/brand/billing/rating_plans.rst:23
 #: ../../administration_portal/brand/clients/residential.rst:48
-#: ../../administration_portal/brand/clients/retail.rst:76
+#: ../../administration_portal/brand/clients/retail.rst:74
 #: ../../administration_portal/brand/clients/virtual_pbx.rst:28
 #: ../../administration_portal/brand/clients/wholesale.rst:49
 #: ../../administration_portal/brand/providers/carriers.rst:33
@@ -1478,7 +1478,7 @@ msgid "Adding/Editing residential clients"
 msgstr ""
 
 #: ../../administration_portal/brand/clients/residential.rst:24
-#: ../../administration_portal/brand/clients/retail.rst:55
+#: ../../administration_portal/brand/clients/retail.rst:53
 #: ../../administration_portal/brand/clients/virtual_pbx.rst:8
 #: ../../administration_portal/brand/clients/wholesale.rst:31
 #: ../../administration_portal/brand/providers/carriers.rst:11
@@ -1493,30 +1493,30 @@ msgid "These are the fields shown when **adding** a new residential client:"
 msgstr ""
 
 #: ../../administration_portal/brand/clients/residential.rst:33
-#: ../../administration_portal/brand/clients/retail.rst:64
+#: ../../administration_portal/brand/clients/retail.rst:62
 #: ../../administration_portal/brand/clients/virtual_pbx.rst:21
 #: ../../administration_portal/brand/clients/wholesale.rst:40
 msgid "Billing method"
 msgstr ""
 
 #: ../../administration_portal/brand/clients/residential.rst:35
-#: ../../administration_portal/brand/clients/retail.rst:66
+#: ../../administration_portal/brand/clients/retail.rst:64
 #: ../../administration_portal/brand/clients/wholesale.rst:42
 msgid "To choose among postpaid, prepaid and pseudo-prepaid."
 msgstr ""
 
 #: ../../administration_portal/brand/clients/residential.rst:42
-#: ../../administration_portal/brand/clients/retail.rst:70
+#: ../../administration_portal/brand/clients/retail.rst:68
 msgid "Country code"
 msgstr ""
 
 #: ../../administration_portal/brand/clients/residential.rst:44
-#: ../../administration_portal/brand/clients/retail.rst:72
+#: ../../administration_portal/brand/clients/retail.rst:70
 msgid "Default country code for DDIs."
 msgstr ""
 
 #: ../../administration_portal/brand/clients/residential.rst:50
-#: ../../administration_portal/brand/clients/retail.rst:78
+#: ../../administration_portal/brand/clients/retail.rst:76
 #: ../../administration_portal/brand/clients/virtual_pbx.rst:30
 #: ../../administration_portal/brand/clients/wholesale.rst:51
 msgid ""
@@ -1525,13 +1525,13 @@ msgid ""
 msgstr ""
 
 #: ../../administration_portal/brand/clients/residential.rst:45
-#: ../../administration_portal/brand/clients/retail.rst:73
+#: ../../administration_portal/brand/clients/retail.rst:71
 #: ../../administration_portal/brand/clients/wholesale.rst:46
 msgid "Default timezone"
 msgstr ""
 
 #: ../../administration_portal/brand/clients/residential.rst:47
-#: ../../administration_portal/brand/clients/retail.rst:75
+#: ../../administration_portal/brand/clients/retail.rst:73
 #: ../../administration_portal/brand/clients/wholesale.rst:48
 msgid "Used for showing call registries dates."
 msgstr ""
@@ -1547,19 +1547,19 @@ msgid "Enable/Disable faxing and call recording for this particular client."
 msgstr ""
 
 #: ../../administration_portal/brand/clients/residential.rst:59
-#: ../../administration_portal/brand/clients/retail.rst:87
+#: ../../administration_portal/brand/clients/retail.rst:85
 msgid "Filter by IP address"
 msgstr ""
 
 #: ../../administration_portal/brand/clients/residential.rst:61
-#: ../../administration_portal/brand/clients/retail.rst:89
+#: ../../administration_portal/brand/clients/retail.rst:87
 msgid ""
 "If set, the platform will only allow calls coming from allowed IP "
 "addresses or network ranges."
 msgstr ""
 
 #: ../../administration_portal/brand/clients/residential.rst:39
-#: ../../administration_portal/brand/clients/retail.rst:67
+#: ../../administration_portal/brand/clients/retail.rst:65
 #: ../../administration_portal/brand/clients/wholesale.rst:43
 #: ../../administration_portal/brand/settings/notification_templates.rst:55
 #: ../../administration_portal/client/residential/residential_devices.rst:59
@@ -1568,20 +1568,20 @@ msgid "Language"
 msgstr ""
 
 #: ../../administration_portal/brand/clients/residential.rst:41
-#: ../../administration_portal/brand/clients/retail.rst:69
+#: ../../administration_portal/brand/clients/retail.rst:67
 #: ../../administration_portal/brand/clients/wholesale.rst:45
 msgid "Used to choose the language of played locutions."
 msgstr ""
 
 #: ../../administration_portal/brand/clients/residential.rst:55
-#: ../../administration_portal/brand/clients/retail.rst:83
+#: ../../administration_portal/brand/clients/retail.rst:81
 #: ../../administration_portal/brand/clients/wholesale.rst:56
 #: ../../administration_portal/platform/brands.rst:38
 msgid "Max calls"
 msgstr ""
 
 #: ../../administration_portal/brand/clients/residential.rst:57
-#: ../../administration_portal/brand/clients/retail.rst:85
+#: ../../administration_portal/brand/clients/retail.rst:83
 #: ../../administration_portal/brand/clients/wholesale.rst:58
 msgid ""
 "Limits both client generated and external received calls to this value (0"
@@ -1590,13 +1590,13 @@ msgid ""
 msgstr ""
 
 #: ../../administration_portal/brand/clients/residential.rst:32
-#: ../../administration_portal/brand/clients/retail.rst:63
+#: ../../administration_portal/brand/clients/retail.rst:61
 #: ../../administration_portal/brand/clients/wholesale.rst:39
 msgid "Used to reference this particular client."
 msgstr ""
 
 #: ../../administration_portal/brand/clients/residential.rst:52
-#: ../../administration_portal/brand/clients/retail.rst:80
+#: ../../administration_portal/brand/clients/retail.rst:78
 #: ../../administration_portal/brand/clients/wholesale.rst:53
 #: ../../administration_portal/client/residential/residential_devices.rst:62
 #: ../../administration_portal/client/retail/retail_accounts.rst:59
@@ -1604,7 +1604,7 @@ msgid "Numeric transformation"
 msgstr ""
 
 #: ../../administration_portal/brand/clients/residential.rst:54
-#: ../../administration_portal/brand/clients/retail.rst:82
+#: ../../administration_portal/brand/clients/retail.rst:80
 #: ../../administration_portal/brand/clients/wholesale.rst:55
 msgid ""
 "Describes the way the client will \"talk\" and the way the client wants "
@@ -1612,25 +1612,25 @@ msgid ""
 msgstr ""
 
 #: ../../administration_portal/brand/clients/residential.rst:64
-#: ../../administration_portal/brand/clients/retail.rst:91
+#: ../../administration_portal/brand/clients/retail.rst:89
 #: ../../administration_portal/brand/clients/wholesale.rst:62
 msgid "When **editing** a client, these additional fields can be configured:"
 msgstr ""
 
 #: ../../administration_portal/brand/clients/residential.rst:72
-#: ../../administration_portal/brand/clients/retail.rst:99
+#: ../../administration_portal/brand/clients/retail.rst:97
 #: ../../administration_portal/brand/clients/wholesale.rst:70
 msgid "Externally rater custom options"
 msgstr ""
 
 #: ../../administration_portal/brand/clients/residential.rst:74
-#: ../../administration_portal/brand/clients/retail.rst:101
+#: ../../administration_portal/brand/clients/retail.rst:99
 #: ../../administration_portal/brand/clients/wholesale.rst:72
 msgid "This field is for setting options for an optional external rating module."
 msgstr ""
 
 #: ../../administration_portal/brand/clients/residential.rst:68
-#: ../../administration_portal/brand/clients/retail.rst:95
+#: ../../administration_portal/brand/clients/retail.rst:93
 #: ../../administration_portal/brand/clients/virtual_pbx.rst:35
 #: ../../administration_portal/brand/clients/wholesale.rst:66
 #: ../../administration_portal/platform/brands.rst:20
@@ -1638,7 +1638,7 @@ msgid "Invoice data"
 msgstr ""
 
 #: ../../administration_portal/brand/clients/residential.rst:70
-#: ../../administration_portal/brand/clients/retail.rst:97
+#: ../../administration_portal/brand/clients/retail.rst:95
 #: ../../administration_portal/brand/clients/wholesale.rst:68
 msgid ""
 "All the fields in this group will be included in invoices generated for "
@@ -1657,14 +1657,14 @@ msgid ""
 msgstr ""
 
 #: ../../administration_portal/brand/clients/residential.rst:75
-#: ../../administration_portal/brand/clients/retail.rst:102
+#: ../../administration_portal/brand/clients/retail.rst:100
 #: ../../administration_portal/brand/clients/virtual_pbx.rst:46
 #: ../../administration_portal/client/vpbx/users.rst:73
 msgid "Outgoing DDI"
 msgstr ""
 
 #: ../../administration_portal/brand/clients/residential.rst:77
-#: ../../administration_portal/brand/clients/retail.rst:104
+#: ../../administration_portal/brand/clients/retail.rst:102
 msgid ""
 "Fallback DDI for external outgoing calls (can be overridden at "
 "residential device level)."
@@ -1683,7 +1683,7 @@ msgid ""
 msgstr ""
 
 #: ../../administration_portal/brand/clients/residential.rst:85
-#: ../../administration_portal/brand/clients/retail.rst:115
+#: ../../administration_portal/brand/clients/retail.rst:113
 #: ../../administration_portal/brand/clients/wholesale.rst:82
 msgid ""
 "Apart from these fields, main operator (*aka* God) will also see a "
@@ -1691,7 +1691,7 @@ msgid ""
 msgstr ""
 
 #: ../../administration_portal/brand/clients/residential.rst:87
-#: ../../administration_portal/brand/clients/retail.rst:117
+#: ../../administration_portal/brand/clients/retail.rst:115
 #: ../../administration_portal/brand/clients/wholesale.rst:84
 msgid "Choosing an specific media relay set for the client."
 msgstr ""
@@ -1703,7 +1703,7 @@ msgid ""
 msgstr ""
 
 #: ../../administration_portal/brand/clients/residential.rst:91
-#: ../../administration_portal/brand/clients/retail.rst:119
+#: ../../administration_portal/brand/clients/retail.rst:117
 msgid ""
 "For outgoing calls, platform will use the CLID provided by the client as "
 "long as it is considered valid, otherwise fallback DDI will be used. The "
@@ -1712,33 +1712,33 @@ msgid ""
 msgstr ""
 
 #: ../../administration_portal/brand/clients/residential.rst:95
-#: ../../administration_portal/brand/clients/retail.rst:123
+#: ../../administration_portal/brand/clients/retail.rst:121
 #: ../../administration_portal/brand/clients/wholesale.rst:87
 msgid "Additional subsections"
 msgstr ""
 
 #: ../../administration_portal/brand/clients/residential.rst:97
-#: ../../administration_portal/brand/clients/retail.rst:125
+#: ../../administration_portal/brand/clients/retail.rst:123
 #: ../../administration_portal/brand/clients/wholesale.rst:89
 msgid "Each entry in this table has these additional options:"
 msgstr ""
 
 #: ../../administration_portal/brand/clients/residential.rst:99
-#: ../../administration_portal/brand/clients/retail.rst:127
+#: ../../administration_portal/brand/clients/retail.rst:125
 msgid ""
 "**List of authorized sources**: if *Filter by IP address* is enabled, "
 "this subsection allows adding addresses or network ranges."
 msgstr ""
 
 #: ../../administration_portal/brand/clients/residential.rst:101
-#: ../../administration_portal/brand/clients/retail.rst:129
+#: ../../administration_portal/brand/clients/retail.rst:127
 msgid ""
 "No outgoing call will be allowed if *Filter by IP address* is enabled and"
 " the corresponding list is empty."
 msgstr ""
 
 #: ../../administration_portal/brand/clients/residential.rst:103
-#: ../../administration_portal/brand/clients/retail.rst:131
+#: ../../administration_portal/brand/clients/retail.rst:129
 #: ../../administration_portal/brand/clients/wholesale.rst:93
 msgid ""
 "**List of client admins**: this subsection allows managing portal "
@@ -1753,7 +1753,7 @@ msgid ""
 msgstr ""
 
 #: ../../administration_portal/brand/clients/residential.rst:107
-#: ../../administration_portal/brand/clients/retail.rst:135
+#: ../../administration_portal/brand/clients/retail.rst:133
 #: ../../administration_portal/brand/clients/wholesale.rst:97
 msgid ""
 "No outgoing call will be allowed for this client unless an active rating "
@@ -1761,7 +1761,7 @@ msgid ""
 msgstr ""
 
 #: ../../administration_portal/brand/clients/residential.rst:110
-#: ../../administration_portal/brand/clients/retail.rst:138
+#: ../../administration_portal/brand/clients/retail.rst:136
 #: ../../administration_portal/brand/clients/wholesale.rst:100
 msgid ""
 "**List of Outgoing routes**: this subsections shows routing rules that "
@@ -1769,7 +1769,7 @@ msgid ""
 msgstr ""
 
 #: ../../administration_portal/brand/clients/residential.rst:112
-#: ../../administration_portal/brand/clients/retail.rst:140
+#: ../../administration_portal/brand/clients/retail.rst:138
 #: ../../administration_portal/brand/clients/wholesale.rst:102
 msgid ""
 "As *Apply all clients* routing rules also will apply for this client, the"
@@ -1798,8 +1798,7 @@ msgstr ""
 #: ../../administration_portal/brand/clients/retail.rst:17
 msgid ""
 "No users, no extensions, no internal calls, no hunt groups, no IVRs, no "
-"voicemail, no call forwards... just **incoming and outgoing external "
-"calls**."
+"voicemail... just **incoming and outgoing external calls**."
 msgstr ""
 
 #: ../../administration_portal/brand/clients/retail.rst:20
@@ -1823,38 +1822,34 @@ msgid "As a result:"
 msgstr ""
 
 #: ../../administration_portal/brand/clients/retail.rst:30
-msgid "No call forwarding features for retail accounts will be allowed."
-msgstr ""
-
-#: ../../administration_portal/brand/clients/retail.rst:32
 msgid "No virtual faxing service for retail clients."
 msgstr ""
 
-#: ../../administration_portal/brand/clients/retail.rst:34
+#: ../../administration_portal/brand/clients/retail.rst:32
 msgid "No voicemail service for retail clients."
 msgstr ""
 
-#: ../../administration_portal/brand/clients/retail.rst:36
+#: ../../administration_portal/brand/clients/retail.rst:34
 msgid "Mandatory call recording for every retail client call."
 msgstr ""
 
-#: ../../administration_portal/brand/clients/retail.rst:38
+#: ../../administration_portal/brand/clients/retail.rst:36
 msgid "But they also have benefits that make them ideal for some situations:"
 msgstr ""
 
-#: ../../administration_portal/brand/clients/retail.rst:40
+#: ../../administration_portal/brand/clients/retail.rst:38
 msgid "No application server traverse, much less load for the platform."
 msgstr ""
 
-#: ../../administration_portal/brand/clients/retail.rst:42
+#: ../../administration_portal/brand/clients/retail.rst:40
 msgid "Call transcoding as a feature."
 msgstr ""
 
-#: ../../administration_portal/brand/clients/retail.rst:44
+#: ../../administration_portal/brand/clients/retail.rst:42
 msgid "Routing tags for different call routing for same destinations."
 msgstr ""
 
-#: ../../administration_portal/brand/clients/retail.rst:46
+#: ../../administration_portal/brand/clients/retail.rst:44
 msgid ""
 "Residential devices are force to talk the codec selected in their "
 "configuration (just one). Retail clients, on the other hand, can talk in "
@@ -1862,46 +1857,46 @@ msgid ""
 "IvozProvider: IvozProvider will make transcoding when necessary."
 msgstr ""
 
-#: ../../administration_portal/brand/clients/retail.rst:50
+#: ../../administration_portal/brand/clients/retail.rst:48
 msgid ""
 "Use retail client type unless you need any of the services provided by "
-"application servers (fax, call forward or voicemails)."
+"application servers (fax or voicemails)."
 msgstr ""
 
-#: ../../administration_portal/brand/clients/retail.rst:53
+#: ../../administration_portal/brand/clients/retail.rst:51
 msgid "Adding/Editing retail clients"
 msgstr ""
 
-#: ../../administration_portal/brand/clients/retail.rst:57
+#: ../../administration_portal/brand/clients/retail.rst:55
 msgid "These are the fields shown when **adding** a new retail client:"
 msgstr ""
 
-#: ../../administration_portal/brand/clients/retail.rst:109
+#: ../../administration_portal/brand/clients/retail.rst:107
 #: ../../administration_portal/brand/clients/wholesale.rst:77
 msgid "Audio transcoding"
 msgstr ""
 
-#: ../../administration_portal/brand/clients/retail.rst:111
+#: ../../administration_portal/brand/clients/retail.rst:109
 #: ../../administration_portal/brand/clients/wholesale.rst:79
 msgid ""
 "This field allows enabling codecs for this specific client. This codecs "
 "will be added to the ones offered by the client in its SDP."
 msgstr ""
 
-#: ../../administration_portal/brand/clients/retail.rst:105
+#: ../../administration_portal/brand/clients/retail.rst:103
 #: ../../administration_portal/brand/clients/wholesale.rst:73
 #: ../../administration_portal/brand/routing/routing_tags.rst:3
 msgid "Routing tags"
 msgstr ""
 
-#: ../../administration_portal/brand/clients/retail.rst:107
+#: ../../administration_portal/brand/clients/retail.rst:105
 #: ../../administration_portal/brand/clients/wholesale.rst:75
 msgid ""
 "This field allows enabling routing tags for this specific client. Call "
 "preceded with this routing tags will be rated and routed differently."
 msgstr ""
 
-#: ../../administration_portal/brand/clients/retail.rst:133
+#: ../../administration_portal/brand/clients/retail.rst:131
 msgid ""
 "**List of Rating profiles**: this subsection allows managing the rating "
 "profiles that will be used to bill its outgoing calls."
@@ -4894,7 +4889,7 @@ msgid "Device register"
 msgstr ""
 
 #: ../../administration_portal/client/residential/residential_devices.rst:111
-#: ../../administration_portal/client/retail/retail_accounts.rst:101
+#: ../../administration_portal/client/retail/retail_accounts.rst:107
 #: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:127
 msgid ""
 "If the system can not be directly access, Asterisk will have to register "
@@ -4902,7 +4897,7 @@ msgid ""
 msgstr ""
 
 #: ../../administration_portal/client/residential/residential_devices.rst:114
-#: ../../administration_portal/client/retail/retail_accounts.rst:104
+#: ../../administration_portal/client/retail/retail_accounts.rst:110
 #: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:130
 msgid "Configuration will be something like this:"
 msgstr ""
@@ -5107,29 +5102,49 @@ msgid "There is no voicemail service for retail clients."
 msgstr ""
 
 #: ../../administration_portal/client/retail/retail_accounts.rst:89
-msgid "There are no call forwarding settings for retail accounts."
+msgid ""
+"Each retail account can have a unique enabled call forward setting, "
+"pointing to an external number."
 msgstr ""
 
-#: ../../administration_portal/client/retail/retail_accounts.rst:92
+#: ../../administration_portal/client/retail/retail_accounts.rst:91
+msgid ""
+"This external called will be called whenever the retail account cannot be"
+" reached:"
+msgstr ""
+
+#: ../../administration_portal/client/retail/retail_accounts.rst:93
+msgid ""
+"Direct connectivity accounts: when no answer is received from defined "
+"address."
+msgstr ""
+
+#: ../../administration_portal/client/retail/retail_accounts.rst:95
+msgid ""
+"Accounts using SIP register: when no answer is received from last contact"
+" address or when no active register is found."
+msgstr ""
+
+#: ../../administration_portal/client/retail/retail_accounts.rst:98
 msgid "Asterisk as a retail account"
 msgstr ""
 
-#: ../../administration_portal/client/retail/retail_accounts.rst:94
+#: ../../administration_portal/client/retail/retail_accounts.rst:100
 msgid ""
 "At the other end of a account can be any kind of SIP entity. This section"
 " takes as example an Asterisk PBX system using SIP channel driver that "
 "wants to connect to IvozProvider."
 msgstr ""
 
-#: ../../administration_portal/client/retail/retail_accounts.rst:99
+#: ../../administration_portal/client/retail/retail_accounts.rst:105
 msgid "Account register"
 msgstr ""
 
-#: ../../administration_portal/client/retail/retail_accounts.rst:111
+#: ../../administration_portal/client/retail/retail_accounts.rst:117
 msgid "Account peer"
 msgstr ""
 
-#: ../../administration_portal/client/retail/retail_accounts.rst:126
+#: ../../administration_portal/client/retail/retail_accounts.rst:132
 msgid ""
 "*Retail accounts* MUST NOT challenge IvozProvider. That's why the "
 "*insecure* setting is used here."

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -827,14 +827,14 @@ route[PARSE_X_HEADERS] {
         $dlg_var(retailAccountId) = $var(header-value);
     }
 
-    if ($dlg_var(type) == 'wholesale' || $dlg_var(type) == 'retail') return;
-
     # Extract xcallid
     $var(header) = 'X-Call-Id';
     route(PARSE_OPTIONAL_X_HEADER);
     if ($var(header-value) != '') $dlg_var(xcallid) = $var(header-value);
 
-    # -- xcallid is mandatory for every normal call.
+    if ($dlg_var(type) == 'wholesale' || $dlg_var(type) == 'retail') return;
+
+    # -- xcallid is mandatory for every vPBX/residential call.
     #    Check if X-Info-Special header is present with 'fax' value (current only exception)
     if ($(dlg_var(xcallid){s.len}) == 0) {
         $var(header) = 'X-Info-Special';
@@ -1326,6 +1326,16 @@ route[CLASSIFY] {
         $var(header) = 'X-Info-Type';
         route(PARSE_MANDATORY_X_HEADER);
         $dlg_var(type) = $var(header-value);
+
+        # Get retailAccountId for retail call-forward calls through AS (MUST have Diversion header)
+        if ($dlg_var(type) == 'retail' && !is_present_hf("X-Info-RetailAccountId")) {
+            if (is_present_hf("Diversion")) {
+                sql_xquery("cb", "SELECT RA.id FROM DDIs D INNER JOIN RetailAccounts RA ON D.retailAccountId=RA.id WHERE DDIE164='$(di{uri.user})'", "rp");
+                $dlg_var(retailAccountId) = $xavp(rp=>id);
+            } else {
+                xwarn("[$dlg_var(cidhash)] CLASSIFY: retail call without X-Info-RetailAccountId nor Diversion");
+            }
+        }
     } else {
         sql_xquery("cb", "SELECT C.brandId, C.id AS companyId, C.type FROM DDIs D JOIN Companies C ON D.companyId=C.id WHERE DDIE164='$rU'", "rp");
         $dlg_var(brandId) = $xavp(rp=>brandId);

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -1036,6 +1036,12 @@ route[LOOKUP] {
     lookup("kam_users_location");
     switch ($?) {
         case -1:
+            if ($dlg_var(retail_forward) == 'yes') {
+                xinfo("[$dlg_var(cidhash)] LOOKUP: 404 calling to retail account with call-forward configured");
+                $avp(apply_cfwd) = 'yes';
+                route(DISPATCH_TO_AS);
+                return;
+            }
             xerr("[$dlg_var(cidhash)] LOOKUP: Contact not found for $ru, 404\n");
             send_reply("404", "Not Found");
             exit;
@@ -1062,6 +1068,29 @@ route[LOOKUP] {
     } else {
         xinfo("[$dlg_var(cidhash)] LOOKUP: t_next_contacts - Multiple contacts found for $tu, parallel forking\n");
     }
+
+    if ($dlg_var(retail_forward) == 'yes') t_on_failure("MANAGE_FAILURE_RETAIL");
+}
+
+route[APPLY_RETAIL_CFW] {
+    # Save From user in PAI if PAI not present
+    if (!is_present_hf("P-Asserted-Identity")) {
+        append_hf("P-Asserted-Identity: <$dlg_var(rcfw_newpaiuri)>\r\n");
+    }
+
+    # Save original caller as caller
+    $dlg_var(caller) = $dlg_var(rcfw_newpaiuser);
+
+    # Set retail account AoR as From header
+    uac_replace_from("","$dlg_var(rcfw_newfromuri)");
+
+    # Set called DDI in Diversion header
+    add_diversion("deflection", "$dlg_var(rcfw_newdiversionuri)");
+
+    # Modify R-URI with call forward target
+    $ru = $dlg_var(rcfw_newruri);
+
+    xinfo("[$dlg_var(cidhash)] APPLY-RETAIL-CFW: Call forward to $rU\n");
 }
 
 route[STATIC_LOCATION] {
@@ -1141,6 +1170,26 @@ route[GET_INFO_FROM_CALLEE] {
     # Remaining info
     $dlg_var(maxcallsUser) = $xavp(ra=>maxCalls);
     $dlg_var(mediaRelaySetsId) = $xavp(ra=>mediaRelaySetsId);
+
+    # Get retail call-forward settings
+    if ($dlg_var(type) == 'retail') {
+        route(GET_RETAIL_CFW_SETTINGS);
+    }
+}
+
+route[GET_RETAIL_CFW_SETTINGS] {
+    sql_xquery("cb", "SELECT RA.name, D.domain, CONCAT(C.countryCode, CFS.numberValue) AS CfwTarget FROM RetailAccounts RA INNER JOIN Domains D ON RA.domainId=D.id INNER JOIN CallForwardSettings CFS ON CFS.retailAccountId=RA.id INNER JOIN Countries C ON C.id=CFS.numberCountryId WHERE CFS.enabled=1 AND CFS.callForwardType='userNotRegistered' AND RA.id='$dlg_var(retailAccountId)'", "ra");
+
+    # Leave if no call forward configured
+    if ($xavp(ra=>CfwTarget) == $null) return;
+
+    $dlg_var(rcfw_newfromuri) =  "sip:" + $xavp(ra=>name) + '@' + $xavp(ra=>domain);
+    $dlg_var(rcfw_newpaiuri) = "sip:" + $fU + '@' + $xavp(ra=>domain);
+    $dlg_var(rcfw_newpaiuser) = $fU;
+    $dlg_var(rcfw_newdiversionuri) = 'sip:' + $dlg_var(callee) + '@' + $xavp(ra=>domain);
+    $dlg_var(rcfw_newruri) = "sip:" + $xavp(ra=>CfwTarget) + '@' + $xavp(ra=>domain);
+
+    $dlg_var(retail_forward) = 'yes';
 }
 
 route[GET_INFO_FROM_CALLER] {
@@ -1677,7 +1726,7 @@ route[ACCOUNTING] {
         $dlg_var(direction) = 'inbound';
 
         # -- Set caller
-        # dlg_var(caller) will be set in all cases in ADAPT_CALLER
+        # dlg_var(caller) will be set in all cases in ADAPT_CALLER (except 404 in retail call forwards that will be set in APPLY_RETAIL_CFW)
     } else {
         # External world talking
         $dlg_var(direction) = 'outbound';
@@ -1754,6 +1803,26 @@ failure_route[MANAGE_FAILURE] {
     }
 }
 
+failure_route[MANAGE_FAILURE_RETAIL] {
+    xerr("[$dlg_var(cidhash)] MANAGE-FAILURE-RETAIL: $rm FAILED: '$T_reply_code $T_reply_reason' to '$cs $rm' from '$fu' ($si:$sp) [$proto]\n");
+
+    route(IS_FROM_INSIDE);
+    route(NATMANAGE);
+
+    if (t_is_canceled()) {
+        xerr("[$dlg_var(cidhash)] MANAGE-FAILURE-RETAIL: t_is_canceled, exit here\n");
+        exit;
+    }
+
+    # Handle 408 to retail accounts and apply call-forward if necessary
+    if (t_branch_timeout() && !t_branch_replied()) {
+        xinfo("[$dlg_var(cidhash)] MANAGE-FAILURE-RETAIL: 408 calling to retail account with call-forward configured");
+        $avp(apply_cfwd) = 'yes';
+        route(DISPATCH_TO_AS);
+        route(RELAY);
+    }
+}
+
 failure_route[MANAGE_FAILURE_AS] {
     xerr("[$dlg_var(cidhash)] MANAGE-FAILURE-AS: $rm FAILED: '$T_reply_code $T_reply_reason' to '$cs $rm' from '$fu' ($si:$sp) [$proto]\n");
 
@@ -1793,9 +1862,13 @@ branch_route[MANAGE_BRANCH] {
 
     # Prepare call
     if ($var(is_from_inside) && !has_totag() && is_method("INVITE")) {
-        route(ADAPT_CALLER);
-        route(ADAPT_DIVERSION);
-        route(ADAPT_RURI_OUT);
+        if ($avp(apply_cfwd) == 'yes') {
+            route(APPLY_RETAIL_CFW);
+        } else {
+            route(ADAPT_CALLER);
+            route(ADAPT_DIVERSION);
+            route(ADAPT_RURI_OUT);
+        }
     }
 
     route(TRANSPORT_DETECT);

--- a/library/DataFixtures/ORM/ProviderRetailAccount.php
+++ b/library/DataFixtures/ORM/ProviderRetailAccount.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace DataFixtures\ORM;
+
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Common\DataFixtures\DependentFixtureInterface;
+use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Ivoz\Provider\Domain\Model\RetailAccount\RetailAccount;
+use Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface;
+
+class ProviderRetailAccount extends Fixture implements DependentFixtureInterface
+{
+    use \DataFixtures\FixtureHelperTrait;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function load(ObjectManager $manager)
+    {
+        $this->disableLifecycleEvents($manager);
+        $manager->getClassMetadata(RetailAccount::class)->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_NONE);
+
+        /** @var RetailAccount $item1 */
+        $item1 = $this->createEntityInstance(RetailAccount::class);
+        (function () {
+            $this->setName('testRetailAccount');
+            $this->setTransport('udp');
+            $this->setDirectConnectivity('yes');
+        })->call($item1);
+
+        $item1->setBrand(
+            $this->getReference('_reference_ProviderBrand1')
+        );
+        $item1->setCompany(
+            $this->getReference('_reference_ProviderCompany3')
+        );
+        $this->addReference('_reference_ProviderRetailAccount1', $item1);
+        $this->sanitizeEntityValues($item1);
+        $manager->persist($item1);
+
+        $manager->flush();
+    }
+
+    public function getDependencies()
+    {
+        return array(
+            ProviderBrand::class,
+            ProviderDomain::class,
+            ProviderCompany::class
+        );
+    }
+}

--- a/library/Ivoz/Ast/Domain/Model/PsEndpoint/PsEndpointAbstract.php
+++ b/library/Ivoz/Ast/Domain/Model/PsEndpoint/PsEndpointAbstract.php
@@ -119,6 +119,11 @@ abstract class PsEndpointAbstract
      */
     protected $residentialDevice;
 
+    /**
+     * @var \Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface
+     */
+    protected $retailAccount;
+
 
     use ChangelogTrait;
 
@@ -230,6 +235,7 @@ abstract class PsEndpointAbstract
             ->setTerminal($fkTransformer->transform($dto->getTerminal()))
             ->setFriend($fkTransformer->transform($dto->getFriend()))
             ->setResidentialDevice($fkTransformer->transform($dto->getResidentialDevice()))
+            ->setRetailAccount($fkTransformer->transform($dto->getRetailAccount()))
         ;
 
         $self->sanitizeValues();
@@ -271,7 +277,8 @@ abstract class PsEndpointAbstract
             ->setTrustIdInbound($dto->getTrustIdInbound())
             ->setTerminal($fkTransformer->transform($dto->getTerminal()))
             ->setFriend($fkTransformer->transform($dto->getFriend()))
-            ->setResidentialDevice($fkTransformer->transform($dto->getResidentialDevice()));
+            ->setResidentialDevice($fkTransformer->transform($dto->getResidentialDevice()))
+            ->setRetailAccount($fkTransformer->transform($dto->getRetailAccount()));
 
 
 
@@ -305,7 +312,8 @@ abstract class PsEndpointAbstract
             ->setTrustIdInbound(self::getTrustIdInbound())
             ->setTerminal(\Ivoz\Provider\Domain\Model\Terminal\Terminal::entityToDto(self::getTerminal(), $depth))
             ->setFriend(\Ivoz\Provider\Domain\Model\Friend\Friend::entityToDto(self::getFriend(), $depth))
-            ->setResidentialDevice(\Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDevice::entityToDto(self::getResidentialDevice(), $depth));
+            ->setResidentialDevice(\Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDevice::entityToDto(self::getResidentialDevice(), $depth))
+            ->setRetailAccount(\Ivoz\Provider\Domain\Model\RetailAccount\RetailAccount::entityToDto(self::getRetailAccount(), $depth));
     }
 
     /**
@@ -332,7 +340,8 @@ abstract class PsEndpointAbstract
             'trust_id_inbound' => self::getTrustIdInbound(),
             'terminalId' => self::getTerminal() ? self::getTerminal()->getId() : null,
             'friendId' => self::getFriend() ? self::getFriend()->getId() : null,
-            'residentialDeviceId' => self::getResidentialDevice() ? self::getResidentialDevice()->getId() : null
+            'residentialDeviceId' => self::getResidentialDevice() ? self::getResidentialDevice()->getId() : null,
+            'retailAccountId' => self::getRetailAccount() ? self::getRetailAccount()->getId() : null
         ];
     }
     // @codeCoverageIgnoreStart
@@ -849,6 +858,30 @@ abstract class PsEndpointAbstract
     public function getResidentialDevice()
     {
         return $this->residentialDevice;
+    }
+
+    /**
+     * Set retailAccount
+     *
+     * @param \Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface $retailAccount
+     *
+     * @return self
+     */
+    public function setRetailAccount(\Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface $retailAccount = null)
+    {
+        $this->retailAccount = $retailAccount;
+
+        return $this;
+    }
+
+    /**
+     * Get retailAccount
+     *
+     * @return \Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface
+     */
+    public function getRetailAccount()
+    {
+        return $this->retailAccount;
     }
 
     // @codeCoverageIgnoreEnd

--- a/library/Ivoz/Ast/Domain/Model/PsEndpoint/PsEndpointDtoAbstract.php
+++ b/library/Ivoz/Ast/Domain/Model/PsEndpoint/PsEndpointDtoAbstract.php
@@ -110,6 +110,11 @@ abstract class PsEndpointDtoAbstract implements DataTransferObjectInterface
      */
     private $residentialDevice;
 
+    /**
+     * @var \Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountDto | null
+     */
+    private $retailAccount;
+
 
     use DtoNormalizer;
 
@@ -147,7 +152,8 @@ abstract class PsEndpointDtoAbstract implements DataTransferObjectInterface
             'id' => 'id',
             'terminalId' => 'terminal',
             'friendId' => 'friend',
-            'residentialDeviceId' => 'residentialDevice'
+            'residentialDeviceId' => 'residentialDevice',
+            'retailAccountId' => 'retailAccount'
         ];
     }
 
@@ -176,7 +182,8 @@ abstract class PsEndpointDtoAbstract implements DataTransferObjectInterface
             'id' => $this->getId(),
             'terminal' => $this->getTerminal(),
             'friend' => $this->getFriend(),
-            'residentialDevice' => $this->getResidentialDevice()
+            'residentialDevice' => $this->getResidentialDevice(),
+            'retailAccount' => $this->getRetailAccount()
         ];
     }
 
@@ -652,6 +659,52 @@ abstract class PsEndpointDtoAbstract implements DataTransferObjectInterface
     public function getResidentialDeviceId()
     {
         if ($dto = $this->getResidentialDevice()) {
+            return $dto->getId();
+        }
+
+        return null;
+    }
+
+    /**
+     * @param \Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountDto $retailAccount
+     *
+     * @return static
+     */
+    public function setRetailAccount(\Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountDto $retailAccount = null)
+    {
+        $this->retailAccount = $retailAccount;
+
+        return $this;
+    }
+
+    /**
+     * @return \Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountDto
+     */
+    public function getRetailAccount()
+    {
+        return $this->retailAccount;
+    }
+
+    /**
+     * @param integer $id | null
+     *
+     * @return static
+     */
+    public function setRetailAccountId($id)
+    {
+        $value = !is_null($id)
+            ? new \Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountDto($id)
+            : null;
+
+        return $this->setRetailAccount($value);
+    }
+
+    /**
+     * @return integer | null
+     */
+    public function getRetailAccountId()
+    {
+        if ($dto = $this->getRetailAccount()) {
             return $dto->getId();
         }
 

--- a/library/Ivoz/Ast/Domain/Model/PsEndpoint/PsEndpointInterface.php
+++ b/library/Ivoz/Ast/Domain/Model/PsEndpoint/PsEndpointInterface.php
@@ -171,4 +171,20 @@ interface PsEndpointInterface extends LoggableEntityInterface
      * @return \Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDeviceInterface
      */
     public function getResidentialDevice();
+
+    /**
+     * Set retailAccount
+     *
+     * @param \Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface $retailAccount
+     *
+     * @return self
+     */
+    public function setRetailAccount(\Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface $retailAccount = null);
+
+    /**
+     * Get retailAccount
+     *
+     * @return \Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface
+     */
+    public function getRetailAccount();
 }

--- a/library/Ivoz/Ast/Domain/Model/PsEndpoint/PsEndpointRepository.php
+++ b/library/Ivoz/Ast/Domain/Model/PsEndpoint/PsEndpointRepository.php
@@ -23,6 +23,12 @@ interface PsEndpointRepository extends ObjectRepository, Selectable
      * @param $id
      * @return null|PsEndpointInterface
      */
+    public function findOneByRetailAccountId($id);
+
+    /**
+     * @param $id
+     * @return null|PsEndpointInterface
+     */
     public function findOneByTerminalId($id);
 
     /**

--- a/library/Ivoz/Ast/Domain/Service/PsEndpoint/UpdateByRetailAccount.php
+++ b/library/Ivoz/Ast/Domain/Service/PsEndpoint/UpdateByRetailAccount.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Ivoz\Ast\Domain\Service\PsEndpoint;
+
+use Ivoz\Ast\Domain\Model\PsEndpoint\PsEndpointRepository;
+use Ivoz\Core\Application\Service\EntityTools;
+use Ivoz\Ast\Domain\Model\PsEndpoint\PsEndpoint;
+use Ivoz\Ast\Domain\Model\PsEndpoint\PsEndpointInterface;
+use Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface;
+use Ivoz\Provider\Domain\Service\RetailAccount\RetailAccountLifecycleEventHandlerInterface;
+
+class UpdateByRetailAccount implements RetailAccountLifecycleEventHandlerInterface
+{
+    /**
+     * @var EntityTools
+     */
+    protected $entityTools;
+
+    /**
+     * @var PsEndpointRepository
+     */
+    protected $psEndpointRepository;
+
+    public function __construct(
+        EntityTools $entityTools,
+        PsEndpointRepository $psEndpointRepository
+    ) {
+        $this->entityTools = $entityTools;
+        $this->psEndpointRepository = $psEndpointRepository;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            self::EVENT_POST_PERSIST => self::PRIORITY_NORMAL
+        ];
+    }
+
+    /**
+     * @param RetailAccountInterface $entity
+     */
+    public function execute(RetailAccountInterface $entity)
+    {
+        /**
+         * @var PsEndpointInterface $endpoint
+         */
+        $endpoint = $this->psEndpointRepository->findOneByRetailAccountId(
+            $entity->getId()
+        );
+
+        // If not found create a new one
+        if (is_null($endpoint)) {
+            $endpointDto = PsEndpoint::createDto();
+            $endpointDto
+                ->setContext('retail')
+                ->setSendDiversion('yes')
+                ->setSendPai('yes');
+        } else {
+            $endpointDto  = $this->entityTools->entityToDto($endpoint);
+        }
+
+        // Use company domain if retail account from-domain not set
+        $fromDomain = $entity->getFromDomain()
+            ? $entity->getFromDomain()
+            : $entity->getDomain()->getDomain();
+
+        // Update/Insert endpoint data
+        $endpointDto
+            ->setRetailAccountId($entity->getId())
+            ->setSorceryId($entity->getSorcery())
+            ->setFromDomain($fromDomain)
+            ->setAors($entity->getSorcery())
+            ->setDisallow("all")
+            ->setAllow("alaw,g729,ulaw")
+            ->setDirectmediaMethod('invite')
+            ->setTrustIdInbound('yes')
+            ->setOutboundProxy('sip:users.ivozprovider.local^3Blr')
+            ->setDirectMediaMethod('invite');
+
+        $this->entityTools->persistDto($endpointDto, $endpoint);
+    }
+}

--- a/library/Ivoz/Ast/Infrastructure/Persistence/Doctrine/Mapping/PsEndpoint.PsEndpointAbstract.orm.yml
+++ b/library/Ivoz/Ast/Infrastructure/Persistence/Doctrine/Mapping/PsEndpoint.PsEndpointAbstract.orm.yml
@@ -164,3 +164,14 @@ Ivoz\Ast\Domain\Model\PsEndpoint\PsEndpointAbstract:
           referencedColumnName: id
           onDelete: cascade
       orphanRemoval: false
+    retailAccount:
+      targetEntity: \Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface
+      cascade: {  }
+      fetch: LAZY
+      mappedBy: null
+      inversedBy: psEndpoints
+      joinColumns:
+        retailAccountId:
+          referencedColumnName: id
+          onDelete: cascade
+      orphanRemoval: false

--- a/library/Ivoz/Ast/Infrastructure/Persistence/Doctrine/PsEndpointDoctrineRepository.php
+++ b/library/Ivoz/Ast/Infrastructure/Persistence/Doctrine/PsEndpointDoctrineRepository.php
@@ -51,6 +51,21 @@ class PsEndpointDoctrineRepository extends ServiceEntityRepository implements Ps
 
     /**
      * @inheritdoc
+     * @see PsEndpointRepository::findOneByRetailAccountId
+     */
+    public function findOneByRetailAccountId($id)
+    {
+        /** @var PsEndpointInterface $response */
+        $response = $this->findOneBy([
+            'retailAccount' => $id
+        ]);
+
+        return $response;
+    }
+
+
+    /**
+     * @inheritdoc
      * @see PsEndpointRepository::findOneByTerminalId
      */
     public function findOneByTerminalId($id)

--- a/library/Ivoz/Provider/Domain/Model/CallForwardSetting/CallForwardSettingAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/CallForwardSetting/CallForwardSettingAbstract.php
@@ -71,6 +71,11 @@ abstract class CallForwardSettingAbstract
      */
     protected $residentialDevice;
 
+    /**
+     * @var \Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface
+     */
+    protected $retailAccount;
+
 
     use ChangelogTrait;
 
@@ -174,6 +179,7 @@ abstract class CallForwardSettingAbstract
             ->setVoiceMailUser($fkTransformer->transform($dto->getVoiceMailUser()))
             ->setNumberCountry($fkTransformer->transform($dto->getNumberCountry()))
             ->setResidentialDevice($fkTransformer->transform($dto->getResidentialDevice()))
+            ->setRetailAccount($fkTransformer->transform($dto->getRetailAccount()))
         ;
 
         $self->sanitizeValues();
@@ -207,7 +213,8 @@ abstract class CallForwardSettingAbstract
             ->setExtension($fkTransformer->transform($dto->getExtension()))
             ->setVoiceMailUser($fkTransformer->transform($dto->getVoiceMailUser()))
             ->setNumberCountry($fkTransformer->transform($dto->getNumberCountry()))
-            ->setResidentialDevice($fkTransformer->transform($dto->getResidentialDevice()));
+            ->setResidentialDevice($fkTransformer->transform($dto->getResidentialDevice()))
+            ->setRetailAccount($fkTransformer->transform($dto->getRetailAccount()));
 
 
 
@@ -233,7 +240,8 @@ abstract class CallForwardSettingAbstract
             ->setExtension(\Ivoz\Provider\Domain\Model\Extension\Extension::entityToDto(self::getExtension(), $depth))
             ->setVoiceMailUser(\Ivoz\Provider\Domain\Model\User\User::entityToDto(self::getVoiceMailUser(), $depth))
             ->setNumberCountry(\Ivoz\Provider\Domain\Model\Country\Country::entityToDto(self::getNumberCountry(), $depth))
-            ->setResidentialDevice(\Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDevice::entityToDto(self::getResidentialDevice(), $depth));
+            ->setResidentialDevice(\Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDevice::entityToDto(self::getResidentialDevice(), $depth))
+            ->setRetailAccount(\Ivoz\Provider\Domain\Model\RetailAccount\RetailAccount::entityToDto(self::getRetailAccount(), $depth));
     }
 
     /**
@@ -252,7 +260,8 @@ abstract class CallForwardSettingAbstract
             'extensionId' => self::getExtension() ? self::getExtension()->getId() : null,
             'voiceMailUserId' => self::getVoiceMailUser() ? self::getVoiceMailUser()->getId() : null,
             'numberCountryId' => self::getNumberCountry() ? self::getNumberCountry()->getId() : null,
-            'residentialDeviceId' => self::getResidentialDevice() ? self::getResidentialDevice()->getId() : null
+            'residentialDeviceId' => self::getResidentialDevice() ? self::getResidentialDevice()->getId() : null,
+            'retailAccountId' => self::getRetailAccount() ? self::getRetailAccount()->getId() : null
         ];
     }
     // @codeCoverageIgnoreStart
@@ -554,6 +563,30 @@ abstract class CallForwardSettingAbstract
     public function getResidentialDevice()
     {
         return $this->residentialDevice;
+    }
+
+    /**
+     * Set retailAccount
+     *
+     * @param \Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface $retailAccount
+     *
+     * @return self
+     */
+    public function setRetailAccount(\Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface $retailAccount = null)
+    {
+        $this->retailAccount = $retailAccount;
+
+        return $this;
+    }
+
+    /**
+     * Get retailAccount
+     *
+     * @return \Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface | null
+     */
+    public function getRetailAccount()
+    {
+        return $this->retailAccount;
     }
 
     // @codeCoverageIgnoreEnd

--- a/library/Ivoz/Provider/Domain/Model/CallForwardSetting/CallForwardSettingDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/CallForwardSetting/CallForwardSettingDtoAbstract.php
@@ -70,6 +70,11 @@ abstract class CallForwardSettingDtoAbstract implements DataTransferObjectInterf
      */
     private $residentialDevice;
 
+    /**
+     * @var \Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountDto | null
+     */
+    private $retailAccount;
+
 
     use DtoNormalizer;
 
@@ -99,7 +104,8 @@ abstract class CallForwardSettingDtoAbstract implements DataTransferObjectInterf
             'extensionId' => 'extension',
             'voiceMailUserId' => 'voiceMailUser',
             'numberCountryId' => 'numberCountry',
-            'residentialDeviceId' => 'residentialDevice'
+            'residentialDeviceId' => 'residentialDevice',
+            'retailAccountId' => 'retailAccount'
         ];
     }
 
@@ -120,7 +126,8 @@ abstract class CallForwardSettingDtoAbstract implements DataTransferObjectInterf
             'extension' => $this->getExtension(),
             'voiceMailUser' => $this->getVoiceMailUser(),
             'numberCountry' => $this->getNumberCountry(),
-            'residentialDevice' => $this->getResidentialDevice()
+            'residentialDevice' => $this->getResidentialDevice(),
+            'retailAccount' => $this->getRetailAccount()
         ];
     }
 
@@ -488,6 +495,52 @@ abstract class CallForwardSettingDtoAbstract implements DataTransferObjectInterf
     public function getResidentialDeviceId()
     {
         if ($dto = $this->getResidentialDevice()) {
+            return $dto->getId();
+        }
+
+        return null;
+    }
+
+    /**
+     * @param \Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountDto $retailAccount
+     *
+     * @return static
+     */
+    public function setRetailAccount(\Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountDto $retailAccount = null)
+    {
+        $this->retailAccount = $retailAccount;
+
+        return $this;
+    }
+
+    /**
+     * @return \Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountDto
+     */
+    public function getRetailAccount()
+    {
+        return $this->retailAccount;
+    }
+
+    /**
+     * @param integer $id | null
+     *
+     * @return static
+     */
+    public function setRetailAccountId($id)
+    {
+        $value = !is_null($id)
+            ? new \Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountDto($id)
+            : null;
+
+        return $this->setRetailAccount($value);
+    }
+
+    /**
+     * @return integer | null
+     */
+    public function getRetailAccountId()
+    {
+        if ($dto = $this->getRetailAccount()) {
             return $dto->getId();
         }
 

--- a/library/Ivoz/Provider/Domain/Model/CallForwardSetting/CallForwardSettingInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/CallForwardSetting/CallForwardSettingInterface.php
@@ -158,6 +158,22 @@ interface CallForwardSettingInterface extends LoggableEntityInterface
     public function getResidentialDevice();
 
     /**
+     * Set retailAccount
+     *
+     * @param \Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface $retailAccount
+     *
+     * @return self
+     */
+    public function setRetailAccount(\Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface $retailAccount = null);
+
+    /**
+     * Get retailAccount
+     *
+     * @return \Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface | null
+     */
+    public function getRetailAccount();
+
+    /**
      * @param string $prefix
      * @return null|string
      */

--- a/library/Ivoz/Provider/Domain/Model/RetailAccount/RetailAccount.php
+++ b/library/Ivoz/Provider/Domain/Model/RetailAccount/RetailAccount.php
@@ -3,6 +3,8 @@
 namespace Ivoz\Provider\Domain\Model\RetailAccount;
 
 use Assert\Assertion;
+use Doctrine\Common\Collections\Criteria;
+use Ivoz\Provider\Domain\Model\Ddi\DdiInterface;
 
 /**
  * RetailAccount
@@ -81,5 +83,43 @@ class RetailAccount extends RetailAccountAbstract implements RetailAccountInterf
         }
 
         return parent::setPort($port);
+    }
+
+    /**
+     * @return string
+     */
+    public function getSorcery()
+    {
+        return sprintf(
+            "b%dc%drt%d_%s",
+            $this->getCompany()->getBrand()->getId(),
+            $this->getCompany()->getId(),
+            $this->getId(),
+            $this->getName()
+        );
+    }
+
+    /**
+     * Get Ddi associated with this retail Account
+     *
+     * @return DdiInterface
+     */
+    public function getDdi($ddieE164)
+    {
+        $criteria = new Criteria();
+
+        if ($ddieE164) {
+            $criteria->where(
+                Criteria::expr()->eq(
+                    'ddie164',
+                    $ddieE164
+                )
+            );
+        }
+
+        $ddis = $this->getDdis($criteria);
+
+
+        return array_shift($ddis);
     }
 }

--- a/library/Ivoz/Provider/Domain/Model/RetailAccount/RetailAccountDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/RetailAccount/RetailAccountDtoAbstract.php
@@ -90,6 +90,11 @@ abstract class RetailAccountDtoAbstract implements DataTransferObjectInterface
      */
     private $ddis = null;
 
+    /**
+     * @var \Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSettingDto[] | null
+     */
+    private $callForwardSettings = null;
+
 
     use DtoNormalizer;
 
@@ -147,7 +152,8 @@ abstract class RetailAccountDtoAbstract implements DataTransferObjectInterface
             'company' => $this->getCompany(),
             'transformationRuleSet' => $this->getTransformationRuleSet(),
             'outgoingDdi' => $this->getOutgoingDdi(),
-            'ddis' => $this->getDdis()
+            'ddis' => $this->getDdis(),
+            'callForwardSettings' => $this->getCallForwardSettings()
         ];
     }
 
@@ -599,5 +605,25 @@ abstract class RetailAccountDtoAbstract implements DataTransferObjectInterface
     public function getDdis()
     {
         return $this->ddis;
+    }
+
+    /**
+     * @param array $callForwardSettings
+     *
+     * @return static
+     */
+    public function setCallForwardSettings($callForwardSettings = null)
+    {
+        $this->callForwardSettings = $callForwardSettings;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getCallForwardSettings()
+    {
+        return $this->callForwardSettings;
     }
 }

--- a/library/Ivoz/Provider/Domain/Model/RetailAccount/RetailAccountDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/RetailAccount/RetailAccountDtoAbstract.php
@@ -86,6 +86,11 @@ abstract class RetailAccountDtoAbstract implements DataTransferObjectInterface
     private $outgoingDdi;
 
     /**
+     * @var \Ivoz\Ast\Domain\Model\PsEndpoint\PsEndpointDto[] | null
+     */
+    private $psEndpoints = null;
+
+    /**
      * @var \Ivoz\Provider\Domain\Model\Ddi\DdiDto[] | null
      */
     private $ddis = null;
@@ -152,6 +157,7 @@ abstract class RetailAccountDtoAbstract implements DataTransferObjectInterface
             'company' => $this->getCompany(),
             'transformationRuleSet' => $this->getTransformationRuleSet(),
             'outgoingDdi' => $this->getOutgoingDdi(),
+            'psEndpoints' => $this->getPsEndpoints(),
             'ddis' => $this->getDdis(),
             'callForwardSettings' => $this->getCallForwardSettings()
         ];
@@ -585,6 +591,26 @@ abstract class RetailAccountDtoAbstract implements DataTransferObjectInterface
         }
 
         return null;
+    }
+
+    /**
+     * @param array $psEndpoints
+     *
+     * @return static
+     */
+    public function setPsEndpoints($psEndpoints = null)
+    {
+        $this->psEndpoints = $psEndpoints;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getPsEndpoints()
+    {
+        return $this->psEndpoints;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/RetailAccount/RetailAccountInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/RetailAccount/RetailAccountInterface.php
@@ -203,4 +203,35 @@ interface RetailAccountInterface extends LoggableEntityInterface
      * @return \Ivoz\Provider\Domain\Model\Ddi\DdiInterface[]
      */
     public function getDdis(\Doctrine\Common\Collections\Criteria $criteria = null);
+
+    /**
+     * Add callForwardSetting
+     *
+     * @param \Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSettingInterface $callForwardSetting
+     *
+     * @return RetailAccountTrait
+     */
+    public function addCallForwardSetting(\Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSettingInterface $callForwardSetting);
+
+    /**
+     * Remove callForwardSetting
+     *
+     * @param \Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSettingInterface $callForwardSetting
+     */
+    public function removeCallForwardSetting(\Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSettingInterface $callForwardSetting);
+
+    /**
+     * Replace callForwardSettings
+     *
+     * @param \Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSettingInterface[] $callForwardSettings
+     * @return self
+     */
+    public function replaceCallForwardSettings(Collection $callForwardSettings);
+
+    /**
+     * Get callForwardSettings
+     *
+     * @return \Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSettingInterface[]
+     */
+    public function getCallForwardSettings(\Doctrine\Common\Collections\Criteria $criteria = null);
 }

--- a/library/Ivoz/Provider/Domain/Model/RetailAccount/RetailAccountInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/RetailAccount/RetailAccountInterface.php
@@ -31,6 +31,18 @@ interface RetailAccountInterface extends LoggableEntityInterface
     public function setPort($port = null);
 
     /**
+     * @return string
+     */
+    public function getSorcery();
+
+    /**
+     * Get Ddi associated with this retail Account
+     *
+     * @return DdiInterface
+     */
+    public function getDdi($ddieE164);
+
+    /**
      * Get name
      *
      * @return string
@@ -172,6 +184,37 @@ interface RetailAccountInterface extends LoggableEntityInterface
      * @return \Ivoz\Provider\Domain\Model\Ddi\DdiInterface
      */
     public function getOutgoingDdi();
+
+    /**
+     * Add psEndpoint
+     *
+     * @param \Ivoz\Ast\Domain\Model\PsEndpoint\PsEndpointInterface $psEndpoint
+     *
+     * @return RetailAccountTrait
+     */
+    public function addPsEndpoint(\Ivoz\Ast\Domain\Model\PsEndpoint\PsEndpointInterface $psEndpoint);
+
+    /**
+     * Remove psEndpoint
+     *
+     * @param \Ivoz\Ast\Domain\Model\PsEndpoint\PsEndpointInterface $psEndpoint
+     */
+    public function removePsEndpoint(\Ivoz\Ast\Domain\Model\PsEndpoint\PsEndpointInterface $psEndpoint);
+
+    /**
+     * Replace psEndpoints
+     *
+     * @param \Ivoz\Ast\Domain\Model\PsEndpoint\PsEndpointInterface[] $psEndpoints
+     * @return self
+     */
+    public function replacePsEndpoints(Collection $psEndpoints);
+
+    /**
+     * Get psEndpoints
+     *
+     * @return \Ivoz\Ast\Domain\Model\PsEndpoint\PsEndpointInterface[]
+     */
+    public function getPsEndpoints(\Doctrine\Common\Collections\Criteria $criteria = null);
 
     /**
      * Add ddi

--- a/library/Ivoz/Provider/Domain/Model/RetailAccount/RetailAccountTrait.php
+++ b/library/Ivoz/Provider/Domain/Model/RetailAccount/RetailAccountTrait.php
@@ -21,6 +21,11 @@ trait RetailAccountTrait
     /**
      * @var Collection
      */
+    protected $psEndpoints;
+
+    /**
+     * @var Collection
+     */
     protected $ddis;
 
     /**
@@ -35,6 +40,7 @@ trait RetailAccountTrait
     protected function __construct()
     {
         parent::__construct(...func_get_args());
+        $this->psEndpoints = new ArrayCollection();
         $this->ddis = new ArrayCollection();
         $this->callForwardSettings = new ArrayCollection();
     }
@@ -54,6 +60,14 @@ trait RetailAccountTrait
          * @var $dto RetailAccountDto
          */
         $self = parent::fromDto($dto, $fkTransformer);
+        if ($dto->getPsEndpoints()) {
+            $self->replacePsEndpoints(
+                $fkTransformer->transformCollection(
+                    $dto->getPsEndpoints()
+                )
+            );
+        }
+
         if ($dto->getDdis()) {
             $self->replaceDdis(
                 $fkTransformer->transformCollection(
@@ -91,6 +105,13 @@ trait RetailAccountTrait
          * @var $dto RetailAccountDto
          */
         parent::updateFromDto($dto, $fkTransformer);
+        if ($dto->getPsEndpoints()) {
+            $this->replacePsEndpoints(
+                $fkTransformer->transformCollection(
+                    $dto->getPsEndpoints()
+                )
+            );
+        }
         if ($dto->getDdis()) {
             $this->replaceDdis(
                 $fkTransformer->transformCollection(
@@ -129,6 +150,78 @@ trait RetailAccountTrait
             'id' => self::getId()
         ];
     }
+    /**
+     * Add psEndpoint
+     *
+     * @param \Ivoz\Ast\Domain\Model\PsEndpoint\PsEndpointInterface $psEndpoint
+     *
+     * @return RetailAccountTrait
+     */
+    public function addPsEndpoint(\Ivoz\Ast\Domain\Model\PsEndpoint\PsEndpointInterface $psEndpoint)
+    {
+        $this->psEndpoints->add($psEndpoint);
+
+        return $this;
+    }
+
+    /**
+     * Remove psEndpoint
+     *
+     * @param \Ivoz\Ast\Domain\Model\PsEndpoint\PsEndpointInterface $psEndpoint
+     */
+    public function removePsEndpoint(\Ivoz\Ast\Domain\Model\PsEndpoint\PsEndpointInterface $psEndpoint)
+    {
+        $this->psEndpoints->removeElement($psEndpoint);
+    }
+
+    /**
+     * Replace psEndpoints
+     *
+     * @param \Ivoz\Ast\Domain\Model\PsEndpoint\PsEndpointInterface[] $psEndpoints
+     * @return self
+     */
+    public function replacePsEndpoints(Collection $psEndpoints)
+    {
+        $updatedEntities = [];
+        $fallBackId = -1;
+        foreach ($psEndpoints as $entity) {
+            $index = $entity->getId() ? $entity->getId() : $fallBackId--;
+            $updatedEntities[$index] = $entity;
+            $entity->setRetailAccount($this);
+        }
+        $updatedEntityKeys = array_keys($updatedEntities);
+
+        foreach ($this->psEndpoints as $key => $entity) {
+            $identity = $entity->getId();
+            if (in_array($identity, $updatedEntityKeys)) {
+                $this->psEndpoints->set($key, $updatedEntities[$identity]);
+            } else {
+                $this->psEndpoints->remove($key);
+            }
+            unset($updatedEntities[$identity]);
+        }
+
+        foreach ($updatedEntities as $entity) {
+            $this->addPsEndpoint($entity);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get psEndpoints
+     *
+     * @return \Ivoz\Ast\Domain\Model\PsEndpoint\PsEndpointInterface[]
+     */
+    public function getPsEndpoints(Criteria $criteria = null)
+    {
+        if (!is_null($criteria)) {
+            return $this->psEndpoints->matching($criteria)->toArray();
+        }
+
+        return $this->psEndpoints->toArray();
+    }
+
     /**
      * Add ddi
      *

--- a/library/Ivoz/Provider/Domain/Model/RetailAccount/RetailAccountTrait.php
+++ b/library/Ivoz/Provider/Domain/Model/RetailAccount/RetailAccountTrait.php
@@ -23,6 +23,11 @@ trait RetailAccountTrait
      */
     protected $ddis;
 
+    /**
+     * @var Collection
+     */
+    protected $callForwardSettings;
+
 
     /**
      * Constructor
@@ -31,6 +36,7 @@ trait RetailAccountTrait
     {
         parent::__construct(...func_get_args());
         $this->ddis = new ArrayCollection();
+        $this->callForwardSettings = new ArrayCollection();
     }
 
     /**
@@ -52,6 +58,14 @@ trait RetailAccountTrait
             $self->replaceDdis(
                 $fkTransformer->transformCollection(
                     $dto->getDdis()
+                )
+            );
+        }
+
+        if ($dto->getCallForwardSettings()) {
+            $self->replaceCallForwardSettings(
+                $fkTransformer->transformCollection(
+                    $dto->getCallForwardSettings()
                 )
             );
         }
@@ -81,6 +95,13 @@ trait RetailAccountTrait
             $this->replaceDdis(
                 $fkTransformer->transformCollection(
                     $dto->getDdis()
+                )
+            );
+        }
+        if ($dto->getCallForwardSettings()) {
+            $this->replaceCallForwardSettings(
+                $fkTransformer->transformCollection(
+                    $dto->getCallForwardSettings()
                 )
             );
         }
@@ -178,5 +199,77 @@ trait RetailAccountTrait
         }
 
         return $this->ddis->toArray();
+    }
+
+    /**
+     * Add callForwardSetting
+     *
+     * @param \Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSettingInterface $callForwardSetting
+     *
+     * @return RetailAccountTrait
+     */
+    public function addCallForwardSetting(\Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSettingInterface $callForwardSetting)
+    {
+        $this->callForwardSettings->add($callForwardSetting);
+
+        return $this;
+    }
+
+    /**
+     * Remove callForwardSetting
+     *
+     * @param \Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSettingInterface $callForwardSetting
+     */
+    public function removeCallForwardSetting(\Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSettingInterface $callForwardSetting)
+    {
+        $this->callForwardSettings->removeElement($callForwardSetting);
+    }
+
+    /**
+     * Replace callForwardSettings
+     *
+     * @param \Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSettingInterface[] $callForwardSettings
+     * @return self
+     */
+    public function replaceCallForwardSettings(Collection $callForwardSettings)
+    {
+        $updatedEntities = [];
+        $fallBackId = -1;
+        foreach ($callForwardSettings as $entity) {
+            $index = $entity->getId() ? $entity->getId() : $fallBackId--;
+            $updatedEntities[$index] = $entity;
+            $entity->setRetailAccount($this);
+        }
+        $updatedEntityKeys = array_keys($updatedEntities);
+
+        foreach ($this->callForwardSettings as $key => $entity) {
+            $identity = $entity->getId();
+            if (in_array($identity, $updatedEntityKeys)) {
+                $this->callForwardSettings->set($key, $updatedEntities[$identity]);
+            } else {
+                $this->callForwardSettings->remove($key);
+            }
+            unset($updatedEntities[$identity]);
+        }
+
+        foreach ($updatedEntities as $entity) {
+            $this->addCallForwardSetting($entity);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get callForwardSettings
+     *
+     * @return \Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSettingInterface[]
+     */
+    public function getCallForwardSettings(Criteria $criteria = null)
+    {
+        if (!is_null($criteria)) {
+            return $this->callForwardSettings->matching($criteria)->toArray();
+        }
+
+        return $this->callForwardSettings->toArray();
     }
 }

--- a/library/Ivoz/Provider/Domain/Service/CallForwardSetting/CheckUniqueness.php
+++ b/library/Ivoz/Provider/Domain/Service/CallForwardSetting/CheckUniqueness.php
@@ -217,10 +217,17 @@ class CheckUniqueness implements CallForwardSettingLifecycleEventHandlerInterfac
 
         $criteria = [
             ['id', 'neq', $entity->getId()],
-            ['user', 'eq', $entity->getUser()],
             ['callTypeFilter', 'in', $callTypeFilterConditions],
             ['enabled', 'eq', 1]
         ];
+
+        if (!is_null($entity->getUser())) {
+            $criteria[] = ['user', 'eq', $entity->getUser()];
+        } elseif (!is_null($entity->getResidentialDevice())) {
+            $criteria[] = ['residentialDevice', 'eq', $entity->getResidentialDevice()];
+        } elseif (!is_null($entity->getRetailAccount())) {
+            $criteria[] = ['retailAccount', 'eq', $entity->getRetailAccount()];
+        }
 
         if ($callForwardType) {
             $criteria[] = [

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/CallForwardSetting.CallForwardSettingAbstract.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/CallForwardSetting.CallForwardSettingAbstract.orm.yml
@@ -103,3 +103,15 @@ Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSettingAbstract:
           nullable: true
           onDelete: cascade
       orphanRemoval: false
+    retailAccount:
+      targetEntity: \Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface
+      cascade: {  }
+      fetch: LAZY
+      mappedBy: null
+      inversedBy: callForwardSettings
+      joinColumns:
+        retailAccountId:
+          referencedColumnName: id
+          nullable: true
+          onDelete: cascade
+      orphanRemoval: false

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/RetailAccount.RetailAccount.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/RetailAccount.RetailAccount.orm.yml
@@ -16,3 +16,6 @@ Ivoz\Provider\Domain\Model\RetailAccount\RetailAccount:
     ddis:
       targetEntity: Ivoz\Provider\Domain\Model\Ddi\DdiInterface
       mappedBy: retailAccount
+    callForwardSettings:
+      targetEntity: Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSettingInterface
+      mappedBy: retailAccount

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/RetailAccount.RetailAccount.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/RetailAccount.RetailAccount.orm.yml
@@ -13,6 +13,9 @@ Ivoz\Provider\Domain\Model\RetailAccount\RetailAccount:
       generator:
         strategy: IDENTITY
   oneToMany:
+    psEndpoints:
+      targetEntity: Ivoz\Ast\Domain\Model\PsEndpoint\PsEndpointInterface
+      mappedBy: retailAccount
     ddis:
       targetEntity: Ivoz\Provider\Domain\Model\Ddi\DdiInterface
       mappedBy: retailAccount

--- a/scheme/app/DoctrineMigrations/Version20190115093223.php
+++ b/scheme/app/DoctrineMigrations/Version20190115093223.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20190115093223 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE CallForwardSettings ADD retailAccountId INT UNSIGNED DEFAULT NULL');
+        $this->addSql('ALTER TABLE CallForwardSettings ADD CONSTRAINT FK_E71B58A45EA9D64D FOREIGN KEY (retailAccountId) REFERENCES RetailAccounts (id) ON DELETE CASCADE');
+        $this->addSql('CREATE INDEX IDX_E71B58A45EA9D64D ON CallForwardSettings (retailAccountId)');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE CallForwardSettings DROP FOREIGN KEY FK_E71B58A45EA9D64D');
+        $this->addSql('DROP INDEX IDX_E71B58A45EA9D64D ON CallForwardSettings');
+        $this->addSql('ALTER TABLE CallForwardSettings DROP retailAccountId');
+    }
+}

--- a/scheme/app/DoctrineMigrations/Version20190115143446.php
+++ b/scheme/app/DoctrineMigrations/Version20190115143446.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20190115143446 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE ast_ps_endpoints ADD retailAccountId INT UNSIGNED DEFAULT NULL AFTER residentialDeviceId');
+        $this->addSql('ALTER TABLE ast_ps_endpoints ADD CONSTRAINT FK_800B60515EA9D64D FOREIGN KEY (retailAccountId) REFERENCES RetailAccounts (id) ON DELETE CASCADE');
+        $this->addSql('CREATE INDEX IDX_800B60515EA9D64D ON ast_ps_endpoints (retailAccountId)');
+
+        $this->addSql('DROP VIEW IF EXISTS ast_ps_aors');
+        $this->addSql('CREATE VIEW ast_ps_aors AS
+                    SELECT CONCAT("b", C.brandId, "c", C.id, E.type, E.id, "_", E.name)
+                        AS sorcery_id, CONCAT("sip:", E.name, "@", D.domain) AS contact, 0 as qualify_frequency
+                    FROM (
+                        SELECT "t" AS type, T.id, T.name, T.domainId, T.companyId FROM
+                            Terminals T UNION SELECT "f" AS type, id, name, domainId, companyId
+                        FROM Friends
+                    UNION
+                        SELECT "r" AS type, id, name, domainId, companyId
+                        FROM ResidentialDevices
+                    UNION
+                        SELECT "rt" AS type, id, name, domainId, companyId
+                        FROM RetailAccounts
+                    ) AS E
+                    INNER JOIN Companies C ON C.id = E.companyId
+                    INNER JOIN Domains D ON D.id = E.domainId'
+        );
+
+        $this->addSql('INSERT INTO ast_ps_endpoints (
+                            sorcery_id,
+                            from_domain,
+                            retailAccountId,
+                            context
+                    ) SELECT
+                            CONCAT("b", C.brandId, "c", C.id, "rt", RA.id),
+                            D.domain,
+                            RA.id,
+                            "retail"
+                    FROM RetailAccounts RA
+                    INNER JOIN Companies C ON C.id = RA.companyId
+                    INNER JOIN Domains D ON D.id = C.domainId'
+        );
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DELETE FROM ast_ps_endpoints WHERE retailAccountId IS NOT NULL');
+
+        $this->addSql('ALTER TABLE ast_ps_endpoints DROP FOREIGN KEY FK_800B60515EA9D64D');
+        $this->addSql('DROP INDEX IDX_800B60515EA9D64D ON ast_ps_endpoints');
+        $this->addSql('ALTER TABLE ast_ps_endpoints DROP retailAccountId');
+
+        $this->addSql('DROP VIEW IF EXISTS ast_ps_aors');
+        $this->addSql('CREATE VIEW ast_ps_aors AS
+                    SELECT CONCAT("b", C.brandId, "c", C.id, E.type, E.id, "_", E.name)
+                        AS sorcery_id, CONCAT("sip:", E.name, "@", D.domain) AS contact, 0 as qualify_frequency
+                    FROM (
+                        SELECT "t" AS type, T.id, T.name, T.domainId, T.companyId FROM
+                            Terminals T UNION SELECT "f" AS type, id, name, domainId, companyId
+                        FROM Friends
+                    UNION
+                        SELECT "r" AS type, id, name, domainId, companyId
+                        FROM ResidentialDevices
+                    UNION
+                        SELECT "rt" AS type, id, name, domainId, companyId
+                        FROM RetailAccounts
+                    ) AS E
+                    INNER JOIN Companies C ON C.id = E.companyId
+                    INNER JOIN Domains D ON D.id = E.domainId'
+        );
+    }
+}

--- a/scheme/tests/DbIntegrationTestHelperTrait.php
+++ b/scheme/tests/DbIntegrationTestHelperTrait.php
@@ -144,13 +144,46 @@ trait DbIntegrationTestHelperTrait
         );
     }
 
+    /**
+     * Becasuse of how doctrine queues entities (spl_object_hash as array key),
+     * we cannot determine what persist order it will follow
+     */
     protected function assetChangedEntities(array $expected)
     {
         $changedEntities = $this->getChangedEntities();
 
-        $this->assertEquals(
+        $missing = array_filter(
             $expected,
-            $changedEntities
+            function ($item) use ($changedEntities) {
+                return !in_array($item, $changedEntities);
+            }
+        );
+
+        $unexpected = array_filter(
+            $changedEntities,
+            function ($item) use ($expected) {
+                return !in_array($item, $expected);
+            }
+        );
+
+        $this->assertEquals(
+            $missing,
+            $unexpected
+        );
+    }
+
+    /**
+     * @param array $arr
+     * @param array $arr2
+     */
+    private function assertEqualArrayValues(array $arr, array $arr2)
+    {
+        sort($arr);
+        sort($arr2);
+
+        $this->assertEquals(
+            $arr,
+            $arr2
         );
     }
 

--- a/scheme/tests/Provider/ResidentialDevice/ResidentialDeviceLifeCycleTest.php
+++ b/scheme/tests/Provider/ResidentialDevice/ResidentialDeviceLifeCycleTest.php
@@ -4,7 +4,6 @@ namespace Tests\Provider\ResidentialDevice;
 
 use Ivoz\Ast\Domain\Model\PsEndpoint\PsEndpoint;
 use Ivoz\Ast\Domain\Model\Voicemail\Voicemail;
-use Ivoz\Cgr\Domain\Model\TpResidentialDevice\TpResidentialDevice;
 use Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDeviceDto;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Tests\DbIntegrationTestHelperTrait;

--- a/scheme/tests/Provider/RetailAccount/RetailAccountLifeCycleTest.php
+++ b/scheme/tests/Provider/RetailAccount/RetailAccountLifeCycleTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Tests\Provider\RetailAccount;
+
+use Ivoz\Ast\Domain\Model\PsEndpoint\PsEndpoint;
+use Ivoz\Ast\Domain\Model\Voicemail\Voicemail;
+use Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountDto;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\DbIntegrationTestHelperTrait;
+use Ivoz\Provider\Domain\Model\RetailAccount\RetailAccount;
+
+class RetailAccountLifeCycleTest extends KernelTestCase
+{
+    use DbIntegrationTestHelperTrait;
+
+    /**
+     * @return RetailAccountDto
+     */
+    protected function createDto()
+    {
+        $retailAccountDto = new RetailAccountDto();
+        $retailAccountDto
+            ->setName('someRetailAccount')
+            ->setTransport('udp')
+            ->setDirectConnectivity('yes')
+            ->setBrandId(1)
+            ->setCompanyId(1);
+
+        return $retailAccountDto;
+    }
+
+    /**
+     * @return RetailAccount
+     */
+    protected function addRetailAccount()
+    {
+        $retailAccountDto = $this->createDto();
+
+        /** @var RetailAccount $retailAccount */
+        $retailAccount = $this->entityTools
+            ->persistDto($retailAccountDto, null, true);
+
+        return $retailAccount;
+    }
+
+
+    protected function updateRetailAccount()
+    {
+        $retailAccountRepository = $this->em
+            ->getRepository(RetailAccount::class);
+
+        $retailAccount = $retailAccountRepository->find(1);
+
+        /** @var RetailAccountDto $retailAccountDto */
+        $retailAccountDto = $this->entityTools->entityToDto($retailAccount);
+
+        $retailAccountDto
+            ->setDirectConnectivity('no');
+
+        return $this
+            ->entityTools
+            ->persistDto($retailAccountDto, $retailAccount, true);
+    }
+
+    protected function removeRetailAccount()
+    {
+        $retailAccountRepository = $this->em
+            ->getRepository(RetailAccount::class);
+
+        $retailAccount = $retailAccountRepository->find(1);
+
+        $this
+            ->entityTools
+            ->remove($retailAccount);
+    }
+
+    /**
+     * @test
+     */
+    public function it_persists_RetailAccounts()
+    {
+        $retailAccount = $this->em
+            ->getRepository(RetailAccount::class);
+        $fixtureRetailAccounts = $retailAccount->findAll();
+
+        $this->addRetailAccount();
+
+        $brands = $retailAccount->findAll();
+        $this->assertCount(count($fixtureRetailAccounts) + 1, $brands);
+    }
+
+    /**
+     * @test
+     */
+    public function it_triggers_lifecycle_services()
+    {
+        $this->addRetailAccount();
+        $this->assetChangedEntities([
+            RetailAccount::class,
+            PsEndpoint::class
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_triggers_update_lifecycle_services()
+    {
+        $this->updateRetailAccount();
+        $this->assetChangedEntities([
+            RetailAccount::class,
+            PsEndpoint::class
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_triggers_remove_lifecycle_services()
+    {
+        $this->removeRetailAccount();
+        $this->assetChangedEntities([
+            RetailAccount::class,
+        ]);
+    }
+}

--- a/web/admin/application/configs/klear/RetailAccountsList.yaml
+++ b/web/admin/application/configs/klear/RetailAccountsList.yaml
@@ -2,6 +2,7 @@
 #include conf.d/actions.yaml
 #include conf.d/documentationLink.yaml
 #include DdisList.yaml
+#include CallForwardSettingsList.yaml
 
 production:
   main:
@@ -44,6 +45,7 @@ production:
           screens:
             retailAccountsEdit_screen: ${auth.canSeeBrand}
             ddisList_screen: true
+            callForwardSettingsList_screen: true
           dialogs:
             retailAccountsDel_dialog: ${auth.canSeeBrand}
           default: retailAccountsEdit_screen
@@ -157,6 +159,26 @@ production:
       <<: *ddisEdit_screenLink
       filterField: retailAccount
 
+    # CallForwardSettings:
+    <<: *callForwardSettings_screensLink
+    callForwardSettingsList_screen:
+      <<: *callForwardSettingsList_screenLink
+      filterField: retailAccount
+      parentOptionCustomizer:
+        - recordCount
+      forcedValues:
+        callTypeFilter: both
+    callForwardSettingsNew_screen:
+      <<: *callForwardSettingsNew_screenLink
+      filterField: retailAccount
+      forcedValues:
+        callTypeFilter: both
+    callForwardSettingsEdit_screen:
+      <<: *callForwardSettingsEdit_screenLink
+      filterField: retailAccount
+      forcedValues:
+        callTypeFilter: both
+
   dialogs: &retailAccounts_dialogsLink
     retailAccountsDel_dialog: &retailAccountsDel_dialogLink
       <<: *RetailAccounts
@@ -170,6 +192,9 @@ production:
       labelOnList: 1
 
     <<: *ddis_dialogsLink
+
+    # CallForwardSettings dialogs:
+    <<: *callForwardSettings_dialogsLink
 
   commands:
     generatePassword_command:

--- a/web/admin/application/configs/klear/model/CallForwardSettings.yaml
+++ b/web/admin/application/configs/klear/model/CallForwardSettings.yaml
@@ -47,6 +47,7 @@ production:
       required: true
       source:
         data: inline
+        filterClass: IvozProvider_Klear_Filter_CallForwardTypes
         values:
           'inconditional':
             title: _('Inconditional')

--- a/web/admin/application/library/IvozProvider/Klear/Filter/CallForwardTypes.php
+++ b/web/admin/application/library/IvozProvider/Klear/Filter/CallForwardTypes.php
@@ -5,11 +5,11 @@ use Ivoz\Provider\Domain\Model\Company\Company;
 use Ivoz\Provider\Domain\Model\Company\CompanyDto;
 
 /**
- * Class IvozProvider_Klear_Filter_TargetTypes
+ * Class IvozProvider_Klear_Filter_CallForwardTypes
  *
  * Filter Call Forward settings based on client type
  */
-class IvozProvider_Klear_Filter_TargetTypes implements KlearMatrix_Model_Field_Select_Filter_Interface
+class IvozProvider_Klear_Filter_CallForwardTypes implements KlearMatrix_Model_Field_Select_Filter_Interface
 {
 
     public function setRouteDispatcher(KlearMatrix_Model_RouteDispatcher $routeDispatcher)
@@ -34,7 +34,6 @@ class IvozProvider_Klear_Filter_TargetTypes implements KlearMatrix_Model_Field_S
             Company::class,
             $user->companyId
         );
-
         if (is_null($companyDto)) {
             // No company feature to filter by
             return [];
@@ -42,12 +41,8 @@ class IvozProvider_Klear_Filter_TargetTypes implements KlearMatrix_Model_Field_S
 
         $excludedRoutes = [];
 
-        if ($companyDto->getType() !== Company::VPBX) {
-            $excludedRoutes[] = "extension";
-        }
-
         if ($companyDto->getType() === Company::RETAIL) {
-            $excludedRoutes[] = "voicemail";
+            $excludedRoutes = ["inconditional", "busy", "noAnswer"];
         }
 
         return $excludedRoutes;

--- a/web/rest/client/features/provider/callForwardSetting/putCallForwardSetting.feature
+++ b/web/rest/client/features/provider/callForwardSetting/putCallForwardSetting.feature
@@ -79,6 +79,7 @@ Feature: Update call forward settings
                   "es": "Europa"
               }
           },
-          "residentialDevice": null
+          "residentialDevice": null,
+          "retailAccount": null
       }
     """


### PR DESCRIPTION
This PR fixes #757 (asked in several other issues such as #284).

From now on, retail account can configure an external number as fallback when they are not reachable (no answer or no registration).