### PR TITLE
kamusers: fix NOTIFY handling (for unsolicited MWI)

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -453,7 +453,7 @@ request_route {
     # Handle REGISTER
     route(REGISTER);
 
-    # Handle SUBSCRIBE and PUBLISH
+    # Handle NOTIFY, SUBSCRIBE and PUBLISH
     route(PRESENCE);
 
     # Set caller and callee to generate PUBLISH
@@ -517,7 +517,7 @@ route[IS_FROM_INSIDE] {
 }
 
 route[FILTER_METHODS] {
-    if (!is_method("INVITE|REGISTER|SUBSCRIBE|PUBLISH")) {
+    if (!is_method("INVITE|REGISTER|SUBSCRIBE|PUBLISH|NOTIFY")) {
         xwarn("[$dlg_var(cidhash)] FILTER-METHODS: $rm not supported for $dlg_var(type)\n");
         send_reply("501", "Not Implemented");
         exit;
@@ -1987,7 +1987,7 @@ route[RTPENGINE] {
 }
 
 route[PRESENCE] {
-    if(!is_method("PUBLISH|SUBSCRIBE")) return;
+    if(!is_method("PUBLISH|SUBSCRIBE|NOTIFY")) return;
 
     if(is_method("SUBSCRIBE") && $hdr(Event)=="message-summary") {
         send_reply("404", "No voicemail service");
@@ -2006,6 +2006,17 @@ route[PRESENCE] {
         record_route();
         handle_subscribe();
         t_release();
+    } else if(is_method("NOTIFY")) {
+        # Handle unsolicited NOTIFY messages (non-related to previous SUBSCRIBE)
+        if (!$var(is_from_inside)) {
+            xwarn("[$dlg_var(cidhash)] NOTIFY: Received $rm from not AS, 405 Method Not Allowed\n");
+            send_reply("405", "Method Not Allowed");
+            exit;
+        }
+
+        # Lookup contact and relay
+        route(LOOKUP);
+        route(RELAY);
     }
     exit;
 }


### PR DESCRIPTION
Application servers send an out-of-dialog NOTIFY message for unsolicited MWI service whenever a voicemail message is received.

This PR fixes handling of this NOTIFY request.