### PR TITLE
core: reset mailer transport before sending mail

### DIFF
--- a/library/Ivoz/Core/Infrastructure/Domain/Service/Mailer/Client.php
+++ b/library/Ivoz/Core/Infrastructure/Domain/Service/Mailer/Client.php
@@ -27,6 +27,12 @@ class Client implements MailerClientInterface
      */
     public function send(Message $message)
     {
+        $transport = $this->mailer->getTransport();
+        if (!$transport->ping()) {
+            $transport->stop();
+            $transport->start();
+        }
+
         $this->mailer
             ->send(
                 $message->toSwiftMessage()


### PR DESCRIPTION
Check if connection to MTA is ready before sending mail. If not, reset connection.