### PR TITLE
T38 passthrough fix

### DIFF
--- a/asterisk/agi/src/Agi/Action/ExternalNumberAction.php
+++ b/asterisk/agi/src/Agi/Action/ExternalNumberAction.php
@@ -114,6 +114,11 @@ class ExternalNumberAction
             $this->agi->setVariable("_RECORD", "yes");
         }
 
+        // Determine if this call has T.38 passthrough enabled
+        if ($caller->isT38PassthroughEnabled()) {
+            $this->agi->setVariable("_T38PASSTHROUGH", "yes");
+        }
+
         // Dial Options
         $options = "";
 

--- a/asterisk/agi/src/Agi/Agents/AgentInterface.php
+++ b/asterisk/agi/src/Agi/Agents/AgentInterface.php
@@ -74,4 +74,11 @@ interface AgentInterface
      * @return LocutionInterface | null
      */
     public function getVoiceMailLocution();
+
+    /**
+     * @brief Determine if Agent's endpoint has T.38 Passthrough enabled
+     *
+     * @return boolean
+     */
+    public function isT38PassthroughEnabled();
 }

--- a/asterisk/agi/src/Agi/Agents/AgentTrait.php
+++ b/asterisk/agi/src/Agi/Agents/AgentTrait.php
@@ -73,4 +73,14 @@ trait AgentTrait
     {
         return null;
     }
+
+    /**
+     * @brief Determine if agent's endpoint has T.38 Passthrough enabled
+     *
+     * @return boolean
+     */
+    public function isT38PassthroughEnabled()
+    {
+        return false;
+    }
 }

--- a/asterisk/agi/src/Agi/Agents/FriendAgent.php
+++ b/asterisk/agi/src/Agi/Agents/FriendAgent.php
@@ -105,4 +105,16 @@ class FriendAgent implements AgentInterface
     {
         return $this->friend->isAllowedToCall($destination);
     }
+
+    /**
+     * @brief Determine if agent's endpoint has T.38 Passthrough enabled
+     *
+     * @return boolean
+     */
+    public function isT38PassthroughEnabled()
+    {
+        $psEndpoint = $this->friend->getAstPsEndpoint();
+
+        return $psEndpoint->getT38Udptl() == FriendInterface::T38PASSTHROUGH_YES;
+    }
 }

--- a/asterisk/agi/src/Agi/Agents/ResidentialAgent.php
+++ b/asterisk/agi/src/Agi/Agents/ResidentialAgent.php
@@ -125,4 +125,16 @@ class ResidentialAgent implements AgentInterface
     {
         return $this->residential->getVoiceMail();
     }
+
+    /**
+     * @brief Determine if agent's endpoint has T.38 Passthrough enabled
+     *
+     * @return boolean
+     */
+    public function isT38PassthroughEnabled()
+    {
+        $psEndpoint = $this->residential->getAstPsEndpoint();
+
+        return $psEndpoint->getT38Udptl() == ResidentialDeviceInterface::T38PASSTHROUGH_YES;
+    }
 }

--- a/asterisk/agi/src/Agi/Agents/RetailAgent.php
+++ b/asterisk/agi/src/Agi/Agents/RetailAgent.php
@@ -3,7 +3,6 @@
 namespace Agi\Agents;
 
 use Agi\Wrapper;
-use Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDeviceInterface;
 use Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface;
 
 class RetailAgent implements AgentInterface
@@ -108,5 +107,17 @@ class RetailAgent implements AgentInterface
     public function isAllowedToCall($destination)
     {
         return true;
+    }
+
+    /**
+     * @brief Determine if agent's endpoint has T.38 Passthrough enabled
+     *
+     * @return boolean
+     */
+    public function isT38PassthroughEnabled()
+    {
+        $psEndpoint = $this->retailAccount->getAstPsEndpoint();
+
+        return $psEndpoint->getT38Udptl() == RetailAccountInterface::T38PASSTHROUGH_YES;
     }
 }

--- a/asterisk/agi/src/Agi/Agents/UserAgent.php
+++ b/asterisk/agi/src/Agi/Agents/UserAgent.php
@@ -5,6 +5,7 @@ namespace Agi\Agents;
 use Agi\Wrapper;
 use Ivoz\Provider\Domain\Model\Locution\LocutionInterface;
 use Ivoz\Provider\Domain\Model\PickUpGroup\PickUpGroupInterface;
