### PR TITLE
doc: use pai for caller and do not use pcre in friends

### DIFF
--- a/doc/sphinx/administration_portal/client/residential/residential_devices.rst
+++ b/doc/sphinx/administration_portal/client/residential/residential_devices.rst
@@ -135,9 +135,11 @@ Device peer
     secret=device-password
     fromdomain=ivozprovider-brand.sip-domain.com
     insecure=port,invite
+    sendrpid=pai
 
 .. warning:: *Residential devices* MUST NOT challenge IvozProvider. That's
              why the *insecure* setting is used here.
 
+.. note:: As from username is used to identify the retail account, P-Asserted-Identity must be used to specify caller number.
 
 

--- a/doc/sphinx/administration_portal/client/retail/retail_accounts.rst
+++ b/doc/sphinx/administration_portal/client/retail/retail_accounts.rst
@@ -128,8 +128,10 @@ Account peer
     secret=account-password
     fromdomain=ivozprovider-brand.sip-domain.com
     insecure=port,invite
+    sendrpid=pai
 
 .. warning:: *Retail accounts* MUST NOT challenge IvozProvider. That's
              why the *insecure* setting is used here.
 
+.. note:: As from username is used to identify the retail account, P-Asserted-Identity must be used to specify caller number.
 

--- a/doc/sphinx/administration_portal/client/vpbx/routing_endpoints/friends.rst
+++ b/doc/sphinx/administration_portal/client/vpbx/routing_endpoints/friends.rst
@@ -148,9 +148,12 @@ peer
     secret=friend-password
     fromdomain=ivozprovider-client.sip-domain.com
     insecure=port,invite
+    sendrpid=pai
 
 .. warning:: *Friends*, like terminals, MUST NOT challenge IvozProvider. That's
              why the *insecure* setting is used here.
+
+.. note:: As from username is used to identify the friend, P-Asserted-Identity must be used to specify caller number.
 
 Summary
 =======

--- a/doc/sphinx/administration_portal/client/vpbx/routing_endpoints/friends.rst
+++ b/doc/sphinx/administration_portal/client/vpbx/routing_endpoints/friends.rst
@@ -55,6 +55,8 @@ a :ref:`friend <friends>` following this logic:
 
 3. If not: This is an external call.
 
+.. important:: Avoid PCRE regular expressions in friend configuration: use [0-9] instead of \\d.
+
 Configuration
 =============
 

--- a/doc/sphinx/locale/es/LC_MESSAGES/administration_portal.po
+++ b/doc/sphinx/locale/es/LC_MESSAGES/administration_portal.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: IvozProvider 2.7\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-02-26 16:01+0100\n"
+"POT-Creation-Date: 2019-02-28 09:31+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -4826,75 +4826,65 @@ msgid ""
 "residential device. If set to 'No', use called number instead."
 msgstr ""
 
-#: ../../administration_portal/client/residential/residential_devices.rst:80
-#: ../../administration_portal/client/vpbx/users.rst:89
-msgid "Max Calls"
-msgstr ""
-
 #: ../../administration_portal/client/residential/residential_devices.rst:82
-#: ../../administration_portal/client/vpbx/users.rst:91
-msgid "Limits the number of concurrent received calls. Set 0 for unlimited calls."
-msgstr ""
-
-#: ../../administration_portal/client/residential/residential_devices.rst:85
 #: ../../administration_portal/client/retail/retail_accounts.rst:82
 msgid "Voicemail settings"
 msgstr ""
 
-#: ../../administration_portal/client/residential/residential_devices.rst:87
+#: ../../administration_portal/client/residential/residential_devices.rst:84
 msgid ""
 "Every residential device has a voicemail that can be accessed using "
 "voicemail service code defined at brand level."
 msgstr ""
 
-#: ../../administration_portal/client/residential/residential_devices.rst:90
+#: ../../administration_portal/client/residential/residential_devices.rst:87
 #: ../../administration_portal/client/retail/retail_accounts.rst:87
 msgid "Call forwarding settings"
 msgstr ""
 
-#: ../../administration_portal/client/residential/residential_devices.rst:92
+#: ../../administration_portal/client/residential/residential_devices.rst:89
 msgid ""
 "Apart from unconditional call forwarding to external number through "
 ":ref:`External call filters` applied to DDI, residential devices may have"
 " additional call forwarding settings that allow:"
 msgstr ""
 
-#: ../../administration_portal/client/residential/residential_devices.rst:95
+#: ../../administration_portal/client/residential/residential_devices.rst:92
 msgid "Forwarding to another external number."
 msgstr ""
 
