### PR TITLE
schema: update DDI E.164 number field with country information

### DIFF
--- a/schema/app/DoctrineMigrations/Version20190529132608.php
+++ b/schema/app/DoctrineMigrations/Version20190529132608.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20190529132608 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql("UPDATE DDIs D INNER JOIN Countries C ON C.id = D.countryId SET DDIE164 = CONCAT(C.countryCode, D.DDI)");
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+
+    }
+}


### PR DESCRIPTION
This PR includes a query to update DDIE164 field of DDIs table with the concatenation of countryCode + DDI (including plus sign)

This change should not change anything in _artemis_ release, but data migrated from previous releases will include the plus sign (_oasis_ uses E.164 without sign).