+use Ivoz\Provider\Domain\Model\Terminal\TerminalInterface;
 use Ivoz\Provider\Domain\Model\User\UserInterface;
 
 class UserAgent implements AgentInterface
@@ -118,5 +119,18 @@ class UserAgent implements AgentInterface
     public function getVoiceMailLocution()
     {
         return $this->user->getVoicemailLocution();
+    }
+
+    /**
+     * @brief Determine if agent's endpoint has T.38 Passthrough enabled
+     *
+     * @return boolean
+     */
+    public function isT38PassthroughEnabled()
+    {
+        $terminal = $this->user->getTerminal();
+        $psEndpoint = $terminal->getAstPsEndpoint();
+
+        return $psEndpoint->getT38Udptl() == TerminalInterface::T38PASSTHROUGH_YES;
     }
 }

--- a/asterisk/agi/src/Dialplan/Retails.php
+++ b/asterisk/agi/src/Dialplan/Retails.php
@@ -101,11 +101,6 @@ class Retails extends RouteHandlerAbstract
             $this->channelInfo->setChannelOrigin($caller);
         }
 
-        // Set variable for later usage
-        if ($isFax) {
-            $this->agi->setVariable("_T38PASSTHROUGH", "yes");
-        }
-
         // Some feedback for asterisk cli
         $this->agi->notice("Processing outgoing call from \e[0;36m%s\e[0;93m to number %s", $retailAccount, $exten);
 

--- a/doc/sphinx/administration_portal/client/residential/residential_devices.rst
+++ b/doc/sphinx/administration_portal/client/residential/residential_devices.rst
@@ -83,9 +83,7 @@ These are the configurable settings of *Residential devices*:
 
     Enable T.38 passthrough
         If set to 'yes', this SIP endpoint must be a **T.38 capable fax sender/receiver**. IvozProvider
-        application servers will act as T.38 gateways, routing calls through a T.38 capable carrier and
-        bridging signalling and media from one to another. See :ref:`Firewall <firewall>` for port exposing concerns
-        related to this kind of traffic.
+        will act as a T.38 gateway, bridging fax-calls of a T.38 capable carrier and a T.38 capable device.
 
 Voicemail settings
 ==================

--- a/doc/sphinx/administration_portal/client/retail/retail_accounts.rst
+++ b/doc/sphinx/administration_portal/client/retail/retail_accounts.rst
@@ -74,9 +74,7 @@ These are the configurable settings of *Retail accounts*:
 
     Enable T.38 passthrough
         If set to 'yes', this SIP endpoint must be a **T.38 capable fax sender/receiver**. IvozProvider
-        application servers will act as T.38 gateways, routing calls through a T.38 capable carrier and
-        bridging signalling and media from one to another. See :ref:`Firewall <firewall>` for port exposing concerns
-        related to this kind of traffic.
+        will act as a T.38 gateway, bridging fax-calls of a T.38 capable carrier and a T.38 capable device.
 
 .. warning:: All retail accounts within a retail client will have the transcoding capabilities configured at client level.
 

--- a/doc/sphinx/administration_portal/client/vpbx/routing_endpoints/friends/remote_friends.rst
+++ b/doc/sphinx/administration_portal/client/vpbx/routing_endpoints/friends/remote_friends.rst
@@ -100,9 +100,7 @@ These are the configurable settings of *friends*:
 
     Enable T.38 passthrough
         If set to 'yes', this SIP endpoint must be a **T.38 capable fax sender/receiver**. IvozProvider
-        application servers will act as T.38 gateways, routing calls through a T.38 capable carrier and
-        bridging signalling and media from one to another. See :ref:`Firewall <firewall>` for port exposing concerns
-        related to this kind of traffic.
+        will act as a T.38 gateway, bridging fax-calls of a T.38 capable carrier and a T.38 capable device.
 
 .. note:: Calls to *friends* are considered internal. That means that ACLs won't
           be checked when calling a friend, no matter if the origin of the call

--- a/doc/sphinx/administration_portal/client/vpbx/terminals.rst
+++ b/doc/sphinx/administration_portal/client/vpbx/terminals.rst
@@ -45,9 +45,7 @@ fields that must be filled.
 
     Enable T.38 passthrough
         If set to 'yes', this SIP endpoint must be a **T.38 capable fax sender/receiver**. IvozProvider
