### PR TITLE
Brand user locations

### DIFF
--- a/library/Ivoz/Provider/Domain/Model/Friend/FriendDto.php
+++ b/library/Ivoz/Provider/Domain/Model/Friend/FriendDto.php
@@ -76,7 +76,7 @@ class FriendDto extends FriendDtoAbstract
     public static function getPropertyMap(string $context = '', string $role = null)
     {
         if ($context === self::CONTEXT_STATUS) {
-            return [
+            $baseAttributes = [
                 'id' => 'id',
                 'name' => 'name',
                 'domainName' => 'domainName',
@@ -86,6 +86,12 @@ class FriendDto extends FriendDtoAbstract
                     'userAgent'
                 ]
             ];
+
+            if ($role === 'ROLE_BRAND_ADMIN') {
+                $baseAttributes['companyId'] = 'company';
+            }
+
+            return $baseAttributes;
         }
 
         if ($context === self::CONTEXT_COLLECTION) {

--- a/library/Ivoz/Provider/Domain/Model/ResidentialDevice/ResidentialDeviceDto.php
+++ b/library/Ivoz/Provider/Domain/Model/ResidentialDevice/ResidentialDeviceDto.php
@@ -75,7 +75,7 @@ class ResidentialDeviceDto extends ResidentialDeviceDtoAbstract
     public static function getPropertyMap(string $context = '', string $role = null)
     {
         if ($context === self::CONTEXT_STATUS) {
-            return [
+            $baseAttributes = [
                 'id' => 'id',
                 'name' => 'name',
                 'domainName' => 'domainName',
@@ -85,6 +85,12 @@ class ResidentialDeviceDto extends ResidentialDeviceDtoAbstract
                     'userAgent'
                 ]
             ];
+
+            if ($role === 'ROLE_BRAND_ADMIN') {
+                $baseAttributes['companyId'] = 'company';
+            }
+
+            return $baseAttributes;
         }
 
         if ($context === self::CONTEXT_COLLECTION) {

--- a/library/Ivoz/Provider/Domain/Model/RetailAccount/RetailAccountDto.php
+++ b/library/Ivoz/Provider/Domain/Model/RetailAccount/RetailAccountDto.php
@@ -75,7 +75,7 @@ class RetailAccountDto extends RetailAccountDtoAbstract
     public static function getPropertyMap(string $context = self::CONTEXT_SIMPLE, string $role = null)
     {
         if ($context === self::CONTEXT_STATUS) {
-            return [
+            $baseAttributes = [
                 'id' => 'id',
                 'name' => 'name',
                 'domainName' => 'domainName',
@@ -85,6 +85,12 @@ class RetailAccountDto extends RetailAccountDtoAbstract
                     'userAgent'
                 ]
             ];
+
+            if ($role === 'ROLE_BRAND_ADMIN') {
+                $baseAttributes['companyId'] = 'company';
+            }
+
+            return $baseAttributes;
         }
 
         if ($context === self::CONTEXT_COLLECTION) {

--- a/library/Ivoz/Provider/Domain/Model/Terminal/TerminalDto.php
+++ b/library/Ivoz/Provider/Domain/Model/Terminal/TerminalDto.php
@@ -66,7 +66,7 @@ class TerminalDto extends TerminalDtoAbstract
     public static function getPropertyMap(string $context = '', string $role = null)
     {
         if ($context === self::CONTEXT_STATUS) {
-            return [
+            $baseAttributes = [
                 'id' => 'id',
                 'name' => 'name',
                 'domainName' => 'domainName',
@@ -76,6 +76,12 @@ class TerminalDto extends TerminalDtoAbstract
                     'userAgent'
                 ]
             ];
+
+            if ($role === 'ROLE_BRAND_ADMIN') {
+                $baseAttributes['companyId'] = 'company';
+            }
+
+            return $baseAttributes;
         }
 
         if ($context === self::CONTEXT_COLLECTION) {

--- a/web/rest/brand/app/config/api/raw/kam.yml
+++ b/web/rest/brand/app/config/api/raw/kam.yml
@@ -1,6 +1,10 @@
 ########################################
 ## Raw
 ########################################
+Ivoz\Kam\Domain\Model\UsersLocation\RegistrationStatus:
+  itemOperations: []
+  collectionOperations: []
+
 Ivoz\Kam\Domain\Model\UsersCdr\UsersCdr:
   attributes:
     access_control: '"ROLE_BRAND_ADMIN" in roles'

--- a/web/rest/brand/app/config/api/raw/provider.yml
+++ b/web/rest/brand/app/config/api/raw/provider.yml
@@ -355,6 +355,26 @@ Ivoz\Provider\Domain\Model\FixedCostsRelInvoice\FixedCostsRelInvoice:
         fixedCost: 'Ivoz\Provider\Domain\Model\FixedCost\FixedCost'
         invoice: 'Ivoz\Provider\Domain\Model\Invoice\Invoice'
 
+Ivoz\Provider\Domain\Model\Friend\Friend:
+  attributes:
+    pagination_client_enabled: true
+    access_control: '"ROLE_BRAND_ADMIN" in roles'
+    read_access_control:
+      ROLE_BRAND_ADMIN:
+        company:
+          in: "companyRepository.getSupervisedCompanyIdsByAdmin(user)"
+    write_access_control:
+      ROLE_BRAND_ADMIN:
+        raw: 'FALSE'
+  itemOperations: []
+  collectionOperations:
+    get_status_collection:
+      method: 'GET'
+      path: 'friends/status'
+      operation_normalization_context: 'status'
+      normalization_context:
+        groups: ['status']
+
 Ivoz\Provider\Domain\Model\Invoice\Invoice:
   attributes:
     access_control: '"ROLE_BRAND_ADMIN" in roles'
@@ -532,22 +552,50 @@ Ivoz\Provider\Domain\Model\RatingProfile\RatingProfile:
 Ivoz\Provider\Domain\Model\RetailAccount\RetailAccount:
   attributes:
     access_control: '"ROLE_BRAND_ADMIN" in roles'
+    pagination_client_enabled: true
     read_access_control:
       ROLE_BRAND_ADMIN:
         brand:
           eq: "user.getBrand().getId()"
         company:
           in: "companyRepository.getSupervisedCompanyIdsByAdmin(user)"
+  itemOperations:
+    get: ~
+    put: ~
+    delete: ~
+  collectionOperations:
+    get: ~
+    post: ~
+    get_status_collection:
+      method: 'GET'
+      path: 'retail_accounts/status'
+      operation_normalization_context: 'status'
+      normalization_context:
+        groups: ['status']
 
 Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDevice:
   attributes:
     access_control: '"ROLE_BRAND_ADMIN" in roles'
+    pagination_client_enabled: true
     read_access_control:
       ROLE_BRAND_ADMIN:
         brand:
           eq: "user.getBrand().getId()"
         company:
           in: "companyRepository.getSupervisedCompanyIdsByAdmin(user)"
+  itemOperations:
+    get: ~
+    put: ~
+    delete: ~
+  collectionOperations:
+    get: ~
+    post: ~
+    get_status_collection:
+      method: 'GET'
+      path: 'residential_devices/status'
+      operation_normalization_context: 'status'
+      normalization_context:
+        groups: ['status']
 
 Ivoz\Provider\Domain\Model\RoutingPatternGroup\RoutingPatternGroup:
   attributes:
@@ -601,6 +649,25 @@ Ivoz\Provider\Domain\Model\Service\Service:
     get: ~
   attributes:
     access_control: '"ROLE_BRAND_ADMIN" in roles'
+
+Ivoz\Provider\Domain\Model\Terminal\Terminal:
+  attributes:
+    access_control: '"ROLE_BRAND_ADMIN" in roles'
+    pagination_client_enabled: true
+    read_access_control:
+      ROLE_BRAND_ADMIN:
+        company:
+          in: "companyRepository.getSupervisedCompanyIdsByAdmin(user)"
+    write_access_control:
+      ROLE_BRAND_ADMIN:
+        raw: 'FALSE'
+  collectionOperations:
+    get_status_collection:
+      method: 'GET'
+      path: 'terminals/status'
+      operation_normalization_context: 'status'
+      normalization_context:
+        groups: ['status']
 
 Ivoz\Provider\Domain\Model\Timezone\Timezone:
   itemOperations:

--- a/web/rest/brand/features/provider/friend/getFriendStatus.feature
+++ b/web/rest/brand/features/provider/friend/getFriendStatus.feature
@@ -1,0 +1,32 @@
+Feature: Retrieve friends status
+  In order to manage friends status
+  As a brand admin
+  I need to be able to retrieve them through the API.
+
+  @createSchema
+  Scenario: Retrieve the friends status json list
+    Given I add Brand Authorization header
+    When I add "Accept" header equal to "application/json"
+    And I send a "GET" request to "friends/status"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+      [
+          {
+              "name": "testFriend",
+              "id": 1,
+              "company": 1,
+              "domainName": "127.0.0.1",
+              "status": [
+                  {
+                      "contact": "sip:yealinktest@10.10.1.107:5060",
+                      "expires": "2031-01-01 00:59:59",
+                      "userAgent": "Yealink SIP-T23G 44.80.0.130"
+                  }
+              ]
+          }
+      ]
+    """
+

--- a/web/rest/brand/features/provider/residentialDevice/getResidentialDeviceStatus.feature
+++ b/web/rest/brand/features/provider/residentialDevice/getResidentialDeviceStatus.feature
@@ -1,0 +1,31 @@
+Feature: Retrieve residential devices status
+  In order to manage residential devices status
+  As a brand admin
+  I need to be able to retrieve them through the API.
+
+  @createSchema
+  Scenario: Retrieve the residential devices status json list
+    Given I add Brand Authorization header
+    When I add "Accept" header equal to "application/json"
+    And I send a "GET" request to "residential_devices/status"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+      [
+          {
+              "name": "residentialDevice",
+              "id": 1,
+              "company": 1,
+              "domainName": "retail.irontec.com",
+              "status": [
+                  {
+                      "contact": "sip:yealinktest@10.10.1.108:5060",
+                      "expires": "2031-01-01 00:59:59",
+                      "userAgent": "Yealink SIP-T23G 44.80.0.130"
+                  }
+              ]
+          }
+      ]
+    """

--- a/web/rest/brand/features/provider/retailAccount/getRetailAccountStatus.feature
+++ b/web/rest/brand/features/provider/retailAccount/getRetailAccountStatus.feature
@@ -1,0 +1,32 @@
+Feature: Retrieve retail accounts status
+  In order to manage retail accounts status
+  As a brand admin
+  I need to be able to retrieve them through the API.
+
+  @createSchema
+  Scenario: Retrieve the retail accounts status json list
+    Given I add Brand Authorization header
+    When I add "Accept" header equal to "application/json"
+    And I send a "GET" request to "retail_accounts/status"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+      [
+          {
+              "name": "testRetailAccount",
+              "id": 1,
+              "company": 1,
+              "domainName": "retail.irontec.com",
+              "status": [
+                  {
+                      "contact": "sip:yealinktest@10.10.1.109:5060",
+                      "expires": "2031-01-01 00:59:59",
+                      "userAgent": "Yealink SIP-T23G 44.80.0.130"
+                  }
+              ]
+          }
+      ]
+    """
+

--- a/web/rest/brand/features/provider/terminal/getTerminalStatus.feature
+++ b/web/rest/brand/features/provider/terminal/getTerminalStatus.feature
@@ -1,0 +1,45 @@
+Feature: Retrieve terminals status
+  In order to manage terminals status
+  As a brand admin
+  I need to be able to retrieve them through the API.
+
+  @createSchema
+  Scenario: Retrieve the terminals status json list
+    Given I add Brand Authorization header
+    When I add "Accept" header equal to "application/json"
+    And I send a "GET" request to "terminals/status"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+      [
+          {
+              "name": "alice",
+              "id": 1,
+              "company": 1,
+              "domainName": "127.0.0.1",
+              "status": [
+                  {
+                      "contact": "sip:yealinktest@10.10.1.106:5060",
+                      "expires": "2031-01-01 00:59:59",
+                      "userAgent": "Yealink SIP-T23G 44.80.0.130"
+                  }
+              ]
+          },
+          {
+              "name": "bob",
+              "id": 2,
+              "company": 1,
+              "domainName": "127.0.0.1",
+              "status": []
+          },
+          {
+              "name": "testTerminal",
+              "id": 3,
+              "company": 1,
+              "domainName": "127.0.0.1",
+              "status": []
+          }
+      ]
+    """


### PR DESCRIPTION
Expose user locations on brand API. Added methods:
- /friends/status
- /residential_devices/status
- /retail_accounts/status
- /terminals/status