### PR TITLE
core: properly handle OutgoingDDIRule keep action

### DIFF
--- a/library/Ivoz/Provider/Domain/Model/OutgoingDdiRule/OutgoingDdiRule.php
+++ b/library/Ivoz/Provider/Domain/Model/OutgoingDdiRule/OutgoingDdiRule.php
@@ -118,6 +118,8 @@ class OutgoingDdiRule extends OutgoingDdiRuleAbstract implements OutgoingDdiRule
             // If we reached here, pattern matched: apply action
             if ($rulePattern->getAction() == OutgoingDdiRulesPatternInterface::ACTION_FORCE) {
                 $finalDdi = $rulePattern->getForcedDdi();
+            } else {
+                $finalDdi = $originalDdi;
             }
 
             break;


### PR DESCRIPTION
Action Keep was not being handled by Outgoing DDI rule pattern action using matchlists.