-        application servers will act as T.38 gateways, routing calls through a T.38 capable carrier and
-        bridging signalling and media from one to another. See :ref:`Firewall <firewall>` for port exposing concerns
-        related to this kind of traffic.
+        will act as a T.38 gateway, bridging fax-calls of a T.38 capable carrier and a T.38 capable device.
 
 .. note:: For **most of devices** that doesn't require provisioning just
    filling **username** and **password** will be enough.

--- a/doc/sphinx/locale/es/LC_MESSAGES/administration_portal.po
+++ b/doc/sphinx/locale/es/LC_MESSAGES/administration_portal.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: IvozProvider 2.7\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-05-09 17:12+0200\n"
+"POT-Creation-Date: 2019-05-20 17:12+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -4411,96 +4411,94 @@ msgstr ""
 #: ../../administration_portal/client/vpbx/terminals.rst:47
 msgid ""
 "If set to 'yes', this SIP endpoint must be a **T.38 capable fax "
-"sender/receiver**. IvozProvider application servers will act as T.38 "
-"gateways, routing calls through a T.38 capable carrier and bridging "
-"signalling and media from one to another. See :ref:`Firewall <firewall>` "
-"for port exposing concerns related to this kind of traffic."
+"sender/receiver**. IvozProvider will act as a T.38 gateway, bridging fax-"
+"calls of a T.38 capable carrier and a T.38 capable device."
 msgstr ""
 
-#: ../../administration_portal/client/residential/residential_devices.rst:91
-#: ../../administration_portal/client/retail/retail_accounts.rst:88
+#: ../../administration_portal/client/residential/residential_devices.rst:89
+#: ../../administration_portal/client/retail/retail_accounts.rst:86
 msgid "Voicemail settings"
 msgstr ""
 
-#: ../../administration_portal/client/residential/residential_devices.rst:93
+#: ../../administration_portal/client/residential/residential_devices.rst:91
 msgid ""
 "Every residential device has a voicemail that can be accessed using "
 "voicemail service code defined at brand level."
 msgstr ""
 
-#: ../../administration_portal/client/residential/residential_devices.rst:96
-#: ../../administration_portal/client/retail/retail_accounts.rst:93
+#: ../../administration_portal/client/residential/residential_devices.rst:94
+#: ../../administration_portal/client/retail/retail_accounts.rst:91
 msgid "Call forwarding settings"
 msgstr ""
 
-#: ../../administration_portal/client/residential/residential_devices.rst:98
+#: ../../administration_portal/client/residential/residential_devices.rst:96
 msgid ""
 "Apart from unconditional call forwarding to external number through "
 ":ref:`External call filters` applied to DDI, residential devices may have"
 " additional call forwarding settings that allow:"
 msgstr ""
 
-#: ../../administration_portal/client/residential/residential_devices.rst:101
+#: ../../administration_portal/client/residential/residential_devices.rst:99
 msgid "Forwarding to another external number."
 msgstr ""
 
-#: ../../administration_portal/client/residential/residential_devices.rst:103
+#: ../../administration_portal/client/residential/residential_devices.rst:101
 msgid "Forwarding to voicemail associated to each residential device."
 msgstr ""
 
-#: ../../administration_portal/client/residential/residential_devices.rst:105
+#: ../../administration_portal/client/residential/residential_devices.rst:103
 msgid ""
 "Supported forwarding types: unconditional, no-answer, non-registered, "
 "busy."
 msgstr ""
 
-#: ../../administration_portal/client/residential/residential_devices.rst:107
+#: ../../administration_portal/client/residential/residential_devices.rst:105
 msgid ""
 ":ref:`External call filters` have precedence over residential devices "
 "call forwarding settings."
 msgstr ""
 
-#: ../../administration_portal/client/residential/residential_devices.rst:111
+#: ../../administration_portal/client/residential/residential_devices.rst:109
 msgid "Asterisk as a residential device"
 msgstr ""
 
-#: ../../administration_portal/client/residential/residential_devices.rst:113
+#: ../../administration_portal/client/residential/residential_devices.rst:111
 msgid ""
 "At the other end of a device can be any kind of SIP entity. This section "
 "takes as example an Asterisk PBX system using SIP channel driver that "
 "wants to connect to IvozProvider."
 msgstr ""
 
-#: ../../administration_portal/client/residential/residential_devices.rst:118
+#: ../../administration_portal/client/residential/residential_devices.rst:116
 msgid "Device register"
 msgstr ""
 
