### PR TITLE
trunks: make bouncer optional

### DIFF
--- a/kamailio/trunks/config/custom_settings.cfg.in
+++ b/kamailio/trunks/config/custom_settings.cfg.in
@@ -1,0 +1,6 @@
+# Rename file to custom_settings.cfg to have custom settings for this particular installation
+
+# Define WITHOUT_BOUNCER to disable bouncing mechanism: all calls will be
+# delivered to carriers, even those to DDIs belonging to the platform
+#!define WITHOUT_BOUNCER
+

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -54,6 +54,8 @@ listen=tcp:IP:SIP_PORT
 listen=tls:IP:SIPS_PORT
 listen=tcp:IP:XMLRPC_PORT
 
+import_file "custom_settings.cfg"
+
 # -- Debug level
 # L_ALERT  - log level -5
 # L_BUG    - log level -4
@@ -488,6 +490,10 @@ route[IS_FROM_INSIDE] {
 }
 
 route[CHECK_BOUNCE] {
+    #!ifdef WITHOUT_BOUNCER
+        return;
+    #!endif
+
     sql_xquery("cb", "SELECT COUNT(*) > 0 AS isMine FROM DDIs WHERE DDIE164='$rU'", "ra");
     if ($xavp(ra=>isMine) == '1') {
         xinfo("[$dlg_var(cidhash)] CHECK-BOUNCE: Call is to one of my DDIs\n");
@@ -1894,4 +1900,10 @@ event_route[htable:mod-init] {
         xerr("Problems resolving users.ivozprovider.local, aborting\n");
         abort();
     }
+
+    #!ifdef WITHOUT_BOUNCER
+        xinfo("External call bouncing NOT ENABLED");
+    #!else
+        xinfo("External call bouncing ENABLED");
+    #!endif
 }


### PR DESCRIPTION
Bouncer mechanism avoids an external call to a DDI existing in DDIs table to
reach the carrier.

This commit makes this behaviour optional, so that all outgoing DDIs reach a
carrier, even those to DDIs belonging to the platform.