-#: ../../administration_portal/client/residential/residential_devices.rst:97
+#: ../../administration_portal/client/residential/residential_devices.rst:94
 msgid "Forwarding to voicemail associated to each residential device."
 msgstr ""
 
-#: ../../administration_portal/client/residential/residential_devices.rst:99
+#: ../../administration_portal/client/residential/residential_devices.rst:96
 msgid ""
 "Supported forwarding types: unconditional, no-answer, non-registered, "
 "busy."
 msgstr ""
 
-#: ../../administration_portal/client/residential/residential_devices.rst:101
+#: ../../administration_portal/client/residential/residential_devices.rst:98
 msgid ""
 ":ref:`External call filters` have precedence over residential devices "
 "call forwarding settings."
 msgstr ""
 
-#: ../../administration_portal/client/residential/residential_devices.rst:105
+#: ../../administration_portal/client/residential/residential_devices.rst:102
 msgid "Asterisk as a residential device"
 msgstr ""
 
-#: ../../administration_portal/client/residential/residential_devices.rst:107
+#: ../../administration_portal/client/residential/residential_devices.rst:104
 msgid ""
 "At the other end of a device can be any kind of SIP entity. This section "
 "takes as example an Asterisk PBX system using SIP channel driver that "
 "wants to connect to IvozProvider."
 msgstr ""
 
-#: ../../administration_portal/client/residential/residential_devices.rst:112
+#: ../../administration_portal/client/residential/residential_devices.rst:109
 msgid "Device register"
 msgstr ""
 
-#: ../../administration_portal/client/residential/residential_devices.rst:114
+#: ../../administration_portal/client/residential/residential_devices.rst:111
 #: ../../administration_portal/client/retail/retail_accounts.rst:107
 #: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:127
 msgid ""
@@ -4902,20 +4892,27 @@ msgid ""
 "in the platform (like a terminal will do)."
 msgstr ""
 
-#: ../../administration_portal/client/residential/residential_devices.rst:117
+#: ../../administration_portal/client/residential/residential_devices.rst:114
 #: ../../administration_portal/client/retail/retail_accounts.rst:110
 #: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:130
 msgid "Configuration will be something like this:"
 msgstr ""
 
-#: ../../administration_portal/client/residential/residential_devices.rst:124
+#: ../../administration_portal/client/residential/residential_devices.rst:121
 msgid "Device peer"
 msgstr ""
 
-#: ../../administration_portal/client/residential/residential_devices.rst:139
+#: ../../administration_portal/client/residential/residential_devices.rst:137
 msgid ""
 "*Residential devices* MUST NOT challenge IvozProvider. That's why the "
 "*insecure* setting is used here."
+msgstr ""
+
+#: ../../administration_portal/client/residential/residential_devices.rst:140
+#: ../../administration_portal/client/retail/retail_accounts.rst:136
+msgid ""
+"As from username is used to identify the retail account, P-Asserted-"
+"Identity must be used to specify caller number."
 msgstr ""
 
 #: ../../administration_portal/client/retail/calls/index.rst:5
@@ -5152,7 +5149,7 @@ msgstr ""
 msgid "Account peer"
 msgstr ""
 
-#: ../../administration_portal/client/retail/retail_accounts.rst:132
+#: ../../administration_portal/client/retail/retail_accounts.rst:133
 msgid ""
 "*Retail accounts* MUST NOT challenge IvozProvider. That's why the "
 "*insecure* setting is used here."
@@ -5881,47 +5878,53 @@ msgstr ""
 msgid "peer"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:152
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:153
 msgid ""
 "*Friends*, like terminals, MUST NOT challenge IvozProvider. That's why "
 "the *insecure* setting is used here."
 msgstr ""
 
 #: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:156
+msgid ""
+"As from username is used to identify the friend, P-Asserted-Identity must"
+" be used to specify caller number."
+msgstr ""
+
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:159
 msgid "Summary"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:158
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:161
 msgid ""
 "The key point is understanding that a *friend* has a direct relation with"
 " the extension-user-terminal trio:"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:161
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:164
 msgid "Can place calls to all internal extensions and other friends."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:163
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:166
 msgid "Can place external calls that its ACL allows"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:165
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:168
 msgid "Display their configured outgoing DDI when calling to external entities"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:167
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:170
 msgid ""
 "Never challenge IvozProvider requests (don't request authentication on "
 "received requests)"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:169
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:172
 msgid ""
 "Answers IvozProvider authentication challenges (All request from them to "
 "IvozProvider must be authenticated for security reasons)"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:172
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:175
 msgid ""
 "Only connects with *Users SIP Proxy*, like terminals. In fact, SIP "
 "traffic from friends are identical to any other user terminal traffic in "
@@ -7423,11 +7426,22 @@ msgid ""
 "still place calls."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:92