-#: ../../administration_portal/client/residential/residential_devices.rst:120
-#: ../../administration_portal/client/retail/retail_accounts.rst:113
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends/remote_friends.rst:120
+#: ../../administration_portal/client/residential/residential_devices.rst:118
+#: ../../administration_portal/client/retail/retail_accounts.rst:111
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends/remote_friends.rst:118
 msgid ""
 "If the system can not be directly access, Asterisk will have to register "
 "in the platform (like a terminal will do)."
 msgstr ""
 
-#: ../../administration_portal/client/residential/residential_devices.rst:123
-#: ../../administration_portal/client/retail/retail_accounts.rst:116
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends/remote_friends.rst:123
+#: ../../administration_portal/client/residential/residential_devices.rst:121
+#: ../../administration_portal/client/retail/retail_accounts.rst:114
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends/remote_friends.rst:121
 msgid "Configuration will be something like this:"
 msgstr ""
 
-#: ../../administration_portal/client/residential/residential_devices.rst:130
+#: ../../administration_portal/client/residential/residential_devices.rst:128
 msgid "Device peer"
 msgstr ""
 
-#: ../../administration_portal/client/residential/residential_devices.rst:148
+#: ../../administration_portal/client/residential/residential_devices.rst:146
 msgid ""
 "*Residential devices* MUST NOT challenge IvozProvider. That's why the "
 "*insecure* setting is used here."
 msgstr ""
 
-#: ../../administration_portal/client/residential/residential_devices.rst:151
-#: ../../administration_portal/client/retail/retail_accounts.rst:144
+#: ../../administration_portal/client/residential/residential_devices.rst:149
+#: ../../administration_portal/client/retail/retail_accounts.rst:142
 msgid ""
 "As from username is used to identify the retail account, P-Asserted-"
 "Identity must be used to specify caller number."
@@ -4700,67 +4698,67 @@ msgid ""
 "account. If set to 'No', use called number instead."
 msgstr ""
 
-#: ../../administration_portal/client/retail/retail_accounts.rst:81
+#: ../../administration_portal/client/retail/retail_accounts.rst:79
 msgid ""
 "All retail accounts within a retail client will have the transcoding "
 "capabilities configured at client level."
 msgstr ""
 
-#: ../../administration_portal/client/retail/retail_accounts.rst:83
+#: ../../administration_portal/client/retail/retail_accounts.rst:81
 msgid ""
 "On retail account edit screen **id** field shows internal identification "
 "number assigned to the retail account. This id is transported to "
 "*Endpoint Id* field in *External Calls* section for CSV export."
 msgstr ""
 
-#: ../../administration_portal/client/retail/retail_accounts.rst:90
+#: ../../administration_portal/client/retail/retail_accounts.rst:88
 msgid "There is no voicemail service for retail clients."
 msgstr ""
 
-#: ../../administration_portal/client/retail/retail_accounts.rst:95
+#: ../../administration_portal/client/retail/retail_accounts.rst:93
 msgid ""
 "Each retail account can have a unique enabled call forward setting, "
 "pointing to an external number."
 msgstr ""
 
-#: ../../administration_portal/client/retail/retail_accounts.rst:97
+#: ../../administration_portal/client/retail/retail_accounts.rst:95
 msgid ""
 "This external called will be called whenever the retail account cannot be"
 " reached:"
 msgstr ""
 
-#: ../../administration_portal/client/retail/retail_accounts.rst:99
+#: ../../administration_portal/client/retail/retail_accounts.rst:97
 msgid ""
 "Direct connectivity accounts: when no answer is received from defined "
 "address."
 msgstr ""
 
-#: ../../administration_portal/client/retail/retail_accounts.rst:101
+#: ../../administration_portal/client/retail/retail_accounts.rst:99
 msgid ""
 "Accounts using SIP register: when no answer is received from last contact"
 " address or when no active register is found."
 msgstr ""
 
-#: ../../administration_portal/client/retail/retail_accounts.rst:104
+#: ../../administration_portal/client/retail/retail_accounts.rst:102
 msgid "Asterisk as a retail account"
 msgstr ""
 
-#: ../../administration_portal/client/retail/retail_accounts.rst:106
+#: ../../administration_portal/client/retail/retail_accounts.rst:104
 msgid ""
 "At the other end of a account can be any kind of SIP entity. This section"
 " takes as example an Asterisk PBX system using SIP channel driver that "
 "wants to connect to IvozProvider."
 msgstr ""
 
