### PR TITLE
Allow unassigned route in Call Forward Settings

### DIFF
--- a/asterisk/agi/src/Agi/Action/RouterAction.php
+++ b/asterisk/agi/src/Agi/Action/RouterAction.php
@@ -385,7 +385,7 @@ class RouterAction
                 $this->routeService();
                 break;
             default:
-                $this->agi->error("No configured route type");
+                $this->agi->notice("No configured route type");
                 break;
         }
     }

--- a/library/Ivoz/Provider/Domain/Model/CallForwardSetting/CallForwardSettingAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/CallForwardSetting/CallForwardSettingAbstract.php
@@ -27,7 +27,7 @@ abstract class CallForwardSettingAbstract
 
     /**
      * comment: enum:number|extension|voicemail
-     * @var string
+     * @var string | null
      */
     protected $targetType;
 
@@ -85,13 +85,11 @@ abstract class CallForwardSettingAbstract
     protected function __construct(
         $callTypeFilter,
         $callForwardType,
-        $targetType,
         $noAnswerTimeout,
         $enabled
     ) {
         $this->setCallTypeFilter($callTypeFilter);
         $this->setCallForwardType($callForwardType);
-        $this->setTargetType($targetType);
         $this->setNoAnswerTimeout($noAnswerTimeout);
         $this->setEnabled($enabled);
     }
@@ -167,12 +165,12 @@ abstract class CallForwardSettingAbstract
         $self = new static(
             $dto->getCallTypeFilter(),
             $dto->getCallForwardType(),
-            $dto->getTargetType(),
             $dto->getNoAnswerTimeout(),
             $dto->getEnabled()
         );
 
         $self
+            ->setTargetType($dto->getTargetType())
             ->setNumberValue($dto->getNumberValue())
             ->setUser($fkTransformer->transform($dto->getUser()))
             ->setExtension($fkTransformer->transform($dto->getExtension()))
@@ -333,15 +331,16 @@ abstract class CallForwardSettingAbstract
      *
      * @return static
      */
-    protected function setTargetType($targetType)
+    protected function setTargetType($targetType = null)
     {
-        Assertion::notNull($targetType, 'targetType value "%s" is null, but non null value was expected.');
-        Assertion::maxLength($targetType, 25, 'targetType value "%s" is too long, it should have no more than %d characters, but has %d characters.');
-        Assertion::choice($targetType, [
-            CallForwardSettingInterface::TARGETTYPE_NUMBER,
-            CallForwardSettingInterface::TARGETTYPE_EXTENSION,
-            CallForwardSettingInterface::TARGETTYPE_VOICEMAIL
-        ], 'targetTypevalue "%s" is not an element of the valid values: %s');
+        if (!is_null($targetType)) {
+            Assertion::maxLength($targetType, 25, 'targetType value "%s" is too long, it should have no more than %d characters, but has %d characters.');
+            Assertion::choice($targetType, [
+                CallForwardSettingInterface::TARGETTYPE_NUMBER,
+                CallForwardSettingInterface::TARGETTYPE_EXTENSION,
+                CallForwardSettingInterface::TARGETTYPE_VOICEMAIL
+            ], 'targetTypevalue "%s" is not an element of the valid values: %s');
+        }
 
         $this->targetType = $targetType;
 
@@ -351,7 +350,7 @@ abstract class CallForwardSettingAbstract
     /**
      * Get targetType
      *
-     * @return string
+     * @return string | null
      */
     public function getTargetType()
     {

--- a/library/Ivoz/Provider/Domain/Model/CallForwardSetting/CallForwardSettingInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/CallForwardSetting/CallForwardSettingInterface.php
@@ -68,7 +68,7 @@ interface CallForwardSettingInterface extends LoggableEntityInterface
     /**
      * Get targetType
      *
-     * @return string
+     * @return string | null
      */
     public function getTargetType();
 

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/CallForwardSetting.CallForwardSettingAbstract.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/CallForwardSetting.CallForwardSettingAbstract.orm.yml
@@ -19,7 +19,7 @@ Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSettingAbstract:
       column: callForwardType
     targetType:
       type: string
-      nullable: false
+      nullable: true
       length: 25
       options:
         fixed: false

--- a/schema/app/DoctrineMigrations/Version20190604110803.php
+++ b/schema/app/DoctrineMigrations/Version20190604110803.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20190604110803 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE CallForwardSettings CHANGE targetType targetType VARCHAR(25) DEFAULT NULL COMMENT \'[enum:number|extension|voicemail]\'');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE CallForwardSettings CHANGE targetType targetType VARCHAR(25) NOT NULL COLLATE utf8_general_ci COMMENT \'[enum:number|extension|voicemail]\'');
+    }
+}

