### PR TITLE
ci: skip Pull Request tests when ci-no-test label is present

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,6 +26,13 @@ pipeline {
         // Prepare stage
         // --------------------------------------------------------------------
         stage('Prepare') {
+            when {
+                anyOf {
+                    expression { env.CHANGE_ID && pullRequest.labels.contains('ci-no-tests') == false }
+                    branch "bleeding"
+                    branch "artemis"
+                }
+            }
             agent {
                 docker {
                     image 'ironartemis/ivozprovider-testing-base'
@@ -43,6 +50,13 @@ pipeline {
         // Testing stage
         // --------------------------------------------------------------------
         stage('Testing') {
+            when {
+                anyOf {
+                    expression { env.CHANGE_ID && pullRequest.labels.contains('ci-no-tests') == false }
+                    branch "bleeding"
+                    branch "artemis"
+                }
+            }
             parallel {
                 stage ('app-console') {
                     agent {


### PR DESCRIPTION
PR label must be set during PR creation, otherwise a first run of the tests will be triggered.

This can be handy while creating documentation or application configuration changes that can not be tested right now.