-#: ../../administration_portal/client/retail/retail_accounts.rst:111
+#: ../../administration_portal/client/retail/retail_accounts.rst:109
 msgid "Account register"
 msgstr ""
 
-#: ../../administration_portal/client/retail/retail_accounts.rst:123
+#: ../../administration_portal/client/retail/retail_accounts.rst:121
 msgid "Account peer"
 msgstr ""
 
-#: ../../administration_portal/client/retail/retail_accounts.rst:141
+#: ../../administration_portal/client/retail/retail_accounts.rst:139
 msgid ""
 "*Retail accounts* MUST NOT challenge IvozProvider. That's why the "
 "*insecure* setting is used here."
@@ -5445,7 +5443,7 @@ msgid ""
 msgstr ""
 
 #: ../../administration_portal/client/vpbx/routing_endpoints/friends/internal_friends.rst:63
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends/remote_friends.rst:107
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends/remote_friends.rst:105
 msgid ""
 "Calls to *friends* are considered internal. That means that ACLs won't be"
 " checked when calling a friend, no matter if the origin of the call is a "
@@ -5623,72 +5621,72 @@ msgid ""
 " If set to 'No', use called number instead."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends/remote_friends.rst:112
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends/remote_friends.rst:110
 msgid "Asterisk as a remote friend"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends/remote_friends.rst:114
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends/remote_friends.rst:112
 msgid ""
 "At the other end of a friend can be any kind of SIP entity. This section "
 "takes as example an Asterisk PBX system using SIP channel driver that "
 "wants to connect to IvozProvider."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends/remote_friends.rst:119
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends/remote_friends.rst:117
 msgid "register"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends/remote_friends.rst:130
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends/remote_friends.rst:128
 msgid "peer"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends/remote_friends.rst:147
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends/remote_friends.rst:145
 msgid ""
 "*Friends*, like terminals, MUST NOT challenge IvozProvider. That's why "
 "the *insecure* setting is used here."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends/remote_friends.rst:150
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends/remote_friends.rst:148
 msgid ""
 "As from username is used to identify the friend, P-Asserted-Identity must"
 " be used to specify caller number."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends/remote_friends.rst:153
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends/remote_friends.rst:151
 msgid "Summary of remote friends"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends/remote_friends.rst:155
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends/remote_friends.rst:153
 msgid ""
 "The key point is understanding that a *remote friend* has a direct "
 "relation with the extension-user-terminal trio:"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends/remote_friends.rst:158
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends/remote_friends.rst:156
 msgid "Can place calls to all internal extensions and other friends."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends/remote_friends.rst:160
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends/remote_friends.rst:158
 msgid "Can place external calls that its ACL allows"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends/remote_friends.rst:162
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends/remote_friends.rst:160
 msgid "Display their configured outgoing DDI when calling to external entities"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends/remote_friends.rst:164
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends/remote_friends.rst:162
 msgid ""
 "Never challenge IvozProvider requests (don't request authentication on "
 "received requests)"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends/remote_friends.rst:166
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends/remote_friends.rst:164
 msgid ""
 "Answers IvozProvider authentication challenges (All request from them to "
 "IvozProvider must be authenticated for security reasons)"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_endpoints/friends/remote_friends.rst:169
+#: ../../administration_portal/client/vpbx/routing_endpoints/friends/remote_friends.rst:167
 msgid ""
 "Only connects with *Users SIP Proxy*, like terminals. In fact, SIP "
 "traffic from friends are identical to any other user terminal traffic in "
@@ -6733,13 +6731,13 @@ msgid ""
 " of the SIP device."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/terminals.rst:52
+#: ../../administration_portal/client/vpbx/terminals.rst:50
 msgid ""
 "For **most of devices** that doesn't require provisioning just filling "
 "**username** and **password** will be enough."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/terminals.rst:55
+#: ../../administration_portal/client/vpbx/terminals.rst:53
 msgid ""
 "Once the terminal has been created, most devices will only require the "
 "name, password and :ref:`Client SIP domain <domain_per_client>` in order "
@@ -8277,87 +8275,4 @@ msgstr ""
 #: ../../administration_portal/platform/terminal_manufacturers.rst:177
 msgid "This example is identical to 't23/yea-{mac}', as subpaths are ignored."
 msgstr ""
