### PR TITLE
agis: fix Voicemail action for Residential Devices

### DIFF
--- a/asterisk/agi/src/Agi/Action/CallForwardAction.php
+++ b/asterisk/agi/src/Agi/Action/CallForwardAction.php
@@ -129,7 +129,7 @@ class CallForwardAction
         $this->routerAction
             ->setRouteType($this->cfw->getTargetType())
             ->setRouteExtension($this->cfw->getExtension())
-            ->setRouteVoicemail($this->cfw->getVoiceMailUser(), true)
+            ->setRouteVoicemail($caller, true)
             ->setRouteExternal($this->cfw->getNumberValueE164())
             ->route();
     }

--- a/asterisk/agi/src/Agi/Action/RouterAction.php
+++ b/asterisk/agi/src/Agi/Action/RouterAction.php
@@ -1,6 +1,7 @@
 <?php
 namespace Agi\Action;
 
+use Agi\Agents\AgentInterface;
 use Agi\ChannelInfo;
 use Agi\Wrapper;
 use Ivoz\Provider\Domain\Model\Company\CompanyInterface;
@@ -272,7 +273,7 @@ class RouterAction
         return $this;
     }
 
-    public function setRouteVoicemail(UserInterface $routeVoicemail = null, bool $playBanner = false)
+    public function setRouteVoicemail(AgentInterface $routeVoicemail = null, bool $playBanner = false)
     {
         $this->routeVoiceMail = $routeVoicemail;
         $this->routeVoicemailBanner = $playBanner;

--- a/asterisk/agi/src/Agi/Action/ServiceAction.php
+++ b/asterisk/agi/src/Agi/Action/ServiceAction.php
@@ -155,11 +155,11 @@ class ServiceAction
                 return;
             }
 
-            // Checkvoicemail for exten user
+            // Check voicemail for exten user
             $this->agi->verbose("Checking user %s voicemail", $extension->getUser()->getName());
             $this->agi->checkVoicemail($extension->getUser()->getVoiceMail());
         } else {
-            // Checkvoicemail for caller user (without requesting password)
+            // Check voicemail for caller user (without requesting password)
             $this->agi->checkVoicemail($caller->getVoiceMail(), "s");
         }
     }

--- a/asterisk/agi/src/Agi/Action/VoiceMailAction.php
+++ b/asterisk/agi/src/Agi/Action/VoiceMailAction.php
@@ -2,6 +2,8 @@
 
 namespace Agi\Action;
 
+use Agi\Agents\AgentInterface;
+use Agi\Agents\UserAgent;
 use Agi\Wrapper;
 use Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDeviceInterface;
 use Ivoz\Provider\Domain\Model\User\UserInterface;
@@ -14,7 +16,7 @@ class VoiceMailAction
     protected $agi;
 
     /**
-     * @var UserInterface|ResidentialDeviceInterface
+     * @var AgentInterface
      */
     protected $voicemail;
 
@@ -45,10 +47,10 @@ class VoiceMailAction
     }
 
     /**
-     * @param UserInterface|ResidentialDeviceInterface|null $voicemail
+     * @param AgentInterface|null $voicemail
      * @return $this
      */
-    public function setVoiceMail($voicemail = null)
+    public function setVoiceMail(AgentInterface $voicemail = null)
     {
         $this->voicemail = $voicemail;
         return $this;
@@ -59,6 +61,8 @@ class VoiceMailAction
         $voicemail = $this->voicemail;
         if (is_null($voicemail)) {
             $this->agi->error("Voicemail is not properly defined. Check configuration.");
+            $this->agi->hangup();
+            return;
         }
 
         // Some feedback for asterisk cli
@@ -76,9 +80,11 @@ class VoiceMailAction
             } else {
                 $vmopts .= "s";         // Skip welcome message
             }
+
+
             $this->agi->voicemail($voicemail->getVoiceMail(), $vmopts);
         } else {
-            $this->agi->error("User %s has voicemail disabled.", $voicemail->getFullName());
+            $this->agi->error("%s has voicemail disabled.", $voicemail);
             $this->agi->busy();
         }
     }

--- a/asterisk/agi/src/Agi/Agents/AgentInterface.php
+++ b/asterisk/agi/src/Agi/Agents/AgentInterface.php
@@ -2,6 +2,7 @@
 namespace Agi\Agents;
 
 use Ivoz\Provider\Domain\Model\Company\CompanyInterface;
+use Ivoz\Provider\Domain\Model\Locution\LocutionInterface;
 use Ivoz\Provider\Domain\Model\PickUpGroup\PickUpGroupInterface;
 
 interface AgentInterface
@@ -63,4 +64,14 @@ interface AgentInterface
      * @return string
      */
     public function getVoiceMail();
+
+    /**
+     * @return bool
+     */
+    public function getVoicemailEnabled();
+
+    /**
+     * @return LocutionInterface | null
+     */
+    public function getVoiceMailLocution();
 }

--- a/asterisk/agi/src/Agi/Agents/AgentTrait.php
+++ b/asterisk/agi/src/Agi/Agents/AgentTrait.php
@@ -63,4 +63,14 @@ trait AgentTrait
     {
         return null;
     }
+
+    public function getVoicemailEnabled()
+    {
+        return false;
+    }
+
+    public function getVoiceMailLocution()
+    {
+        return null;
+    }
 }

--- a/asterisk/agi/src/Agi/Agents/ResidentialAgent.php
+++ b/asterisk/agi/src/Agi/Agents/ResidentialAgent.php
@@ -110,6 +110,14 @@ class ResidentialAgent implements AgentInterface
     }
 
     /**
+     * Residential devices have always voicemail enabled
+     */
+    public function getVoicemailEnabled()
+    {
+        return true;
+    }
+
+    /**
      * Return residential voicemail identifier
      * @return string
      */

--- a/asterisk/agi/src/Agi/Agents/UserAgent.php
+++ b/asterisk/agi/src/Agi/Agents/UserAgent.php
@@ -3,6 +3,7 @@
 namespace Agi\Agents;
 
 use Agi\Wrapper;
+use Ivoz\Provider\Domain\Model\Locution\LocutionInterface;
 use Ivoz\Provider\Domain\Model\PickUpGroup\PickUpGroupInterface;
 use Ivoz\Provider\Domain\Model\User\UserInterface;
 
@@ -95,11 +96,27 @@ class UserAgent implements AgentInterface
     }
 
     /**
+     * @return bool
+     */
+    public function getVoicemailEnabled()
+    {
+        return $this->user->getVoicemailEnabled();
+    }
+
+    /**
      * Return user voicemail identifier
      * @return string
      */
     public function getVoiceMail()
     {
         return $this->user->getVoiceMail();
+    }
+
+    /**
+     * @return LocutionInterface|null
+     */
+    public function getVoiceMailLocution()
+    {
+        return $this->user->getVoicemailLocution();
     }
 }


### PR DESCRIPTION
Fixes Voicemail action implementation for Residential Devices.

Originally, this action only supported voicemail for Users, so I have added required methods to AgentInterface to support the same action for any other agent (included Residential).


Fixes #934 