### PR TITLE
Avoid destination ambiguity in DDI-prefix and routing-tags

### DIFF
--- a/asterisk/agi/src/Agi/Agents/UserAgent.php
+++ b/asterisk/agi/src/Agi/Agents/UserAgent.php
@@ -61,7 +61,7 @@ class UserAgent implements AgentInterface
         $outgoingDDIRule = $this->user->getOutgoingDDIRule();
         if ($outgoingDDIRule) {
             // Get calling Prefix if header is present
-            $prefix = $this->agi->getSIPHeader('X-Info-Prefix');
+            $prefix = $this->agi->getSIPHeader('X-Info-DDI-Prefix');
 
             $this->agi->verbose("Checking %s for destination %s and prefix %s", $outgoingDDIRule, $destination, $prefix);
 

--- a/doc/sphinx/administration_portal/brand/routing/routing_tags.rst
+++ b/doc/sphinx/administration_portal/brand/routing/routing_tags.rst
@@ -23,6 +23,8 @@ Routing tag definition only implies these two fields:
     Tag
         Prefix itself
 
+.. important:: Tag **must** have this format: from 1 to 3 digits ended by # symbol.
+
 Using routing tags
 ------------------
 

--- a/doc/sphinx/administration_portal/client/vpbx/user_configuration/outgoing_ddi_rules.rst
+++ b/doc/sphinx/administration_portal/client/vpbx/user_configuration/outgoing_ddi_rules.rst
@@ -61,3 +61,5 @@ the DDI to 666666666.
 
 In this case, the User will present 666666666 DDI when calling any destination
 with 111 prefix and 777777777 when not using any prefix.
+
+.. important:: Prefix **must** have this format: from 1 to 3 digits ended by * symbol.

--- a/doc/sphinx/locale/es/LC_MESSAGES/administration_portal.po
+++ b/doc/sphinx/locale/es/LC_MESSAGES/administration_portal.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: IvozProvider 2.7\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-06-19 10:08+0200\n"
+"POT-Creation-Date: 2019-06-04 10:06+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -53,7 +53,7 @@ msgstr ""
 #: ../../administration_portal/client/vpbx/routing_endpoints/hunt_groups.rst:13
 #: ../../administration_portal/client/vpbx/routing_endpoints/ivrs.rst:21
 #: ../../administration_portal/client/vpbx/routing_endpoints/queues.rst:26
-#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:16
+#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:19
 #: ../../administration_portal/client/vpbx/routing_tools/external_call_filters.rst:17
 #: ../../administration_portal/client/vpbx/routing_tools/route_locks.rst:21
 #: ../../administration_portal/client/vpbx/terminals.rst:15
@@ -6239,8 +6239,8 @@ msgid ""
 "schedules, multiples calendars can be combined."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:9
-msgid "Calendar Holidays"
+#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:8
+msgid "Let's imagine three calendars with the following configuration:"
 msgstr ""
 
 #: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:11
@@ -6249,127 +6249,75 @@ msgid ""
 "what days will be holidays using the buttons in its row:"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:18
-msgid "Unique name to identify this holiday date"
-msgstr ""
-
-#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:19
-#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:64
-msgid "Locution"
+#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:15
+msgid ""
+"From this moment on, the calendar has the 1st of January of 2016 as "
+"holiday date with the locution \"Happy New Year\"."
 msgstr ""
 
 #: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:21
-msgid "Override default External call filter holiday locution"
+msgid "Unique name to identify this holiday date"
 msgstr ""
 
 #: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:22
-msgid "Event Date"
+msgid "Locution"
 msgstr ""
 
 #: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:24
-msgid "Day of the calendar to be marked as holiday"
+msgid "Override default External call filter holiday locution"
 msgstr ""
 
 #: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:25
-msgid "Whole day event"
+msgid "Event Date"
 msgstr ""
 
 #: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:27
-msgid "Enable this to create an event that lasts all the day"
+msgid "Day of the calendar to be marked as holiday"
 msgstr ""
 
 #: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:28
-msgid "Time In/Time out"
+msgid "Whole day event"
 msgstr ""
 
 #: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:30
+msgid "Enable this to create an event that lasts all the day"
+msgstr ""
+
+#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:31
+msgid "Time In/Time out"
+msgstr ""
+
+#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:33
 msgid ""
 "For not whole day events, specify the time interval the event will be "
 "active"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:31
+#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:34
 msgid "Routing options"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:33
+#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:36
 msgid "Override default External call filter holiday routing"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:35
+#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:38
 msgid ""
 "Calendars logic is opposite to Schedulers: If a day is not defined as "
 "holiday in any of the calendars, it will considered a normal day and no "
 "filtering will be applied."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:39
+#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:42
 msgid ""
 "Holidays without special locutions will apply the external call filter "
 "holiday locution."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:42
+#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:45
 msgid ""
 "Holidays without special routing will apply the external call filter "
 "holiday routing."
-msgstr ""
-
-#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:47
-msgid "Calendar Periods"
-msgstr ""
-
-#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:49
-msgid ""
-"Calendars can also be used to override some time periods with a different"
-" schedule. This can be handy if vPBX has a summer schedule or other types"
-" of schedule based events."
-msgstr ""
-
-#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:52
-msgid ""
-"Calendar periods can define a custom Scheduler and override External Call"
-" filters configurations:"
-msgstr ""
-
-#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:55
-msgid "Start Date"
-msgstr ""
-
-#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:57
-msgid "Since when the schedules will override the filters configuration"
-msgstr ""
-
-#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:58
-msgid "End Date"
-msgstr ""
-
-#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:60
-msgid "Last day of the period (included)"
-msgstr ""
-
-#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:61
-#: ../../administration_portal/client/vpbx/routing_tools/external_call_filters.rst:59
-#: ../../administration_portal/client/vpbx/routing_tools/schedules.rst:3
-msgid "Schedules"
-msgstr ""
-
-#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:63
-msgid "Schedules that will be used in the defined period"
-msgstr ""
-
-#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:66
-msgid ""
-"In case of Out of schedule, this locution that will be played. Leave "
-"empty to use External call filter's locution."
-msgstr ""
-
-#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:68
-msgid "Route options"
-msgstr ""
-
-#: ../../administration_portal/client/vpbx/routing_tools/calendars.rst:70
-msgid "Override default external call filter Out of schedule options"
 msgstr ""
 
 #: ../../administration_portal/client/vpbx/routing_tools/external_call_filters.rst:7
@@ -6470,6 +6418,11 @@ msgstr ""
 msgid ""
 "One or more calendars can be associated with the filter. The combination "
 "of all the calendars will be applied."
+msgstr ""
+
+#: ../../administration_portal/client/vpbx/routing_tools/external_call_filters.rst:59
+#: ../../administration_portal/client/vpbx/routing_tools/schedules.rst:3
+msgid "Schedules"
 msgstr ""
 
 #: ../../administration_portal/client/vpbx/routing_tools/external_call_filters.rst:61
@@ -6926,22 +6879,17 @@ msgstr ""
 #: ../../administration_portal/client/vpbx/user_configuration/outgoing_ddi_rules.rst:11
 msgid ""
 "But there are some cases when a single outgoing DDI is not enough, and "
-"the presented DDI depends on the called number or a given prefix. To "
-"archive this dynamic outgoing DDI selection you can use Outgoing DDI "
-"rules."
+"the presented DDI depends on the called number. To archive this dynamic "
+"outgoing DDI selection you can use Outgoing DDI rules."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/user_configuration/outgoing_ddi_rules.rst:17
-msgid "Outgoing DDI based on destination"
-msgstr ""
-
-#: ../../administration_portal/client/vpbx/user_configuration/outgoing_ddi_rules.rst:19
+#: ../../administration_portal/client/vpbx/user_configuration/outgoing_ddi_rules.rst:15
 msgid ""
-"For destination based rules, you would require first group the "
+"Before creating a new rule, it would be required to first group the "
 "destination numbers in :ref:`match_lists`."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/user_configuration/outgoing_ddi_rules.rst:22
+#: ../../administration_portal/client/vpbx/user_configuration/outgoing_ddi_rules.rst:18
 msgid ""
 "For this example, we will create a match list of corporate mobiles with "
 "all the mobile numbers of our client workers. When we call to those "
@@ -6950,76 +6898,48 @@ msgid ""
 "outgoing DDI."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/user_configuration/outgoing_ddi_rules.rst:28
-#: ../../administration_portal/client/vpbx/user_configuration/outgoing_ddi_rules.rst:53
+#: ../../administration_portal/client/vpbx/user_configuration/outgoing_ddi_rules.rst:24
 msgid "Create a new Outgoing DDI Rule"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/user_configuration/outgoing_ddi_rules.rst:29
+#: ../../administration_portal/client/vpbx/user_configuration/outgoing_ddi_rules.rst:25
 msgid ""
 "The main creation screen defines the action that will take place when no "
 "rule matches the dialed destination, so we define to force the main "
 "client DDI here."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/user_configuration/outgoing_ddi_rules.rst:33
+#: ../../administration_portal/client/vpbx/user_configuration/outgoing_ddi_rules.rst:29
 msgid "Assign rule lists actions"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/user_configuration/outgoing_ddi_rules.rst:34
+#: ../../administration_portal/client/vpbx/user_configuration/outgoing_ddi_rules.rst:30
 msgid ""
 "Now we add a new rule that will match our mobiles to make the user's "
 "outgoing DDI be kept untouched."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/user_configuration/outgoing_ddi_rules.rst:38
+#: ../../administration_portal/client/vpbx/user_configuration/outgoing_ddi_rules.rst:34
 msgid "Assign rule to callers"
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/user_configuration/outgoing_ddi_rules.rst:39
+#: ../../administration_portal/client/vpbx/user_configuration/outgoing_ddi_rules.rst:35
 msgid ""
 "At last, we have to configure who will use this rule to dynamically "
 "change it's presentation number. We can do this in the **Client's edit "
 "screen** or the **Users's edit screen**."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/user_configuration/outgoing_ddi_rules.rst:43
+#: ../../administration_portal/client/vpbx/user_configuration/outgoing_ddi_rules.rst:39
 msgid ""
 "In this case, the User will present 777777777 DDI when calling corporate "
 "mobiles and 666666666 when calling the rest of the external numbers."
 msgstr ""
 
-#: ../../administration_portal/client/vpbx/user_configuration/outgoing_ddi_rules.rst:47
-msgid "Outgoing DDI based on prefix"
-msgstr ""
-
-#: ../../administration_portal/client/vpbx/user_configuration/outgoing_ddi_rules.rst:49
+#: ../../administration_portal/client/vpbx/user_configuration/outgoing_ddi_rules.rst:42
 msgid ""
-"Outgoing DDI Rules can be also used to change the default Outgoing DDI "
-"based on a call prefix."
-msgstr ""
-
-#: ../../administration_portal/client/vpbx/user_configuration/outgoing_ddi_rules.rst:54
-msgid ""
-"The main creation screen defines the action that will take place when no "
-"rule matches the dialed destination, we will keep original DDI if no "
-"prefix is used."
-msgstr ""
-
-#: ../../administration_portal/client/vpbx/user_configuration/outgoing_ddi_rules.rst:58
-msgid "Assign a prefix pattern"
-msgstr ""
-
-#: ../../administration_portal/client/vpbx/user_configuration/outgoing_ddi_rules.rst:59
-msgid ""
-"Now we add a new rule that with prefix (let's say 111) and action to "
-"force the DDI to 666666666."
-msgstr ""
-
-#: ../../administration_portal/client/vpbx/user_configuration/outgoing_ddi_rules.rst:62
-msgid ""
-"In this case, the User will present 666666666 DDI when calling any "
-"destination with 111 prefix and 777777777 when not using any prefix."
+"Current implementation of Outgoing DDI rules won't work for diverted "
+"calls (out of schedule, holidays or user's call forward settings)."
 msgstr ""
 
 #: ../../administration_portal/client/vpbx/user_configuration/pick_up_groups.rst:5

--- a/doc/sphinx/locale/es/LC_MESSAGES/basic_concepts.po
+++ b/doc/sphinx/locale/es/LC_MESSAGES/basic_concepts.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: IvozProvider 2.7\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-07-09 10:19+0200\n"
+"POT-Creation-Date: 2019-06-04 10:06+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -550,12 +550,6 @@ msgid "It's possible to change any of this values anytime by running:"
 msgstr ""
 "Es posible cambiar cualquiera de estos valores una vez instalado "
 "IvozProvider volviendo a ejecutar:"
-
-#: ../../basic_concepts/installation/debian_install.rst:89
-msgid ""
-"You must reboot your machine after a package installation in order to "
-"start all required sevices."
-msgstr ""
 
 #: ../../basic_concepts/installation/extra_components.rst:3
 msgid "Extra components"

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -556,7 +556,6 @@ route[ADAPT_RURI_OUT] {
 
 route[ADAPT_RURI_IN] {
 # Only in initial INVITE requests from subscribers
-    route(GET_ROUTING_TAG);
 
     $var(number) = $rU;
     route(IS_INTERNAL);
@@ -565,29 +564,31 @@ route[ADAPT_RURI_IN] {
         return;
     }
 
-    route(GET_DDI_PREFIX);
+    # External call, look for route/DDI prefixes
+    if ($dlg_var(type) == 'wholesale' || $dlg_var(type) == 'retail') {
+        route(GET_ROUTING_TAG);
+    } else if ($dlg_var(type) == 'vpbx' && $dlg_var(userId) != $null) {
+        # Only users can force DDI using a prefix (through Outgoing DDI Rules)
+        route(GET_DDI_PREFIX);
+    }
 
-    xinfo("[$dlg_var(cidhash)] ADAPT-RURI-IN: Adapt '$var(number)' using rule '$var(transformation)'\n");
     $var(number) = $rU;
     $var(transformation) = $dlg_var(tr_callee_in);
+    xinfo("[$dlg_var(cidhash)] ADAPT-RURI-IN: Adapt '$var(number)' using rule '$var(transformation)'\n");
     route(APPLY_TRANSFORMATION);
     $rU = $var(transformated);
 }
 
-# Detects routing tag, sets header with tag and strips it from r-uri
-route[GET_ROUTING_TAG] {
-    if ($dlg_var(type) != 'wholesale' && $dlg_var(type) != 'retail') return;
-
-    # Guess routing tag
-    sql_query("cb", "SELECT tag, RT.id FROM RoutingTags RT INNER JOIN CompaniesRelRoutingTags CRRT ON CRRT.routingTagId = RT.id WHERE CRRT.companyId = '$dlg_var(companyId)'", "rb");
-    $var(tag) = "";
+# Iterates through $drb, sets $var(prefix) and $var(prefixId) if R-URI matches prefix and strips it
+route[SEARCH_AND_STRIP_PREFIX] {
+    $var(prefix) = "";
     if ($dbr(rb=>rows) > 0) {
         $var(i) = 0;
         while($var(i) < $dbr(rb=>rows)) {
-            $var(currentTag) = $dbr(rb=>[$var(i),0]);
-            if ($rU =~ "^" + $var(currentTag)) {
-                $var(tag) = $var(currentTag);
-                $var(tagId) = $dbr(rb=>[$var(i),1]);
+            $var(currentPrefix) = $dbr(rb=>[$var(i),0]);
+            if ($(rU{s.substr,0,$(var(currentPrefix){s.len})}) == $var(currentPrefix)) {
+                $var(prefix) = $var(currentPrefix);
+                $var(prefixId) = $dbr(rb=>[$var(i),1]);
                 break;
             }
             $var(i) = $var(i) + 1;
@@ -595,39 +596,49 @@ route[GET_ROUTING_TAG] {
     }
     sql_result_free("rb");
 
-    # Leave if no routing tag matched
-    if ($var(tag) == "") return;
-
-    # Add headers and strip from request uri
-    insert_hf("X-Info-RoutingTagId: $var(tagId)\r\n");
-    insert_hf("X-Info-RoutingTag: $var(tag)\r\n");
-    $rU = $(rU{s.strip, $(var(tag){s.len})});
-
-    xinfo("[$dlg_var(cidhash)] GET-ROUTING-TAG: Detected tag '$var(tag)' (id: $var(tagId)), new destination: $rU\n");
-
-    return;
+    # Strip from R-URI if routing tag matched
+    if ($var(prefix) != "") {
+        $rU = $(rU{s.strip, $(var(prefix){s.len})});
+    }
 }
 
-route[GET_DDI_PREFIX] {
-    if ($dlg_var(userId) == $null) return;
+# Detects routing tag, sets header with tag and id and strips it from r-uri
+route[GET_ROUTING_TAG] {
+    sql_query("cb", "SELECT tag, RT.id FROM RoutingTags RT INNER JOIN CompaniesRelRoutingTags CRRT ON CRRT.routingTagId = RT.id WHERE CRRT.companyId = '$dlg_var(companyId)'", "rb");
+    route(SEARCH_AND_STRIP_PREFIX);
 
-    sql_xquery("cb", "SELECT ODRP.prefix FROM OutgoingDDIRulesPatterns ODRP INNER JOIN OutgoingDDIRules ODR ON ODR.id = ODRP.outgoingDDIRuleId INNER JOIN Companies C ON C.id = ODR.companyId INNER JOIN Users U ON U.companyId = C.id WHERE ODR.id = COALESCE(U.outgoingDDIRuleId, C.outgoingDDIRuleId) AND U.id = '$dlg_var(userId)' AND ODRP.type = 'prefix' ORDER BY priority", "pref");
-
-    $var(i) = 0;
-    while($xavp(pref[$var(i)]) != $null) {
-        $var(prefix) = $xavp(pref[$var(i)]=>prefix);
-
-        if ($rU =~ "^" + $var(prefix)) {
-            xinfo("[$dlg_var(cidhash)] GET-DDI-PREFIX: '$var(prefix)' detected as DDI prefix\n");
-            append_hf("X-Info-Prefix: $var(prefix)\r\n");
-            $rU = $(rU{s.strip, $(var(prefix){s.len})});
-            break;
-        }
-
-        $var(i) = $var(i) + 1;
+    # Prevent multiple routing tag usage
+    if ($rU =~ "#") {
+        xerr("[$dlg_var(cidhash)] GET-ROUTING-TAG: Destination cannot contain '#' after stripping routing tag\n");
+        send_reply("404", "Invalid destination");
+        exit;
     }
 
-    return;
+    # Add headers if routing tag matched
+    if ($var(prefix) != "") {
+        xinfo("[$dlg_var(cidhash)] GET-ROUTING-TAG: Detected tag '$var(prefix)' (id: $var(prefixId)), new destination: $rU\n");
+        append_hf("X-Info-RoutingTagId: $var(prefixId)\r\n");
+        append_hf("X-Info-RoutingTag: $var(prefix)\r\n");
+    }
+}
+
+# Detects ddi prefix, sets header with prefix and strips it from r-uri
+route[GET_DDI_PREFIX] {
+    sql_query("cb", "SELECT ODRP.prefix, ODRP.id FROM OutgoingDDIRulesPatterns ODRP INNER JOIN OutgoingDDIRules ODR ON ODR.id = ODRP.outgoingDDIRuleId INNER JOIN Companies C ON C.id = ODR.companyId INNER JOIN Users U ON U.companyId = C.id WHERE ODR.id = COALESCE(U.outgoingDDIRuleId, C.outgoingDDIRuleId) AND U.id ='$dlg_var(userId)' AND ODRP.type = 'prefix' ORDER BY priority", "rb");
+    route(SEARCH_AND_STRIP_PREFIX);
+
+    # Prevent multiple ddi prefix usage
+    if ($rU =~ "\*") {
+        xerr("[$dlg_var(cidhash)] GET-DDI-PREFIX: Destination cannot contain '*' after stripping ddi prefix\n");
+        send_reply("404", "Invalid destination");
+        exit;
+    }
+
+    # Add headers if ddi prefix matched
+    if ($var(prefix) != "") {
+        xinfo("[$dlg_var(cidhash)] GET-DDI-PREFIX: Detected ddi prefix '$var(prefix)', new destination: $rU\n");
+        append_hf("X-Info-DDI-Prefix: $var(prefix)\r\n");
+    }
 }
 
 route[ADAPT_REFERTO] {

--- a/library/DataFixtures/ORM/ProviderRoutingTag.php
+++ b/library/DataFixtures/ORM/ProviderRoutingTag.php
@@ -25,7 +25,7 @@ class ProviderRoutingTag extends Fixture implements DependentFixtureInterface
         $item1 = $this->createEntityInstance(RoutingTag::class);
         (function () {
             $this->setName("TagName");
-            $this->setTag('aTag');
+            $this->setTag('123#');
         })->call($item1);
 
         $item1->setBrand(

--- a/library/Ivoz/Provider/Domain/Model/OutgoingDdiRulesPattern/OutgoingDdiRulesPattern.php
+++ b/library/Ivoz/Provider/Domain/Model/OutgoingDdiRulesPattern/OutgoingDdiRulesPattern.php
@@ -2,6 +2,8 @@
 
 namespace Ivoz\Provider\Domain\Model\OutgoingDdiRulesPattern;
 
+use Ivoz\Core\Domain\Assert\Assertion;
+
 /**
  * OutgoingDdiRulesPattern
  */
@@ -48,6 +50,23 @@ class OutgoingDdiRulesPattern extends OutgoingDdiRulesPatternAbstract implements
             $setter = 'set' . ucfirst($fieldName);
             $this->{$setter}(null);
         }
+    }
+
+    /**
+     * @param string| null $prefix
+     * @return static
+     * @throws \Exception
+     */
+    protected function setPrefix($prefix = null)
+    {
+        if (!is_null($prefix)) {
+            Assertion::regex(
+                $prefix,
+                '/^[0-9]{1,3}[*]$/'
+            );
+        }
+
+        return parent::setPrefix($prefix);
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/RoutingTag/RoutingTag.php
+++ b/library/Ivoz/Provider/Domain/Model/RoutingTag/RoutingTag.php
@@ -2,6 +2,8 @@
 
 namespace Ivoz\Provider\Domain\Model\RoutingTag;
 
+use Ivoz\Core\Domain\Assert\Assertion;
+
 /**
  * RoutingTag
  */
@@ -16,6 +18,16 @@ class RoutingTag extends RoutingTagAbstract implements RoutingTagInterface
     public function getChangeSet()
     {
         return parent::getChangeSet();
+    }
+
+    protected function setTag($tag)
+    {
+        Assertion::regex(
+            $tag,
+            '/^[0-9]{1,3}#$/'
+        );
+
+        return parent::setTag($tag);
     }
 
     /**

--- a/library/spec/Ivoz/Provider/Domain/Model/RoutingTag/RoutingTagSpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Model/RoutingTag/RoutingTagSpec.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace spec\Ivoz\Provider\Domain\Model\RoutingTag;
+
+use Ivoz\Provider\Domain\Model\Brand\BrandInterface;
+use Ivoz\Provider\Domain\Model\RoutingTag\RoutingTag;
+use Ivoz\Provider\Domain\Model\RoutingTag\RoutingTagDto;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use spec\HelperTrait;
+
+class RoutingTagSpec extends ObjectBehavior
+{
+    use HelperTrait;
+
+    /**
+     * @var RoutingTagDto
+     */
+    protected $dto;
+
+    protected $brand;
+
+    function let()
+    {
+        $this->dto = $dto = new RoutingTagDto();
+        $this->brand = $this->getTestDouble(
+            BrandInterface::class,
+            true
+        );
+
+        $dto
+            ->setName('Name')
+            ->setTag('987#');
+
+        $this->hydrate(
+            $dto,
+            [
+                'brand' => $this->brand->reveal()
+            ]
+        );
+
+        $this->beConstructedThrough(
+            'fromDto',
+            [$dto, new \spec\DtoToEntityFakeTransformer()]
+        );
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(RoutingTag::class);
+    }
+
+
+    function it_throws_exception_on_invalid_tag_format()
+    {
+        $validTags = [
+            '1#', '12#', '123#'
+        ];
+
+        foreach ($validTags as $validTag) {
+            $this
+                ->dto
+                ->setTag($validTag);
+
+            $response = $this->updateFromDto(
+                $this->dto,
+                new \spec\DtoToEntityFakeTransformer()
+            );
+
+            $this
+                ->getTag($validTag)
+                ->shouldReturn($validTag);
+        }
+
+        $invalidTagd = [
+            null,
+            '123',
+            '1234#'
+        ];
+
+        foreach ($invalidTagd as $invalidTag) {
+            $this
+                ->dto
+                ->setTag($invalidTag);
+
+            $this
+                ->shouldThrow('\Exception')
+                ->during(
+                    'updateFromDto',
+                    [
+                        $this->dto,
+                        new \spec\DtoToEntityFakeTransformer()
+                    ]
+                );
+        }
+    }
+}

--- a/schema/tests/Provider/RoutingPatternGroupsRelPattern/RoutingPatternGroupsRelPatternLifeCycleTest.php
+++ b/schema/tests/Provider/RoutingPatternGroupsRelPattern/RoutingPatternGroupsRelPatternLifeCycleTest.php
@@ -172,7 +172,7 @@ class RoutingPatternGroupsRelPatternLifeCycleTest extends KernelTestCase
             $changelog->getData(),
             [
                 'lcr_id' => 1,
-                'prefix' => 'aTag+35',
+                'prefix' => '123#+35',
                 'from_uri' => '^b1c1$',
                 'stopper' => 0,
                 'enabled' => 1,

--- a/schema/tests/Provider/RoutingTag/RoutingTagLifeCycleTest.php
+++ b/schema/tests/Provider/RoutingTag/RoutingTagLifeCycleTest.php
@@ -21,7 +21,7 @@ class RoutingTagLifeCycleTest extends KernelTestCase
         $routingTagDto = new RoutingTagDto();
         $routingTagDto
             ->setName('1')
-            ->setTag('2')
+            ->setTag('2#')
             ->setBrandId(1);
 
         return $routingTagDto;
@@ -48,7 +48,7 @@ class RoutingTagLifeCycleTest extends KernelTestCase
         $routingTag = $outgoingRouting->getRoutingTag();
         $routingTagDto = $this->entityTools->entityToDto($routingTag);
 
-        $routingTagDto->setTag('Something');
+        $routingTagDto->setTag('32#');
         $this->entityTools->persistDto(
             $routingTagDto,
             $routingTag,

--- a/web/admin/application/configs/klear/model/OutgoingDdiRulesPatterns.yaml
+++ b/web/admin/application/configs/klear/model/OutgoingDdiRulesPatterns.yaml
@@ -37,9 +37,15 @@ production:
       title: _('Prefix')
       type: text
       trim: both
-      pattern: "^[1-9].*$"
+      pattern: "^[0-9]{1,3}[*]$"
       required: true
       default: true
+      info:
+        type: box
+        position: left
+        icon: help
+        text: _("From 1 to 3 digits ended by * symbol")
+        label: _("Need help?")
     matchList:
       title: _('Match List')
       type: select

--- a/web/admin/application/configs/klear/model/RoutingTags.yaml
+++ b/web/admin/application/configs/klear/model/RoutingTags.yaml
@@ -10,8 +10,15 @@ production:
     tag:
       title: _('Tag')
       type: text
+      pattern: "^[0-9]{1,3}#$"
       required: true
       maxLength: 15
+      info:
+        type: box
+        position: left
+        icon: help
+        text: _("From 1 to 3 digits ended by # symbol")
+        label: _("Need help?")
     brand:
       title: ngettext('Brand', 'Brands', 1)
       type: select

--- a/web/admin/application/languages/en_US/en_US.po
+++ b/web/admin/application/languages/en_US/en_US.po
@@ -997,6 +997,12 @@ msgstr[1] "Friend Patterns"
 msgid "Friend value"
 msgstr "Friend value"
 
+msgid "From 1 to 3 digits ended by # symbol"
+msgstr "From 1 to 3 digits ended by # symbol"
+
+msgid "From 1 to 3 digits ended by * symbol"
+msgstr "From 1 to 3 digits ended by * symbol"
+
 msgid "From address"
 msgstr "From address"
 

--- a/web/admin/application/languages/es_ES/es_ES.po
+++ b/web/admin/application/languages/es_ES/es_ES.po
@@ -1010,6 +1010,12 @@ msgstr[1] "Patrones de Friend"
 msgid "Friend value"
 msgstr "Número friend"
 
+msgid "From 1 to 3 digits ended by # symbol"
+msgstr "De 1 a 3 dígitos seguidos de *"
+
+msgid "From 1 to 3 digits ended by * symbol"
+msgstr "De 1 a 3 dígitos seguidos de #"
+
 msgid "From address"
 msgstr "Dirección origen"
 

--- a/web/rest/brand/features/provider/outgoingRouting/getOutgoingRouting.feature
+++ b/web/rest/brand/features/provider/outgoingRouting/getOutgoingRouting.feature
@@ -72,7 +72,7 @@ Feature: Retrieve outgoing routings
           "routingPatternGroup": null,
           "routingTag": {
               "name": "TagName",
-              "tag": "aTag",
+              "tag": "123#",
               "id": 1,
               "brand": 1
           },

--- a/web/rest/brand/features/provider/routingTag/getRoutingTag.feature
+++ b/web/rest/brand/features/provider/routingTag/getRoutingTag.feature
@@ -32,7 +32,7 @@ Feature: Retrieve routing tag
     """
       {
           "name": "TagName",
-          "tag": "aTag",
+          "tag": "123#",
           "id": 1,
           "brand": {
               "name": "DemoBrand",

--- a/web/rest/brand/features/provider/routingTag/postRoutingTag.feature
+++ b/web/rest/brand/features/provider/routingTag/postRoutingTag.feature
@@ -12,7 +12,7 @@ Feature: Create routing tags
     """
       {
           "name": "Mine",
-          "tag": "00",
+          "tag": "00#",
           "id": 1,
           "brand": 1
       }
@@ -24,7 +24,7 @@ Feature: Create routing tags
     """
       {
           "name": "Mine",
-          "tag": "00",
+          "tag": "00#",
           "id": 2,
           "brand": 1
       }
@@ -41,7 +41,7 @@ Feature: Create routing tags
     """
       {
           "name": "Mine",
-          "tag": "00",
+          "tag": "00#",
           "id": 2,
           "brand": "~"
       }

--- a/web/rest/brand/features/provider/routingTag/putRoutingTag.feature
+++ b/web/rest/brand/features/provider/routingTag/putRoutingTag.feature
@@ -12,7 +12,7 @@ Feature: Update routing tags
     """
       {
           "name": "TagName",
-          "tag": "090",
+          "tag": "090#",
           "id": 1,
           "brand": 1
       }
@@ -24,7 +24,7 @@ Feature: Update routing tags
     """
       {
           "name": "TagName",
-          "tag": "090",
+          "tag": "090#",
           "id": 1,
           "brand": "~"
       }

--- a/web/rest/client/features/provider/outgoingDdiRulesPattern/putOutgoingDdiRulesPattern.feature
+++ b/web/rest/client/features/provider/outgoingDdiRulesPattern/putOutgoingDdiRulesPattern.feature
@@ -13,10 +13,11 @@ Feature: Update outgoing ddi rules patterns
       {
           "action": "force",
           "priority": 10,
-          "id": 1,
           "outgoingDdiRule": 1,
           "matchList": 2,
-          "forcedDdi": 1
+          "forcedDdi": 1,
+          "type": "prefix",
+          "prefix": "12*"
       }
     """
     Then the response status code should be 200
@@ -25,6 +26,8 @@ Feature: Update outgoing ddi rules patterns
      And the JSON should be like:
     """
       {
+          "type": "prefix",
+          "prefix": "12*",
           "action": "force",
           "priority": 10,
           "id": 1,
@@ -35,11 +38,7 @@ Feature: Update outgoing ddi rules patterns
               "company": 1,
               "forcedDdi": null
           },
-          "matchList": {
-              "name": "testMatchlist2",
-              "id": 2,
-              "company": 1
-          },
+          "matchList": null,
           "forcedDdi": "~"
       }
     """


### PR DESCRIPTION
This PR introduces restrictions in DDI-prefix and routing-tags format to avoid ambiguity in destination number. From now on:

- DDI-prefix must have this format: 1-3 digits ended by *.
- Routing-tag must have this format: 1-3 digits ended by #.

This way it is possible to distinguish prefix part from destination number.