-msgid "Calls from non-granted IPs:"
+#: ../../administration_portal/client/vpbx/users.rst:89
+msgid "Max Calls"
+msgstr ""
+
+#: ../../administration_portal/client/vpbx/users.rst:91
+msgid ""
+"Limits the number of received calls if the user is handling "
+"simultaneously (inbound and outbound) more than the number set. Set 0 for"
+" unlimited calls."
 msgstr ""
 
 #: ../../administration_portal/client/vpbx/users.rst:94
+msgid "Calls from non-granted IPs:"
+msgstr ""
+
+#: ../../administration_portal/client/vpbx/users.rst:96
 msgid ""
 "Enable calling from non-granted IP addresses for this user. It limits the"
 " number of outgoing calls to avoid toll-fraud. 'None' value makes "
@@ -7435,208 +7449,208 @@ msgid ""
 ":ref:`roadwarrior_users` for further reference."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:101
+#: ../../administration_portal/client/vpbx/users.rst:103
 msgid "Voicemail"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:105
+#: ../../administration_portal/client/vpbx/users.rst:107
 msgid "VoiceMail enabled"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:107
+#: ../../administration_portal/client/vpbx/users.rst:109
 msgid ""
 "Enables or disables the **existance** of a users voicemail. This only "
 "makes the voicemail available to be routed as destination of a call "
 "forwarding."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:109
+#: ../../administration_portal/client/vpbx/users.rst:111
 msgid "Voicemail Locution"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:111
+#: ../../administration_portal/client/vpbx/users.rst:113
 msgid ""
 "If set, this locution is played as voicemail welcome message when a "
 "voicemail for this user is going to be recorded. This only applies for "
 "call forwards to voicemail."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:114
+#: ../../administration_portal/client/vpbx/users.rst:116
 msgid "Email notification"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:116
+#: ../../administration_portal/client/vpbx/users.rst:118
 msgid ""
 "Send an email to the configured user address when a new voicemail is "
 "received."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:118
+#: ../../administration_portal/client/vpbx/users.rst:120
 msgid "Attach sounds:"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:120
+#: ../../administration_portal/client/vpbx/users.rst:122
 msgid "Attach the audio message to the sent email."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:122
+#: ../../administration_portal/client/vpbx/users.rst:124
 msgid ""
 "If voicemail locution is not assigned, default locution will be used as "
 "long as the user has not recorded a custom message through the voicemail "
 "menu (calling to voicemail service code)."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:128
+#: ../../administration_portal/client/vpbx/users.rst:130
 msgid "Boss-Assistant"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:130
+#: ../../administration_portal/client/vpbx/users.rst:132
 msgid ""
 "This feature will turn the user into a boss that can only be directly "
 "call by:"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:132
+#: ../../administration_portal/client/vpbx/users.rst:134
 msgid "The selected assistant."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:134
+#: ../../administration_portal/client/vpbx/users.rst:136
 msgid "Any origin that matches the white list."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:136
+#: ../../administration_portal/client/vpbx/users.rst:138
 msgid "The rest of the calls to *a boss* will be redirected to the assistant."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:139
+#: ../../administration_portal/client/vpbx/users.rst:141
 msgid "Is boss"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:141
+#: ../../administration_portal/client/vpbx/users.rst:143
 msgid "Determines if this user is a boss."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:142
+#: ../../administration_portal/client/vpbx/users.rst:144
 msgid "Assistant"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:144
+#: ../../administration_portal/client/vpbx/users.rst:146
 msgid "Who will receive the redirected calls of this boss."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:145
+#: ../../administration_portal/client/vpbx/users.rst:147
 msgid "Whitelist"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:147
+#: ../../administration_portal/client/vpbx/users.rst:149
 msgid ""
 ":ref:`match_lists` with origins that are allowed to call directly to the "
 "boss."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:150
+#: ../../administration_portal/client/vpbx/users.rst:152
 msgid ""
 "With the setup in the image, every call to *Alice* will be redirected to "
 "*Bob*, except the ones placed by *Bob* itself and those coming from any "
 "origin that matches *Alice's friends* matchlist."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:156
+#: ../../administration_portal/client/vpbx/users.rst:158
 msgid "Group Configuration"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:158
+#: ../../administration_portal/client/vpbx/users.rst:160
 msgid ""
 "As described in the sections :ref:`huntgroups` and :ref:`capture_groups`,"
 " the user can be part of one or more hunt groups and pickup groups."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:161
+#: ../../administration_portal/client/vpbx/users.rst:163
 msgid ""
 "Those groups can be configured from the sections :ref:`huntgroups` and "
 ":ref:`capture_groups` or the user's screen if the groups already exists."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:164