-
-#~ msgid ""
-#~ "Once a call that implies cost is"
-#~ " hung up and is parsed by an"
-#~ " asynchronous process, it is listed "
-#~ "in :ref:`billable_calls`."
-#~ msgstr ""
-
-#~ msgid "Billable calls"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "**Billable calls** section only lists "
-#~ "**calls that imply cost for clients**,"
-#~ " usually external outgoing calls."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "An asynchronous process parses each "
-#~ "billable call and adds it to this"
-#~ " list a few minutes after call "
-#~ "hangup."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "At **brand level**, there is an "
-#~ "additional available operation: **Rerate "
-#~ "call**. This option allows calling "
-#~ "rating engine again for a call or"
-#~ " a bunch of calls."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This section is identical to "
-#~ ":ref:`Invoice schedulers` except to the "
-#~ "fields that do not apply to CSVs"
-#~ " (Invoice number sequence, Tax rate...)"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Apart from the fields above, everything"
-#~ " described in :ref:`Invoice schedulers` "
-#~ "applies here:"
-#~ msgstr ""
-
-#~ msgid "Frequency/Unit configuration."
-#~ msgstr ""
-
-#~ msgid "Email send."
-#~ msgstr ""
-
-#~ msgid "View generated CSVs in **List of Call CSV reports**."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The last step is pressing **Generate "
-#~ "invoice** suboption to create the final"
-#~ " PDF. Afterwards, we can see which"
-#~ " calls have been included in a "
-#~ "particular invoice with **List of "
-#~ "Billable Calls** option or download the"
-#~ " PDF file."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If rating of any call included in"
-#~ " an invoice is wrong, :ref:`Billable "
-#~ "Calls` section allows rerating it, as"
-#~ " long as the invoice that includes"
-#~ " the call is previously deleted."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "On retail account edit screen **id** "
-#~ "field shows internal identification number "
-#~ "assigned to the retail account. This "
-#~ "id is transported to *Endpoint Id* "
-#~ "field in *Billable Calls* section for"
-#~ " CSV export."
-#~ msgstr ""
-
-#~ msgid "Used for showing dates in Billable Calls and similar sections."
-#~ msgstr ""
 

--- a/doc/sphinx/locale/es/LC_MESSAGES/security_and_maintenance.po
+++ b/doc/sphinx/locale/es/LC_MESSAGES/security_and_maintenance.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: IvozProvider 2.7\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-04-23 17:09+0200\n"
+"POT-Creation-Date: 2019-05-20 17:12+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -639,38 +639,6 @@ msgid ""
 msgstr ""
 "Recomendamos utilizar el **módulo geoIP de iptables** para rechazar "
 "conexiones de países en los que no tengamos clientes."
-
-#: ../../security_and_maintenance/security/firewall.rst:43
-msgid "T.38 passthrough mode"
-msgstr "Modo pasarela T.38"
-
-#: ../../security_and_maintenance/security/firewall.rst:45
-msgid ""
-"vPBX terminals/friends, residential devices and retail accounts can be "
-"configured with T.38 passthrough enabled. In this kind of setup, T.38 "
-"capable devices will exchange T.38 RTP traffic directly to Application "
-"Servers."
-msgstr ""
-"Los terminales/friends de clientes vPBX, dispositivos residenciales y "
-"cuentas retail se pueden configurar con el modo pasarela T.38 activado. "
-"En este tipo de escenarios los dispositivos T.38 intercambiarán tráfico "
-"RTP T.38 directamente con los servidores de aplicación."
-
-#: ../../security_and_maintenance/security/firewall.rst:48
-msgid "This means that when this mode is needed:"
-msgstr "Esto significa que con este modo activado:"
-
-#: ../../security_and_maintenance/security/firewall.rst:50
-msgid ""
-"Application Server must have an exposed IP address (usually public IP "
-"address)."
-msgstr ""
-"Los servidores de aplicación tienen que estar expuestos (es decir, requerirán "
-"una IP pública)."
-
-#: ../../security_and_maintenance/security/firewall.rst:52
-msgid "Firewall will need to expose those IP addresses' 4000-4999 UDP port range."
-msgstr "El cortafuegos tendrá que exponer el rango 4000-4999 UDP de dichas IPs."
 
 #: ../../security_and_maintenance/security/index.rst:3
 msgid "Security"