--- a/web/admin/application/configs/klear/model/CallForwardSettings.yaml
+++ b/web/admin/application/configs/klear/model/CallForwardSettings.yaml
@@ -68,11 +68,16 @@ production:
     targetType:
       title: _('Target type')
       type: select
-      required: true
+      required: false
       source:
         data: inline
         filterClass: IvozProvider_Klear_Filter_TargetTypes
         values:
+          '__null__':
+            title: _('Unassigned')
+            visualFilter:
+              show: [ ]
+              hide: [ extension, voiceMailUser, numberCountry, numberValue ]
           'number':
             title: _('Number')
             visualFilter:

--- a/web/user/app/languages/locale-en.json
+++ b/web/user/app/languages/locale-en.json
@@ -1,4 +1,5 @@
 {
+    "Unassigned": "Unassigned",
     "Username": "Username",
     "email": "Email",
     "Password": "Password",

--- a/web/user/app/languages/locale-es.json
+++ b/web/user/app/languages/locale-es.json
@@ -1,4 +1,5 @@
 {
+    "Unassigned": "Sin asignar",
     "Username": "Nombre de usuario",
     "email": "Correo electrónico",
     "Password": "Contraseña",

--- a/web/user/app/modules/detours/detoursEditCtrl.js
+++ b/web/user/app/modules/detours/detoursEditCtrl.js
@@ -148,6 +148,13 @@ angular
                 break;
 
             default:
+                $scope.voiceMailUserShow = false;
+                $scope.numberValueShow = false;
+                $scope.extensionShow = false;
+
+                if ($scope.detour) {
+                    $scope.detour.targetType = null;
+                }
                 break;
         }
     });

--- a/web/user/app/modules/detours/detoursNewCtrl.js
+++ b/web/user/app/modules/detours/detoursNewCtrl.js
@@ -83,7 +83,7 @@ angular
     });
 
     $scope.$watch('detour.targetType', function(type) {
-        
+
         switch (type) {
             case 'extension':
                 $scope.detour.numberValue = '';
@@ -112,6 +112,13 @@ angular
                 
                 $scope.detour.voiceMailUser = null;
                 $scope.voiceMailUserShow = false;
+                break;
+
+            default:
+                $scope.voiceMailUserShow = false;
+                $scope.numberValueShow = false;
+                $scope.extensionShow = false;
+                $scope.detour.targetType = null;
                 break;
         }
     });

--- a/web/user/app/views/detours/edit.html
+++ b/web/user/app/views/detours/edit.html
@@ -121,8 +121,8 @@
                                     id="targetType"
                                     name="targetType"
                                     ng-model="detour.targetType"
-                                    required="required"
                             >
+                                <option translate="Unassigned"></option>
                                 <option value="number" translate="number"></option>
                                 <option value="extension" translate="extension"></option>
                                 <option value="voicemail" translate="voicemail"></option>

--- a/web/user/app/views/detours/new.html
+++ b/web/user/app/views/detours/new.html
@@ -142,8 +142,8 @@
                                     id="targetType"
                                     name="targetType"
                                     ng-model="detour.targetType"
-                                    required="required"
                             >
+                                <option translate="Unassigned"></option>
                                 <option value="number" translate="number"></option>
                                 <option value="extension" translate="extension"></option>
                                 <option value="voicemail" translate="voicemail"></option>

--- a/web/user/app/views/detours/table-detours.html
+++ b/web/user/app/views/detours/table-detours.html
@@ -20,7 +20,7 @@
           </td>
           <td data-th="{{'callTypeFilter' | translate}}">{{detour.callTypeFilter | translate}}</td>
           <td data-th="{{'callForwardType' | translate}}">{{detour.callForwardType | translate}}</td>
-          <td data-th="{{'targetType' | translate}}">{{detour.targetType | translate}}</td>
+          <td data-th="{{'targetType' | translate}}">{{(detour.targetType || 'Unassigned')| translate}}</td>
           <td data-th="{{'destiny' | translate}}">{{detourTarget(detour)}}</td>
           
           <td data-th="{{'options' | translate}}">


### PR DESCRIPTION
This allows creating Call Forward settings without handler.

Although this may not seem to have too much logic, it could be used to setup dial timeout by adding a NoAnswer CallForwardSettings to ResidentialDevices or Users