+#: ../../administration_portal/client/vpbx/users.rst:166
 msgid ""
 "You can also configure the user's **hunt groups** from the icon in each "
 "user line of the users list."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:169
+#: ../../administration_portal/client/vpbx/users.rst:171
 msgid "User Call Forward"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:171
+#: ../../administration_portal/client/vpbx/users.rst:173
 msgid ""
 "The user's call forward can be configured with the **List of call forward"
 " settings**  button."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:173
+#: ../../administration_portal/client/vpbx/users.rst:175
 msgid "These are the fields and available values:"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:176
+#: ../../administration_portal/client/vpbx/users.rst:178
 msgid "Call Type"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:178
+#: ../../administration_portal/client/vpbx/users.rst:180
 msgid ""
 "Determines if the forward must be applied to external, internal or any "
 "type of call."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:180
+#: ../../administration_portal/client/vpbx/users.rst:182
 msgid "Forward type"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:189
+#: ../../administration_portal/client/vpbx/users.rst:191
 msgid "When this forward must be applied:"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:183
+#: ../../administration_portal/client/vpbx/users.rst:185
 msgid "Unconditional: always"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:184
+#: ../../administration_portal/client/vpbx/users.rst:186
 msgid "No answer: when the call is not answered in X seconds"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:185
+#: ../../administration_portal/client/vpbx/users.rst:187
 msgid ""
 "Busy: When the user is talking to someone (and call waiting is disabled),"
 " when *Do not disturb* is enabled or when the user rejects an incoming "
 "call."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:188
+#: ../../administration_portal/client/vpbx/users.rst:190
 msgid ""
 "Not registered: when the user SIP terminal is not registered against "
 "IvozProvider."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:190
+#: ../../administration_portal/client/vpbx/users.rst:192
 msgid "Target type"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:194
+#: ../../administration_portal/client/vpbx/users.rst:196
 msgid "What route will use the forwarded call."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:193
+#: ../../administration_portal/client/vpbx/users.rst:195
 msgid "VoiceMail"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:194
+#: ../../administration_portal/client/vpbx/users.rst:196
 msgid "Number (external)"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:195
+#: ../../administration_portal/client/vpbx/users.rst:197
 msgid "Extension (internal)"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:197
+#: ../../administration_portal/client/vpbx/users.rst:199
 msgid ""
 "If we want to forward to other process, we can create an extension routed"
 " to that object and use the target type *Extension*."

--- a/doc/sphinx/locale/es/LC_MESSAGES/administration_portal.po
+++ b/doc/sphinx/locale/es/LC_MESSAGES/administration_portal.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: IvozProvider 2.7\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-02-28 09:31+0100\n"
+"POT-Creation-Date: 2019-02-28 09:55+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -49,7 +49,7 @@ msgstr ""
 #: ../../administration_portal/client/retail/retail_accounts.rst:43
 #: ../../administration_portal/client/vpbx/faxes.rst:24
 #: ../../administration_portal/client/vpbx/routing_endpoints/conference_rooms.rst:22
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:69
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:71
 #: ../../administration_portal/client/vpbx/routing_endpoints/hunt_groups.rst:13
 #: ../../administration_portal/client/vpbx/routing_endpoints/ivrs.rst:21
 #: ../../administration_portal/client/vpbx/routing_endpoints/queues.rst:26
@@ -75,7 +75,7 @@ msgstr ""
 #: ../../administration_portal/brand/settings/numeric_transformations.rst:96
 #: ../../administration_portal/client/residential/residential_devices.rst:48
 #: ../../administration_portal/client/retail/retail_accounts.rst:48
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:73
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:75
 #: ../../administration_portal/client/vpbx/routing_endpoints/hunt_groups.rst:16
 #: ../../administration_portal/client/vpbx/routing_tools/route_locks.rst:24
 msgid "Description"
@@ -2916,7 +2916,7 @@ msgstr ""
 #: ../../administration_portal/brand/providers/ddi_providers.rst:65
 #: ../../administration_portal/client/residential/residential_devices.rst:51
 #: ../../administration_portal/client/retail/retail_accounts.rst:51
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:81
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:83
 #: ../../administration_portal/client/vpbx/terminals.rst:19
 #: ../../administration_portal/client/vpbx/users.rst:50
 #: ../../administration_portal/platform/main_operators.rst:14
@@ -3071,7 +3071,7 @@ msgid ""
 msgstr ""
 
 #: ../../administration_portal/brand/routing/outgoing_routings.rst:26
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:76
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:78
 msgid "Priority"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgstr ""
 
 #: ../../administration_portal/client/residential/residential_devices.rst:65
 #: ../../administration_portal/client/retail/retail_accounts.rst:62
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:94
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:96
 msgid "Fallback Outgoing DDI"
 msgstr ""
 
