### PR TITLE
Strict change detection

### DIFF
--- a/library/Ivoz/Core/Domain/Model/ChangelogTrait.php
+++ b/library/Ivoz/Core/Domain/Model/ChangelogTrait.php
@@ -121,7 +121,7 @@ trait ChangelogTrait
         $changes = [];
         $currentValues = $this->__toArray();
         foreach ($currentValues as $key => $value) {
-            if ($this->_initialValues[$key] == $currentValues[$key]) {
+            if ($this->_initialValues[$key] === $currentValues[$key]) {
                 continue;
             }
 

--- a/scheme/tests/Provider/ApplicationServer/ApplicationServerLifeCycleTest.php
+++ b/scheme/tests/Provider/ApplicationServer/ApplicationServerLifeCycleTest.php
@@ -196,6 +196,9 @@ class ApplicationServerLifeCycleTest extends KernelTestCase
             [
                 'setid' => 1,
                 'destination' => 'sip:127.2.2.2:6060',
+                'flags' => 0,
+                'priority' => 0,
+                'attrs' => '',
                 'description' => 'test002',
                 'applicationServerId' => 3,
                 'id' => 3,

--- a/scheme/tests/Provider/CallCsvReport/CallCsvReportLifeCycleTest.php
+++ b/scheme/tests/Provider/CallCsvReport/CallCsvReportLifeCycleTest.php
@@ -85,6 +85,7 @@ class CallCsvReportLifeCycleTest extends KernelTestCase
                 'inDate' => '2017-12-31 23:00:00',
                 'outDate' => '2018-12-31 22:59:59',
                 'createdOn' => '2018-12-31 23:59:59',
+                'csvFileSize' => 0,
                 'csvMimeType' => 'inode/x-empty; charset=binary',
                 'csvBaseName' => 'DemoCompany-20180101-20181231.csv',
                 'companyId' => 1,

--- a/scheme/tests/Provider/Carrier/CarrierLifeCycleTest.php
+++ b/scheme/tests/Provider/Carrier/CarrierLifeCycleTest.php
@@ -144,6 +144,10 @@ class CarrierLifeCycleTest extends KernelTestCase
         $changelog = $changelogEntries[0];
 
         $diff = $changelog->getData();
+        //Skip empty default values
+        $diff = array_filter($diff, function ($value) {
+            return !empty($value);
+        });
         $this->assertArraySubset(
             [
                 'tpid' => 'b1',
@@ -187,6 +191,11 @@ class CarrierLifeCycleTest extends KernelTestCase
         $changelog = $changelogEntries[0];
 
         $diff = $changelog->getData();
+        //Skip empty default values
+        $diff = array_filter($diff, function ($value) {
+            return !empty($value);
+        });
+
         $expectedSubset = [
             'tpid' => 'b1',
             'loadid' => 'DATABASE',

--- a/scheme/tests/Provider/DdiProviderAddress/DdiProviderAddressLifeCycleTest.php
+++ b/scheme/tests/Provider/DdiProviderAddress/DdiProviderAddressLifeCycleTest.php
@@ -154,7 +154,8 @@ class DdiProviderAddressLifeCycleTest extends KernelTestCase
             'ip_addr' => '127.1.1.1',
             'mask' => 32,
             'ddiProviderAddressId' => 2,
-            'id' => 1
+            'id' => 1,
+            'port' => 0
         ];
 
         $this->assertEquals(

--- a/scheme/tests/Provider/DdiProviderRegistration/DdiProviderRegistrationLifeCycleTest.php
+++ b/scheme/tests/Provider/DdiProviderRegistration/DdiProviderRegistrationLifeCycleTest.php
@@ -160,7 +160,10 @@ class DdiProviderRegistrationLifeCycleTest extends KernelTestCase
             'expires' => 1,
             'ddiProviderRegistrationId' => 2,
             'brandId' => 1,
-            'id' => 2
+            'id' => 2,
+            'auth_ha1' => '',
+            'flags' => 0,
+            'reg_delay' => 0.
         ];
 
         $this->assertEquals(

--- a/scheme/tests/Provider/Queue/QueueLifeCycleTest.php
+++ b/scheme/tests/Provider/Queue/QueueLifeCycleTest.php
@@ -165,6 +165,7 @@ class QueueLifeCycleTest extends KernelTestCase
                 'timeout' => 1,
                 'autopause' => 'no',
                 'ringinuse' => 'no',
+                'wrapuptime' => 0,
                 'maxlen' => 5,
                 'strategy' => 'rrmemory',
                 'weight' => 5,

--- a/scheme/tests/Provider/RoutingPatternGroupsRelPattern/RoutingPatternGroupsRelPatternLifeCycleTest.php
+++ b/scheme/tests/Provider/RoutingPatternGroupsRelPattern/RoutingPatternGroupsRelPatternLifeCycleTest.php
@@ -174,6 +174,7 @@ class RoutingPatternGroupsRelPatternLifeCycleTest extends KernelTestCase
                 'lcr_id' => 1,
                 'prefix' => 'aTag+35',
                 'from_uri' => '^b1c1$',
+                'stopper' => 0,
                 'enabled' => 1,
                 'routingPatternId' => 2,
                 'outgoingRoutingId' => 1,
@@ -202,7 +203,7 @@ class RoutingPatternGroupsRelPatternLifeCycleTest extends KernelTestCase
         $this->assertEquals(
             $changelog->getData(),
             [
-                'lcr_id' => '1',
+                'lcr_id' => 1,
                 'priority' => 1,
                 'weight' => 1,
                 'ruleId' => 3,


### PR DESCRIPTION
Because a non strict comparation, some change were not being properly registered. Null to zero value change for instead. 