### PR TITLE
kamtrunks: fix DDI recognition logic

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -887,48 +887,54 @@ route[TRANSFORMATE_WITHINDLG] {
 
 # Get incoming tranformations (sets tr_* dlg_vars)
 route[GET_TRANSFORMATIONS_IN] {
-    # Get all DDI candidates
-    sql_query("cb", "SELECT D.DDIE164, CONCAT(DP.transformationRuleSetId, 1) AS callee_in, CONCAT(DP.transformationRuleSetId, 0) AS caller_in, CONCAT(DP.transformationRuleSetId, 2) AS caller_out, CONCAT(DP.transformationRuleSetId, 3) AS callee_out FROM DDIProviderAddresses DPA INNER JOIN DDIProviders DP ON DPA.ddiProviderId=DP.id INNER JOIN DDIs D ON D.ddiProviderId=DP.id WHERE ip='$si'", "ra");
+    # Get DDI Providers by DDI and their transformation rules
+    sql_query("cb", "SELECT brandId, CONCAT(DP.transformationRuleSetId, 1) AS callee_in, CONCAT(DP.transformationRuleSetId, 0) AS caller_in, CONCAT(DP.transformationRuleSetId, 2) AS caller_out, CONCAT(DP.transformationRuleSetId, 3) AS callee_out FROM DDIProviderAddresses DPA INNER JOIN DDIProviders DP ON DPA.ddiProviderId=DP.id WHERE ip='$si'", "ra");
 
-    # Are there any candidates?
+    # Found?
     if ($dbr(ra=>rows) == 0) {
-        xwarn("[$dlg_var(cidhash)] GET-TRANSFORMATIONS-IN: $rU not recognized in any company, 404 Not Found\n");
-        send_reply("404", "Not Here");
+        xwarn("[$dlg_var(cidhash)] GET-TRANSFORMATIONS-IN: $si not recognized as a valid DDI Provider, 403 Forbidden\n");
+        send_reply("403", "Forbidden");
         exit;
-    } else {
-        xinfo("[$dlg_var(cidhash)] GET-TRANSFORMATIONS-IN: There are $dbr(ra=>rows) DDI candidates, proceed\n");
     }
 
-    # Evaluate all candidates ($rU after transformation must be equal to candidate, otherwise it is rejected)
+    # Iterate through all matching DDI Providers
     $var(i) = 0;
+    $var(found) = 0;
     while ($var(i)<$dbr(ra=>rows)) {
-        $var(candidate) = $dbr(ra=>[$var(i), 0]);
-        $var(transformation) = $dbr(ra=>[$var(i), 1]);
+        # Save transformations for further application
+        $dlg_var(tr_callee_in) = $dbr(ra=>[$var(i), 1]);
+        $dlg_var(tr_caller_in) = $dbr(ra=>[$var(i), 2]);
+        $dlg_var(tr_caller_out) = $dbr(ra=>[$var(i), 3]);
+        $dlg_var(tr_callee_out) = $dbr(ra=>[$var(i), 4]);
+
+        # Apply transformations to $rU
+        $var(transformation) = $dlg_var(tr_callee_in);
         $var(number) = $rU;
         route(APPLY_TRANSFORMATION); # Apply $var(transformation) to $var(number)
-        if ($var(transformated) == $var(candidate)) {
-            # We have a winner candidate!!
-            xinfo("[$dlg_var(cidhash)] GET-TRANSFORMATIONS-IN: Callee $rU is recognized as $var(candidate) (should be E164)\n");
 
-            # Save transformations for further application
-            $dlg_var(tr_callee_in) = $dbr(ra=>[$var(i), 1]);
-            $dlg_var(tr_caller_in) = $dbr(ra=>[$var(i), 2]);
-            $dlg_var(tr_caller_out) = $dbr(ra=>[$var(i), 3]);
-            $dlg_var(tr_callee_out) = $dbr(ra=>[$var(i), 4]);
+        # Search for DDI in brand
+        sql_query("cb", "SELECT companyId FROM DDIs WHERE DDIE164='$var(transformated)' AND brandId='$dbr(ra=>[$var(i), 0])'", "rb");
 
-            # Free and leave
-            sql_result_free("ra");
-            return;
+        # Found?
+        if ($dbr(rb=>rows) > 0) {
+            xinfo("[$dlg_var(cidhash)] GET-TRANSFORMATIONS-IN: DDI $rU recognized as $var(transformated) (b$dbr(ra=>[$var(i), 0])c$dbr(rb=>[0, 0])), proceed\n");
+            $var(found) = 1;
+            break;
         }
+
+        # Try next DDI Provider
         $var(i) = $var(i) + 1;
     }
 
     sql_result_free("ra");
+    sql_result_free("rb");
 
-    # No candidate succeeded after applying transformations
-    xwarn("[$dlg_var(cidhash)] GET-TRANSFORMATIONS-IN: No DDI candidate succeeded after applying transformations to $rU, 404 Not Found");
-    send_reply("404", "Not Here");
-    exit;
+    if ($var(found) == 0) {
+        # No candidate succeeded after applying transformations
+        xwarn("[$dlg_var(cidhash)] GET-TRANSFORMATIONS-IN: DDI '$rU' not recognized, 404 Not Found");
+        send_reply("404", "Not Here");
+        exit;
+    }
 }
 
 # This route apply transformations to rU, PAI and Diversion to E.164


### PR DESCRIPTION
This PR fixes DDI recognition current logic, that crashes if more than 100 DDIs are assigned to the same DDI Provider (loop exceeded).

New logic does:

- Gets all DDI Providers matching IP address and get their transformation sets.

- Apply transformation set to R-URI username.

- Find transformated DDI within brand's DDIs.