@@ -4804,7 +4804,7 @@ msgstr ""
 
 #: ../../administration_portal/client/residential/residential_devices.rst:72
 #: ../../administration_portal/client/retail/retail_accounts.rst:66
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:104
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:106
 msgid "From domain"
 msgstr ""
 
@@ -4816,7 +4816,7 @@ msgstr ""
 
 #: ../../administration_portal/client/residential/residential_devices.rst:76
 #: ../../administration_portal/client/retail/retail_accounts.rst:70
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:108
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:110
 msgid "DDI In"
 msgstr ""
 
@@ -4826,89 +4826,99 @@ msgid ""
 "residential device. If set to 'No', use called number instead."
 msgstr ""
 
+#: ../../administration_portal/client/residential/residential_devices.rst:80
+#: ../../administration_portal/client/vpbx/users.rst:89
+msgid "Max Calls"
+msgstr ""
+
 #: ../../administration_portal/client/residential/residential_devices.rst:82
+#: ../../administration_portal/client/vpbx/users.rst:91
+msgid "Limits the number of concurrent received calls. Set 0 for unlimited calls."
+msgstr ""
+
+#: ../../administration_portal/client/residential/residential_devices.rst:85
 #: ../../administration_portal/client/retail/retail_accounts.rst:82
 msgid "Voicemail settings"
 msgstr ""
 
-#: ../../administration_portal/client/residential/residential_devices.rst:84
+#: ../../administration_portal/client/residential/residential_devices.rst:87
 msgid ""
 "Every residential device has a voicemail that can be accessed using "
 "voicemail service code defined at brand level."
 msgstr ""
 
-#: ../../administration_portal/client/residential/residential_devices.rst:87
+#: ../../administration_portal/client/residential/residential_devices.rst:90
 #: ../../administration_portal/client/retail/retail_accounts.rst:87
 msgid "Call forwarding settings"
 msgstr ""
 
-#: ../../administration_portal/client/residential/residential_devices.rst:89
+#: ../../administration_portal/client/residential/residential_devices.rst:92
 msgid ""
 "Apart from unconditional call forwarding to external number through "
 ":ref:`External call filters` applied to DDI, residential devices may have"
 " additional call forwarding settings that allow:"
 msgstr ""
 
-#: ../../administration_portal/client/residential/residential_devices.rst:92
+#: ../../administration_portal/client/residential/residential_devices.rst:95
 msgid "Forwarding to another external number."
 msgstr ""
 
-#: ../../administration_portal/client/residential/residential_devices.rst:94
+#: ../../administration_portal/client/residential/residential_devices.rst:97
 msgid "Forwarding to voicemail associated to each residential device."
 msgstr ""
 
-#: ../../administration_portal/client/residential/residential_devices.rst:96
+#: ../../administration_portal/client/residential/residential_devices.rst:99
 msgid ""
 "Supported forwarding types: unconditional, no-answer, non-registered, "
 "busy."
 msgstr ""
 
-#: ../../administration_portal/client/residential/residential_devices.rst:98
+#: ../../administration_portal/client/residential/residential_devices.rst:101
 msgid ""
 ":ref:`External call filters` have precedence over residential devices "
 "call forwarding settings."
 msgstr ""
 
-#: ../../administration_portal/client/residential/residential_devices.rst:102
+#: ../../administration_portal/client/residential/residential_devices.rst:105
 msgid "Asterisk as a residential device"
 msgstr ""
 
-#: ../../administration_portal/client/residential/residential_devices.rst:104
+#: ../../administration_portal/client/residential/residential_devices.rst:107
 msgid ""
 "At the other end of a device can be any kind of SIP entity. This section "
 "takes as example an Asterisk PBX system using SIP channel driver that "
 "wants to connect to IvozProvider."
 msgstr ""
 
-#: ../../administration_portal/client/residential/residential_devices.rst:109
+#: ../../administration_portal/client/residential/residential_devices.rst:112
 msgid "Device register"
 msgstr ""
 
-#: ../../administration_portal/client/residential/residential_devices.rst:111
+#: ../../administration_portal/client/residential/residential_devices.rst:114
 #: ../../administration_portal/client/retail/retail_accounts.rst:107
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:127
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:129
 msgid ""
 "If the system can not be directly access, Asterisk will have to register "
 "in the platform (like a terminal will do)."
 msgstr ""
 
-#: ../../administration_portal/client/residential/residential_devices.rst:114
+#: ../../administration_portal/client/residential/residential_devices.rst:117
 #: ../../administration_portal/client/retail/retail_accounts.rst:110
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:130
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:132
 msgid "Configuration will be something like this:"
 msgstr ""
 
