### PR TITLE
core: remove some deprecation warnings

### DIFF
--- a/library/ApiBundle/Resources/config/services.yml
+++ b/library/ApiBundle/Resources/config/services.yml
@@ -9,6 +9,10 @@ services:
     autoconfigure: true
     public: false
 
+  lexik_jwt_authentication.jwt_manager.public:
+    alias: lexik_jwt_authentication.jwt_manager
+    public: true
+
   Ivoz\Provider\Infrastructure\Api\Jwt\UserAuthenticationSuccessHandler:
     arguments:
       - '@lexik_jwt_authentication.jwt_manager'

--- a/library/CoreBundle/Resources/config/services/events.yml
+++ b/library/CoreBundle/Resources/config/services/events.yml
@@ -13,6 +13,7 @@ services:
   # DomainEventPublisher calls are autocompleted on cache regenerations (Compiler fase)
   Ivoz\Core\Domain\Service\DomainEventPublisher:
      shared: true
+     public: true
      calls:
       - [subscribe, ['@Ivoz\Core\Application\Service\CommandEventSubscriber']]
       - [subscribe, ['@Ivoz\Core\Domain\Service\EntityEventSubscriber']]

--- a/library/Ivoz/Api/Behat/Context/FeatureContext.php
+++ b/library/Ivoz/Api/Behat/Context/FeatureContext.php
@@ -28,6 +28,9 @@ class FeatureContext extends RawMinkContext implements Context, SnippetAccepting
      */
     protected $request;
 
+    /**
+     * @var JWTTokenManagerInterface
+     */
     protected $jwtTokenManager;
     protected $administratorRepository;
 
@@ -45,9 +48,7 @@ class FeatureContext extends RawMinkContext implements Context, SnippetAccepting
         $this->cacheDir = $kernel->getCacheDir();
         $this->fs = new Filesystem();
         $this->request = $request;
-        $this->jwtTokenManager = $kernel->getContainer()->get(
-            JWTTokenManagerInterface::class
-        );
+        $this->jwtTokenManager = $kernel->getContainer()->get('lexik_jwt_authentication.jwt_manager.public');
         $this->administratorRepository = $kernel->getContainer()->get(
             AdministratorRepository::class
         );

--- a/library/Ivoz/Core/Infrastructure/Symfony/DependencyInjection/Compiler/RepositoryCompiler.php
+++ b/library/Ivoz/Core/Infrastructure/Symfony/DependencyInjection/Compiler/RepositoryCompiler.php
@@ -35,10 +35,12 @@ class RepositoryCompiler implements CompilerPassInterface
                 $fqdn
             );
 
-            $this->container->setAlias(
+            $alias = $this->container->setAlias(
                 $repositoryInterface,
                 $fqdn
             );
+
+            $alias->setPublic(true);
         }
     }
 }


### PR DESCRIPTION
make public directly accessed services so that they don't throw deprecation erros like:

`php.INFO: User Deprecated: The "Ivoz\Core\Domain\Service\DomainEventPublisher" service is private, getting it from the container is deprecated since Symfony 3.2 and will fail in 4.0. You should either make the service public, or stop using the container directly and use dependency injection instead. `