### PR TITLE
web/rest: allow file sizes up to 30M on destinationRateGroup importer

### DIFF
--- a/debian/ivozprovider-web-admin.postinst
+++ b/debian/ivozprovider-web-admin.postinst
@@ -15,8 +15,8 @@ chown www-data.www-data /opt/irontec/ivozprovider/web/admin/public/invoice-templ
 # Enable php environment variables
 /bin/sed -i 's/variables_order = "GPCS"/variables_order = "EGPCS"/g' 		/etc/php/7.0/cli/php.ini
 /bin/sed -i 's/variables_order = "GPCS"/variables_order = "EGPCS"/g' 		/etc/php/7.0/apache2/php.ini
-/bin/sed -i 's/upload_max_filesize = [0-9]\+M/upload_max_filesize = 20M/g' 	/etc/php/7.0/apache2/php.ini
-/bin/sed -i 's/post_max_size = [0-9]\+M/post_max_size = 20M/g' 				/etc/php/7.0/apache2/php.ini
+/bin/sed -i 's/upload_max_filesize = [0-9]\+M/upload_max_filesize = 30M/g' 	/etc/php/7.0/apache2/php.ini
+/bin/sed -i 's/post_max_size = [0-9]\+M/post_max_size = 30M/g' 				/etc/php/7.0/apache2/php.ini
 /bin/sed -i 's/; max_input_vars = 1000/max_input_vars = 10000/g' 			/etc/php/7.0/apache2/php.ini
 
 # Setup portal language

--- a/library/CoreBundle/Resources/config/services/path_resolvers.yml
+++ b/library/CoreBundle/Resources/config/services/path_resolvers.yml
@@ -146,7 +146,7 @@ services:
   Service\StoragePathResolverCollection::DestinationRateGroup:
      class: Ivoz\Core\Application\Service\StoragePathResolverCollection
      calls:
-      - [addPathResolver, ['File', '@Service\CommonStoragePathResolver::DestinationRateGroupFile']]
+      - [addPathResolver, ['file', '@Service\CommonStoragePathResolver::DestinationRateGroupFile']]
      public: true
 
   Service\CommonStoragePathResolver::DestinationRateGroupFile:

--- a/library/Ivoz/Provider/Application/Service/DestinationRateGroup/DestinationRateGroupDtoAssembler.php
+++ b/library/Ivoz/Provider/Application/Service/DestinationRateGroup/DestinationRateGroupDtoAssembler.php
@@ -49,7 +49,7 @@ class DestinationRateGroupDtoAssembler implements CustomDtoAssemblerInterface
         if ($entity->getFile()->getFileSize()) {
             $pathResolver = $this
                 ->storagePathResolver
-                ->getPathResolver('File');
+                ->getPathResolver('file');
 
             $pathResolver
                 ->setOriginalFileName(

--- a/library/Ivoz/Provider/Domain/Model/DestinationRateGroup/DestinationRateGroup.php
+++ b/library/Ivoz/Provider/Domain/Model/DestinationRateGroup/DestinationRateGroup.php
@@ -42,7 +42,7 @@ class DestinationRateGroup extends DestinationRateGroupAbstract implements FileC
     public function getFileObjects()
     {
         return [
-            'File'
+            'file'
         ];
     }
 
@@ -54,7 +54,7 @@ class DestinationRateGroup extends DestinationRateGroupAbstract implements FileC
      */
     public function addTmpFile($fldName, TempFile $file)
     {
-        if ($fldName == 'File') {
+        if ($fldName == 'file') {
             $this->setStatus('waiting');
         }
         $this->_addTmpFile($fldName, $file);

--- a/library/Ivoz/Provider/Domain/Model/DestinationRateGroup/DestinationRateGroupDto.php
+++ b/library/Ivoz/Provider/Domain/Model/DestinationRateGroup/DestinationRateGroupDto.php
@@ -28,7 +28,7 @@ class DestinationRateGroupDto extends DestinationRateGroupDtoAbstract
     public function getFileObjects()
     {
         return [
-            'File'
+            'file'
         ];
     }
 

--- a/web/admin/application/configs/klear/DestinationRateGroupsList.yaml
+++ b/web/admin/application/configs/klear/DestinationRateGroupsList.yaml
@@ -132,7 +132,7 @@ production:
       controller: import-destination-rates-custom-file
       action: import
       class:  ui-silk-page-white-get
-      freeUploadCommand: importDestinationRateGroupsFreeUpload_command
+      freeUploadCommand: destinationRateGroupsFileUpload_command
       delimiter: ","
       enclosure: '"'
       escape: "\\"
@@ -153,7 +153,7 @@ production:
       <<: *DestinationRateGroups
       controller: File
       action: upload
-      mainColumn: File
+      mainColumn: file
     importDestinationRateGroupsFreeUpload_command:
       <<: *DestinationRateGroups
       controller: File

--- a/web/admin/application/configs/klear/model/DestinationRateGroups.yaml
+++ b/web/admin/application/configs/klear/model/DestinationRateGroups.yaml
@@ -37,7 +37,7 @@ production:
       type: file
       source:
         data: fso
-        size_limit: 20M
+        size_limit: 30M
         options:
           hiddenName: false
           download:


### PR DESCRIPTION
Requieres to increase upload_max_filesize and post_max_size on php.ini