--- a/doc/sphinx/security_and_maintenance/security/firewall.rst
+++ b/doc/sphinx/security_and_maintenance/security/firewall.rst
@@ -38,15 +38,3 @@ These are the **ports IvozProvider needs to expose** to work properly:
 
 .. hint:: We recommend using **iptables geoIP module** to drop connections from
           countries where we don't have any clients.
-
-T.38 passthrough mode
----------------------
-
-vPBX terminals/friends, residential devices and retail accounts can be configured with T.38 passthrough enabled. In this
-kind of setup, T.38 capable devices will exchange T.38 RTP traffic directly to Application Servers.
-
-This means that when this mode is needed:
-
-- Application Server must have an exposed IP address (usually public IP address).
-
-- Firewall will need to expose those IP addresses' 4000-4999 UDP port range.

--- a/library/Ivoz/Ast/Domain/Model/PsEndpoint/PsEndpointAbstract.php
+++ b/library/Ivoz/Ast/Domain/Model/PsEndpoint/PsEndpointAbstract.php
@@ -116,20 +116,20 @@ abstract class PsEndpointAbstract
      * comment: enum:none|fec|redundancy
      * @var string
      */
-    protected $t38UdptlEc = 'none';
+    protected $t38UdptlEc = 'redundancy';
 
     /**
      * column: t38_udptl_maxdatagram
      * @var integer
      */
-    protected $t38UdptlMaxdatagram = 0;
+    protected $t38UdptlMaxdatagram = 1440;
 
     /**
      * column: t38_udptl_nat
      * comment: enum:yes|no
      * @var string
      */
-    protected $t38UdptlNat = 'yes';
+    protected $t38UdptlNat = 'no';
 
     /**
      * @var \Ivoz\Provider\Domain\Model\Terminal\TerminalInterface

--- a/library/Ivoz/Ast/Domain/Model/PsEndpoint/PsEndpointDtoAbstract.php
+++ b/library/Ivoz/Ast/Domain/Model/PsEndpoint/PsEndpointDtoAbstract.php
@@ -98,17 +98,17 @@ abstract class PsEndpointDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $t38UdptlEc = 'none';
+    private $t38UdptlEc = 'redundancy';
 
     /**
      * @var integer
      */
-    private $t38UdptlMaxdatagram = 0;
+    private $t38UdptlMaxdatagram = 1440;
 
     /**
      * @var string
      */
