### PR TITLE
Fix typo in transferred external calls.

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -609,7 +609,7 @@ route[GET_ROUTING_TAG] {
 route[ADAPT_REFERTO] {
 # Only in within-dialog REFER requests from subscribers
     if(!is_method("REFER")) return;
-    if($dlg_var(type ) != 'vpbx') return;
+    if($dlg_var(type) != 'vpbx') return;
 
     if (search_hf("Refer-To", "Replaces", "a")) {
         xinfo("[$dlg_var(cidhash)] ADAPT-REFERTO: Replacer found in Refer-To, return\n");


### PR DESCRIPTION
I could not make call transfer to an external number. After some debugging, it turns out that the external number was not properly transformed so it was rejected by kamailio@trunks.

The bug is due to a tiny typo in kamailio.cfg of kamailio@users.