### PR TITLE
Map nullable on delete cascade fk fields properly

### DIFF
--- a/library/Ivoz/Provider/Domain/Model/CallForwardSetting/CallForwardSettingAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/CallForwardSetting/CallForwardSettingAbstract.php
@@ -52,12 +52,12 @@ abstract class CallForwardSettingAbstract
     protected $user;
 
     /**
-     * @var \Ivoz\Provider\Domain\Model\Extension\ExtensionInterface
+     * @var \Ivoz\Provider\Domain\Model\Extension\ExtensionInterface | null
      */
     protected $extension;
 
     /**
-     * @var \Ivoz\Provider\Domain\Model\User\UserInterface
+     * @var \Ivoz\Provider\Domain\Model\User\UserInterface | null
      */
     protected $voiceMailUser;
 
@@ -480,7 +480,7 @@ abstract class CallForwardSettingAbstract
     /**
      * Get extension
      *
-     * @return \Ivoz\Provider\Domain\Model\Extension\ExtensionInterface
+     * @return \Ivoz\Provider\Domain\Model\Extension\ExtensionInterface | null
      */
     public function getExtension()
     {
@@ -504,7 +504,7 @@ abstract class CallForwardSettingAbstract
     /**
      * Get voiceMailUser
      *
-     * @return \Ivoz\Provider\Domain\Model\User\UserInterface
+     * @return \Ivoz\Provider\Domain\Model\User\UserInterface | null
      */
     public function getVoiceMailUser()
     {

--- a/library/Ivoz/Provider/Domain/Model/CallForwardSetting/CallForwardSettingInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/CallForwardSetting/CallForwardSettingInterface.php
@@ -121,7 +121,7 @@ interface CallForwardSettingInterface extends LoggableEntityInterface
     /**
      * Get extension
      *
-     * @return \Ivoz\Provider\Domain\Model\Extension\ExtensionInterface
+     * @return \Ivoz\Provider\Domain\Model\Extension\ExtensionInterface | null
      */
     public function getExtension();
 
@@ -137,7 +137,7 @@ interface CallForwardSettingInterface extends LoggableEntityInterface
     /**
      * Get voiceMailUser
      *
-     * @return \Ivoz\Provider\Domain\Model\User\UserInterface
+     * @return \Ivoz\Provider\Domain\Model\User\UserInterface | null
      */
     public function getVoiceMailUser();
 

--- a/library/Ivoz/Provider/Domain/Model/Company/CompanyAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Company/CompanyAbstract.php
@@ -149,7 +149,7 @@ abstract class CompanyAbstract
     protected $applicationServer;
 
     /**
-     * @var \Ivoz\Provider\Domain\Model\Country\CountryInterface
+     * @var \Ivoz\Provider\Domain\Model\Country\CountryInterface | null
      */
     protected $country;
 
@@ -1218,7 +1218,7 @@ abstract class CompanyAbstract
     /**
      * Get country
      *
-     * @return \Ivoz\Provider\Domain\Model\Country\CountryInterface
+     * @return \Ivoz\Provider\Domain\Model\Country\CountryInterface | null
      */
     public function getCountry()
     {

--- a/library/Ivoz/Provider/Domain/Model/Company/CompanyInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/Company/CompanyInterface.php
@@ -389,7 +389,7 @@ interface CompanyInterface extends LoggableEntityInterface
     /**
      * Get country
      *
-     * @return \Ivoz\Provider\Domain\Model\Country\CountryInterface
+     * @return \Ivoz\Provider\Domain\Model\Country\CountryInterface | null
      */
     public function getCountry();
 

--- a/library/Ivoz/Provider/Domain/Model/HolidayDate/HolidayDateAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/HolidayDate/HolidayDateAbstract.php
@@ -65,7 +65,7 @@ abstract class HolidayDateAbstract
     protected $extension;
 
     /**
-     * @var \Ivoz\Provider\Domain\Model\User\UserInterface
+     * @var \Ivoz\Provider\Domain\Model\User\UserInterface | null
      */
     protected $voiceMailUser;
 
@@ -530,7 +530,7 @@ abstract class HolidayDateAbstract
     /**
      * Get voiceMailUser
      *
-     * @return \Ivoz\Provider\Domain\Model\User\UserInterface
+     * @return \Ivoz\Provider\Domain\Model\User\UserInterface | null
      */
     public function getVoiceMailUser()
     {

--- a/library/Ivoz/Provider/Domain/Model/HolidayDate/HolidayDateInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/HolidayDate/HolidayDateInterface.php
@@ -141,7 +141,7 @@ interface HolidayDateInterface extends LoggableEntityInterface
     /**
      * Get voiceMailUser
      *
-     * @return \Ivoz\Provider\Domain\Model\User\UserInterface
+     * @return \Ivoz\Provider\Domain\Model\User\UserInterface | null
      */
     public function getVoiceMailUser();
 

--- a/library/Ivoz/Provider/Domain/Model/IvrEntry/IvrEntryAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/IvrEntry/IvrEntryAbstract.php
@@ -40,17 +40,17 @@ abstract class IvrEntryAbstract
     protected $welcomeLocution;
 
     /**
-     * @var \Ivoz\Provider\Domain\Model\Extension\ExtensionInterface
+     * @var \Ivoz\Provider\Domain\Model\Extension\ExtensionInterface | null
      */
     protected $extension;
 
     /**
-     * @var \Ivoz\Provider\Domain\Model\User\UserInterface
+     * @var \Ivoz\Provider\Domain\Model\User\UserInterface | null
      */
     protected $voiceMailUser;
 
     /**
-     * @var \Ivoz\Provider\Domain\Model\ConditionalRoute\ConditionalRouteInterface
+     * @var \Ivoz\Provider\Domain\Model\ConditionalRoute\ConditionalRouteInterface | null
      */
     protected $conditionalRoute;
 
@@ -377,7 +377,7 @@ abstract class IvrEntryAbstract
     /**
      * Get extension
      *
-     * @return \Ivoz\Provider\Domain\Model\Extension\ExtensionInterface
+     * @return \Ivoz\Provider\Domain\Model\Extension\ExtensionInterface | null
      */
     public function getExtension()
     {
@@ -401,7 +401,7 @@ abstract class IvrEntryAbstract
     /**
      * Get voiceMailUser
      *
-     * @return \Ivoz\Provider\Domain\Model\User\UserInterface
+     * @return \Ivoz\Provider\Domain\Model\User\UserInterface | null
      */
     public function getVoiceMailUser()
     {
@@ -425,7 +425,7 @@ abstract class IvrEntryAbstract
     /**
      * Get conditionalRoute
      *
-     * @return \Ivoz\Provider\Domain\Model\ConditionalRoute\ConditionalRouteInterface
+     * @return \Ivoz\Provider\Domain\Model\ConditionalRoute\ConditionalRouteInterface | null
      */
     public function getConditionalRoute()
     {

--- a/library/Ivoz/Provider/Domain/Model/IvrEntry/IvrEntryInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/IvrEntry/IvrEntryInterface.php
@@ -90,7 +90,7 @@ interface IvrEntryInterface extends LoggableEntityInterface
     /**
      * Get extension
      *
-     * @return \Ivoz\Provider\Domain\Model\Extension\ExtensionInterface
+     * @return \Ivoz\Provider\Domain\Model\Extension\ExtensionInterface | null
      */
     public function getExtension();
 
@@ -106,7 +106,7 @@ interface IvrEntryInterface extends LoggableEntityInterface
     /**
      * Get voiceMailUser
      *
-     * @return \Ivoz\Provider\Domain\Model\User\UserInterface
+     * @return \Ivoz\Provider\Domain\Model\User\UserInterface | null
      */
     public function getVoiceMailUser();
 
@@ -122,7 +122,7 @@ interface IvrEntryInterface extends LoggableEntityInterface
     /**
      * Get conditionalRoute
      *
-     * @return \Ivoz\Provider\Domain\Model\ConditionalRoute\ConditionalRouteInterface
+     * @return \Ivoz\Provider\Domain\Model\ConditionalRoute\ConditionalRouteInterface | null
      */
     public function getConditionalRoute();
 

--- a/library/Ivoz/Provider/Domain/Model/OutgoingRouting/OutgoingRoutingAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/OutgoingRouting/OutgoingRoutingAbstract.php
@@ -55,7 +55,7 @@ abstract class OutgoingRoutingAbstract
     protected $brand;
 
     /**
-     * @var \Ivoz\Provider\Domain\Model\Company\CompanyInterface
+     * @var \Ivoz\Provider\Domain\Model\Company\CompanyInterface | null
      */
     protected $company;
 
@@ -65,17 +65,17 @@ abstract class OutgoingRoutingAbstract
     protected $carrier;
 
     /**
-     * @var \Ivoz\Provider\Domain\Model\RoutingPattern\RoutingPatternInterface
+     * @var \Ivoz\Provider\Domain\Model\RoutingPattern\RoutingPatternInterface | null
      */
     protected $routingPattern;
 
     /**
-     * @var \Ivoz\Provider\Domain\Model\RoutingPatternGroup\RoutingPatternGroupInterface
+     * @var \Ivoz\Provider\Domain\Model\RoutingPatternGroup\RoutingPatternGroupInterface | null
      */
     protected $routingPatternGroup;
 
     /**
-     * @var \Ivoz\Provider\Domain\Model\RoutingTag\RoutingTagInterface
+     * @var \Ivoz\Provider\Domain\Model\RoutingTag\RoutingTagInterface | null
      */
     protected $routingTag;
 
@@ -506,7 +506,7 @@ abstract class OutgoingRoutingAbstract
     /**
      * Get company
      *
-     * @return \Ivoz\Provider\Domain\Model\Company\CompanyInterface
+     * @return \Ivoz\Provider\Domain\Model\Company\CompanyInterface | null
      */
     public function getCompany()
     {
@@ -554,7 +554,7 @@ abstract class OutgoingRoutingAbstract
     /**
      * Get routingPattern
      *
-     * @return \Ivoz\Provider\Domain\Model\RoutingPattern\RoutingPatternInterface
+     * @return \Ivoz\Provider\Domain\Model\RoutingPattern\RoutingPatternInterface | null
      */
     public function getRoutingPattern()
     {
@@ -578,7 +578,7 @@ abstract class OutgoingRoutingAbstract
     /**
      * Get routingPatternGroup
      *
-     * @return \Ivoz\Provider\Domain\Model\RoutingPatternGroup\RoutingPatternGroupInterface
+     * @return \Ivoz\Provider\Domain\Model\RoutingPatternGroup\RoutingPatternGroupInterface | null
      */
     public function getRoutingPatternGroup()
     {
@@ -602,7 +602,7 @@ abstract class OutgoingRoutingAbstract
     /**
      * Get routingTag
      *
-     * @return \Ivoz\Provider\Domain\Model\RoutingTag\RoutingTagInterface
+     * @return \Ivoz\Provider\Domain\Model\RoutingTag\RoutingTagInterface | null
      */
     public function getRoutingTag()
     {

--- a/library/Ivoz/Provider/Domain/Model/OutgoingRouting/OutgoingRoutingInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/OutgoingRouting/OutgoingRoutingInterface.php
@@ -121,7 +121,7 @@ interface OutgoingRoutingInterface extends LoggableEntityInterface
     /**
      * Get company
      *
-     * @return \Ivoz\Provider\Domain\Model\Company\CompanyInterface
+     * @return \Ivoz\Provider\Domain\Model\Company\CompanyInterface | null
      */
     public function getCompany();
 
@@ -153,7 +153,7 @@ interface OutgoingRoutingInterface extends LoggableEntityInterface
     /**
      * Get routingPattern
      *
-     * @return \Ivoz\Provider\Domain\Model\RoutingPattern\RoutingPatternInterface
+     * @return \Ivoz\Provider\Domain\Model\RoutingPattern\RoutingPatternInterface | null
      */
     public function getRoutingPattern();
 
@@ -169,7 +169,7 @@ interface OutgoingRoutingInterface extends LoggableEntityInterface
     /**
      * Get routingPatternGroup
      *
-     * @return \Ivoz\Provider\Domain\Model\RoutingPatternGroup\RoutingPatternGroupInterface
+     * @return \Ivoz\Provider\Domain\Model\RoutingPatternGroup\RoutingPatternGroupInterface | null
      */
     public function getRoutingPatternGroup();
 
@@ -185,7 +185,7 @@ interface OutgoingRoutingInterface extends LoggableEntityInterface
     /**
      * Get routingTag
      *
-     * @return \Ivoz\Provider\Domain\Model\RoutingTag\RoutingTagInterface
+     * @return \Ivoz\Provider\Domain\Model\RoutingTag\RoutingTagInterface | null
      */
     public function getRoutingTag();
 

--- a/library/Ivoz/Provider/Domain/Model/QueueMember/QueueMemberAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/QueueMember/QueueMemberAbstract.php
@@ -19,12 +19,12 @@ abstract class QueueMemberAbstract
     protected $penalty;
 
     /**
-     * @var \Ivoz\Provider\Domain\Model\Queue\QueueInterface
+     * @var \Ivoz\Provider\Domain\Model\Queue\QueueInterface | null
      */
     protected $queue;
 
     /**
-     * @var \Ivoz\Provider\Domain\Model\User\UserInterface
+     * @var \Ivoz\Provider\Domain\Model\User\UserInterface | null
      */
     protected $user;
 
@@ -214,7 +214,7 @@ abstract class QueueMemberAbstract
     /**
      * Get queue
      *
-     * @return \Ivoz\Provider\Domain\Model\Queue\QueueInterface
+     * @return \Ivoz\Provider\Domain\Model\Queue\QueueInterface | null
      */
     public function getQueue()
     {
@@ -238,7 +238,7 @@ abstract class QueueMemberAbstract
     /**
      * Get user
      *
-     * @return \Ivoz\Provider\Domain\Model\User\UserInterface
+     * @return \Ivoz\Provider\Domain\Model\User\UserInterface | null
      */
     public function getUser()
     {

--- a/library/Ivoz/Provider/Domain/Model/QueueMember/QueueMemberAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/QueueMember/QueueMemberAbstract.php
@@ -19,12 +19,12 @@ abstract class QueueMemberAbstract
     protected $penalty;
 
     /**
-     * @var \Ivoz\Provider\Domain\Model\Queue\QueueInterface | null
+     * @var \Ivoz\Provider\Domain\Model\Queue\QueueInterface
      */
     protected $queue;
 
     /**
-     * @var \Ivoz\Provider\Domain\Model\User\UserInterface | null
+     * @var \Ivoz\Provider\Domain\Model\User\UserInterface
      */
     protected $user;
 
@@ -204,7 +204,7 @@ abstract class QueueMemberAbstract
      *
      * @return static
      */
-    public function setQueue(\Ivoz\Provider\Domain\Model\Queue\QueueInterface $queue = null)
+    public function setQueue(\Ivoz\Provider\Domain\Model\Queue\QueueInterface $queue)
     {
         $this->queue = $queue;
 
@@ -214,7 +214,7 @@ abstract class QueueMemberAbstract
     /**
      * Get queue
      *
-     * @return \Ivoz\Provider\Domain\Model\Queue\QueueInterface | null
+     * @return \Ivoz\Provider\Domain\Model\Queue\QueueInterface
      */
     public function getQueue()
     {
@@ -238,7 +238,7 @@ abstract class QueueMemberAbstract
     /**
      * Get user
      *
-     * @return \Ivoz\Provider\Domain\Model\User\UserInterface | null
+     * @return \Ivoz\Provider\Domain\Model\User\UserInterface
      */
     public function getUser()
     {

--- a/library/Ivoz/Provider/Domain/Model/QueueMember/QueueMemberInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/QueueMember/QueueMemberInterface.php
@@ -31,7 +31,7 @@ interface QueueMemberInterface extends LoggableEntityInterface
     /**
      * Get queue
      *
-     * @return \Ivoz\Provider\Domain\Model\Queue\QueueInterface
+     * @return \Ivoz\Provider\Domain\Model\Queue\QueueInterface | null
      */
     public function getQueue();
 
@@ -47,7 +47,7 @@ interface QueueMemberInterface extends LoggableEntityInterface
     /**
      * Get user
      *
-     * @return \Ivoz\Provider\Domain\Model\User\UserInterface
+     * @return \Ivoz\Provider\Domain\Model\User\UserInterface | null
      */
     public function getUser();
 }

--- a/library/Ivoz/Provider/Domain/Model/QueueMember/QueueMemberInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/QueueMember/QueueMemberInterface.php
@@ -26,12 +26,12 @@ interface QueueMemberInterface extends LoggableEntityInterface
      *
      * @return static
      */
-    public function setQueue(\Ivoz\Provider\Domain\Model\Queue\QueueInterface $queue = null);
+    public function setQueue(\Ivoz\Provider\Domain\Model\Queue\QueueInterface $queue);
 
     /**
      * Get queue
      *
-     * @return \Ivoz\Provider\Domain\Model\Queue\QueueInterface | null
+     * @return \Ivoz\Provider\Domain\Model\Queue\QueueInterface
      */
     public function getQueue();
 
@@ -47,7 +47,7 @@ interface QueueMemberInterface extends LoggableEntityInterface
     /**
      * Get user
      *
-     * @return \Ivoz\Provider\Domain\Model\User\UserInterface | null
+     * @return \Ivoz\Provider\Domain\Model\User\UserInterface
      */
     public function getUser();
 }

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/CallForwardSetting.CallForwardSettingAbstract.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/CallForwardSetting.CallForwardSettingAbstract.orm.yml
@@ -68,6 +68,7 @@ Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSettingAbstract:
         extensionId:
           referencedColumnName: id
           onDelete: cascade
+          nullable: true
       orphanRemoval: false
     voiceMailUser:
       targetEntity: \Ivoz\Provider\Domain\Model\User\UserInterface
@@ -79,6 +80,7 @@ Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSettingAbstract:
         voiceMailUserId:
           referencedColumnName: id
           onDelete: cascade
+          nullable: true
       orphanRemoval: false
     numberCountry:
       targetEntity: \Ivoz\Provider\Domain\Model\Country\CountryInterface

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/Company.CompanyAbstract.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/Company.CompanyAbstract.orm.yml
@@ -226,6 +226,7 @@ Ivoz\Provider\Domain\Model\Company\CompanyAbstract:
         countryId:
           referencedColumnName: id
           onDelete: cascade
+          nullable: true
       orphanRemoval: false
     currency:
       targetEntity: \Ivoz\Provider\Domain\Model\Currency\CurrencyInterface

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/HolidayDate.HolidayDateAbstract.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/HolidayDate.HolidayDateAbstract.orm.yml
@@ -86,6 +86,7 @@ Ivoz\Provider\Domain\Model\HolidayDate\HolidayDateAbstract:
         voiceMailUserId:
           referencedColumnName: id
           onDelete: cascade
+          nullable: true
       orphanRemoval: false
     numberCountry:
       targetEntity: \Ivoz\Provider\Domain\Model\Country\CountryInterface

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/IvrEntry.IvrEntryAbstract.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/IvrEntry.IvrEntryAbstract.orm.yml
@@ -61,6 +61,7 @@ Ivoz\Provider\Domain\Model\IvrEntry\IvrEntryAbstract:
         extensionId:
           referencedColumnName: id
           onDelete: cascade
+          nullable: true
       orphanRemoval: false
     voiceMailUser:
       targetEntity: \Ivoz\Provider\Domain\Model\User\UserInterface
@@ -72,6 +73,7 @@ Ivoz\Provider\Domain\Model\IvrEntry\IvrEntryAbstract:
         voiceMailUserId:
           referencedColumnName: id
           onDelete: cascade
+          nullable: true
       orphanRemoval: false
     conditionalRoute:
       targetEntity: \Ivoz\Provider\Domain\Model\ConditionalRoute\ConditionalRouteInterface
@@ -83,6 +85,7 @@ Ivoz\Provider\Domain\Model\IvrEntry\IvrEntryAbstract:
         conditionalRouteId:
           referencedColumnName: id
           onDelete: cascade
+          nullable: true
       orphanRemoval: false
     numberCountry:
       targetEntity: \Ivoz\Provider\Domain\Model\Country\CountryInterface

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/OutgoingRouting.OutgoingRoutingAbstract.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/OutgoingRouting.OutgoingRoutingAbstract.orm.yml
@@ -70,6 +70,7 @@ Ivoz\Provider\Domain\Model\OutgoingRouting\OutgoingRoutingAbstract:
         companyId:
           referencedColumnName: id
           onDelete: cascade
+          nullable: true
       orphanRemoval: false
     carrier:
       targetEntity: \Ivoz\Provider\Domain\Model\Carrier\CarrierInterface
@@ -93,6 +94,7 @@ Ivoz\Provider\Domain\Model\OutgoingRouting\OutgoingRoutingAbstract:
         routingPatternId:
           referencedColumnName: id
           onDelete: cascade
+          nullable: true
       orphanRemoval: false
     routingPatternGroup:
       targetEntity: \Ivoz\Provider\Domain\Model\RoutingPatternGroup\RoutingPatternGroupInterface
@@ -104,6 +106,7 @@ Ivoz\Provider\Domain\Model\OutgoingRouting\OutgoingRoutingAbstract:
         routingPatternGroupId:
           referencedColumnName: id
           onDelete: cascade
+          nullable: true
       orphanRemoval: false
     routingTag:
       targetEntity: \Ivoz\Provider\Domain\Model\RoutingTag\RoutingTagInterface
@@ -115,6 +118,7 @@ Ivoz\Provider\Domain\Model\OutgoingRouting\OutgoingRoutingAbstract:
         routingTagId:
           referencedColumnName: id
           onDelete: cascade
+          nullable: true
       orphanRemoval: false
     clidCountry:
       targetEntity: \Ivoz\Provider\Domain\Model\Country\CountryInterface

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/QueueMember.QueueMemberAbstract.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/QueueMember.QueueMemberAbstract.orm.yml
@@ -17,6 +17,7 @@ Ivoz\Provider\Domain\Model\QueueMember\QueueMemberAbstract:
         queueId:
           referencedColumnName: id
           onDelete: cascade
+          nullable: true
       orphanRemoval: false
     user:
       targetEntity: \Ivoz\Provider\Domain\Model\User\UserInterface
@@ -28,4 +29,5 @@ Ivoz\Provider\Domain\Model\QueueMember\QueueMemberAbstract:
         userId:
           referencedColumnName: id
           onDelete: cascade
+          nullable: true
       orphanRemoval: false

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/QueueMember.QueueMemberAbstract.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/QueueMember.QueueMemberAbstract.orm.yml
@@ -17,7 +17,7 @@ Ivoz\Provider\Domain\Model\QueueMember\QueueMemberAbstract:
         queueId:
           referencedColumnName: id
           onDelete: cascade
-          nullable: true
+          nullable: false
       orphanRemoval: false
     user:
       targetEntity: \Ivoz\Provider\Domain\Model\User\UserInterface
@@ -29,5 +29,5 @@ Ivoz\Provider\Domain\Model\QueueMember\QueueMemberAbstract:
         userId:
           referencedColumnName: id
           onDelete: cascade
-          nullable: true
+          nullable: false
       orphanRemoval: false

--- a/schema/app/DoctrineMigrations/Version20190618064619.php
+++ b/schema/app/DoctrineMigrations/Version20190618064619.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20190618064619 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE QueueMembers CHANGE queueId queueId INT UNSIGNED NOT NULL, CHANGE userId userId INT UNSIGNED NOT NULL');
+        $this->addSql('ALTER TABLE CallForwardSettings CHANGE targetType targetType VARCHAR(25) DEFAULT NULL COMMENT \'[enum:number|extension|voicemail]\'');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE CallForwardSettings CHANGE targetType targetType VARCHAR(25) NOT NULL COLLATE utf8_general_ci COMMENT \'[enum:number|extension|voicemail]\'');
+        $this->addSql('ALTER TABLE QueueMembers CHANGE queueId queueId INT UNSIGNED DEFAULT NULL, CHANGE userId userId INT UNSIGNED DEFAULT NULL');
+    }
+}


### PR DESCRIPTION
Mark explicitly nullable on delete cascade foreign keys (default behaviour when nullablility is not defined) so that models and API are properly documented