### PR TITLE
core: added agent argument on CommandWasExecuted

### DIFF
--- a/asterisk/agi/app/MicroKernel.php
+++ b/asterisk/agi/app/MicroKernel.php
@@ -112,6 +112,7 @@ class MicroKernel extends Kernel
             $requestId->toString(),
             'AGI:' . $service,
             'process',
+            [],
             []
         );
 

--- a/library/Ivoz/Core/Application/RegisterCommandTrait.php
+++ b/library/Ivoz/Core/Application/RegisterCommandTrait.php
@@ -24,6 +24,7 @@ trait RegisterCommandTrait
             $this->requestId->toString(),
             $service,
             $method,
+            [],
             []
         );
 

--- a/microservices/balances/app/MicroKernel.php
+++ b/microservices/balances/app/MicroKernel.php
@@ -77,6 +77,7 @@ class MicroKernel extends Kernel
             $requestId->toString(),
             'Balances',
             'sync',
+            [],
             []
         );
 

--- a/microservices/recordings/app/MicroKernel.php
+++ b/microservices/recordings/app/MicroKernel.php
@@ -69,6 +69,7 @@ class MicroKernel extends Kernel
             $requestId->toString(),
             'Recordings',
             'processRtpRecording',
+            [],
             []
         );
 


### PR DESCRIPTION
Fixed bug introduced on https://github.com/irontec/ivozprovider/pull/937 because of merge order