### PR TITLE
kamtrunks: cgrates ignore errors in LcrGet

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -629,7 +629,7 @@ route[ADD_LCR_CARRIERS] {
     xinfo("[$dlg_var(cidhash)] GET-LCR-CARRIERS: Ask CGRateS for LCR carriers ($var(cgrTenant):$var(cgrAccount):$var(cgrSubject):$var(cgrDestination):$var(cgrCategory))");
 
     # Ask CGRateS for LCR carriers
-    $var(rc) = http_connect("cgrates", "/jsonrpc", "application/json", "{\"method\":\"ApierV1.GetLcr\",\"params\":[{\"Tenant\":\"$var(cgrTenant)\",\"Category\":\"$var(cgrCategory)\",\"Account\":\"$var(cgrAccount)\",\"Subject\":\"$var(cgrSubject)\",\"Destination\":\"$var(cgrDestination)\"}],\"id\":1}", "$avp(response)");
+    $var(rc) = http_connect("cgrates", "/jsonrpc", "application/json", "{\"method\":\"ApierV1.GetLcr\",\"params\":[{\"Tenant\":\"$var(cgrTenant)\",\"Category\":\"$var(cgrCategory)\",\"Account\":\"$var(cgrAccount)\",\"Subject\":\"$var(cgrSubject)\",\"Destination\":\"$var(cgrDestination)\",\"IgnoreErrors\":true}],\"id\":1}", "$avp(response)");
     xinfo("[$dlg_var(cidhash)] GET-LCR-CARRIERS: API-server HTTP connection result code: $var(rc)\n");
     xinfo("[$dlg_var(cidhash)] GET-LCR-CARRIERS: API-server HTTP connection response: $avp(response)\n");
 

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -639,13 +639,19 @@ route[ADD_LCR_CARRIERS] {
         xerr("[$dlg_var(cidhash)] GET-LCR-CARRIERS: Error non-empty or non-200 retcode");
         return;
     }
-    json_get_field("$avp(response)", "result", "$var(resultField)");
 
+    # Is there any carrier?
+    jansson_get("result.Suppliers", $avp(response), "$var(Suppliers)");
+    if ($var(Suppliers) == 0) {
+        xwarn("[$dlg_var(cidhash)] GET-LCR-CARRIERS: No carrier in '$var(cgrCategory)' is able to rate '$var(cgrDestination)'");
+        return;
+    }
+
+    # Yes, iterate
     $var(count) = 0;
-    jansson_array_size("Suppliers", $var(resultField), "$var(size)");
+    jansson_array_size("result.Suppliers", $avp(response), "$var(size)");
     while($var(count) < $var(size)) {
-        jansson_get("Suppliers[$var(count)]", $var(resultField), "$var(v)");
-        json_get_field("$var(v)", "Supplier", "$var(carrier)");
+        jansson_get("result.Suppliers[$var(count)].Supplier", $avp(response), "$var(carrier)");
         xinfo("[$dlg_var(cidhash)] GET-LCR-CARRIERS: Add carrier $var(carrier)");
 
         $var(carrierId) = $(var(carrier){s.numeric});


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
<!-- Describe your changes in detail -->

*ApierV1.GetLcr* call in kamailio.cfg for LCR routes fails with _LCR_COMPUTE_ERRORS_ when a carrier of LCR route cannot bill given destination.

This PR silently skips carriers that cannot bill given destination, adding only to Suppliers array those who can.