### PR TITLE
core: do not rely on entity concrete implementation constants

### DIFF
--- a/asterisk/agi/src/Agi/Action/HuntGroupAction.php
+++ b/asterisk/agi/src/Agi/Action/HuntGroupAction.php
@@ -11,12 +11,12 @@ class HuntGroupAction
 {
     /**
      * Available Hunt Group strategies
+     * @deprecated
      */
-    const RingAll       = 'ringAll';
-    const Linear        = 'linear';
-    const RoundRobin    = 'roundRobin';
-    const Random        = 'random';
-
+    const RingAll       = HuntGroupInterface::STRATEGY_RINGALL;
+    const Linear        = HuntGroupInterface::STRATEGY_LINEAR;
+    const RoundRobin    = HuntGroupInterface::STRATEGY_ROUNDROBIN;
+    const Random        = HuntGroupInterface::STRATEGY_RANDOM;
     /**
      * @var Wrapper
      */

--- a/library/Ivoz/Ast/Domain/Model/PsEndpoint/PsEndpointAbstract.php
+++ b/library/Ivoz/Ast/Domain/Model/PsEndpoint/PsEndpointAbstract.php
@@ -13,10 +13,6 @@ use Ivoz\Core\Domain\Model\EntityInterface;
  */
 abstract class PsEndpointAbstract
 {
-    const DIRECTMEDIAMETHOD_UPDATE = 'update';
-    const DIRECTMEDIAMETHOD_INVITE = 'invite';
-    const DIRECTMEDIAMETHOD_REINVITE = 'reinvite';
-
     /**
      * column: sorcery_id
      * @var string
@@ -572,9 +568,9 @@ abstract class PsEndpointAbstract
     {
         if (!is_null($directMediaMethod)) {
             Assertion::choice($directMediaMethod, [
-                self::DIRECTMEDIAMETHOD_UPDATE,
-                self::DIRECTMEDIAMETHOD_INVITE,
-                self::DIRECTMEDIAMETHOD_REINVITE
+                PsEndpointInterface::DIRECTMEDIAMETHOD_UPDATE,
+                PsEndpointInterface::DIRECTMEDIAMETHOD_INVITE,
+                PsEndpointInterface::DIRECTMEDIAMETHOD_REINVITE
             ], 'directMediaMethodvalue "%s" is not an element of the valid values: %s');
         }
 

--- a/library/Ivoz/Ast/Domain/Model/PsEndpoint/PsEndpointInterface.php
+++ b/library/Ivoz/Ast/Domain/Model/PsEndpoint/PsEndpointInterface.php
@@ -6,6 +6,11 @@ use Ivoz\Core\Domain\Model\LoggableEntityInterface;
 
 interface PsEndpointInterface extends LoggableEntityInterface
 {
+    const DIRECTMEDIAMETHOD_UPDATE = 'update';
+    const DIRECTMEDIAMETHOD_INVITE = 'invite';
+    const DIRECTMEDIAMETHOD_REINVITE = 'reinvite';
+
+
     /**
      * @codeCoverageIgnore
      * @return array

--- a/library/Ivoz/Cgr/Domain/Service/TpLcrRule/CreatedByOutgoingRouting.php
+++ b/library/Ivoz/Cgr/Domain/Service/TpLcrRule/CreatedByOutgoingRouting.php
@@ -41,7 +41,7 @@ class CreatedByOutgoingRouting implements OutgoingRoutingLifecycleEventHandlerIn
      */
     public function execute(OutgoingRoutingInterface $outgoingRouting)
     {
-        if ($outgoingRouting->getRoutingMode() != OutgoingRouting::MODE_LCR) {
+        if ($outgoingRouting->getRoutingMode() != OutgoingRoutingInterface::ROUTINGMODE_LCR) {
             return;
         }
 

--- a/library/Ivoz/Cgr/Domain/Service/TpTiming/CreatedByRatingPlan.php
+++ b/library/Ivoz/Cgr/Domain/Service/TpTiming/CreatedByRatingPlan.php
@@ -3,6 +3,7 @@
 namespace Ivoz\Cgr\Domain\Service\TpTiming;
 
 use Ivoz\Cgr\Domain\Model\TpTiming\TpTiming;
+
 use Ivoz\Core\Application\Service\EntityTools;
 use Ivoz\Provider\Domain\Model\RatingPlan\RatingPlan;
 use Ivoz\Provider\Domain\Model\RatingPlan\RatingPlanInterface;
@@ -38,7 +39,7 @@ class CreatedByRatingPlan implements RatingPlanLifecycleEventHandlerInterface
     public function execute(RatingPlanInterface $ratingPlan)
     {
         // Always timings don't have timing entity related
-        if ($ratingPlan->getTimingType() == RatingPlan::TIMING_TYPE_ALWAYS) {
+        if ($ratingPlan->getTimingType() == RatingPlanInterface::TIMINGTYPE_ALWAYS) {
             return;
         }
 

--- a/library/Ivoz/Kam/Domain/Service/TrunksLcrRuleTarget/TrunksLcrRuleTargetFactory.php
+++ b/library/Ivoz/Kam/Domain/Service/TrunksLcrRuleTarget/TrunksLcrRuleTargetFactory.php
@@ -43,7 +43,7 @@ class TrunksLcrRuleTargetFactory
         $lcrGateways = array();
 
         switch ($outgoingRouting->getRoutingMode()) {
-            case OutgoingRouting::MODE_STATIC:
+            case OutgoingRoutingInterface::ROUTINGMODE_STATIC:
                 $carrier = $outgoingRouting->getCarrier();
                 if (empty($carrier)) {
                     throw new \DomainException('Carrier not found');
@@ -57,7 +57,7 @@ class TrunksLcrRuleTargetFactory
                 }
                 break;
 
-            case OutgoingRouting::MODE_LCR:
+            case OutgoingRoutingInterface::ROUTINGMODE_LCR:
                 // Lcr Rules use special dummy gateway
                 $lcrGateways[] = $this->trunksLcrGatewayRepository->findDummyGateway();
                 break;

--- a/library/Ivoz/Provider/Domain/Model/CallAcl/CallAclAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/CallAcl/CallAclAbstract.php
@@ -13,9 +13,6 @@ use Ivoz\Core\Domain\Model\EntityInterface;
  */
 abstract class CallAclAbstract
 {
-    const DEFAULTPOLICY_ALLOW = 'allow';
-    const DEFAULTPOLICY_DENY = 'deny';
-
     /**
      * @var string
      */
@@ -209,8 +206,8 @@ abstract class CallAclAbstract
         Assertion::notNull($defaultPolicy, 'defaultPolicy value "%s" is null, but non null value was expected.');
         Assertion::maxLength($defaultPolicy, 10, 'defaultPolicy value "%s" is too long, it should have no more than %d characters, but has %d characters.');
         Assertion::choice($defaultPolicy, [
-            self::DEFAULTPOLICY_ALLOW,
-            self::DEFAULTPOLICY_DENY
+            CallAclInterface::DEFAULTPOLICY_ALLOW,
+            CallAclInterface::DEFAULTPOLICY_DENY
         ], 'defaultPolicyvalue "%s" is not an element of the valid values: %s');
 
         $this->defaultPolicy = $defaultPolicy;

--- a/library/Ivoz/Provider/Domain/Model/CallAcl/CallAclInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/CallAcl/CallAclInterface.php
@@ -8,6 +8,10 @@ use Doctrine\Common\Collections\ArrayCollection;
 
 interface CallAclInterface extends LoggableEntityInterface
 {
+    const DEFAULTPOLICY_ALLOW = 'allow';
+    const DEFAULTPOLICY_DENY = 'deny';
+
+
     /**
      * @codeCoverageIgnore
      * @return array

--- a/library/Ivoz/Provider/Domain/Model/CallAclRelMatchList/CallAclRelMatchListAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/CallAclRelMatchList/CallAclRelMatchListAbstract.php
@@ -13,9 +13,6 @@ use Ivoz\Core\Domain\Model\EntityInterface;
  */
 abstract class CallAclRelMatchListAbstract
 {
-    const POLICY_ALLOW = 'allow';
-    const POLICY_DENY = 'deny';
-
     /**
      * @var integer
      */
@@ -218,8 +215,8 @@ abstract class CallAclRelMatchListAbstract
         Assertion::notNull($policy, 'policy value "%s" is null, but non null value was expected.');
         Assertion::maxLength($policy, 25, 'policy value "%s" is too long, it should have no more than %d characters, but has %d characters.');
         Assertion::choice($policy, [
-            self::POLICY_ALLOW,
-            self::POLICY_DENY
+            CallAclRelMatchListInterface::POLICY_ALLOW,
+            CallAclRelMatchListInterface::POLICY_DENY
         ], 'policyvalue "%s" is not an element of the valid values: %s');
 
         $this->policy = $policy;

--- a/library/Ivoz/Provider/Domain/Model/CallAclRelMatchList/CallAclRelMatchListInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/CallAclRelMatchList/CallAclRelMatchListInterface.php
@@ -6,6 +6,10 @@ use Ivoz\Core\Domain\Model\LoggableEntityInterface;
 
 interface CallAclRelMatchListInterface extends LoggableEntityInterface
 {
+    const POLICY_ALLOW = 'allow';
+    const POLICY_DENY = 'deny';
+
+
     /**
      * @codeCoverageIgnore
      * @return array

--- a/library/Ivoz/Provider/Domain/Model/CallCsvScheduler/CallCsvSchedulerAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/CallCsvScheduler/CallCsvSchedulerAbstract.php
@@ -13,10 +13,6 @@ use Ivoz\Core\Domain\Model\EntityInterface;
  */
 abstract class CallCsvSchedulerAbstract
 {
-    const UNIT_DAY = 'day';
-    const UNIT_WEEK = 'week';
-    const UNIT_MONTH = 'month';
-
     /**
      * @var string
      */
@@ -275,9 +271,9 @@ abstract class CallCsvSchedulerAbstract
         Assertion::notNull($unit, 'unit value "%s" is null, but non null value was expected.');
         Assertion::maxLength($unit, 30, 'unit value "%s" is too long, it should have no more than %d characters, but has %d characters.');
         Assertion::choice($unit, [
-            self::UNIT_DAY,
-            self::UNIT_WEEK,
-            self::UNIT_MONTH
+            CallCsvSchedulerInterface::UNIT_DAY,
+            CallCsvSchedulerInterface::UNIT_WEEK,
+            CallCsvSchedulerInterface::UNIT_MONTH
         ], 'unitvalue "%s" is not an element of the valid values: %s');
 
         $this->unit = $unit;

--- a/library/Ivoz/Provider/Domain/Model/CallCsvScheduler/CallCsvSchedulerInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/CallCsvScheduler/CallCsvSchedulerInterface.php
@@ -7,6 +7,11 @@ use Ivoz\Core\Domain\Model\LoggableEntityInterface;
 
 interface CallCsvSchedulerInterface extends SchedulerInterface, LoggableEntityInterface
 {
+    const UNIT_DAY = 'day';
+    const UNIT_WEEK = 'week';
+    const UNIT_MONTH = 'month';
+
+
     /**
      * @codeCoverageIgnore
      * @return array

--- a/library/Ivoz/Provider/Domain/Model/CallForwardSetting/CallForwardSettingAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/CallForwardSetting/CallForwardSettingAbstract.php
@@ -13,21 +13,6 @@ use Ivoz\Core\Domain\Model\EntityInterface;
  */
 abstract class CallForwardSettingAbstract
 {
-    const CALLTYPEFILTER_INTERNAL = 'internal';
-    const CALLTYPEFILTER_EXTERNAL = 'external';
-    const CALLTYPEFILTER_BOTH = 'both';
-
-
-    const CALLFORWARDTYPE_INCONDITIONAL = 'inconditional';
-    const CALLFORWARDTYPE_NOANSWER = 'noAnswer';
-    const CALLFORWARDTYPE_BUSY = 'busy';
-    const CALLFORWARDTYPE_USERNOTREGISTERED = 'userNotRegistered';
-
-
-    const TARGETTYPE_NUMBER = 'number';
-    const TARGETTYPE_EXTENSION = 'extension';
-    const TARGETTYPE_VOICEMAIL = 'voicemail';
-
     /**
      * comment: enum:internal|external|both
      * @var string
@@ -285,9 +270,9 @@ abstract class CallForwardSettingAbstract
         Assertion::notNull($callTypeFilter, 'callTypeFilter value "%s" is null, but non null value was expected.');
         Assertion::maxLength($callTypeFilter, 25, 'callTypeFilter value "%s" is too long, it should have no more than %d characters, but has %d characters.');
         Assertion::choice($callTypeFilter, [
-            self::CALLTYPEFILTER_INTERNAL,
-            self::CALLTYPEFILTER_EXTERNAL,
-            self::CALLTYPEFILTER_BOTH
+            CallForwardSettingInterface::CALLTYPEFILTER_INTERNAL,
+            CallForwardSettingInterface::CALLTYPEFILTER_EXTERNAL,
+            CallForwardSettingInterface::CALLTYPEFILTER_BOTH
         ], 'callTypeFiltervalue "%s" is not an element of the valid values: %s');
 
         $this->callTypeFilter = $callTypeFilter;
@@ -317,10 +302,10 @@ abstract class CallForwardSettingAbstract
         Assertion::notNull($callForwardType, 'callForwardType value "%s" is null, but non null value was expected.');
         Assertion::maxLength($callForwardType, 25, 'callForwardType value "%s" is too long, it should have no more than %d characters, but has %d characters.');
         Assertion::choice($callForwardType, [
-            self::CALLFORWARDTYPE_INCONDITIONAL,
-            self::CALLFORWARDTYPE_NOANSWER,
-            self::CALLFORWARDTYPE_BUSY,
-            self::CALLFORWARDTYPE_USERNOTREGISTERED
+            CallForwardSettingInterface::CALLFORWARDTYPE_INCONDITIONAL,
+            CallForwardSettingInterface::CALLFORWARDTYPE_NOANSWER,
+            CallForwardSettingInterface::CALLFORWARDTYPE_BUSY,
+            CallForwardSettingInterface::CALLFORWARDTYPE_USERNOTREGISTERED
         ], 'callForwardTypevalue "%s" is not an element of the valid values: %s');
 
         $this->callForwardType = $callForwardType;
@@ -350,9 +335,9 @@ abstract class CallForwardSettingAbstract
         Assertion::notNull($targetType, 'targetType value "%s" is null, but non null value was expected.');
         Assertion::maxLength($targetType, 25, 'targetType value "%s" is too long, it should have no more than %d characters, but has %d characters.');
         Assertion::choice($targetType, [
-            self::TARGETTYPE_NUMBER,
-            self::TARGETTYPE_EXTENSION,
-            self::TARGETTYPE_VOICEMAIL
+            CallForwardSettingInterface::TARGETTYPE_NUMBER,
+            CallForwardSettingInterface::TARGETTYPE_EXTENSION,
+            CallForwardSettingInterface::TARGETTYPE_VOICEMAIL
         ], 'targetTypevalue "%s" is not an element of the valid values: %s');
 
         $this->targetType = $targetType;

--- a/library/Ivoz/Provider/Domain/Model/CallForwardSetting/CallForwardSettingInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/CallForwardSetting/CallForwardSettingInterface.php
@@ -6,6 +6,22 @@ use Ivoz\Core\Domain\Model\LoggableEntityInterface;
 
 interface CallForwardSettingInterface extends LoggableEntityInterface
 {
+    const CALLTYPEFILTER_INTERNAL = 'internal';
+    const CALLTYPEFILTER_EXTERNAL = 'external';
+    const CALLTYPEFILTER_BOTH = 'both';
+
+
+    const CALLFORWARDTYPE_INCONDITIONAL = 'inconditional';
+    const CALLFORWARDTYPE_NOANSWER = 'noAnswer';
+    const CALLFORWARDTYPE_BUSY = 'busy';
+    const CALLFORWARDTYPE_USERNOTREGISTERED = 'userNotRegistered';
+
+
+    const TARGETTYPE_NUMBER = 'number';
+    const TARGETTYPE_EXTENSION = 'extension';
+    const TARGETTYPE_VOICEMAIL = 'voicemail';
+
+
     /**
      * @codeCoverageIgnore
      * @return array

--- a/library/Ivoz/Provider/Domain/Model/Codec/CodecAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Codec/CodecAbstract.php
@@ -13,9 +13,6 @@ use Ivoz\Core\Domain\Model\EntityInterface;
  */
 abstract class CodecAbstract
 {
-    const TYPE_AUDIO = 'audio';
-    const TYPE_VIDEO = 'video';
-
     /**
      * comment: enum:audio|video
      * @var string
@@ -180,8 +177,8 @@ abstract class CodecAbstract
         Assertion::notNull($type, 'type value "%s" is null, but non null value was expected.');
         Assertion::maxLength($type, 10, 'type value "%s" is too long, it should have no more than %d characters, but has %d characters.');
         Assertion::choice($type, [
-            self::TYPE_AUDIO,
-            self::TYPE_VIDEO
+            CodecInterface::TYPE_AUDIO,
+            CodecInterface::TYPE_VIDEO
         ], 'typevalue "%s" is not an element of the valid values: %s');
 
         $this->type = $type;

--- a/library/Ivoz/Provider/Domain/Model/Codec/CodecInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/Codec/CodecInterface.php
@@ -6,6 +6,10 @@ use Ivoz\Core\Domain\Model\LoggableEntityInterface;
 
 interface CodecInterface extends LoggableEntityInterface
 {
+    const TYPE_AUDIO = 'audio';
+    const TYPE_VIDEO = 'video';
+
+
     /**
      * @codeCoverageIgnore
      * @return array

--- a/library/Ivoz/Provider/Domain/Model/Company/Company.php
+++ b/library/Ivoz/Provider/Domain/Model/Company/Company.php
@@ -87,7 +87,7 @@ class Company extends CompanyAbstract implements CompanyInterface
             $this->setOnDemandRecordCode('');
         }
 
-        if ($this->getType() == Company::RETAIL) {
+        if ($this->getType() == self::TYPE_RETAIL) {
             if (!$this->getDomain()) {
                 $this->setDomain(
                     $this->getBrand()->getDomain()
@@ -95,7 +95,7 @@ class Company extends CompanyAbstract implements CompanyInterface
             }
         }
 
-        if ($this->getType() == Company::RESIDENTIAL) {
+        if ($this->getType() == self::TYPE_RESIDENTIAL) {
             if (!$this->getDomain()) {
                 $this->setDomain(
                     $this->getBrand()->getDomain()

--- a/library/Ivoz/Provider/Domain/Model/Company/CompanyAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Company/CompanyAbstract.php
@@ -13,21 +13,6 @@ use Ivoz\Core\Domain\Model\EntityInterface;
  */
 abstract class CompanyAbstract
 {
-    const TYPE_VPBX = 'vpbx';
-    const TYPE_RETAIL = 'retail';
-    const TYPE_WHOLESALE = 'wholesale';
-    const TYPE_RESIDENTIAL = 'residential';
-
-
-    const DISTRIBUTEMETHOD_STATIC = 'static';
-    const DISTRIBUTEMETHOD_RR = 'rr';
-    const DISTRIBUTEMETHOD_HASH = 'hash';
-
-
-    const BILLINGMETHOD_POSTPAID = 'postpaid';
-    const BILLINGMETHOD_PREPAID = 'prepaid';
-    const BILLINGMETHOD_PSEUDOPREPAID = 'pseudoprepaid';
-
     /**
      * comment: enum:vpbx|retail|wholesale|residential
      * @var string
@@ -506,10 +491,10 @@ abstract class CompanyAbstract
         Assertion::notNull($type, 'type value "%s" is null, but non null value was expected.');
         Assertion::maxLength($type, 25, 'type value "%s" is too long, it should have no more than %d characters, but has %d characters.');
         Assertion::choice($type, [
-            self::TYPE_VPBX,
-            self::TYPE_RETAIL,
-            self::TYPE_WHOLESALE,
-            self::TYPE_RESIDENTIAL
+            CompanyInterface::TYPE_VPBX,
+            CompanyInterface::TYPE_RETAIL,
+            CompanyInterface::TYPE_WHOLESALE,
+            CompanyInterface::TYPE_RESIDENTIAL
         ], 'typevalue "%s" is not an element of the valid values: %s');
 
         $this->type = $type;
@@ -621,9 +606,9 @@ abstract class CompanyAbstract
         Assertion::notNull($distributeMethod, 'distributeMethod value "%s" is null, but non null value was expected.');
         Assertion::maxLength($distributeMethod, 25, 'distributeMethod value "%s" is too long, it should have no more than %d characters, but has %d characters.');
         Assertion::choice($distributeMethod, [
-            self::DISTRIBUTEMETHOD_STATIC,
-            self::DISTRIBUTEMETHOD_RR,
-            self::DISTRIBUTEMETHOD_HASH
+            CompanyInterface::DISTRIBUTEMETHOD_STATIC,
+            CompanyInterface::DISTRIBUTEMETHOD_RR,
+            CompanyInterface::DISTRIBUTEMETHOD_HASH
         ], 'distributeMethodvalue "%s" is not an element of the valid values: %s');
 
         $this->distributeMethod = $distributeMethod;
@@ -990,9 +975,9 @@ abstract class CompanyAbstract
         Assertion::notNull($billingMethod, 'billingMethod value "%s" is null, but non null value was expected.');
         Assertion::maxLength($billingMethod, 25, 'billingMethod value "%s" is too long, it should have no more than %d characters, but has %d characters.');
         Assertion::choice($billingMethod, [
-            self::BILLINGMETHOD_POSTPAID,
-            self::BILLINGMETHOD_PREPAID,
-            self::BILLINGMETHOD_PSEUDOPREPAID
+            CompanyInterface::BILLINGMETHOD_POSTPAID,
+            CompanyInterface::BILLINGMETHOD_PREPAID,
+            CompanyInterface::BILLINGMETHOD_PSEUDOPREPAID
         ], 'billingMethodvalue "%s" is not an element of the valid values: %s');
 
         $this->billingMethod = $billingMethod;

--- a/library/Ivoz/Provider/Domain/Model/Company/CompanyInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/Company/CompanyInterface.php
@@ -8,6 +8,22 @@ use Doctrine\Common\Collections\ArrayCollection;
 
 interface CompanyInterface extends LoggableEntityInterface
 {
+    const TYPE_VPBX = 'vpbx';
+    const TYPE_RETAIL = 'retail';
+    const TYPE_WHOLESALE = 'wholesale';
+    const TYPE_RESIDENTIAL = 'residential';
+
+
+    const DISTRIBUTEMETHOD_STATIC = 'static';
+    const DISTRIBUTEMETHOD_RR = 'rr';
+    const DISTRIBUTEMETHOD_HASH = 'hash';
+
+
+    const BILLINGMETHOD_POSTPAID = 'postpaid';
+    const BILLINGMETHOD_PREPAID = 'prepaid';
+    const BILLINGMETHOD_PSEUDOPREPAID = 'pseudoprepaid';
+
+
     /**
      * @codeCoverageIgnore
      * @return array

--- a/library/Ivoz/Provider/Domain/Model/ConditionalRoute/ConditionalRouteAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/ConditionalRoute/ConditionalRouteAbstract.php
@@ -13,16 +13,6 @@ use Ivoz\Core\Domain\Model\EntityInterface;
  */
 abstract class ConditionalRouteAbstract
 {
-    const ROUTETYPE_USER = 'user';
-    const ROUTETYPE_NUMBER = 'number';
-    const ROUTETYPE_IVR = 'ivr';
-    const ROUTETYPE_HUNTGROUP = 'huntGroup';
-    const ROUTETYPE_VOICEMAIL = 'voicemail';
-    const ROUTETYPE_FRIEND = 'friend';
-    const ROUTETYPE_QUEUE = 'queue';
-    const ROUTETYPE_CONFERENCEROOM = 'conferenceRoom';
-    const ROUTETYPE_EXTENSION = 'extension';
-
     /**
      * @var string
      */
@@ -314,15 +304,15 @@ abstract class ConditionalRouteAbstract
         if (!is_null($routetype)) {
             Assertion::maxLength($routetype, 25, 'routetype value "%s" is too long, it should have no more than %d characters, but has %d characters.');
             Assertion::choice($routetype, [
-                self::ROUTETYPE_USER,
-                self::ROUTETYPE_NUMBER,
-                self::ROUTETYPE_IVR,
-                self::ROUTETYPE_HUNTGROUP,
-                self::ROUTETYPE_VOICEMAIL,
-                self::ROUTETYPE_FRIEND,
-                self::ROUTETYPE_QUEUE,
-                self::ROUTETYPE_CONFERENCEROOM,
-                self::ROUTETYPE_EXTENSION
+                ConditionalRouteInterface::ROUTETYPE_USER,
+                ConditionalRouteInterface::ROUTETYPE_NUMBER,
+                ConditionalRouteInterface::ROUTETYPE_IVR,
+                ConditionalRouteInterface::ROUTETYPE_HUNTGROUP,
+                ConditionalRouteInterface::ROUTETYPE_VOICEMAIL,
+                ConditionalRouteInterface::ROUTETYPE_FRIEND,
+                ConditionalRouteInterface::ROUTETYPE_QUEUE,
+                ConditionalRouteInterface::ROUTETYPE_CONFERENCEROOM,
+                ConditionalRouteInterface::ROUTETYPE_EXTENSION
             ], 'routetypevalue "%s" is not an element of the valid values: %s');
         }
 

--- a/library/Ivoz/Provider/Domain/Model/ConditionalRoute/ConditionalRouteInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/ConditionalRoute/ConditionalRouteInterface.php
@@ -8,6 +8,17 @@ use Doctrine\Common\Collections\ArrayCollection;
 
 interface ConditionalRouteInterface extends LoggableEntityInterface
 {
+    const ROUTETYPE_USER = 'user';
+    const ROUTETYPE_NUMBER = 'number';
+    const ROUTETYPE_IVR = 'ivr';
+    const ROUTETYPE_HUNTGROUP = 'huntGroup';
+    const ROUTETYPE_VOICEMAIL = 'voicemail';
+    const ROUTETYPE_FRIEND = 'friend';
+    const ROUTETYPE_QUEUE = 'queue';
+    const ROUTETYPE_CONFERENCEROOM = 'conferenceRoom';
+    const ROUTETYPE_EXTENSION = 'extension';
+
+
     /**
      * @codeCoverageIgnore
      * @return array

--- a/library/Ivoz/Provider/Domain/Model/ConditionalRoutesCondition/ConditionalRoutesConditionAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/ConditionalRoutesCondition/ConditionalRoutesConditionAbstract.php
@@ -13,16 +13,6 @@ use Ivoz\Core\Domain\Model\EntityInterface;
  */
 abstract class ConditionalRoutesConditionAbstract
 {
-    const ROUTETYPE_USER = 'user';
-    const ROUTETYPE_NUMBER = 'number';
-    const ROUTETYPE_IVR = 'ivr';
-    const ROUTETYPE_HUNTGROUP = 'huntGroup';
-    const ROUTETYPE_VOICEMAIL = 'voicemail';
-    const ROUTETYPE_FRIEND = 'friend';
-    const ROUTETYPE_QUEUE = 'queue';
-    const ROUTETYPE_CONFERENCEROOM = 'conferenceRoom';
-    const ROUTETYPE_EXTENSION = 'extension';
-
     /**
      * @var integer
      */
@@ -314,15 +304,15 @@ abstract class ConditionalRoutesConditionAbstract
         if (!is_null($routeType)) {
             Assertion::maxLength($routeType, 25, 'routeType value "%s" is too long, it should have no more than %d characters, but has %d characters.');
             Assertion::choice($routeType, [
-                self::ROUTETYPE_USER,
-                self::ROUTETYPE_NUMBER,
-                self::ROUTETYPE_IVR,
-                self::ROUTETYPE_HUNTGROUP,
-                self::ROUTETYPE_VOICEMAIL,
-                self::ROUTETYPE_FRIEND,
-                self::ROUTETYPE_QUEUE,
-                self::ROUTETYPE_CONFERENCEROOM,
-                self::ROUTETYPE_EXTENSION
+                ConditionalRoutesConditionInterface::ROUTETYPE_USER,
+                ConditionalRoutesConditionInterface::ROUTETYPE_NUMBER,
+                ConditionalRoutesConditionInterface::ROUTETYPE_IVR,
+                ConditionalRoutesConditionInterface::ROUTETYPE_HUNTGROUP,
+                ConditionalRoutesConditionInterface::ROUTETYPE_VOICEMAIL,
+                ConditionalRoutesConditionInterface::ROUTETYPE_FRIEND,
+                ConditionalRoutesConditionInterface::ROUTETYPE_QUEUE,
+                ConditionalRoutesConditionInterface::ROUTETYPE_CONFERENCEROOM,
+                ConditionalRoutesConditionInterface::ROUTETYPE_EXTENSION
             ], 'routeTypevalue "%s" is not an element of the valid values: %s');
         }
 

--- a/library/Ivoz/Provider/Domain/Model/ConditionalRoutesCondition/ConditionalRoutesConditionInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/ConditionalRoutesCondition/ConditionalRoutesConditionInterface.php
@@ -8,6 +8,17 @@ use Doctrine\Common\Collections\ArrayCollection;
 
 interface ConditionalRoutesConditionInterface extends LoggableEntityInterface
 {
+    const ROUTETYPE_USER = 'user';
+    const ROUTETYPE_NUMBER = 'number';
+    const ROUTETYPE_IVR = 'ivr';
+    const ROUTETYPE_HUNTGROUP = 'huntGroup';
+    const ROUTETYPE_VOICEMAIL = 'voicemail';
+    const ROUTETYPE_FRIEND = 'friend';
+    const ROUTETYPE_QUEUE = 'queue';
+    const ROUTETYPE_CONFERENCEROOM = 'conferenceRoom';
+    const ROUTETYPE_EXTENSION = 'extension';
+
+
     /**
      * @codeCoverageIgnore
      * @return array

--- a/library/Ivoz/Provider/Domain/Model/Ddi/DdiAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Ddi/DdiAbstract.php
@@ -13,23 +13,6 @@ use Ivoz\Core\Domain\Model\EntityInterface;
  */
 abstract class DdiAbstract
 {
-    const RECORDCALLS_NONE = 'none';
-    const RECORDCALLS_ALL = 'all';
-    const RECORDCALLS_INBOUND = 'inbound';
-    const RECORDCALLS_OUTBOUND = 'outbound';
-
-
-    const ROUTETYPE_USER = 'user';
-    const ROUTETYPE_IVR = 'ivr';
-    const ROUTETYPE_HUNTGROUP = 'huntGroup';
-    const ROUTETYPE_FAX = 'fax';
-    const ROUTETYPE_CONFERENCEROOM = 'conferenceRoom';
-    const ROUTETYPE_FRIEND = 'friend';
-    const ROUTETYPE_QUEUE = 'queue';
-    const ROUTETYPE_CONDITIONAL = 'conditional';
-    const ROUTETYPE_RESIDENTIAL = 'residential';
-    const ROUTETYPE_RETAIL = 'retail';
-
     /**
      * @var string
      */
@@ -424,10 +407,10 @@ abstract class DdiAbstract
         Assertion::notNull($recordCalls, 'recordCalls value "%s" is null, but non null value was expected.');
         Assertion::maxLength($recordCalls, 25, 'recordCalls value "%s" is too long, it should have no more than %d characters, but has %d characters.');
         Assertion::choice($recordCalls, [
-            self::RECORDCALLS_NONE,
-            self::RECORDCALLS_ALL,
-            self::RECORDCALLS_INBOUND,
-            self::RECORDCALLS_OUTBOUND
+            DdiInterface::RECORDCALLS_NONE,
+            DdiInterface::RECORDCALLS_ALL,
+            DdiInterface::RECORDCALLS_INBOUND,
+            DdiInterface::RECORDCALLS_OUTBOUND
         ], 'recordCallsvalue "%s" is not an element of the valid values: %s');
 
         $this->recordCalls = $recordCalls;
@@ -485,16 +468,16 @@ abstract class DdiAbstract
         if (!is_null($routeType)) {
             Assertion::maxLength($routeType, 25, 'routeType value "%s" is too long, it should have no more than %d characters, but has %d characters.');
             Assertion::choice($routeType, [
-                self::ROUTETYPE_USER,
-                self::ROUTETYPE_IVR,
-                self::ROUTETYPE_HUNTGROUP,
-                self::ROUTETYPE_FAX,
-                self::ROUTETYPE_CONFERENCEROOM,
-                self::ROUTETYPE_FRIEND,
-                self::ROUTETYPE_QUEUE,
-                self::ROUTETYPE_CONDITIONAL,
-                self::ROUTETYPE_RESIDENTIAL,
-                self::ROUTETYPE_RETAIL
+                DdiInterface::ROUTETYPE_USER,
+                DdiInterface::ROUTETYPE_IVR,
+                DdiInterface::ROUTETYPE_HUNTGROUP,
+                DdiInterface::ROUTETYPE_FAX,
+                DdiInterface::ROUTETYPE_CONFERENCEROOM,
+                DdiInterface::ROUTETYPE_FRIEND,
+                DdiInterface::ROUTETYPE_QUEUE,
+                DdiInterface::ROUTETYPE_CONDITIONAL,
+                DdiInterface::ROUTETYPE_RESIDENTIAL,
+                DdiInterface::ROUTETYPE_RETAIL
             ], 'routeTypevalue "%s" is not an element of the valid values: %s');
         }
 

--- a/library/Ivoz/Provider/Domain/Model/Ddi/DdiInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/Ddi/DdiInterface.php
@@ -6,6 +6,24 @@ use Ivoz\Core\Domain\Model\LoggableEntityInterface;
 
 interface DdiInterface extends LoggableEntityInterface
 {
+    const RECORDCALLS_NONE = 'none';
+    const RECORDCALLS_ALL = 'all';
+    const RECORDCALLS_INBOUND = 'inbound';
+    const RECORDCALLS_OUTBOUND = 'outbound';
+
+
+    const ROUTETYPE_USER = 'user';
+    const ROUTETYPE_IVR = 'ivr';
+    const ROUTETYPE_HUNTGROUP = 'huntGroup';
+    const ROUTETYPE_FAX = 'fax';
+    const ROUTETYPE_CONFERENCEROOM = 'conferenceRoom';
+    const ROUTETYPE_FRIEND = 'friend';
+    const ROUTETYPE_QUEUE = 'queue';
+    const ROUTETYPE_CONDITIONAL = 'conditional';
+    const ROUTETYPE_RESIDENTIAL = 'residential';
+    const ROUTETYPE_RETAIL = 'retail';
+
+
     /**
      * @codeCoverageIgnore
      * @return array

--- a/library/Ivoz/Provider/Domain/Model/DestinationRateGroup/DestinationRateGroupAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/DestinationRateGroup/DestinationRateGroupAbstract.php
@@ -13,11 +13,6 @@ use Ivoz\Core\Domain\Model\EntityInterface;
  */
 abstract class DestinationRateGroupAbstract
 {
-    const STATUS_WAITING = 'waiting';
-    const STATUS_INPROGRESS = 'inProgress';
-    const STATUS_IMPORTED = 'imported';
-    const STATUS_ERROR = 'error';
-
     /**
      * comment: enum:waiting|inProgress|imported|error
      * @var string | null
@@ -259,10 +254,10 @@ abstract class DestinationRateGroupAbstract
         if (!is_null($status)) {
             Assertion::maxLength($status, 20, 'status value "%s" is too long, it should have no more than %d characters, but has %d characters.');
             Assertion::choice($status, [
-                self::STATUS_WAITING,
-                self::STATUS_INPROGRESS,
-                self::STATUS_IMPORTED,
-                self::STATUS_ERROR
+                DestinationRateGroupInterface::STATUS_WAITING,
+                DestinationRateGroupInterface::STATUS_INPROGRESS,
+                DestinationRateGroupInterface::STATUS_IMPORTED,
+                DestinationRateGroupInterface::STATUS_ERROR
             ], 'statusvalue "%s" is not an element of the valid values: %s');
         }
 

--- a/library/Ivoz/Provider/Domain/Model/DestinationRateGroup/DestinationRateGroupInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/DestinationRateGroup/DestinationRateGroupInterface.php
@@ -9,6 +9,12 @@ use Doctrine\Common\Collections\ArrayCollection;
 
 interface DestinationRateGroupInterface extends FileContainerInterface, LoggableEntityInterface
 {
+    const STATUS_WAITING = 'waiting';
+    const STATUS_INPROGRESS = 'inProgress';
+    const STATUS_IMPORTED = 'imported';
+    const STATUS_ERROR = 'error';
+
+
     /**
      * @codeCoverageIgnore
      * @return array

--- a/library/Ivoz/Provider/Domain/Model/Extension/ExtensionAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Extension/ExtensionAbstract.php
@@ -13,15 +13,6 @@ use Ivoz\Core\Domain\Model\EntityInterface;
  */
 abstract class ExtensionAbstract
 {
-    const ROUTETYPE_USER = 'user';
-    const ROUTETYPE_NUMBER = 'number';
-    const ROUTETYPE_IVR = 'ivr';
-    const ROUTETYPE_HUNTGROUP = 'huntGroup';
-    const ROUTETYPE_CONFERENCEROOM = 'conferenceRoom';
-    const ROUTETYPE_FRIEND = 'friend';
-    const ROUTETYPE_QUEUE = 'queue';
-    const ROUTETYPE_CONDITIONAL = 'conditional';
-
     /**
      * @var string
      */
@@ -295,14 +286,14 @@ abstract class ExtensionAbstract
         if (!is_null($routeType)) {
             Assertion::maxLength($routeType, 25, 'routeType value "%s" is too long, it should have no more than %d characters, but has %d characters.');
             Assertion::choice($routeType, [
-                self::ROUTETYPE_USER,
-                self::ROUTETYPE_NUMBER,
-                self::ROUTETYPE_IVR,
-                self::ROUTETYPE_HUNTGROUP,
-                self::ROUTETYPE_CONFERENCEROOM,
-                self::ROUTETYPE_FRIEND,
-                self::ROUTETYPE_QUEUE,
-                self::ROUTETYPE_CONDITIONAL
+                ExtensionInterface::ROUTETYPE_USER,
+                ExtensionInterface::ROUTETYPE_NUMBER,
+                ExtensionInterface::ROUTETYPE_IVR,
+                ExtensionInterface::ROUTETYPE_HUNTGROUP,
+                ExtensionInterface::ROUTETYPE_CONFERENCEROOM,
+                ExtensionInterface::ROUTETYPE_FRIEND,
+                ExtensionInterface::ROUTETYPE_QUEUE,
+                ExtensionInterface::ROUTETYPE_CONDITIONAL
             ], 'routeTypevalue "%s" is not an element of the valid values: %s');
         }
 

--- a/library/Ivoz/Provider/Domain/Model/Extension/ExtensionInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/Extension/ExtensionInterface.php
@@ -8,6 +8,16 @@ use Doctrine\Common\Collections\ArrayCollection;
 
 interface ExtensionInterface extends LoggableEntityInterface
 {
+    const ROUTETYPE_USER = 'user';
+    const ROUTETYPE_NUMBER = 'number';
+    const ROUTETYPE_IVR = 'ivr';
+    const ROUTETYPE_HUNTGROUP = 'huntGroup';
+    const ROUTETYPE_CONFERENCEROOM = 'conferenceRoom';
+    const ROUTETYPE_FRIEND = 'friend';
+    const ROUTETYPE_QUEUE = 'queue';
+    const ROUTETYPE_CONDITIONAL = 'conditional';
+
+
     /**
      * @codeCoverageIgnore
      * @return array

--- a/library/Ivoz/Provider/Domain/Model/ExternalCallFilter/ExternalCallFilterAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/ExternalCallFilter/ExternalCallFilterAbstract.php
@@ -13,15 +13,6 @@ use Ivoz\Core\Domain\Model\EntityInterface;
  */
 abstract class ExternalCallFilterAbstract
 {
-    const HOLIDAYTARGETTYPE_NUMBER = 'number';
-    const HOLIDAYTARGETTYPE_EXTENSION = 'extension';
-    const HOLIDAYTARGETTYPE_VOICEMAIL = 'voicemail';
-
-
-    const OUTOFSCHEDULETARGETTYPE_NUMBER = 'number';
-    const OUTOFSCHEDULETARGETTYPE_EXTENSION = 'extension';
-    const OUTOFSCHEDULETARGETTYPE_VOICEMAIL = 'voicemail';
-
     /**
      * @var string
      */
@@ -323,9 +314,9 @@ abstract class ExternalCallFilterAbstract
         if (!is_null($holidayTargetType)) {
             Assertion::maxLength($holidayTargetType, 25, 'holidayTargetType value "%s" is too long, it should have no more than %d characters, but has %d characters.');
             Assertion::choice($holidayTargetType, [
-                self::HOLIDAYTARGETTYPE_NUMBER,
-                self::HOLIDAYTARGETTYPE_EXTENSION,
-                self::HOLIDAYTARGETTYPE_VOICEMAIL
+                ExternalCallFilterInterface::HOLIDAYTARGETTYPE_NUMBER,
+                ExternalCallFilterInterface::HOLIDAYTARGETTYPE_EXTENSION,
+                ExternalCallFilterInterface::HOLIDAYTARGETTYPE_VOICEMAIL
             ], 'holidayTargetTypevalue "%s" is not an element of the valid values: %s');
         }
 
@@ -384,9 +375,9 @@ abstract class ExternalCallFilterAbstract
         if (!is_null($outOfScheduleTargetType)) {
             Assertion::maxLength($outOfScheduleTargetType, 25, 'outOfScheduleTargetType value "%s" is too long, it should have no more than %d characters, but has %d characters.');
             Assertion::choice($outOfScheduleTargetType, [
-                self::OUTOFSCHEDULETARGETTYPE_NUMBER,
-                self::OUTOFSCHEDULETARGETTYPE_EXTENSION,
-                self::OUTOFSCHEDULETARGETTYPE_VOICEMAIL
+                ExternalCallFilterInterface::OUTOFSCHEDULETARGETTYPE_NUMBER,
+                ExternalCallFilterInterface::OUTOFSCHEDULETARGETTYPE_EXTENSION,
+                ExternalCallFilterInterface::OUTOFSCHEDULETARGETTYPE_VOICEMAIL
             ], 'outOfScheduleTargetTypevalue "%s" is not an element of the valid values: %s');
         }
 

--- a/library/Ivoz/Provider/Domain/Model/ExternalCallFilter/ExternalCallFilterInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/ExternalCallFilter/ExternalCallFilterInterface.php
@@ -8,6 +8,16 @@ use Doctrine\Common\Collections\ArrayCollection;
 
 interface ExternalCallFilterInterface extends LoggableEntityInterface
 {
+    const HOLIDAYTARGETTYPE_NUMBER = 'number';
+    const HOLIDAYTARGETTYPE_EXTENSION = 'extension';
+    const HOLIDAYTARGETTYPE_VOICEMAIL = 'voicemail';
+
+
+    const OUTOFSCHEDULETARGETTYPE_NUMBER = 'number';
+    const OUTOFSCHEDULETARGETTYPE_EXTENSION = 'extension';
+    const OUTOFSCHEDULETARGETTYPE_VOICEMAIL = 'voicemail';
+
+
     /**
      * @codeCoverageIgnore
      * @return array

--- a/library/Ivoz/Provider/Domain/Model/FaxesInOut/FaxesInOutAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/FaxesInOut/FaxesInOutAbstract.php
@@ -13,9 +13,6 @@ use Ivoz\Core\Domain\Model\EntityInterface;
  */
 abstract class FaxesInOutAbstract
 {
-    const TYPE_IN = 'In';
-    const TYPE_OUT = 'Out';
-
     /**
      * @var \DateTime
      */
@@ -338,8 +335,8 @@ abstract class FaxesInOutAbstract
         if (!is_null($type)) {
             Assertion::maxLength($type, 20, 'type value "%s" is too long, it should have no more than %d characters, but has %d characters.');
             Assertion::choice($type, [
-                self::TYPE_IN,
-                self::TYPE_OUT
+                FaxesInOutInterface::TYPE_IN,
+                FaxesInOutInterface::TYPE_OUT
             ], 'typevalue "%s" is not an element of the valid values: %s');
         }
 

--- a/library/Ivoz/Provider/Domain/Model/FaxesInOut/FaxesInOutInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/FaxesInOut/FaxesInOutInterface.php
@@ -7,6 +7,10 @@ use Ivoz\Core\Domain\Model\LoggableEntityInterface;
 
 interface FaxesInOutInterface extends FileContainerInterface, LoggableEntityInterface
 {
+    const TYPE_IN = 'In';
+    const TYPE_OUT = 'Out';
+
+
     /**
      * @codeCoverageIgnore
      * @return array

--- a/library/Ivoz/Provider/Domain/Model/Friend/FriendAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Friend/FriendAbstract.php
@@ -13,30 +13,6 @@ use Ivoz\Core\Domain\Model\EntityInterface;
  */
 abstract class FriendAbstract
 {
-    const TRANSPORT_UDP = 'udp';
-    const TRANSPORT_TCP = 'tcp';
-    const TRANSPORT_TLS = 'tls';
-
-
-    const DIRECTMEDIAMETHOD_INVITE = 'invite';
-    const DIRECTMEDIAMETHOD_UPDATE = 'update';
-
-
-    const CALLERIDUPDATEHEADER_PAI = 'pai';
-    const CALLERIDUPDATEHEADER_RPID = 'rpid';
-
-
-    const UPDATECALLERID_YES = 'yes';
-    const UPDATECALLERID_NO = 'no';
-
-
-    const DIRECTCONNECTIVITY_YES = 'yes';
-    const DIRECTCONNECTIVITY_NO = 'no';
-
-
-    const DDIIN_YES = 'yes';
-    const DDIIN_NO = 'no';
-
     /**
      * @var string
      */
@@ -460,9 +436,9 @@ abstract class FriendAbstract
         Assertion::notNull($transport, 'transport value "%s" is null, but non null value was expected.');
         Assertion::maxLength($transport, 25, 'transport value "%s" is too long, it should have no more than %d characters, but has %d characters.');
         Assertion::choice($transport, [
-            self::TRANSPORT_UDP,
-            self::TRANSPORT_TCP,
-            self::TRANSPORT_TLS
+            FriendInterface::TRANSPORT_UDP,
+            FriendInterface::TRANSPORT_TCP,
+            FriendInterface::TRANSPORT_TLS
         ], 'transportvalue "%s" is not an element of the valid values: %s');
 
         $this->transport = $transport;
@@ -686,8 +662,8 @@ abstract class FriendAbstract
     {
         Assertion::notNull($directMediaMethod, 'directMediaMethod value "%s" is null, but non null value was expected.');
         Assertion::choice($directMediaMethod, [
-            self::DIRECTMEDIAMETHOD_INVITE,
-            self::DIRECTMEDIAMETHOD_UPDATE
+            FriendInterface::DIRECTMEDIAMETHOD_INVITE,
+            FriendInterface::DIRECTMEDIAMETHOD_UPDATE
         ], 'directMediaMethodvalue "%s" is not an element of the valid values: %s');
 
         $this->directMediaMethod = $directMediaMethod;
@@ -716,8 +692,8 @@ abstract class FriendAbstract
     {
         Assertion::notNull($calleridUpdateHeader, 'calleridUpdateHeader value "%s" is null, but non null value was expected.');
         Assertion::choice($calleridUpdateHeader, [
-            self::CALLERIDUPDATEHEADER_PAI,
-            self::CALLERIDUPDATEHEADER_RPID
+            FriendInterface::CALLERIDUPDATEHEADER_PAI,
+            FriendInterface::CALLERIDUPDATEHEADER_RPID
         ], 'calleridUpdateHeadervalue "%s" is not an element of the valid values: %s');
 
         $this->calleridUpdateHeader = $calleridUpdateHeader;
@@ -746,8 +722,8 @@ abstract class FriendAbstract
     {
         Assertion::notNull($updateCallerid, 'updateCallerid value "%s" is null, but non null value was expected.');
         Assertion::choice($updateCallerid, [
-            self::UPDATECALLERID_YES,
-            self::UPDATECALLERID_NO
+            FriendInterface::UPDATECALLERID_YES,
+            FriendInterface::UPDATECALLERID_NO
         ], 'updateCalleridvalue "%s" is not an element of the valid values: %s');
 
         $this->updateCallerid = $updateCallerid;
@@ -804,8 +780,8 @@ abstract class FriendAbstract
     {
         Assertion::notNull($directConnectivity, 'directConnectivity value "%s" is null, but non null value was expected.');
         Assertion::choice($directConnectivity, [
-            self::DIRECTCONNECTIVITY_YES,
-            self::DIRECTCONNECTIVITY_NO
+            FriendInterface::DIRECTCONNECTIVITY_YES,
+            FriendInterface::DIRECTCONNECTIVITY_NO
         ], 'directConnectivityvalue "%s" is not an element of the valid values: %s');
 
         $this->directConnectivity = $directConnectivity;
@@ -834,8 +810,8 @@ abstract class FriendAbstract
     {
         Assertion::notNull($ddiIn, 'ddiIn value "%s" is null, but non null value was expected.');
         Assertion::choice($ddiIn, [
-            self::DDIIN_YES,
-            self::DDIIN_NO
+            FriendInterface::DDIIN_YES,
+            FriendInterface::DDIIN_NO
         ], 'ddiInvalue "%s" is not an element of the valid values: %s');
 
         $this->ddiIn = $ddiIn;

--- a/library/Ivoz/Provider/Domain/Model/Friend/FriendInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/Friend/FriendInterface.php
@@ -8,6 +8,31 @@ use Doctrine\Common\Collections\ArrayCollection;
 
 interface FriendInterface extends LoggableEntityInterface
 {
+    const TRANSPORT_UDP = 'udp';
+    const TRANSPORT_TCP = 'tcp';
+    const TRANSPORT_TLS = 'tls';
+
+
+    const DIRECTMEDIAMETHOD_INVITE = 'invite';
+    const DIRECTMEDIAMETHOD_UPDATE = 'update';
+
+
+    const CALLERIDUPDATEHEADER_PAI = 'pai';
+    const CALLERIDUPDATEHEADER_RPID = 'rpid';
+
+
+    const UPDATECALLERID_YES = 'yes';
+    const UPDATECALLERID_NO = 'no';
+
+
+    const DIRECTCONNECTIVITY_YES = 'yes';
+    const DIRECTCONNECTIVITY_NO = 'no';
+
+
+    const DDIIN_YES = 'yes';
+    const DDIIN_NO = 'no';
+
+
     /**
      * @codeCoverageIgnore
      * @return array

--- a/library/Ivoz/Provider/Domain/Model/HolidayDate/HolidayDateAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/HolidayDate/HolidayDateAbstract.php
@@ -13,10 +13,6 @@ use Ivoz\Core\Domain\Model\EntityInterface;
  */
 abstract class HolidayDateAbstract
 {
-    const ROUTETYPE_NUMBER = 'number';
-    const ROUTETYPE_EXTENSION = 'extension';
-    const ROUTETYPE_VOICEMAIL = 'voicemail';
-
     /**
      * @var string
      */
@@ -399,9 +395,9 @@ abstract class HolidayDateAbstract
         if (!is_null($routeType)) {
             Assertion::maxLength($routeType, 25, 'routeType value "%s" is too long, it should have no more than %d characters, but has %d characters.');
             Assertion::choice($routeType, [
-                self::ROUTETYPE_NUMBER,
-                self::ROUTETYPE_EXTENSION,
-                self::ROUTETYPE_VOICEMAIL
+                HolidayDateInterface::ROUTETYPE_NUMBER,
+                HolidayDateInterface::ROUTETYPE_EXTENSION,
+                HolidayDateInterface::ROUTETYPE_VOICEMAIL
             ], 'routeTypevalue "%s" is not an element of the valid values: %s');
         }
 

--- a/library/Ivoz/Provider/Domain/Model/HolidayDate/HolidayDateInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/HolidayDate/HolidayDateInterface.php
@@ -6,6 +6,11 @@ use Ivoz\Core\Domain\Model\LoggableEntityInterface;
 
 interface HolidayDateInterface extends LoggableEntityInterface
 {
+    const ROUTETYPE_NUMBER = 'number';
+    const ROUTETYPE_EXTENSION = 'extension';
+    const ROUTETYPE_VOICEMAIL = 'voicemail';
+
+
     /**
      * @codeCoverageIgnore
      * @return array

--- a/library/Ivoz/Provider/Domain/Model/HuntGroup/HuntGroupAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/HuntGroup/HuntGroupAbstract.php
@@ -13,16 +13,6 @@ use Ivoz\Core\Domain\Model\EntityInterface;
  */
 abstract class HuntGroupAbstract
 {
-    const STRATEGY_RINGALL = 'ringAll';
-    const STRATEGY_LINEAR = 'linear';
-    const STRATEGY_ROUNDROBIN = 'roundRobin';
-    const STRATEGY_RANDOM = 'random';
-
-
-    const NOANSWERTARGETTYPE_NUMBER = 'number';
-    const NOANSWERTARGETTYPE_EXTENSION = 'extension';
-    const NOANSWERTARGETTYPE_VOICEMAIL = 'voicemail';
-
     /**
      * @var string
      */
@@ -333,10 +323,10 @@ abstract class HuntGroupAbstract
         Assertion::notNull($strategy, 'strategy value "%s" is null, but non null value was expected.');
         Assertion::maxLength($strategy, 25, 'strategy value "%s" is too long, it should have no more than %d characters, but has %d characters.');
         Assertion::choice($strategy, [
-            self::STRATEGY_RINGALL,
-            self::STRATEGY_LINEAR,
-            self::STRATEGY_ROUNDROBIN,
-            self::STRATEGY_RANDOM
+            HuntGroupInterface::STRATEGY_RINGALL,
+            HuntGroupInterface::STRATEGY_LINEAR,
+            HuntGroupInterface::STRATEGY_ROUNDROBIN,
+            HuntGroupInterface::STRATEGY_RANDOM
         ], 'strategyvalue "%s" is not an element of the valid values: %s');
 
         $this->strategy = $strategy;
@@ -393,9 +383,9 @@ abstract class HuntGroupAbstract
         if (!is_null($noAnswerTargetType)) {
             Assertion::maxLength($noAnswerTargetType, 25, 'noAnswerTargetType value "%s" is too long, it should have no more than %d characters, but has %d characters.');
             Assertion::choice($noAnswerTargetType, [
-                self::NOANSWERTARGETTYPE_NUMBER,
-                self::NOANSWERTARGETTYPE_EXTENSION,
-                self::NOANSWERTARGETTYPE_VOICEMAIL
+                HuntGroupInterface::NOANSWERTARGETTYPE_NUMBER,
+                HuntGroupInterface::NOANSWERTARGETTYPE_EXTENSION,
+                HuntGroupInterface::NOANSWERTARGETTYPE_VOICEMAIL
             ], 'noAnswerTargetTypevalue "%s" is not an element of the valid values: %s');
         }
 

--- a/library/Ivoz/Provider/Domain/Model/HuntGroup/HuntGroupInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/HuntGroup/HuntGroupInterface.php
@@ -8,6 +8,17 @@ use Doctrine\Common\Collections\ArrayCollection;
 
 interface HuntGroupInterface extends LoggableEntityInterface
 {
+    const STRATEGY_RINGALL = 'ringAll';
+    const STRATEGY_LINEAR = 'linear';
+    const STRATEGY_ROUNDROBIN = 'roundRobin';
+    const STRATEGY_RANDOM = 'random';
+
+
+    const NOANSWERTARGETTYPE_NUMBER = 'number';
+    const NOANSWERTARGETTYPE_EXTENSION = 'extension';
+    const NOANSWERTARGETTYPE_VOICEMAIL = 'voicemail';
+
+
     /**
      * @codeCoverageIgnore
      * @return array

--- a/library/Ivoz/Provider/Domain/Model/HuntGroupsRelUser/HuntGroupsRelUser.php
+++ b/library/Ivoz/Provider/Domain/Model/HuntGroupsRelUser/HuntGroupsRelUser.php
@@ -3,6 +3,7 @@ namespace Ivoz\Provider\Domain\Model\HuntGroupsRelUser;
 
 use Ivoz\Core\Domain\Assert\Assertion;
 use Ivoz\Provider\Domain\Model\HuntGroup\HuntGroup;
+use Ivoz\Provider\Domain\Model\HuntGroup\HuntGroupInterface;
 
 /**
  * HuntGroupsRelUser
@@ -15,7 +16,7 @@ class HuntGroupsRelUser extends HuntGroupsRelUserAbstract implements HuntGroupsR
     {
         $huntGroup = $this->getHuntGroup();
 
-        if ($huntGroup->getStrategy() === HuntGroup::STRATEGY_RINGALL) {
+        if ($huntGroup->getStrategy() === HuntGroupInterface::STRATEGY_RINGALL) {
             return;
         }
 

--- a/library/Ivoz/Provider/Domain/Model/Invoice/InvoiceAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Invoice/InvoiceAbstract.php
@@ -13,11 +13,6 @@ use Ivoz\Core\Domain\Model\EntityInterface;
  */
 abstract class InvoiceAbstract
 {
-    const STATUS_WAITING = 'waiting';
-    const STATUS_PROCESSING = 'processing';
-    const STATUS_CREATED = 'created';
-    const STATUS_ERROR = 'error';
-
     /**
      * @var string | null
      */
@@ -481,10 +476,10 @@ abstract class InvoiceAbstract
         if (!is_null($status)) {
             Assertion::maxLength($status, 25, 'status value "%s" is too long, it should have no more than %d characters, but has %d characters.');
             Assertion::choice($status, [
-                self::STATUS_WAITING,
-                self::STATUS_PROCESSING,
-                self::STATUS_CREATED,
-                self::STATUS_ERROR
+                InvoiceInterface::STATUS_WAITING,
+                InvoiceInterface::STATUS_PROCESSING,
+                InvoiceInterface::STATUS_CREATED,
+                InvoiceInterface::STATUS_ERROR
             ], 'statusvalue "%s" is not an element of the valid values: %s');
         }
 

--- a/library/Ivoz/Provider/Domain/Model/Invoice/InvoiceInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/Invoice/InvoiceInterface.php
@@ -9,6 +9,12 @@ use Doctrine\Common\Collections\ArrayCollection;
 
 interface InvoiceInterface extends FileContainerInterface, LoggableEntityInterface
 {
+    const STATUS_WAITING = 'waiting';
+    const STATUS_PROCESSING = 'processing';
+    const STATUS_CREATED = 'created';
+    const STATUS_ERROR = 'error';
+
+
     /**
      * @codeCoverageIgnore
      * @return array

--- a/library/Ivoz/Provider/Domain/Model/InvoiceScheduler/InvoiceSchedulerAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/InvoiceScheduler/InvoiceSchedulerAbstract.php
@@ -13,10 +13,6 @@ use Ivoz\Core\Domain\Model\EntityInterface;
  */
 abstract class InvoiceSchedulerAbstract
 {
-    const UNIT_WEEK = 'week';
-    const UNIT_MONTH = 'month';
-    const UNIT_YEAR = 'year';
-
     /**
      * @var string
      */
@@ -293,9 +289,9 @@ abstract class InvoiceSchedulerAbstract
         Assertion::notNull($unit, 'unit value "%s" is null, but non null value was expected.');
         Assertion::maxLength($unit, 30, 'unit value "%s" is too long, it should have no more than %d characters, but has %d characters.');
         Assertion::choice($unit, [
-            self::UNIT_WEEK,
-            self::UNIT_MONTH,
-            self::UNIT_YEAR
+            InvoiceSchedulerInterface::UNIT_WEEK,
+            InvoiceSchedulerInterface::UNIT_MONTH,
+            InvoiceSchedulerInterface::UNIT_YEAR
         ], 'unitvalue "%s" is not an element of the valid values: %s');
 
         $this->unit = $unit;

--- a/library/Ivoz/Provider/Domain/Model/InvoiceScheduler/InvoiceSchedulerInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/InvoiceScheduler/InvoiceSchedulerInterface.php
@@ -9,6 +9,11 @@ use Doctrine\Common\Collections\ArrayCollection;
 
 interface InvoiceSchedulerInterface extends SchedulerInterface, LoggableEntityInterface
 {
+    const UNIT_WEEK = 'week';
+    const UNIT_MONTH = 'month';
+    const UNIT_YEAR = 'year';
+
+
     /**
      * @codeCoverageIgnore
      * @return array

--- a/library/Ivoz/Provider/Domain/Model/Ivr/IvrAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Ivr/IvrAbstract.php
@@ -13,15 +13,6 @@ use Ivoz\Core\Domain\Model\EntityInterface;
  */
 abstract class IvrAbstract
 {
-    const NOINPUTROUTETYPE_NUMBER = 'number';
-    const NOINPUTROUTETYPE_EXTENSION = 'extension';
-    const NOINPUTROUTETYPE_VOICEMAIL = 'voicemail';
-
-
-    const ERRORROUTETYPE_NUMBER = 'number';
-    const ERRORROUTETYPE_EXTENSION = 'extension';
-    const ERRORROUTETYPE_VOICEMAIL = 'voicemail';
-
     /**
      * @var string
      */
@@ -449,9 +440,9 @@ abstract class IvrAbstract
         if (!is_null($noInputRouteType)) {
             Assertion::maxLength($noInputRouteType, 25, 'noInputRouteType value "%s" is too long, it should have no more than %d characters, but has %d characters.');
             Assertion::choice($noInputRouteType, [
-                self::NOINPUTROUTETYPE_NUMBER,
-                self::NOINPUTROUTETYPE_EXTENSION,
-                self::NOINPUTROUTETYPE_VOICEMAIL
+                IvrInterface::NOINPUTROUTETYPE_NUMBER,
+                IvrInterface::NOINPUTROUTETYPE_EXTENSION,
+                IvrInterface::NOINPUTROUTETYPE_VOICEMAIL
             ], 'noInputRouteTypevalue "%s" is not an element of the valid values: %s');
         }
 
@@ -510,9 +501,9 @@ abstract class IvrAbstract
         if (!is_null($errorRouteType)) {
             Assertion::maxLength($errorRouteType, 25, 'errorRouteType value "%s" is too long, it should have no more than %d characters, but has %d characters.');
             Assertion::choice($errorRouteType, [
-                self::ERRORROUTETYPE_NUMBER,
-                self::ERRORROUTETYPE_EXTENSION,
-                self::ERRORROUTETYPE_VOICEMAIL
+                IvrInterface::ERRORROUTETYPE_NUMBER,
+                IvrInterface::ERRORROUTETYPE_EXTENSION,
+                IvrInterface::ERRORROUTETYPE_VOICEMAIL
             ], 'errorRouteTypevalue "%s" is not an element of the valid values: %s');
         }
 

--- a/library/Ivoz/Provider/Domain/Model/Ivr/IvrInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/Ivr/IvrInterface.php
@@ -8,6 +8,16 @@ use Doctrine\Common\Collections\ArrayCollection;
 
 interface IvrInterface extends LoggableEntityInterface
 {
+    const NOINPUTROUTETYPE_NUMBER = 'number';
+    const NOINPUTROUTETYPE_EXTENSION = 'extension';
+    const NOINPUTROUTETYPE_VOICEMAIL = 'voicemail';
+
+
+    const ERRORROUTETYPE_NUMBER = 'number';
+    const ERRORROUTETYPE_EXTENSION = 'extension';
+    const ERRORROUTETYPE_VOICEMAIL = 'voicemail';
+
+
     /**
      * @codeCoverageIgnore
      * @return array

--- a/library/Ivoz/Provider/Domain/Model/IvrEntry/IvrEntryAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/IvrEntry/IvrEntryAbstract.php
@@ -13,11 +13,6 @@ use Ivoz\Core\Domain\Model\EntityInterface;
  */
 abstract class IvrEntryAbstract
 {
-    const ROUTETYPE_NUMBER = 'number';
-    const ROUTETYPE_EXTENSION = 'extension';
-    const ROUTETYPE_VOICEMAIL = 'voicemail';
-    const ROUTETYPE_CONDITIONAL = 'conditional';
-
     /**
      * @var string
      */
@@ -265,10 +260,10 @@ abstract class IvrEntryAbstract
         Assertion::notNull($routeType, 'routeType value "%s" is null, but non null value was expected.');
         Assertion::maxLength($routeType, 25, 'routeType value "%s" is too long, it should have no more than %d characters, but has %d characters.');
         Assertion::choice($routeType, [
-            self::ROUTETYPE_NUMBER,
-            self::ROUTETYPE_EXTENSION,
-            self::ROUTETYPE_VOICEMAIL,
-            self::ROUTETYPE_CONDITIONAL
+            IvrEntryInterface::ROUTETYPE_NUMBER,
+            IvrEntryInterface::ROUTETYPE_EXTENSION,
+            IvrEntryInterface::ROUTETYPE_VOICEMAIL,
+            IvrEntryInterface::ROUTETYPE_CONDITIONAL
         ], 'routeTypevalue "%s" is not an element of the valid values: %s');
 
         $this->routeType = $routeType;

--- a/library/Ivoz/Provider/Domain/Model/IvrEntry/IvrEntryInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/IvrEntry/IvrEntryInterface.php
@@ -6,6 +6,12 @@ use Ivoz\Core\Domain\Model\LoggableEntityInterface;
 
 interface IvrEntryInterface extends LoggableEntityInterface
 {
+    const ROUTETYPE_NUMBER = 'number';
+    const ROUTETYPE_EXTENSION = 'extension';
+    const ROUTETYPE_VOICEMAIL = 'voicemail';
+    const ROUTETYPE_CONDITIONAL = 'conditional';
+
+
     /**
      * @codeCoverageIgnore
      * @return array

--- a/library/Ivoz/Provider/Domain/Model/Locution/LocutionAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Locution/LocutionAbstract.php
@@ -13,11 +13,6 @@ use Ivoz\Core\Domain\Model\EntityInterface;
  */
 abstract class LocutionAbstract
 {
-    const STATUS_PENDING = 'pending';
-    const STATUS_ENCODING = 'encoding';
-    const STATUS_READY = 'ready';
-    const STATUS_ERROR = 'error';
-
     /**
      * @var string
      */
@@ -265,10 +260,10 @@ abstract class LocutionAbstract
         if (!is_null($status)) {
             Assertion::maxLength($status, 20, 'status value "%s" is too long, it should have no more than %d characters, but has %d characters.');
             Assertion::choice($status, [
-                self::STATUS_PENDING,
-                self::STATUS_ENCODING,
-                self::STATUS_READY,
-                self::STATUS_ERROR
+                LocutionInterface::STATUS_PENDING,
+                LocutionInterface::STATUS_ENCODING,
+                LocutionInterface::STATUS_READY,
+                LocutionInterface::STATUS_ERROR
             ], 'statusvalue "%s" is not an element of the valid values: %s');
         }
 

--- a/library/Ivoz/Provider/Domain/Model/Locution/LocutionInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/Locution/LocutionInterface.php
@@ -7,6 +7,12 @@ use Ivoz\Core\Domain\Model\LoggableEntityInterface;
 
 interface LocutionInterface extends FileContainerInterface, LoggableEntityInterface
 {
+    const STATUS_PENDING = 'pending';
+    const STATUS_ENCODING = 'encoding';
+    const STATUS_READY = 'ready';
+    const STATUS_ERROR = 'error';
+
+
     /**
      * @codeCoverageIgnore
      * @return array

--- a/library/Ivoz/Provider/Domain/Model/MatchListPattern/MatchListPatternAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/MatchListPattern/MatchListPatternAbstract.php
@@ -13,9 +13,6 @@ use Ivoz\Core\Domain\Model\EntityInterface;
  */
 abstract class MatchListPatternAbstract
 {
-    const TYPE_NUMBER = 'number';
-    const TYPE_REGEXP = 'regexp';
-
     /**
      * @var string | null
      */
@@ -236,8 +233,8 @@ abstract class MatchListPatternAbstract
         Assertion::notNull($type, 'type value "%s" is null, but non null value was expected.');
         Assertion::maxLength($type, 10, 'type value "%s" is too long, it should have no more than %d characters, but has %d characters.');
         Assertion::choice($type, [
-            self::TYPE_NUMBER,
-            self::TYPE_REGEXP
+            MatchListPatternInterface::TYPE_NUMBER,
+            MatchListPatternInterface::TYPE_REGEXP
         ], 'typevalue "%s" is not an element of the valid values: %s');
 
         $this->type = $type;

--- a/library/Ivoz/Provider/Domain/Model/MatchListPattern/MatchListPatternInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/MatchListPattern/MatchListPatternInterface.php
@@ -6,6 +6,10 @@ use Ivoz\Core\Domain\Model\LoggableEntityInterface;
 
 interface MatchListPatternInterface extends LoggableEntityInterface
 {
+    const TYPE_NUMBER = 'number';
+    const TYPE_REGEXP = 'regexp';
+
+
     /**
      * @codeCoverageIgnore
      * @return array

--- a/library/Ivoz/Provider/Domain/Model/MusicOnHold/MusicOnHoldAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/MusicOnHold/MusicOnHoldAbstract.php
@@ -13,11 +13,6 @@ use Ivoz\Core\Domain\Model\EntityInterface;
  */
 abstract class MusicOnHoldAbstract
 {
-    const STATUS_PENDING = 'pending';
-    const STATUS_ENCODING = 'encoding';
-    const STATUS_READY = 'ready';
-    const STATUS_ERROR = 'error';
-
     /**
      * @var string
      */
@@ -274,10 +269,10 @@ abstract class MusicOnHoldAbstract
         if (!is_null($status)) {
             Assertion::maxLength($status, 20, 'status value "%s" is too long, it should have no more than %d characters, but has %d characters.');
             Assertion::choice($status, [
-                self::STATUS_PENDING,
-                self::STATUS_ENCODING,
-                self::STATUS_READY,
-                self::STATUS_ERROR
+                MusicOnHoldInterface::STATUS_PENDING,
+                MusicOnHoldInterface::STATUS_ENCODING,
+                MusicOnHoldInterface::STATUS_READY,
+                MusicOnHoldInterface::STATUS_ERROR
             ], 'statusvalue "%s" is not an element of the valid values: %s');
         }
 

--- a/library/Ivoz/Provider/Domain/Model/MusicOnHold/MusicOnHoldInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/MusicOnHold/MusicOnHoldInterface.php
@@ -7,6 +7,12 @@ use Ivoz\Core\Domain\Model\LoggableEntityInterface;
 
 interface MusicOnHoldInterface extends FileContainerInterface, LoggableEntityInterface
 {
+    const STATUS_PENDING = 'pending';
+    const STATUS_ENCODING = 'encoding';
+    const STATUS_READY = 'ready';
+    const STATUS_ERROR = 'error';
+
+
     /**
      * @codeCoverageIgnore
      * @return array

--- a/library/Ivoz/Provider/Domain/Model/NotificationTemplate/NotificationTemplateAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/NotificationTemplate/NotificationTemplateAbstract.php
@@ -13,13 +13,6 @@ use Ivoz\Core\Domain\Model\EntityInterface;
  */
 abstract class NotificationTemplateAbstract
 {
-    const TYPE_VOICEMAIL = 'voicemail';
-    const TYPE_FAX = 'fax';
-    const TYPE_LIMIT = 'limit';
-    const TYPE_LOWBALANCE = 'lowbalance';
-    const TYPE_INVOICE = 'invoice';
-    const TYPE_CALLCSV = 'callCsv';
-
     /**
      * @var string
      */
@@ -213,12 +206,12 @@ abstract class NotificationTemplateAbstract
         Assertion::notNull($type, 'type value "%s" is null, but non null value was expected.');
         Assertion::maxLength($type, 25, 'type value "%s" is too long, it should have no more than %d characters, but has %d characters.');
         Assertion::choice($type, [
-            self::TYPE_VOICEMAIL,
-            self::TYPE_FAX,
-            self::TYPE_LIMIT,
-            self::TYPE_LOWBALANCE,
-            self::TYPE_INVOICE,
-            self::TYPE_CALLCSV
+            NotificationTemplateInterface::TYPE_VOICEMAIL,
+            NotificationTemplateInterface::TYPE_FAX,
+            NotificationTemplateInterface::TYPE_LIMIT,
+            NotificationTemplateInterface::TYPE_LOWBALANCE,
+            NotificationTemplateInterface::TYPE_INVOICE,
+            NotificationTemplateInterface::TYPE_CALLCSV
         ], 'typevalue "%s" is not an element of the valid values: %s');
 
         $this->type = $type;

--- a/library/Ivoz/Provider/Domain/Model/NotificationTemplate/NotificationTemplateInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/NotificationTemplate/NotificationTemplateInterface.php
@@ -8,6 +8,14 @@ use Doctrine\Common\Collections\ArrayCollection;
 
 interface NotificationTemplateInterface extends LoggableEntityInterface
 {
+    const TYPE_VOICEMAIL = 'voicemail';
+    const TYPE_FAX = 'fax';
+    const TYPE_LIMIT = 'limit';
+    const TYPE_LOWBALANCE = 'lowbalance';
+    const TYPE_INVOICE = 'invoice';
+    const TYPE_CALLCSV = 'callCsv';
+
+
     /**
      * @codeCoverageIgnore
      * @return array

--- a/library/Ivoz/Provider/Domain/Model/NotificationTemplateContent/NotificationTemplateContentAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/NotificationTemplateContent/NotificationTemplateContentAbstract.php
@@ -13,9 +13,6 @@ use Ivoz\Core\Domain\Model\EntityInterface;
  */
 abstract class NotificationTemplateContentAbstract
 {
-    const BODYTYPE_TEXTPLAIN = 'text/plain';
-    const BODYTYPE_TEXTHTML = 'text/html';
-
     /**
      * @var string | null
      */
@@ -329,8 +326,8 @@ abstract class NotificationTemplateContentAbstract
         Assertion::notNull($bodyType, 'bodyType value "%s" is null, but non null value was expected.');
         Assertion::maxLength($bodyType, 25, 'bodyType value "%s" is too long, it should have no more than %d characters, but has %d characters.');
         Assertion::choice($bodyType, [
-            self::BODYTYPE_TEXTPLAIN,
-            self::BODYTYPE_TEXTHTML
+            NotificationTemplateContentInterface::BODYTYPE_TEXTPLAIN,
+            NotificationTemplateContentInterface::BODYTYPE_TEXTHTML
         ], 'bodyTypevalue "%s" is not an element of the valid values: %s');
 
         $this->bodyType = $bodyType;

--- a/library/Ivoz/Provider/Domain/Model/NotificationTemplateContent/NotificationTemplateContentInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/NotificationTemplateContent/NotificationTemplateContentInterface.php
@@ -6,6 +6,10 @@ use Ivoz\Core\Domain\Model\LoggableEntityInterface;
 
 interface NotificationTemplateContentInterface extends LoggableEntityInterface
 {
+    const BODYTYPE_TEXTPLAIN = 'text/plain';
+    const BODYTYPE_TEXTHTML = 'text/html';
+
+
     /**
      * @codeCoverageIgnore
      * @return array

--- a/library/Ivoz/Provider/Domain/Model/OutgoingDdiRule/OutgoingDdiRuleAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/OutgoingDdiRule/OutgoingDdiRuleAbstract.php
@@ -13,9 +13,6 @@ use Ivoz\Core\Domain\Model\EntityInterface;
  */
 abstract class OutgoingDdiRuleAbstract
 {
-    const DEFAULTACTION_KEEP = 'keep';
-    const DEFAULTACTION_FORCE = 'force';
-
     /**
      * @var string
      */
@@ -218,8 +215,8 @@ abstract class OutgoingDdiRuleAbstract
         Assertion::notNull($defaultAction, 'defaultAction value "%s" is null, but non null value was expected.');
         Assertion::maxLength($defaultAction, 10, 'defaultAction value "%s" is too long, it should have no more than %d characters, but has %d characters.');
         Assertion::choice($defaultAction, [
-            self::DEFAULTACTION_KEEP,
-            self::DEFAULTACTION_FORCE
+            OutgoingDdiRuleInterface::DEFAULTACTION_KEEP,
+            OutgoingDdiRuleInterface::DEFAULTACTION_FORCE
         ], 'defaultActionvalue "%s" is not an element of the valid values: %s');
 
         $this->defaultAction = $defaultAction;

--- a/library/Ivoz/Provider/Domain/Model/OutgoingDdiRule/OutgoingDdiRuleInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/OutgoingDdiRule/OutgoingDdiRuleInterface.php
@@ -8,6 +8,10 @@ use Doctrine\Common\Collections\ArrayCollection;
 
 interface OutgoingDdiRuleInterface extends LoggableEntityInterface
 {
+    const DEFAULTACTION_KEEP = 'keep';
+    const DEFAULTACTION_FORCE = 'force';
+
+
     /**
      * @codeCoverageIgnore
      * @return array

--- a/library/Ivoz/Provider/Domain/Model/OutgoingDdiRulesPattern/OutgoingDdiRulesPatternAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/OutgoingDdiRulesPattern/OutgoingDdiRulesPatternAbstract.php
@@ -13,9 +13,6 @@ use Ivoz\Core\Domain\Model\EntityInterface;
  */
 abstract class OutgoingDdiRulesPatternAbstract
 {
-    const ACTION_KEEP = 'keep';
-    const ACTION_FORCE = 'force';
-
     /**
      * comment: enum:keep|force
      * @var string
@@ -200,8 +197,8 @@ abstract class OutgoingDdiRulesPatternAbstract
         Assertion::notNull($action, 'action value "%s" is null, but non null value was expected.');
         Assertion::maxLength($action, 10, 'action value "%s" is too long, it should have no more than %d characters, but has %d characters.');
         Assertion::choice($action, [
-            self::ACTION_KEEP,
-            self::ACTION_FORCE
+            OutgoingDdiRulesPatternInterface::ACTION_KEEP,
+            OutgoingDdiRulesPatternInterface::ACTION_FORCE
         ], 'actionvalue "%s" is not an element of the valid values: %s');
 
         $this->action = $action;

--- a/library/Ivoz/Provider/Domain/Model/OutgoingDdiRulesPattern/OutgoingDdiRulesPatternInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/OutgoingDdiRulesPattern/OutgoingDdiRulesPatternInterface.php
@@ -6,6 +6,10 @@ use Ivoz\Core\Domain\Model\LoggableEntityInterface;
 
 interface OutgoingDdiRulesPatternInterface extends LoggableEntityInterface
 {
+    const ACTION_KEEP = 'keep';
+    const ACTION_FORCE = 'force';
+
+
     /**
      * @codeCoverageIgnore
      * @return array

--- a/library/Ivoz/Provider/Domain/Model/OutgoingRouting/OutgoingRoutingAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/OutgoingRouting/OutgoingRoutingAbstract.php
@@ -13,9 +13,6 @@ use Ivoz\Core\Domain\Model\EntityInterface;
  */
 abstract class OutgoingRoutingAbstract
 {
-    const ROUTINGMODE_STATIC = 'static';
-    const ROUTINGMODE_LCR = 'lcr';
-
     /**
      * @var string | null
      */
@@ -364,8 +361,8 @@ abstract class OutgoingRoutingAbstract
         if (!is_null($routingMode)) {
             Assertion::maxLength($routingMode, 25, 'routingMode value "%s" is too long, it should have no more than %d characters, but has %d characters.');
             Assertion::choice($routingMode, [
-                self::ROUTINGMODE_STATIC,
-                self::ROUTINGMODE_LCR
+                OutgoingRoutingInterface::ROUTINGMODE_STATIC,
+                OutgoingRoutingInterface::ROUTINGMODE_LCR
             ], 'routingModevalue "%s" is not an element of the valid values: %s');
         }
 

--- a/library/Ivoz/Provider/Domain/Model/OutgoingRouting/OutgoingRoutingInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/OutgoingRouting/OutgoingRoutingInterface.php
@@ -8,6 +8,10 @@ use Doctrine\Common\Collections\ArrayCollection;
 
 interface OutgoingRoutingInterface extends LoggableEntityInterface
 {
+    const ROUTINGMODE_STATIC = 'static';
+    const ROUTINGMODE_LCR = 'lcr';
+
+
     /**
      * @codeCoverageIgnore
      * @return array

--- a/library/Ivoz/Provider/Domain/Model/Queue/QueueAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Queue/QueueAbstract.php
@@ -13,15 +13,6 @@ use Ivoz\Core\Domain\Model\EntityInterface;
  */
 abstract class QueueAbstract
 {
-    const TIMEOUTTARGETTYPE_NUMBER = 'number';
-    const TIMEOUTTARGETTYPE_EXTENSION = 'extension';
-    const TIMEOUTTARGETTYPE_VOICEMAIL = 'voicemail';
-
-
-    const FULLTARGETTYPE_NUMBER = 'number';
-    const FULLTARGETTYPE_EXTENSION = 'extension';
-    const FULLTARGETTYPE_VOICEMAIL = 'voicemail';
-
     /**
      * @var string | null
      */
@@ -416,9 +407,9 @@ abstract class QueueAbstract
         if (!is_null($timeoutTargetType)) {
             Assertion::maxLength($timeoutTargetType, 25, 'timeoutTargetType value "%s" is too long, it should have no more than %d characters, but has %d characters.');
             Assertion::choice($timeoutTargetType, [
-                self::TIMEOUTTARGETTYPE_NUMBER,
-                self::TIMEOUTTARGETTYPE_EXTENSION,
-                self::TIMEOUTTARGETTYPE_VOICEMAIL
+                QueueInterface::TIMEOUTTARGETTYPE_NUMBER,
+                QueueInterface::TIMEOUTTARGETTYPE_EXTENSION,
+                QueueInterface::TIMEOUTTARGETTYPE_VOICEMAIL
             ], 'timeoutTargetTypevalue "%s" is not an element of the valid values: %s');
         }
 
@@ -508,9 +499,9 @@ abstract class QueueAbstract
         if (!is_null($fullTargetType)) {
             Assertion::maxLength($fullTargetType, 25, 'fullTargetType value "%s" is too long, it should have no more than %d characters, but has %d characters.');
             Assertion::choice($fullTargetType, [
-                self::FULLTARGETTYPE_NUMBER,
-                self::FULLTARGETTYPE_EXTENSION,
-                self::FULLTARGETTYPE_VOICEMAIL
+                QueueInterface::FULLTARGETTYPE_NUMBER,
+                QueueInterface::FULLTARGETTYPE_EXTENSION,
+                QueueInterface::FULLTARGETTYPE_VOICEMAIL
             ], 'fullTargetTypevalue "%s" is not an element of the valid values: %s');
         }
 

--- a/library/Ivoz/Provider/Domain/Model/Queue/QueueInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/Queue/QueueInterface.php
@@ -6,6 +6,16 @@ use Ivoz\Core\Domain\Model\LoggableEntityInterface;
 
 interface QueueInterface extends LoggableEntityInterface
 {
+    const TIMEOUTTARGETTYPE_NUMBER = 'number';
+    const TIMEOUTTARGETTYPE_EXTENSION = 'extension';
+    const TIMEOUTTARGETTYPE_VOICEMAIL = 'voicemail';
+
+
+    const FULLTARGETTYPE_NUMBER = 'number';
+    const FULLTARGETTYPE_EXTENSION = 'extension';
+    const FULLTARGETTYPE_VOICEMAIL = 'voicemail';
+
+
     /**
      * @codeCoverageIgnore
      * @return array

--- a/library/Ivoz/Provider/Domain/Model/RatingPlan/RatingPlan.php
+++ b/library/Ivoz/Provider/Domain/Model/RatingPlan/RatingPlan.php
@@ -11,7 +11,14 @@ class RatingPlan extends RatingPlanAbstract implements RatingPlanInterface
 {
     use RatingPlanTrait;
 
+    /**
+     * @deprecated
+     */
     const TIMING_TYPE_ALWAYS = self::TIMINGTYPE_ALWAYS;
+
+    /**
+     * @deprecated
+     */
     const TIMING_TYPE_CUSTOM = self::TIMINGTYPE_CUSTOM;
 
     /**
@@ -26,7 +33,7 @@ class RatingPlan extends RatingPlanAbstract implements RatingPlanInterface
 
     protected function sanitizeValues()
     {
-        if ($this->getTimingType() == RatingPlan::TIMING_TYPE_ALWAYS) {
+        if ($this->getTimingType() == self::TIMINGTYPE_ALWAYS) {
             $this
                 ->setMonday(true)
                 ->setTuesday(true)

--- a/library/Ivoz/Provider/Domain/Model/RatingPlan/RatingPlanAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/RatingPlan/RatingPlanAbstract.php
@@ -13,9 +13,6 @@ use Ivoz\Core\Domain\Model\EntityInterface;
  */
 abstract class RatingPlanAbstract
 {
-    const TIMINGTYPE_ALWAYS = 'always';
-    const TIMINGTYPE_CUSTOM = 'custom';
-
     /**
      * @var float
      */
@@ -292,8 +289,8 @@ abstract class RatingPlanAbstract
         if (!is_null($timingType)) {
             Assertion::maxLength($timingType, 10, 'timingType value "%s" is too long, it should have no more than %d characters, but has %d characters.');
             Assertion::choice($timingType, [
-                self::TIMINGTYPE_ALWAYS,
-                self::TIMINGTYPE_CUSTOM
+                RatingPlanInterface::TIMINGTYPE_ALWAYS,
+                RatingPlanInterface::TIMINGTYPE_CUSTOM
             ], 'timingTypevalue "%s" is not an element of the valid values: %s');
         }
 

--- a/library/Ivoz/Provider/Domain/Model/RatingPlan/RatingPlanInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/RatingPlan/RatingPlanInterface.php
@@ -6,6 +6,10 @@ use Ivoz\Core\Domain\Model\EntityInterface;
 
 interface RatingPlanInterface extends EntityInterface
 {
+    const TIMINGTYPE_ALWAYS = 'always';
+    const TIMINGTYPE_CUSTOM = 'custom';
+
+
     /**
      * Transform Weekdays booleans to a string for TpTimings
      *

--- a/library/Ivoz/Provider/Domain/Model/Recording/RecordingAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Recording/RecordingAbstract.php
@@ -13,9 +13,6 @@ use Ivoz\Core\Domain\Model\EntityInterface;
  */
 abstract class RecordingAbstract
 {
-    const TYPE_ONDEMAND = 'ondemand';
-    const TYPE_DDI = 'ddi';
-
     /**
      * @var string | null
      */
@@ -315,8 +312,8 @@ abstract class RecordingAbstract
     {
         Assertion::notNull($type, 'type value "%s" is null, but non null value was expected.');
         Assertion::choice($type, [
-            self::TYPE_ONDEMAND,
-            self::TYPE_DDI
+            RecordingInterface::TYPE_ONDEMAND,
+            RecordingInterface::TYPE_DDI
         ], 'typevalue "%s" is not an element of the valid values: %s');
 
         $this->type = $type;

--- a/library/Ivoz/Provider/Domain/Model/Recording/RecordingInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/Recording/RecordingInterface.php
@@ -7,6 +7,10 @@ use Ivoz\Core\Domain\Model\LoggableEntityInterface;
 
 interface RecordingInterface extends FileContainerInterface, LoggableEntityInterface
 {
+    const TYPE_ONDEMAND = 'ondemand';
+    const TYPE_DDI = 'ddi';
+
+
     /**
      * @codeCoverageIgnore
      * @return array

--- a/library/Ivoz/Provider/Domain/Model/ResidentialDevice/ResidentialDeviceAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/ResidentialDevice/ResidentialDeviceAbstract.php
@@ -13,30 +13,6 @@ use Ivoz\Core\Domain\Model\EntityInterface;
  */
 abstract class ResidentialDeviceAbstract
 {
-    const TRANSPORT_UDP = 'udp';
-    const TRANSPORT_TCP = 'tcp';
-    const TRANSPORT_TLS = 'tls';
-
-
-    const DIRECTMEDIAMETHOD_INVITE = 'invite';
-    const DIRECTMEDIAMETHOD_UPDATE = 'update';
-
-
-    const CALLERIDUPDATEHEADER_PAI = 'pai';
-    const CALLERIDUPDATEHEADER_RPID = 'rpid';
-
-
-    const UPDATECALLERID_YES = 'yes';
-    const UPDATECALLERID_NO = 'no';
-
-
-    const DIRECTCONNECTIVITY_YES = 'yes';
-    const DIRECTCONNECTIVITY_NO = 'no';
-
-
-    const DDIIN_YES = 'yes';
-    const DDIIN_NO = 'no';
-
     /**
      * @var string
      */
@@ -460,9 +436,9 @@ abstract class ResidentialDeviceAbstract
         Assertion::notNull($transport, 'transport value "%s" is null, but non null value was expected.');
         Assertion::maxLength($transport, 25, 'transport value "%s" is too long, it should have no more than %d characters, but has %d characters.');
         Assertion::choice($transport, [
-            self::TRANSPORT_UDP,
-            self::TRANSPORT_TCP,
-            self::TRANSPORT_TLS
+            ResidentialDeviceInterface::TRANSPORT_UDP,
+            ResidentialDeviceInterface::TRANSPORT_TCP,
+            ResidentialDeviceInterface::TRANSPORT_TLS
         ], 'transportvalue "%s" is not an element of the valid values: %s');
 
         $this->transport = $transport;
@@ -659,8 +635,8 @@ abstract class ResidentialDeviceAbstract
     {
         Assertion::notNull($directMediaMethod, 'directMediaMethod value "%s" is null, but non null value was expected.');
         Assertion::choice($directMediaMethod, [
-            self::DIRECTMEDIAMETHOD_INVITE,
-            self::DIRECTMEDIAMETHOD_UPDATE
+            ResidentialDeviceInterface::DIRECTMEDIAMETHOD_INVITE,
+            ResidentialDeviceInterface::DIRECTMEDIAMETHOD_UPDATE
         ], 'directMediaMethodvalue "%s" is not an element of the valid values: %s');
 
         $this->directMediaMethod = $directMediaMethod;
@@ -689,8 +665,8 @@ abstract class ResidentialDeviceAbstract
     {
         Assertion::notNull($calleridUpdateHeader, 'calleridUpdateHeader value "%s" is null, but non null value was expected.');
         Assertion::choice($calleridUpdateHeader, [
-            self::CALLERIDUPDATEHEADER_PAI,
-            self::CALLERIDUPDATEHEADER_RPID
+            ResidentialDeviceInterface::CALLERIDUPDATEHEADER_PAI,
+            ResidentialDeviceInterface::CALLERIDUPDATEHEADER_RPID
         ], 'calleridUpdateHeadervalue "%s" is not an element of the valid values: %s');
 
         $this->calleridUpdateHeader = $calleridUpdateHeader;
@@ -719,8 +695,8 @@ abstract class ResidentialDeviceAbstract
     {
         Assertion::notNull($updateCallerid, 'updateCallerid value "%s" is null, but non null value was expected.');
         Assertion::choice($updateCallerid, [
-            self::UPDATECALLERID_YES,
-            self::UPDATECALLERID_NO
+            ResidentialDeviceInterface::UPDATECALLERID_YES,
+            ResidentialDeviceInterface::UPDATECALLERID_NO
         ], 'updateCalleridvalue "%s" is not an element of the valid values: %s');
 
         $this->updateCallerid = $updateCallerid;
@@ -777,8 +753,8 @@ abstract class ResidentialDeviceAbstract
     {
         Assertion::notNull($directConnectivity, 'directConnectivity value "%s" is null, but non null value was expected.');
         Assertion::choice($directConnectivity, [
-            self::DIRECTCONNECTIVITY_YES,
-            self::DIRECTCONNECTIVITY_NO
+            ResidentialDeviceInterface::DIRECTCONNECTIVITY_YES,
+            ResidentialDeviceInterface::DIRECTCONNECTIVITY_NO
         ], 'directConnectivityvalue "%s" is not an element of the valid values: %s');
 
         $this->directConnectivity = $directConnectivity;
@@ -807,8 +783,8 @@ abstract class ResidentialDeviceAbstract
     {
         Assertion::notNull($ddiIn, 'ddiIn value "%s" is null, but non null value was expected.');
         Assertion::choice($ddiIn, [
-            self::DDIIN_YES,
-            self::DDIIN_NO
+            ResidentialDeviceInterface::DDIIN_YES,
+            ResidentialDeviceInterface::DDIIN_NO
         ], 'ddiInvalue "%s" is not an element of the valid values: %s');
 
         $this->ddiIn = $ddiIn;

--- a/library/Ivoz/Provider/Domain/Model/ResidentialDevice/ResidentialDeviceInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/ResidentialDevice/ResidentialDeviceInterface.php
@@ -8,6 +8,31 @@ use Doctrine\Common\Collections\ArrayCollection;
 
 interface ResidentialDeviceInterface extends LoggableEntityInterface
 {
+    const TRANSPORT_UDP = 'udp';
+    const TRANSPORT_TCP = 'tcp';
+    const TRANSPORT_TLS = 'tls';
+
+
+    const DIRECTMEDIAMETHOD_INVITE = 'invite';
+    const DIRECTMEDIAMETHOD_UPDATE = 'update';
+
+
+    const CALLERIDUPDATEHEADER_PAI = 'pai';
+    const CALLERIDUPDATEHEADER_RPID = 'rpid';
+
+
+    const UPDATECALLERID_YES = 'yes';
+    const UPDATECALLERID_NO = 'no';
+
+
+    const DIRECTCONNECTIVITY_YES = 'yes';
+    const DIRECTCONNECTIVITY_NO = 'no';
+
+
+    const DDIIN_YES = 'yes';
+    const DDIIN_NO = 'no';
+
+
     /**
      * @codeCoverageIgnore
      * @return array

--- a/library/Ivoz/Provider/Domain/Model/RetailAccount/RetailAccountAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/RetailAccount/RetailAccountAbstract.php
@@ -13,18 +13,6 @@ use Ivoz\Core\Domain\Model\EntityInterface;
  */
 abstract class RetailAccountAbstract
 {
-    const TRANSPORT_UDP = 'udp';
-    const TRANSPORT_TCP = 'tcp';
-    const TRANSPORT_TLS = 'tls';
-
-
-    const DIRECTCONNECTIVITY_YES = 'yes';
-    const DIRECTCONNECTIVITY_NO = 'no';
-
-
-    const DDIIN_YES = 'yes';
-    const DDIIN_NO = 'no';
-
     /**
      * @var string
      */
@@ -354,9 +342,9 @@ abstract class RetailAccountAbstract
         Assertion::notNull($transport, 'transport value "%s" is null, but non null value was expected.');
         Assertion::maxLength($transport, 25, 'transport value "%s" is too long, it should have no more than %d characters, but has %d characters.');
         Assertion::choice($transport, [
-            self::TRANSPORT_UDP,
-            self::TRANSPORT_TCP,
-            self::TRANSPORT_TLS
+            RetailAccountInterface::TRANSPORT_UDP,
+            RetailAccountInterface::TRANSPORT_TCP,
+            RetailAccountInterface::TRANSPORT_TLS
         ], 'transportvalue "%s" is not an element of the valid values: %s');
 
         $this->transport = $transport;
@@ -501,8 +489,8 @@ abstract class RetailAccountAbstract
     {
         Assertion::notNull($directConnectivity, 'directConnectivity value "%s" is null, but non null value was expected.');
         Assertion::choice($directConnectivity, [
-            self::DIRECTCONNECTIVITY_YES,
-            self::DIRECTCONNECTIVITY_NO
+            RetailAccountInterface::DIRECTCONNECTIVITY_YES,
+            RetailAccountInterface::DIRECTCONNECTIVITY_NO
         ], 'directConnectivityvalue "%s" is not an element of the valid values: %s');
 
         $this->directConnectivity = $directConnectivity;
@@ -531,8 +519,8 @@ abstract class RetailAccountAbstract
     {
         Assertion::notNull($ddiIn, 'ddiIn value "%s" is null, but non null value was expected.');
         Assertion::choice($ddiIn, [
-            self::DDIIN_YES,
-            self::DDIIN_NO
+            RetailAccountInterface::DDIIN_YES,
+            RetailAccountInterface::DDIIN_NO
         ], 'ddiInvalue "%s" is not an element of the valid values: %s');
 
         $this->ddiIn = $ddiIn;

--- a/library/Ivoz/Provider/Domain/Model/RetailAccount/RetailAccountInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/RetailAccount/RetailAccountInterface.php
@@ -8,6 +8,19 @@ use Doctrine\Common\Collections\ArrayCollection;
 
 interface RetailAccountInterface extends LoggableEntityInterface
 {
+    const TRANSPORT_UDP = 'udp';
+    const TRANSPORT_TCP = 'tcp';
+    const TRANSPORT_TLS = 'tls';
+
+
+    const DIRECTCONNECTIVITY_YES = 'yes';
+    const DIRECTCONNECTIVITY_NO = 'no';
+
+
+    const DDIIN_YES = 'yes';
+    const DDIIN_NO = 'no';
+
+
     /**
      * @codeCoverageIgnore
      * @return array

--- a/library/Ivoz/Provider/Domain/Model/Terminal/TerminalAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Terminal/TerminalAbstract.php
@@ -13,10 +13,6 @@ use Ivoz\Core\Domain\Model\EntityInterface;
  */
 abstract class TerminalAbstract
 {
-    const DIRECTMEDIAMETHOD_UPDATE = 'update';
-    const DIRECTMEDIAMETHOD_INVITE = 'invite';
-    const DIRECTMEDIAMETHOD_REINVITE = 'reinvite';
-
     /**
      * @var string | null
      */
@@ -374,9 +370,9 @@ abstract class TerminalAbstract
     {
         Assertion::notNull($directMediaMethod, 'directMediaMethod value "%s" is null, but non null value was expected.');
         Assertion::choice($directMediaMethod, [
-            self::DIRECTMEDIAMETHOD_UPDATE,
-            self::DIRECTMEDIAMETHOD_INVITE,
-            self::DIRECTMEDIAMETHOD_REINVITE
+            TerminalInterface::DIRECTMEDIAMETHOD_UPDATE,
+            TerminalInterface::DIRECTMEDIAMETHOD_INVITE,
+            TerminalInterface::DIRECTMEDIAMETHOD_REINVITE
         ], 'directMediaMethodvalue "%s" is not an element of the valid values: %s');
 
         $this->directMediaMethod = $directMediaMethod;

--- a/library/Ivoz/Provider/Domain/Model/Terminal/TerminalInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/Terminal/TerminalInterface.php
@@ -8,6 +8,11 @@ use Doctrine\Common\Collections\ArrayCollection;
 
 interface TerminalInterface extends LoggableEntityInterface
 {
+    const DIRECTMEDIAMETHOD_UPDATE = 'update';
+    const DIRECTMEDIAMETHOD_INVITE = 'invite';
+    const DIRECTMEDIAMETHOD_REINVITE = 'reinvite';
+
+
     /**
      * @return array
      */

--- a/library/Ivoz/Provider/Domain/Model/TransformationRule/TransformationRuleAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/TransformationRule/TransformationRuleAbstract.php
@@ -13,11 +13,6 @@ use Ivoz\Core\Domain\Model\EntityInterface;
  */
 abstract class TransformationRuleAbstract
 {
-    const TYPE_CALLERIN = 'callerin';
-    const TYPE_CALLEEIN = 'calleein';
-    const TYPE_CALLEROUT = 'callerout';
-    const TYPE_CALLEEOUT = 'calleeout';
-
     /**
      * comment: enum:callerin|calleein|callerout|calleeout
      * @var string
@@ -211,10 +206,10 @@ abstract class TransformationRuleAbstract
         Assertion::notNull($type, 'type value "%s" is null, but non null value was expected.');
         Assertion::maxLength($type, 10, 'type value "%s" is too long, it should have no more than %d characters, but has %d characters.');
         Assertion::choice($type, [
-            self::TYPE_CALLERIN,
-            self::TYPE_CALLEEIN,
-            self::TYPE_CALLEROUT,
-            self::TYPE_CALLEEOUT
+            TransformationRuleInterface::TYPE_CALLERIN,
+            TransformationRuleInterface::TYPE_CALLEEIN,
+            TransformationRuleInterface::TYPE_CALLEROUT,
+            TransformationRuleInterface::TYPE_CALLEEOUT
         ], 'typevalue "%s" is not an element of the valid values: %s');
 
         $this->type = $type;

--- a/library/Ivoz/Provider/Domain/Model/TransformationRule/TransformationRuleInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/TransformationRule/TransformationRuleInterface.php
@@ -6,6 +6,12 @@ use Ivoz\Core\Domain\Model\LoggableEntityInterface;
 
 interface TransformationRuleInterface extends LoggableEntityInterface
 {
+    const TYPE_CALLERIN = 'callerin';
+    const TYPE_CALLEEIN = 'calleein';
+    const TYPE_CALLEROUT = 'callerout';
+    const TYPE_CALLEEOUT = 'calleeout';
+
+
     /**
      * @codeCoverageIgnore
      * @return array

--- a/library/Ivoz/Provider/Domain/Model/User/UserAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/User/UserAbstract.php
@@ -13,11 +13,6 @@ use Ivoz\Core\Domain\Model\EntityInterface;
  */
 abstract class UserAbstract
 {
-    const EXTERNALIPCALLS_0 = '0';
-    const EXTERNALIPCALLS_1 = '1';
-    const EXTERNALIPCALLS_2 = '2';
-    const EXTERNALIPCALLS_3 = '3';
-
     /**
      * @var string
      */
@@ -631,10 +626,10 @@ abstract class UserAbstract
         Assertion::notNull($externalIpCalls, 'externalIpCalls value "%s" is null, but non null value was expected.');
         Assertion::maxLength($externalIpCalls, 1, 'externalIpCalls value "%s" is too long, it should have no more than %d characters, but has %d characters.');
         Assertion::choice($externalIpCalls, [
-            self::EXTERNALIPCALLS_0,
-            self::EXTERNALIPCALLS_1,
-            self::EXTERNALIPCALLS_2,
-            self::EXTERNALIPCALLS_3
+            UserInterface::EXTERNALIPCALLS_0,
+            UserInterface::EXTERNALIPCALLS_1,
+            UserInterface::EXTERNALIPCALLS_2,
+            UserInterface::EXTERNALIPCALLS_3
         ], 'externalIpCallsvalue "%s" is not an element of the valid values: %s');
 
         $this->externalIpCalls = $externalIpCalls;

--- a/library/Ivoz/Provider/Domain/Model/User/UserInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/User/UserInterface.php
@@ -8,6 +8,12 @@ use Doctrine\Common\Collections\ArrayCollection;
 
 interface UserInterface extends LoggableEntityInterface
 {
+    const EXTERNALIPCALLS_0 = '0';
+    const EXTERNALIPCALLS_1 = '1';
+    const EXTERNALIPCALLS_2 = '2';
+    const EXTERNALIPCALLS_3 = '3';
+
+
     /**
      * @return array
      */

--- a/library/Ivoz/Provider/Domain/Model/WebPortal/WebPortalAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/WebPortal/WebPortalAbstract.php
@@ -13,11 +13,6 @@ use Ivoz\Core\Domain\Model\EntityInterface;
  */
 abstract class WebPortalAbstract
 {
-    const URLTYPE_GOD = 'god';
-    const URLTYPE_BRAND = 'brand';
-    const URLTYPE_ADMIN = 'admin';
-    const URLTYPE_USER = 'user';
-
     /**
      * @var string
      */
@@ -292,10 +287,10 @@ abstract class WebPortalAbstract
         Assertion::notNull($urlType, 'urlType value "%s" is null, but non null value was expected.');
         Assertion::maxLength($urlType, 25, 'urlType value "%s" is too long, it should have no more than %d characters, but has %d characters.');
         Assertion::choice($urlType, [
-            self::URLTYPE_GOD,
-            self::URLTYPE_BRAND,
-            self::URLTYPE_ADMIN,
-            self::URLTYPE_USER
+            WebPortalInterface::URLTYPE_GOD,
+            WebPortalInterface::URLTYPE_BRAND,
+            WebPortalInterface::URLTYPE_ADMIN,
+            WebPortalInterface::URLTYPE_USER
         ], 'urlTypevalue "%s" is not an element of the valid values: %s');
 
         $this->urlType = $urlType;

--- a/library/Ivoz/Provider/Domain/Model/WebPortal/WebPortalInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/WebPortal/WebPortalInterface.php
@@ -7,6 +7,12 @@ use Ivoz\Core\Domain\Model\LoggableEntityInterface;
 
 interface WebPortalInterface extends FileContainerInterface, LoggableEntityInterface
 {
+    const URLTYPE_GOD = 'god';
+    const URLTYPE_BRAND = 'brand';
+    const URLTYPE_ADMIN = 'admin';
+    const URLTYPE_USER = 'user';
+
+
     /**
      * @codeCoverageIgnore
      * @return array


### PR DESCRIPTION
Constants should be at EntityInterfaces, not at concrete implementations