### PR TITLE
kamtrunks: allow within country calls if CGRateS is unreachable

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -443,8 +443,12 @@ request_route {
             route(CGRATES_AUTH_REQUEST);
 
             # From now on, only executed if CGRateS is DOWN
+            route(IS_WITHIN_COUNTRY);
+
             if ($sel(cfg_get.config.allow_calls_without_cgrates) == 1) {
                 xwarn("[$dlg_var(cidhash)] Allow call despite CGRateS being down");
+            } else if ($var(is_within_country)) {
+                xwarn("[$dlg_var(cidhash)] Allow within country call despite CGRateS being down");
             } else {
                 xerr("[$dlg_var(cidhash)] Drop call as CGRateS is down");
                 send_reply("503","Charging controller unreachable");
@@ -1691,6 +1695,27 @@ route[CONTROL_MAXCALLS] {
 
         exit;
     }
+}
+
+# This route sets $var(is_within_country) to 1 for within country calls
+route[IS_WITHIN_COUNTRY] {
+    $var(is_within_country) = 0;
+
+    sql_query("cb", "SELECT countryCode FROM Companies C JOIN Countries CS ON C.countryId=CS.id WHERE C.id=$dlg_var(companyId)", "ra");
+
+    if ($dbr(ra=>rows) > 0) {
+        $var(countryCode) = $dbr(ra=>[0, 0]);
+        if ($(rU{s.substr,0,$(var(countryCode){s.len})}) == $var(countryCode)) {
+            xinfo("[$dlg_var(cidhash)] IS-WITHIN-COUNTRY: '$rU' matches company's country code ($var(countryCode))\n");
+            $var(is_within_country) = 1;
+        } else {
+            xinfo("[$dlg_var(cidhash)] IS-WITHIN-COUNTRY: '$rU' DOES NOT match company's country code ($var(countryCode))\n");
+        }
+    } else {
+        xinfo("[$dlg_var(cidhash)] IS-WITHIN-COUNTRY: company$dlg_var(companyId) without country code\n");
+    }
+
+    sql_result_free("ra");
 }
 
 #################################################


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

CGRATES_AUTH_REQUEST route asks CGRateS whether a call can be billed before placing a call. If CGRateS is unreachable, no call is allowed.

[_allow_calls_without_cgrates_](https://github.com/irontec/ivozprovider/blob/41ff0905e5e200b49a92d955ad59d91ee70df875/kamailio/trunks/config/kamailio.cfg#L37) runtime variable disabled this check temporarily, for maintenance operations that need stopping CGRateS.

This PR aims to allow within country calls despite CGRateS being unreachable and _allow_calls_without_cgrates_ is not set.