### PR TITLE
core: remove brand domain when retail and residential are disabled

### DIFF
--- a/library/Ivoz/Provider/Domain/Model/Brand/Brand.php
+++ b/library/Ivoz/Provider/Domain/Model/Brand/Brand.php
@@ -6,6 +6,7 @@ use Ivoz\Core\Domain\Model\TempFileContainnerTrait;
 use Ivoz\Core\Domain\Service\FileContainerInterface;
 use Ivoz\Core\Infrastructure\Persistence\Doctrine\Model\Helper\CriteriaHelper;
 use Ivoz\Provider\Domain\Model\Company\CompanyInterface;
+use Ivoz\Provider\Domain\Model\Feature\Feature;
 use Ivoz\Provider\Domain\Model\Feature\FeatureInterface;
 
 /**
@@ -43,6 +44,14 @@ class Brand extends BrandAbstract implements FileContainerInterface, BrandInterf
     public function getId()
     {
         return $this->id;
+    }
+
+    protected function sanitizeValues()
+    {
+        if (!$this->hasFeature(Feature::RETAIL)
+            && !$this->hasFeature(Feature::RESIDENTIAL)) {
+                $this->setDomainUsers("");
+        }
     }
 
     /**


### PR DESCRIPTION
This shouldn't happen often, as usually Brand features are not a toy, but for the sake of consistency, this sanitize removes brand domain when the field is hidden on the screen.