-#: ../../administration_portal/client/residential/residential_devices.rst:121
+#: ../../administration_portal/client/residential/residential_devices.rst:124
 msgid "Device peer"
 msgstr ""
 
-#: ../../administration_portal/client/residential/residential_devices.rst:137
+#: ../../administration_portal/client/residential/residential_devices.rst:140
 msgid ""
 "*Residential devices* MUST NOT challenge IvozProvider. That's why the "
 "*insecure* setting is used here."
 msgstr ""
 
-#: ../../administration_portal/client/residential/residential_devices.rst:140
+#: ../../administration_portal/client/residential/residential_devices.rst:143
 #: ../../administration_portal/client/retail/retail_accounts.rst:136
 msgid ""
 "As from username is used to identify the retail account, P-Asserted-"
@@ -5751,180 +5761,186 @@ msgstr ""
 msgid "If not: This is an external call."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:59
-msgid "Configuration"
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:58
+msgid ""
+"Avoid PCRE regular expressions in friend configuration: use [0-9] instead"
+" of \\\\d."
 msgstr ""
 
 #: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:61
+msgid "Configuration"
+msgstr ""
+
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:63
 msgid ""
 "The **Friend** configuration is a merge between a **User** and a "
 "**Terminal**"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:63
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:65
 msgid ""
 "**Friends** are so similar to **Users** that both talk SIP with the "
 ":ref:`proxyusers`."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:66
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:68
 msgid "This are the configurable settings of *friends*:"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:71
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:73
 msgid ""
 "Name of the **friend**, like in **Terminals**. This will also be used in "
 "SIP messages (sent **From User**)."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:75
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:77
 msgid "Optional. Extra information for this **friend**."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:78
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:80
 msgid ""
 "Used to solve conflicts while routing calls through **friends**. If a "
 "call destination **matches** more than one friend regular expression the "
 "call will be routed through the friend with **less priority value**."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:83
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:85
 msgid ""
 "When the *friend* send requests, IvozProvider will authenticate it using "
 "this password. Like in terminals **using password IS A MUST**."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:85
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:87
 msgid "Direct connection"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:87
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:89
 msgid ""
 "If you choose 'Yes' here, you'll have to fill the protocol, address and "
 "port where this *friend* can be contacted."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:89
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:91
 #: ../../administration_portal/client/vpbx/user_configuration/call_acls.rst:40
 #: ../../administration_portal/client/vpbx/users.rst:81
 msgid "Call ACL"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:91
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:93
 msgid ""
 "Similar to :ref:`internal users <users>`, friends can place internal "
 "client calls without restriction (including Extension or other Friends). "
 "When calling to external numbers, this ACL will be checked if set."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:96
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:98
 msgid ""
 "External calls from this *friend* will be presented with this DDI, "
 "**unless the source presented by friend is a DDI that exists in DDIs "
 "section**."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:98
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:100
 msgid "Country and Area code"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:100
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:102
 msgid "Used for number transformation from and to this friend."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:101
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:103
 msgid "Allowed codecs"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:103
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:105
 msgid "Like a terminal, *friends* will talk the selected codec."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:106
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:108
 msgid ""
 "Request from IvozProvider to this friend will include this domain in the "
 "From header."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:110
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:112
 msgid ""
 "If set to 'Yes', use endpoint username in R-URI when calling this friend."
 " If set to 'No', use called number instead."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:113
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:115
 msgid ""
 "Calls to *friends* are considered internal. That means that ACLs won't be"
 " checked when calling a friend, no matter if the origin of the call is a "
 "user or another friend."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:118
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:120
 msgid "Asterisk as a friend"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:120
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:122
 msgid ""
 "At the other end of a friend can be any kind of SIP entity. This section "
 "takes as example an Asterisk PBX system using SIP channel driver that "
 "wants to connect to IvozProvider."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:125
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:127
 msgid "register"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:137
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:139
 msgid "peer"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:153
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:155
 msgid ""
 "*Friends*, like terminals, MUST NOT challenge IvozProvider. That's why "
 "the *insecure* setting is used here."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:156
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:158
 msgid ""
 "As from username is used to identify the friend, P-Asserted-Identity must"
 " be used to specify caller number."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:159
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:161
 msgid "Summary"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:161
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:163
 msgid ""
 "The key point is understanding that a *friend* has a direct relation with"
 " the extension-user-terminal trio:"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:164
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:166
 msgid "Can place calls to all internal extensions and other friends."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:166
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:168
 msgid "Can place external calls that its ACL allows"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:168
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:170
 msgid "Display their configured outgoing DDI when calling to external entities"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:170
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:172
 msgid ""
 "Never challenge IvozProvider requests (don't request authentication on "
 "received requests)"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:172
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:174
 msgid ""
 "Answers IvozProvider authentication challenges (All request from them to "
 "IvozProvider must be authenticated for security reasons)"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:175
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends.rst:177
 msgid ""
 "Only connects with *Users SIP Proxy*, like terminals. In fact, SIP "
 "traffic from friends are identical to any other user terminal traffic in "