-    private $t38UdptlNat = 'yes';
+    private $t38UdptlNat = 'no';
 
     /**
      * @var integer

--- a/library/Ivoz/Ast/Infrastructure/Persistence/Doctrine/Mapping/PsEndpoint.PsEndpointAbstract.orm.yml
+++ b/library/Ivoz/Ast/Infrastructure/Persistence/Doctrine/Mapping/PsEndpoint.PsEndpointAbstract.orm.yml
@@ -146,13 +146,13 @@ Ivoz\Ast\Domain\Model\PsEndpoint\PsEndpointAbstract:
       options:
         fixed: false
         comment: '[enum:none|fec|redundancy]'
-        default: none
+        default: redundancy
       column: t38_udptl_ec
     t38UdptlMaxdatagram:
       type: integer
       nullable: false
       options:
-        default: 0
+        default: 1440
         unsigned: true
       column: t38_udptl_maxdatagram
     t38UdptlNat:
@@ -162,7 +162,7 @@ Ivoz\Ast\Domain\Model\PsEndpoint\PsEndpointAbstract:
       options:
         fixed: false
         comment: '[enum:yes|no]'
-        default: yes
+        default: no
       column: t38_udptl_nat
   manyToOne:
     terminal:

--- a/library/Ivoz/Provider/Domain/Model/Friend/Friend.php
+++ b/library/Ivoz/Provider/Domain/Model/Friend/Friend.php
@@ -211,6 +211,9 @@ class Friend extends FriendAbstract implements FriendInterface
         return $callAcl->dstIsCallable($exten);
     }
 
+    /**
+     * @return \Ivoz\Ast\Domain\Model\PsEndpoint\PsEndpointInterface|mixed
+     */
     public function getAstPsEndpoint()
     {
         $astPsEnpoints = $this->getPsEndpoints(

--- a/library/Ivoz/Provider/Domain/Model/Friend/FriendInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/Friend/FriendInterface.php
@@ -98,6 +98,9 @@ interface FriendInterface extends LoggableEntityInterface
      */
     public function isAllowedToCall($exten);
 
+    /**
+     * @return \Ivoz\Ast\Domain\Model\PsEndpoint\PsEndpointInterface|mixed
+     */
     public function getAstPsEndpoint();
 
     public function getLanguageCode();

--- a/library/Ivoz/Provider/Domain/Model/RetailAccount/RetailAccount.php
+++ b/library/Ivoz/Provider/Domain/Model/RetailAccount/RetailAccount.php
@@ -85,6 +85,19 @@ class RetailAccount extends RetailAccountAbstract implements RetailAccountInterf
     }
 
     /**
+     * @return \Ivoz\Ast\Domain\Model\PsEndpoint\PsEndpointInterface|mixed
+     */
+    public function getAstPsEndpoint()
+    {
+        $astPsEnpoints = $this->getPsEndpoints(
+            Criteria::create()->setMaxResults(1)
+        );
+
+        return current($astPsEnpoints);
+    }
+
+
+    /**
      * @return string
      */
     public function getSorcery()

--- a/library/Ivoz/Provider/Domain/Model/RetailAccount/RetailAccountInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/RetailAccount/RetailAccountInterface.php
@@ -49,6 +49,11 @@ interface RetailAccountInterface extends LoggableEntityInterface
     public function setPort($port = null);
 
     /**
+     * @return \Ivoz\Ast\Domain\Model\PsEndpoint\PsEndpointInterface|mixed
+     */
+    public function getAstPsEndpoint();
+
+    /**
      * @return string
      */
     public function getSorcery();

--- a/schema/app/DoctrineMigrations/Version20190520145100.php
+++ b/schema/app/DoctrineMigrations/Version20190520145100.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20190520145100 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE ast_ps_endpoints CHANGE t38_udptl_ec t38_udptl_ec VARCHAR(255) DEFAULT \'redundancy\' NOT NULL COMMENT \'[enum:none|fec|redundancy]\', CHANGE t38_udptl_maxdatagram t38_udptl_maxdatagram INT UNSIGNED DEFAULT 1440 NOT NULL, CHANGE t38_udptl_nat t38_udptl_nat VARCHAR(255) DEFAULT \'no\' NOT NULL COMMENT \'[enum:yes|no]\'');
+
+        // Update existing endpoints
+        $this->addSql("UPDATE ast_ps_endpoints SET t38_udptl_nat='no', t38_udptl_ec='redundancy', t38_udptl_maxdatagram=1440");
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE ast_ps_endpoints CHANGE t38_udptl_ec t38_udptl_ec VARCHAR(255) DEFAULT \'none\' NOT NULL COLLATE utf8_general_ci COMMENT \'[enum:none|fec|redundancy]\', CHANGE t38_udptl_maxdatagram t38_udptl_maxdatagram INT UNSIGNED DEFAULT 0 NOT NULL, CHANGE t38_udptl_nat t38_udptl_nat VARCHAR(255) DEFAULT \'yes\' NOT NULL COLLATE utf8_general_ci COMMENT \'[enum:yes|no]\'');
+
+        // Update existing endpoints
+        $this->addSql("UPDATE ast_ps_endpoints SET t38_udptl_nat='yes', t38_udptl_ec='none', t38_udptl_maxdatagram=0");
+    }
+}

--- a/schema/tests/Provider/ResidentialDevice/ResidentialDeviceLifeCycleTest.php
+++ b/schema/tests/Provider/ResidentialDevice/ResidentialDeviceLifeCycleTest.php
@@ -171,9 +171,9 @@ class ResidentialDeviceLifeCycleTest extends KernelTestCase
                 'outbound_proxy' => 'sip:users.ivozprovider.local^3Blr',
                 'trust_id_inbound' => 'yes',
                 't38_udptl' => 'no',
-                't38_udptl_ec' => 'none',
-                't38_udptl_maxdatagram' => 0,
-                't38_udptl_nat' => 'yes',
+                't38_udptl_ec' => 'redundancy',
+                't38_udptl_maxdatagram' => 1440,
+                't38_udptl_nat' => 'no',
                 'residentialDeviceId' => 2,
                 'id' => 6
             ]


### PR DESCRIPTION
After some T.38 passthrough real-life tests, we have learnt:
    
- t38_udptl_ec: 'redundancy' seems better than 'none'.
- t38_udptl_maxdatagram: 1440 seems an standard value (and fixes some problems).
- t38_udptl_nat: set to 'no' as rtpengine does relay t.38 traffic.

This last point is very important: no Application Server exposure is needed.
