### PR TITLE
kamtrunks: order outgoing routes by priority

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -298,6 +298,7 @@ modparam("lcr", "ping_from", "sip:pinger@localhost")
 modparam("lcr", "lcr_count", 1)
 modparam("lcr", "dont_strip_or_prefix_flag", 1)
 modparam("lcr", "rule_id_avp", "$avp(lcr_rule_id)")
+modparam("lcr", "priority_ordering", 1)
 
 # TM
 modparam("tm", "fr_timer", 5000)


### PR DESCRIPTION
LCR kamailio module orders by prefix length, then by prio.

This changes this behaviour, causing strict prio ordering.

e.g.

- Calling +34676000000
* Prio 1: +34 CarrierA
* Prio 2: +346 CarrierB

Prior to this change, CarrierB would be used. After this change, CarrierA.