### PR TITLE
kamusers: keep From displayName

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -750,24 +750,28 @@ route[SET_CALLER] {
 
 # Sets $var(transformated) in new PAI or existing PAI (and makes From username equal)
 route[SET_PAI] {
+    $var(displayName) = "";
+    if ($(fn{s.len}) > 0) {
+        $var(displayName) = $fn;
+    }
+
     if (is_request() && !has_totag()) {
         if ($fU != $var(transformated)) {
             $var(newfromuri) = 'sip:' + $var(transformated) + '@' + $fd;
-            uac_replace_from("", "$var(newfromuri)");
+            uac_replace_from("$var(displayName)", "$var(newfromuri)");
         }
     }
 
     if (is_present_hf("Remote-Party-ID")) remove_hf("Remote-Party-ID");
 
     if (is_present_hf("P-Asserted-Identity")) {
-        if ($(ai{uri.user}) != $var(transformated)) { # If new value differs from previous, change
-            remove_hf("P-Asserted-Identity");
-            append_hf("P-Asserted-Identity: <sip:$var(transformated)@$(ai{uri.host})>\r\n");
-        }
+        $var(newpai) = 'sip:' + $var(transformated) + '@' + $(ai{uri.host});
+        remove_hf("P-Asserted-Identity");
     } else {
         $var(newpai) = 'sip:' + $var(transformated) + '@' + $fd;
-        append_hf("P-Asserted-Identity: <$var(newpai)>\r\n");
     }
+
+    append_hf("P-Asserted-Identity: $var(displayName) <$var(newpai)>\r\n");
 
     return;
 }


### PR DESCRIPTION
Application servers set a preferred display name in vPBX/residential calls for certain DDIs.

KamUsers was overriding this display name.

This PR fixes this feature.