@@ -7426,22 +7442,11 @@ msgid ""
 "still place calls."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:89
-msgid "Max Calls"
-msgstr ""
-
-#: ../../administration_portal/client/vpbx/users.rst:91
-msgid ""
-"Limits the number of received calls if the user is handling "
-"simultaneously (inbound and outbound) more than the number set. Set 0 for"
-" unlimited calls."
-msgstr ""
-
-#: ../../administration_portal/client/vpbx/users.rst:94
+#: ../../administration_portal/client/vpbx/users.rst:92
 msgid "Calls from non-granted IPs:"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:96
+#: ../../administration_portal/client/vpbx/users.rst:94
 msgid ""
 "Enable calling from non-granted IP addresses for this user. It limits the"
 " number of outgoing calls to avoid toll-fraud. 'None' value makes "
@@ -7449,208 +7454,208 @@ msgid ""
 ":ref:`roadwarrior_users` for further reference."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:103
+#: ../../administration_portal/client/vpbx/users.rst:101
 msgid "Voicemail"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:107
+#: ../../administration_portal/client/vpbx/users.rst:105
 msgid "VoiceMail enabled"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:109
+#: ../../administration_portal/client/vpbx/users.rst:107
 msgid ""
 "Enables or disables the **existance** of a users voicemail. This only "
 "makes the voicemail available to be routed as destination of a call "
 "forwarding."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:111
+#: ../../administration_portal/client/vpbx/users.rst:109
 msgid "Voicemail Locution"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:113
+#: ../../administration_portal/client/vpbx/users.rst:111
 msgid ""
 "If set, this locution is played as voicemail welcome message when a "
 "voicemail for this user is going to be recorded. This only applies for "
 "call forwards to voicemail."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:116
+#: ../../administration_portal/client/vpbx/users.rst:114
 msgid "Email notification"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:118
+#: ../../administration_portal/client/vpbx/users.rst:116
 msgid ""
 "Send an email to the configured user address when a new voicemail is "
 "received."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:120
+#: ../../administration_portal/client/vpbx/users.rst:118
 msgid "Attach sounds:"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:122
+#: ../../administration_portal/client/vpbx/users.rst:120
 msgid "Attach the audio message to the sent email."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:124
+#: ../../administration_portal/client/vpbx/users.rst:122
 msgid ""
 "If voicemail locution is not assigned, default locution will be used as "
 "long as the user has not recorded a custom message through the voicemail "
 "menu (calling to voicemail service code)."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:130
+#: ../../administration_portal/client/vpbx/users.rst:128
 msgid "Boss-Assistant"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:132
+#: ../../administration_portal/client/vpbx/users.rst:130
 msgid ""
 "This feature will turn the user into a boss that can only be directly "
 "call by:"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:134
+#: ../../administration_portal/client/vpbx/users.rst:132
 msgid "The selected assistant."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:136
+#: ../../administration_portal/client/vpbx/users.rst:134
 msgid "Any origin that matches the white list."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:138
+#: ../../administration_portal/client/vpbx/users.rst:136
 msgid "The rest of the calls to *a boss* will be redirected to the assistant."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:141
+#: ../../administration_portal/client/vpbx/users.rst:139
 msgid "Is boss"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:143
+#: ../../administration_portal/client/vpbx/users.rst:141
 msgid "Determines if this user is a boss."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:144
+#: ../../administration_portal/client/vpbx/users.rst:142
 msgid "Assistant"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:146
+#: ../../administration_portal/client/vpbx/users.rst:144
 msgid "Who will receive the redirected calls of this boss."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:147
+#: ../../administration_portal/client/vpbx/users.rst:145
 msgid "Whitelist"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:149
+#: ../../administration_portal/client/vpbx/users.rst:147
 msgid ""
 ":ref:`match_lists` with origins that are allowed to call directly to the "
 "boss."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:152
+#: ../../administration_portal/client/vpbx/users.rst:150
 msgid ""
 "With the setup in the image, every call to *Alice* will be redirected to "
 "*Bob*, except the ones placed by *Bob* itself and those coming from any "
 "origin that matches *Alice's friends* matchlist."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:158
+#: ../../administration_portal/client/vpbx/users.rst:156
 msgid "Group Configuration"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:160
