### PR TITLE
core: update endpoints pickupgroups when user or extension changes

### DIFF
--- a/library/Ivoz/Ast/Domain/Service/PsEndpoint/UpdateByExtension.php
+++ b/library/Ivoz/Ast/Domain/Service/PsEndpoint/UpdateByExtension.php
@@ -85,6 +85,9 @@ class UpdateByExtension implements ExtensionLifecycleEventHandlerInterface
             $endpointDto->setMailboxes($user->getVoiceMail());
         }
 
+        // Update endpoint pickup groups
+        $endpointDto->setNamedPickupGroup($user->getPickUpGroupsIds());
+
         $this->entityTools->persistDto(
             $endpointDto,
             $endpoint

--- a/library/Ivoz/Ast/Domain/Service/PsEndpoint/UpdateByUser.php
+++ b/library/Ivoz/Ast/Domain/Service/PsEndpoint/UpdateByUser.php
@@ -46,7 +46,8 @@ class UpdateByUser implements UserLifecycleEventHandlerInterface
 
         $endpointDto
             ->setCallerid($callerId)
-            ->setMailboxes($user->getVoiceMail());
+            ->setMailboxes($user->getVoiceMail())
+            ->setNamedPickupGroup($user->getPickUpGroupsIds());
 
         $this
             ->entityTools

--- a/library/spec/Ivoz/Ast/Domain/Service/PsEndpoint/UpdateByExtensionSpec.php
+++ b/library/spec/Ivoz/Ast/Domain/Service/PsEndpoint/UpdateByExtensionSpec.php
@@ -126,6 +126,14 @@ class UpdateByExtensionSpec extends ObjectBehavior
             ->setMailboxes('userVoiceMail')
             ->shouldBeCalled();
 
+        $user
+            ->getPickUpGroupsIds()
+            ->willReturn(1);
+
+        $psEndpointDto
+            ->setNamedPickupGroup(1)
+            ->shouldBeCalled();
+
         $this
             ->entityTools
             ->persistDto(

--- a/scheme/tests/Provider/Extension/ExtensionLifeCycleTest.php
+++ b/scheme/tests/Provider/Extension/ExtensionLifeCycleTest.php
@@ -223,7 +223,8 @@ class ExtensionLifeCycleTest extends KernelTestCase
                 $changelogEntry->getData(),
                 [
                     'callerid' => 'Alice Allison <104>',
-                    'mailboxes' => 'user1@company1'
+                    'mailboxes' => 'user1@company1',
+                    'named_pickup_group' => '1'
                 ]
             );
         }

--- a/scheme/tests/Provider/User/UserLifeCycleTest.php
+++ b/scheme/tests/Provider/User/UserLifeCycleTest.php
@@ -143,6 +143,7 @@ class UserLifeCycleTest extends KernelTestCase
     {
         $this->removeUser();
         $this->assetChangedEntities([
+            PsEndpoint::class,
             PickUpRelUser::class, // Orphan removal
             User::class,
             Extension::class,


### PR DESCRIPTION
For vPBX users, PsEndpoints store some Terminal and User data. When user is assigned a new Terminal, the PsEndpoint data is updated with new User related data.

This PR fixes the field PsEndpoints.named_pickup_groups that was only being updated when the user is added or removed from a PickupGroup. If this user still doesn't have a Terminal assigned, [the service in charge or filling named_pickup_group](https://github.com/irontec/ivozprovider/blob/1c280aa7cf56eec8129f9c8503ac8ad97af5d5d3/library/Ivoz/Ast/Domain/Service/PsEndpoint/UpdateByPickUpRelUser.php) won't do anything at all.

This may break some tests 0:-)