### PR TITLE
core: run rtpengine.reload when changes in media-relays

### DIFF
--- a/library/Ivoz/Kam/Domain/Service/Rtpengine/RtpengineLifecycleEventHandlerInterface.php
+++ b/library/Ivoz/Kam/Domain/Service/Rtpengine/RtpengineLifecycleEventHandlerInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Ivoz\Kam\Domain\Service\Rtpengine;
+
+use Ivoz\Core\Domain\Service\LifecycleEventHandlerInterface;
+use Ivoz\Kam\Domain\Model\Rtpengine\RtpengineInterface;
+
+interface RtpengineLifecycleEventHandlerInterface extends LifecycleEventHandlerInterface
+{
+    public function execute(RtpengineInterface $entity);
+}

--- a/library/Ivoz/Kam/Domain/Service/Rtpengine/RtpengineLifecycleServiceCollection.php
+++ b/library/Ivoz/Kam/Domain/Service/Rtpengine/RtpengineLifecycleServiceCollection.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Ivoz\Kam\Domain\Service\Rtpengine;
+
+use Ivoz\Core\Domain\Service\LifecycleServiceCollectionInterface;
+use Ivoz\Core\Domain\Service\LifecycleServiceCollectionTrait;
+
+/**
+ * @codeCoverageIgnore
+ */
+class RtpengineLifecycleServiceCollection implements LifecycleServiceCollectionInterface
+{
+    use LifecycleServiceCollectionTrait;
+
+    protected function addService(RtpengineLifecycleEventHandlerInterface $service)
+    {
+        $this->services[] = $service;
+    }
+}

--- a/library/Ivoz/Kam/Domain/Service/TrunksClientInterface.php
+++ b/library/Ivoz/Kam/Domain/Service/TrunksClientInterface.php
@@ -11,6 +11,7 @@ interface TrunksClientInterface
     const PERMISSIONS_ADDRESS_RELOAD_ACTION = 'permissions.addressReload';
     const UAC_REG_RELOAD_ACTION = 'uac.reg_reload';
     const DLG_PROFILE_GET_SIZE = 'dlg.profile_get_size';
