### PR TITLE
web/admin: forced close of add/edit tabs on emulation

### DIFF
--- a/web/admin/application/assets/js/customMenu.js
+++ b/web/admin/application/assets/js/customMenu.js
@@ -143,10 +143,24 @@
                             external:false
                             }
                         , function(resp) {
-                            $("#tabsList li").klearModule('reDispatch');
+
+                            $("#tabsList li")
+                                .filter(function () {
+                                    var controller = $(this).data('controller');
+                                    return (controller == 'edit' || controller == 'new');
+                                })
+                                .klearModule("close", {forced: true});
+
+                            $("#tabsList li")
+                                .filter(function () {
+                                    var controller = $(this).data('controller');
+                                    return !controller || controller == 'list';
+                                })
+                                .klearModule('reDispatch');
+
                             $.klear.restart({}, false);
                             $_dialog.dialog("destroy").remove();
-                            
+
                         }, function(error) {
                             $_dialog.dialog("destroy").remove();
                             console.log("ERROR", error);

--- a/web/admin/application/controllers/KlearCustomExtraAuthController.php
+++ b/web/admin/application/controllers/KlearCustomExtraAuthController.php
@@ -45,7 +45,13 @@ class KlearCustomExtraAuthController extends Zend_Controller_Action
         $dataGateway = \Zend_Registry::get('data_gateway');
         if ($type == 'brand') {
             if ($this->_user->canSeeMain) {
-                $html .= '<p>' . $this->view->translate('Select the brand you want to emulate.') . '</p></div>';
+                $html .=
+                    '<p>'
+                    . $this->view->translate('Select the brand you want to emulate.')
+                    . '</p>'
+                    . '<br/><span class="ui-silk inline ui-silk-error"></span><p>'
+                    . $this->view->translate('Notice that edition/creation tabs will be closed.')
+                    . '</p></div>';
                 $title = $this->view->translate('Select Brand');
 
                 $options = $dataGateway->findBy(
@@ -63,9 +69,15 @@ class KlearCustomExtraAuthController extends Zend_Controller_Action
         } elseif ($type == 'company') {
             if ($this->_user->canSeeBrand) {
                 if (is_null($this->_user->brandId)) {
-                    $html .= '<p>' . $this->view->translate('You have to emulate a brand to be able to emulate a company') . '</p></div>';
+                    $html .= '<p>' . $this->view->translate('You have to emulate a brand to be able to emulate a client') . '</p></div>';
                 } else {
-                    $html .= '<p>' . $this->view->translate('Select the company you want to emulate') . '</p></div>';
+                    $html .=
+                        '<p>'
+                        . $this->view->translate('Select the client you want to emulate')
+                        . '</p>'
+                        . '<span class="ui-icon ui-icon-circle-close"></span><p>'
+                        . $this->view->translate('Notice that edition/creation tabs will be closed.')
+                        . '</p></div>';
                     $options = $dataGateway->findBy(
                         Company::class,
                         ['Company.brand = ' . $this->_user->brandId],
@@ -197,7 +209,6 @@ class KlearCustomExtraAuthController extends Zend_Controller_Action
         throw new Zend_Exception($this->view->translate('Access denied'), Zend_Controller_Plugin_ErrorHandler::EXCEPTION_NO_ACTION);
     }
 
-
     public function emulateAction()
     {
         /** @var \Ivoz\Core\Application\Service\DataGateway $dataGateway */
@@ -234,7 +245,11 @@ class KlearCustomExtraAuthController extends Zend_Controller_Action
     protected function _getEmulateDefaultData($type, $model)
     {
         $title = $this->view->translate('Emulate %s', $type);
-        $message = $this->view->translate('Are you sure that you want to emulate the %s "%2s"?', $type, $model->getName());
+        $message = $this->view->translate(
+            'Are you sure that you want to emulate the %s "%2s"?',
+            $type,
+            $model->getName()
+        );
 
         $data = array(
                 "title" => $title,

--- a/web/admin/application/languages/en_US/en_US.po
+++ b/web/admin/application/languages/en_US/en_US.po
@@ -1669,6 +1669,9 @@ msgstr "None"
 msgid "Not Registered"
 msgstr "Not Registered"
 
+msgid "Notice that edition/creation tabs will be closed."
+msgstr "Notice that edition/creation tabs will be closed."
+
 msgid "Notification Threshold"
 msgstr "Notification Threshold"
 
@@ -2256,8 +2259,8 @@ msgstr "Select file to import"
 msgid "Select the brand you want to emulate."
 msgstr "Select the brand you want to emulate."
 
-msgid "Select the company you want to emulate"
-msgstr "Select the company you want to emulate"
+msgid "Select the client you want to emulate"
+msgstr "Select the client you want to emulate"
 
 msgid "Selected weight is already in use"
 msgstr "Selected weight is already in use"
@@ -2857,8 +2860,8 @@ msgstr ""
 msgid "You can't create a pricing plan that starts in de past"
 msgstr "You can't create a pricing plan that starts in de past"
 
-msgid "You have to emulate a brand to be able to emulate a company"
-msgstr "You have to emulate a brand to be able to emulate a company"
+msgid "You have to emulate a brand to be able to emulate a client"
+msgstr "You have to emulate a brand to be able to emulate a client"
 
 msgid "allow"
 msgstr "allow"

--- a/web/admin/application/languages/es_ES/es_ES.po
+++ b/web/admin/application/languages/es_ES/es_ES.po
@@ -1693,6 +1693,9 @@ msgstr "Ninguna"
 msgid "Not Registered"
 msgstr "No registrado"
 
+msgid "Notice that edition/creation tabs will be closed."
+msgstr "Las pestañas de edición/creación serán cerradas."
+
 msgid "Notification Threshold"
 msgstr "Límite de notificación"
 
@@ -2285,8 +2288,8 @@ msgstr "Seleccione fichero a importar"
 msgid "Select the brand you want to emulate."
 msgstr "Seleccione la marca que desea emular."
 
-msgid "Select the company you want to emulate"
-msgstr "Seleccione la empresa que desea emular"
+msgid "Select the client you want to emulate"
+msgstr "Seleccione el cliente que desea emular"
 
 msgid "Selected weight is already in use"
 msgstr "El peso seleccionado ya está en uso"
@@ -2895,8 +2898,8 @@ msgstr ""
 msgid "You can't create a pricing plan that starts in de past"
 msgstr "No es posible crear un Plan de precios en el pasado"
 
-msgid "You have to emulate a brand to be able to emulate a company"
-msgstr "Debe emular una marca antes de emular una compañía"
+msgid "You have to emulate a brand to be able to emulate a client"
+msgstr "Debe emular una marca antes de emular un cliente"
 
 msgid "allow"
 msgstr "permitir"


### PR DESCRIPTION
Close edit/add tabs when a brand/client is emulated so that you don't end up adding an entity with unexpected company/brand values