+#: ../../administration_portal/client/vpbx/users.rst:158
 msgid ""
 "As described in the sections :ref:`huntgroups` and :ref:`capture_groups`,"
 " the user can be part of one or more hunt groups and pickup groups."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:163
+#: ../../administration_portal/client/vpbx/users.rst:161
 msgid ""
 "Those groups can be configured from the sections :ref:`huntgroups` and "
 ":ref:`capture_groups` or the user's screen if the groups already exists."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:166
+#: ../../administration_portal/client/vpbx/users.rst:164
 msgid ""
 "You can also configure the user's **hunt groups** from the icon in each "
 "user line of the users list."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:171
+#: ../../administration_portal/client/vpbx/users.rst:169
 msgid "User Call Forward"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:173
+#: ../../administration_portal/client/vpbx/users.rst:171
 msgid ""
 "The user's call forward can be configured with the **List of call forward"
 " settings**  button."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:175
+#: ../../administration_portal/client/vpbx/users.rst:173
 msgid "These are the fields and available values:"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:178
+#: ../../administration_portal/client/vpbx/users.rst:176
 msgid "Call Type"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:180
+#: ../../administration_portal/client/vpbx/users.rst:178
 msgid ""
 "Determines if the forward must be applied to external, internal or any "
 "type of call."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:182
+#: ../../administration_portal/client/vpbx/users.rst:180
 msgid "Forward type"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:191
+#: ../../administration_portal/client/vpbx/users.rst:189
 msgid "When this forward must be applied:"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:185
+#: ../../administration_portal/client/vpbx/users.rst:183
 msgid "Unconditional: always"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:186
+#: ../../administration_portal/client/vpbx/users.rst:184
 msgid "No answer: when the call is not answered in X seconds"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:187
+#: ../../administration_portal/client/vpbx/users.rst:185
 msgid ""
 "Busy: When the user is talking to someone (and call waiting is disabled),"
 " when *Do not disturb* is enabled or when the user rejects an incoming "
 "call."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:190
+#: ../../administration_portal/client/vpbx/users.rst:188
 msgid ""
 "Not registered: when the user SIP terminal is not registered against "
 "IvozProvider."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:192
+#: ../../administration_portal/client/vpbx/users.rst:190
 msgid "Target type"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:196
+#: ../../administration_portal/client/vpbx/users.rst:194
 msgid "What route will use the forwarded call."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:195
+#: ../../administration_portal/client/vpbx/users.rst:193
 msgid "VoiceMail"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:196
+#: ../../administration_portal/client/vpbx/users.rst:194
 msgid "Number (external)"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:197
+#: ../../administration_portal/client/vpbx/users.rst:195
 msgid "Extension (internal)"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/users.rst:199
+#: ../../administration_portal/client/vpbx/users.rst:197
 msgid ""
 "If we want to forward to other process, we can create an extension routed"
 " to that object and use the target type *Extension*."

--- a/web/admin/application/configs/klear/model/FriendsPatterns.yaml
+++ b/web/admin/application/configs/klear/model/FriendsPatterns.yaml
@@ -26,6 +26,12 @@ production:
       type: text
       required: true
       maxLength: 255
+      info:
+        type: box
+        position: left
+        icon: help
+        label: _("Need help?")
+        text: _("Avoid PCRE regular expressions here: use [0-9] instead of \\d.")
 staging:
   _extends: production
 testing:

--- a/web/admin/application/languages/en_US/en_US.po
+++ b/web/admin/application/languages/en_US/en_US.po
@@ -203,6 +203,9 @@ msgstr[1] "Authorized sources"
 msgid "Automatic creation of rules"
 msgstr "Automatic creation of rules"
 
+msgid "Avoid PCRE regular expressions here: use [0-9] instead of \\d."
+msgstr "Avoid PCRE regular expressions here: use [0-9] instead of \\d."
+
 msgid "Balance"
 msgstr "Balance"
 

--- a/web/admin/application/languages/es_ES/es_ES.po
+++ b/web/admin/application/languages/es_ES/es_ES.po
@@ -208,6 +208,9 @@ msgstr[1] "Redes autorizadas"
 msgid "Automatic creation of rules"
 msgstr "Creación automática de reglas"
 
+msgid "Avoid PCRE regular expressions here: use [0-9] instead of \\d."
+msgstr "Evitar las expresiones regulares PCRE: utilizar [0-9] en lugar de \\d."
+
 msgid "Balance"
 msgstr "Saldo"
 


### PR DESCRIPTION
Two doc quick-fixes here:

- Use PAI to specify caller in retail/residential/friends.

- Do not use \d in friend's regexps, use [0-9].