+    const RTPENGINE_RELOAD_ACTION = 'rtpengine.reload';
 
     const TRUNKS_ACTIONS = [
         self::DIALPLAN_RELOAD_ACTION,
@@ -19,7 +20,8 @@ interface TrunksClientInterface
         self::PERMISSIONS_TRUSTED_RELOAD_ACTION,
         self::PERMISSIONS_ADDRESS_RELOAD_ACTION,
         self::UAC_REG_RELOAD_ACTION,
-        self::DLG_PROFILE_GET_SIZE
+        self::DLG_PROFILE_GET_SIZE,
+        self::RTPENGINE_RELOAD_ACTION
     ];
 
     /**
@@ -50,4 +52,6 @@ interface TrunksClientInterface
     public function reloadAddressPermissions();
 
     public function reloadUacReg();
+
+    public function reloadRtpengine();
 }

--- a/library/Ivoz/Kam/Domain/Service/UsersClientInterface.php
+++ b/library/Ivoz/Kam/Domain/Service/UsersClientInterface.php
@@ -9,13 +9,15 @@ interface UsersClientInterface
     const PERMISSIONS_TRUSTED_RELOAD_ACTION = 'permissions.trustedReload';
     const PERMISSIONS_ADDRESS_RELOAD_ACTION = 'permissions.addressReload';
     const DIALPLAN_RELOAD_ACTION = 'dialplan.reload';
+    const RTPENGINE_RELOAD_ACTION = 'rtpengine.reload';
 
     const USERS_ACTIONS = [
         self::DISPATCHER_RELOAD_ACTION,
         self::DOMAIN_RELOAD_ACTION,
         self::PERMISSIONS_TRUSTED_RELOAD_ACTION,
         self::PERMISSIONS_ADDRESS_RELOAD_ACTION,
-        self::DIALPLAN_RELOAD_ACTION
+        self::DIALPLAN_RELOAD_ACTION,
+        self::RTPENGINE_RELOAD_ACTION
     ];
 
     public function reloadDispatcher();
@@ -27,4 +29,6 @@ interface UsersClientInterface
     public function reloadAddressPermissions();
 
     public function reloadDialplan();
+
+    public function reloadRtpengine();
 }

--- a/library/Ivoz/Kam/Infrastructure/Domain/Service/Rtpengine/SendTrunksRtpengineReloadRequest.php
+++ b/library/Ivoz/Kam/Infrastructure/Domain/Service/Rtpengine/SendTrunksRtpengineReloadRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Ivoz\Kam\Infrastructure\Domain\Service\Rtpengine;
+
+use Ivoz\Kam\Domain\Model\Rtpengine\RtpengineInterface;
+use Ivoz\Kam\Domain\Service\Rtpengine\RtpengineLifecycleEventHandlerInterface;
+use Ivoz\Kam\Domain\Service\TrunksClientInterface;
+
+class SendTrunksRtpengineReloadRequest implements RtpengineLifecycleEventHandlerInterface
+{
+    const ON_COMMIT_PRIORITY = self::PRIORITY_NORMAL;
+
+    protected $trunksClient;
+
+    public function __construct(
+        TrunksClientInterface $trunksClient
+    ) {
+        $this->trunksClient = $trunksClient;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            self::EVENT_ON_COMMIT => self::ON_COMMIT_PRIORITY
+        ];
+    }
+
+    public function execute(RtpengineInterface $entity)
+    {
+        $this->trunksClient->reloadRtpengine();
+    }
+}

--- a/library/Ivoz/Kam/Infrastructure/Domain/Service/Rtpengine/SendUsersRtpengineReloadRequest.php
+++ b/library/Ivoz/Kam/Infrastructure/Domain/Service/Rtpengine/SendUsersRtpengineReloadRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Ivoz\Kam\Infrastructure\Domain\Service\Rtpengine;
+
+use Ivoz\Kam\Domain\Model\Rtpengine\RtpengineInterface;
+use Ivoz\Kam\Domain\Service\Rtpengine\RtpengineLifecycleEventHandlerInterface;
+use Ivoz\Kam\Domain\Service\UsersClientInterface;
+
+class SendUsersRtpengineReloadRequest implements RtpengineLifecycleEventHandlerInterface
+{
+    const ON_COMMIT_PRIORITY = self::PRIORITY_NORMAL;
+
+    protected $usersClient;
+
+    public function __construct(
+        UsersClientInterface $usersClient
+    ) {
+        $this->usersClient = $usersClient;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            self::EVENT_ON_COMMIT => self::ON_COMMIT_PRIORITY
+        ];
+    }
+
+    public function execute(RtpengineInterface $entity)
+    {
+        $this->usersClient->reloadRtpengine();
+    }
+}

--- a/library/Ivoz/Kam/Infrastructure/Kamailio/TrunksClient.php
+++ b/library/Ivoz/Kam/Infrastructure/Kamailio/TrunksClient.php
@@ -65,6 +65,13 @@ class TrunksClient implements TrunksClientInterface
         );
     }
 
+    public function reloadRtpengine()
+    {
+        return $this->germanClient->send(
+            self::RTPENGINE_RELOAD_ACTION
+        );
+    }
+
     /**
      * @param int $companyId
      * @return int

--- a/library/Ivoz/Kam/Infrastructure/Kamailio/UsersClient.php
+++ b/library/Ivoz/Kam/Infrastructure/Kamailio/UsersClient.php
@@ -53,4 +53,11 @@ class UsersClient implements UsersClientInterface
             self::DIALPLAN_RELOAD_ACTION
         );
     }
+
+    public function reloadRtpengine()
+    {
+        return $this->germanClient->send(
+            self::RTPENGINE_RELOAD_ACTION
+        );
+    }
 }


### PR DESCRIPTION
Currently kamailio processes must be restarted.