### PR TITLE
kamtrunks: 486 in incoming maxcalls rejected calls

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -1664,18 +1664,27 @@ route[CONTROL_MAXCALLS] {
         }
     }
 
+    $var(maxcalls_exceeded) = 0;
     if ($dlg_var(maxCallsBrand) > 0 && $avp(activeCallsBrand) >= $dlg_var(maxCallsBrand)) {
-        xwarn("[$dlg_var(cidhash)] CONTROL-MAXCALLS: Call NOT allowed for brand$dlg_var(brandId), 403 Maxcalls exceeded\n");
-        send_reply("403", "Maxcalls exceeded");
-        exit;
+        xwarn("[$dlg_var(cidhash)] CONTROL-MAXCALLS: Call NOT allowed for brand$dlg_var(brandId)\n");
+        $var(maxcalls_exceeded) = 1;
     } else if ($dlg_var(maxCallsCompany) > 0 && $avp(activeCallsCompany) >= $dlg_var(maxCallsCompany)) {
-        xwarn("[$dlg_var(cidhash)] CONTROL-MAXCALLS: Call NOT allowed for company$dlg_var(companyId), 403 Maxcalls exceeded\n");
-        send_reply("403", "Maxcalls exceeded");
-        exit;
+        xwarn("[$dlg_var(cidhash)] CONTROL-MAXCALLS: Call NOT allowed for company$dlg_var(companyId)\n");
+        $var(maxcalls_exceeded) = 1;
     } else {
         xinfo("[$dlg_var(cidhash)] CONTROL-MAXCALLS: Call ALLOWED for brand$dlg_var(brandId) - company$dlg_var(companyId)\n");
         set_dlg_profile("activeCallsCompany", "$dlg_var(companyId)");
         set_dlg_profile("activeCallsBrand", "$dlg_var(brandId)");
+    }
+
+    if ($var(maxcalls_exceeded)) {
+        if ($var(is_from_inside)) {
+            send_reply("403", "Maxcalls exceeded");
+        } else {
+            send_reply("486", "Busy");
+        }
+
+        exit;
     }
 }
 


### PR DESCRIPTION
Kamtrunks controls maxcalls in CONTROL_MAXCALLS route.

When exceeded, "403 Maxcalls exceeded" was replied.

This PR changes this behaviour for external incoming calls, converting that reply into a 486 Busy.