### PR TITLE
web/rest: show register status on ddi provider registrations

### DIFF
--- a/library/CoreBundle/Resources/config/services/assemblers.yml
+++ b/library/CoreBundle/Resources/config/services/assemblers.yml
@@ -57,7 +57,6 @@ services:
     arguments:
       $storagePathResolver: '@Service\StoragePathResolverCollection::FaxesInOut'
 
-
   ##########################################
   ## Friend
   ##########################################
@@ -139,3 +138,8 @@ services:
   ## Terminal
   ##########################################
   Ivoz\Provider\Application\Service\Terminal\TerminalDtoAssembler: ~
+
+  ##########################################
+  ## DdiProviderRegistration
+  ##########################################
+  Ivoz\Provider\Application\Service\DdiProviderRegistration\DdiProviderRegistrationDtoAssembler: ~

--- a/library/Ivoz/Core/Application/Model/DtoNormalizer.php
+++ b/library/Ivoz/Core/Application/Model/DtoNormalizer.php
@@ -26,7 +26,7 @@ trait DtoNormalizer
             $response,
             function ($value, $key) use ($contextProperties) {
 
-                $isEmbedded = is_array($value);
+                $isEmbedded = is_array($value) || is_object($value);
 
                 return
                     in_array($key, $contextProperties, true)

--- a/library/Ivoz/Kam/Domain/Model/TrunksUacreg/DdiProviderRegistrationStatus.php
+++ b/library/Ivoz/Kam/Domain/Model/TrunksUacreg/DdiProviderRegistrationStatus.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Ivoz\Kam\Domain\Model\TrunksUacreg;
+
+use Ivoz\Api\Core\Annotation\AttributeDefinition;
+
+class DdiProviderRegistrationStatus
+{
+   /**
+    * @AttributeDefinition(type="bool")
+    */
+    protected $registered = false;
+
+    /**
+     * @AttributeDefinition(type="bool")
+     */
+    protected $inProgress = false;
+
+    /**
+     * @AttributeDefinition(type="int", required=false)
+     */
+    protected $expires = null;
+
+    public function __construct(
+        int $statusCode,
+        int $expires = null
+    ) {
+        if ($statusCode === 20) {
+            $this
+                ->setRegistered(true)
+                ->setExpires($expires);
+        }
+
+        if (in_array($statusCode, [24, 18], true)) {
+            $this->setInProgress(true);
+        }
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'registered' => $this->getRegistered(),
+            'inProgress' => $this->getInProgress(),
+            'expires' => $this->getExpires()
+        ];
+    }
+
+    public function getRegistered(): bool
+    {
+        return $this->registered;
+    }
+
+    private function setRegistered(bool $registered): self
+    {
+        $this->registered = $registered;
+
+        return $this;
+    }
+
+    public function getInProgress(): bool
+    {
+        return $this->inProgress;
+    }
+
+    private function setInProgress(string $inProgress): self
+    {
+        $this->inProgress = $inProgress;
+
+        return $this;
+    }
+
+    /**
+     * @return string | null
+     */
+    public function getExpires()
+    {
+        return $this->expires;
+    }
+
+    private function setExpires(int $expires = null): self
+    {
+        $this->expires = $expires;
+
+        return $this;
+    }
+}

--- a/library/Ivoz/Kam/Infrastructure/Kamailio/TrunksClient.php
+++ b/library/Ivoz/Kam/Infrastructure/Kamailio/TrunksClient.php
@@ -76,6 +76,26 @@ class TrunksClient implements TrunksClientInterface
             return [];
         }
 
+        /**
+         * Expected response format
+         * [
+         *   "l_uuid" => 913512345,
+         *   "l_username" => "unused",
+         *   "l_domain" => "unused",
+         *   "r_username" => "S201707071003224",
+         *   "r_domain" => "trunksip2.domain.es",
+         *   "realm" => "",
+         *   "auth_username" => S201700001003224,
+         *   "auth_password" => "rqf00006n02QZjy",
+         *   "auth_proxy" => "sip:trunksip2.domain.es",
+         *   "expires" => 3600,
+         *   "flags" => 20,
+         *   "diff_expires" => 938,
+         *   "timer_expires" => 1567071127,
+         *   "reg_init" => 1564434542,
+         *   "reg_delay" => 0
+         * ]
+         */
         return (array) $response->result;
     }
 

--- a/library/Ivoz/Provider/Application/Service/DdiProviderRegistration/DdiProviderRegistrationDtoAssembler.php
+++ b/library/Ivoz/Provider/Application/Service/DdiProviderRegistration/DdiProviderRegistrationDtoAssembler.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Ivoz\Provider\Application\Service\DdiProviderRegistration;
+
+use Ivoz\Core\Application\DataTransferObjectInterface;
+use Ivoz\Core\Domain\Model\EntityInterface;
+use Ivoz\Core\Application\Service\Assembler\CustomDtoAssemblerInterface;
+use Ivoz\Kam\Domain\Model\TrunksUacreg\DdiProviderRegistrationStatus;
+use Ivoz\Kam\Domain\Service\TrunksClientInterface;
+use Ivoz\Provider\Domain\Model\DdiProviderRegistration\DdiProviderRegistrationDto;
+use Ivoz\Provider\Domain\Model\DdiProviderRegistration\DdiProviderRegistrationInterface;
+use Assert\Assertion;
+
+class DdiProviderRegistrationDtoAssembler implements CustomDtoAssemblerInterface
+{
+    protected $trunksClient;
+
+    public function __construct(
+        TrunksClientInterface $trunksClient
+    ) {
+        $this->trunksClient = $trunksClient;
+    }
+
+    /**
+     * @param DdiProviderRegistrationInterface $ddiProviderRegistration
+     * @throws \Exception
+     */
+    public function toDto(EntityInterface $ddiProviderRegistration, int $depth = 0, string $context = null): DataTransferObjectInterface
+    {
+        Assertion::isInstanceOf($ddiProviderRegistration, DdiProviderRegistrationInterface::class);
+
+        /** @var DdiProviderRegistrationDto $dto */
+        $dto = $ddiProviderRegistration->toDto($depth);
+
+        if (DdiProviderRegistrationDto::CONTEXT_DETAILED_COLLECTION !== $context) {
+            return $dto;
+        }
+
+        $trunksUacreg = $ddiProviderRegistration->getTrunksUacreg();
+
+        $uacRegistrationInfo = $this->trunksClient->getUacRegistrationInfo(
+            $trunksUacreg->getLUuid()
+        );
+
+        $statusCode = $uacRegistrationInfo['flags'] ?? -1;
+        $expires = $uacRegistrationInfo['diff_expires'] ?? null;
+
+        $dto->setStatus(
+            new DdiProviderRegistrationStatus(
+                $statusCode,
+                $expires
+            )
+        );
+
+        return $dto;
+    }
+}

--- a/library/Ivoz/Provider/Domain/Model/DdiProviderRegistration/DdiProviderRegistrationDto.php
+++ b/library/Ivoz/Provider/Domain/Model/DdiProviderRegistration/DdiProviderRegistrationDto.php
@@ -2,8 +2,20 @@
 
 namespace Ivoz\Provider\Domain\Model\DdiProviderRegistration;
 
+use Ivoz\Api\Core\Annotation\AttributeDefinition;
+use Ivoz\Kam\Domain\Model\TrunksUacreg\DdiProviderRegistrationStatus;
+
 class DdiProviderRegistrationDto extends DdiProviderRegistrationDtoAbstract
 {
+    /**
+     * @AttributeDefinition(
+     *     type="object",
+     *     class="Ivoz\Kam\Domain\Model\TrunksUacreg\DdiProviderRegistrationStatus",
+     *     description="Registration status"
+     * )
+     */
+    protected $status;
+
     /**
      * @inheritdoc
      * @codeCoverageIgnore
@@ -12,9 +24,53 @@ class DdiProviderRegistrationDto extends DdiProviderRegistrationDtoAbstract
     {
         $response =  parent::getPropertyMap(...func_get_args());
 
+        if ($context === self::CONTEXT_DETAILED_COLLECTION) {
+            return [
+                'id' => 'id',
+                'username' => 'username',
+                'domain' => 'domain',
+                'status' => [
+                    'registered',
+                    'inProgress',
+                    'expires'
+                ]
+            ];
+        }
+
         // Remove application entity relation
         unset($response['trunksUacregId']);
 
         return $response;
+    }
+
+
+    public function normalize(string $context, string $role = '')
+    {
+        $response = parent::normalize(...func_get_args());
+
+        if (!isset($response['status'])) {
+            return $response;
+        }
+
+        /**
+         * @var DdiProviderRegistrationStatus $status
+         */
+        $status = $response['status'];
+        $response['status'] = $status->toArray();
+
+        return $response;
+    }
+
+    public function toArray($hideSensitiveData = false)
+    {
+        $response = parent::toArray($hideSensitiveData);
+        $response['status'] = $this->status;
+
+        return $response;
+    }
+
+    public function setStatus(DdiProviderRegistrationStatus $status)
+    {
+        $this->status = $status;
     }
 }

--- a/library/spec/Ivoz/Provider/Application/Service/DdiProviderRegistration/DdiProviderRegistrationDtoAssemblerSpec.php
+++ b/library/spec/Ivoz/Provider/Application/Service/DdiProviderRegistration/DdiProviderRegistrationDtoAssemblerSpec.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace spec\Ivoz\Provider\Application\Service\DdiProviderRegistration;
+
+use Ivoz\Kam\Domain\Model\TrunksUacreg\DdiProviderRegistrationStatus;
+use Ivoz\Kam\Domain\Model\TrunksUacreg\TrunksUacregInterface;
+use Ivoz\Kam\Domain\Service\TrunksClientInterface;
+use Ivoz\Provider\Application\Service\DdiProviderRegistration\DdiProviderRegistrationDtoAssembler;
+use Ivoz\Provider\Domain\Model\DdiProviderRegistration\DdiProviderRegistrationDto;
+use Ivoz\Provider\Domain\Model\DdiProviderRegistration\DdiProviderRegistrationInterface;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use spec\HelperTrait;
+
+class DdiProviderRegistrationDtoAssemblerSpec extends ObjectBehavior
+{
+    use HelperTrait;
+
+    /** @var TrunksClientInterface */
+    protected $trunksClient;
+
+    /** @var DdiProviderRegistrationInterface */
+    protected $ddiProviderRegistration;
+
+    /** @var DdiProviderRegistrationDto */
+    protected $ddiProviderRegistrationDto;
+
+    /** @var TrunksUacregInterface */
+    protected $trunksUacreg;
+
+    public function let(
+        TrunksClientInterface $trunksClient
+    ) {
+        $this->trunksClient = $trunksClient;
+
+        $this->beConstructedWith($trunksClient);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(DdiProviderRegistrationDtoAssembler::class);
+    }
+
+    function it_does_nothing_on_empty_status()
+    {
+        $this->prepareExecution();
+
+        $this->ddiProviderRegistration
+            ->getTrunksUacreg()
+            ->shouldNotBeCalled();
+
+        $this
+            ->toDto($this->ddiProviderRegistration)
+            ->shouldReturn($this->ddiProviderRegistrationDto);
+    }
+
+    function it_sets_status_on_detailed_collection_context()
+    {
+        $this->prepareExecution();
+
+        $this
+            ->ddiProviderRegistrationDto
+            ->setStatus(
+                Argument::type(DdiProviderRegistrationStatus::class)
+            )
+            ->shouldBeCalled();
+
+        $this
+            ->toDto(
+                $this->ddiProviderRegistration,
+                0,
+                DdiProviderRegistrationDto::CONTEXT_DETAILED_COLLECTION
+            )
+            ->shouldReturn(
+                $this->ddiProviderRegistrationDto
+            );
+    }
+
+    protected function prepareExecution()
+    {
+        $this->ddiProviderRegistration = $this->getTestDouble(
+            DdiProviderRegistrationInterface::class
+        );
+        $ddiProviderRegistration = $this->ddiProviderRegistration;
+
+        $this->ddiProviderRegistrationDto = $this->getTestDouble(
+            DdiProviderRegistrationDto::class
+        );
+        $dto = $this->ddiProviderRegistrationDto;
+
+        $this->trunksUacreg = $this->getTestDouble(
+            TrunksUacregInterface::class
+        );
+        $trunksUacreg = $this->trunksUacreg;
+
+
+        $ddiProviderRegistration
+            ->toDto(
+                Argument::any()
+            )
+            ->willReturn($dto);
+
+        $ddiProviderRegistration
+            ->getTrunksUacreg()
+            ->willReturn($trunksUacreg);
+
+        $luuid = 'luuid';
+        $trunksUacreg
+            ->getLUuid()
+            ->willReturn($luuid);
+
+        $uacRegistrationInfo = [
+            "flags" => 20,
+            "diff_expires" => 938,
+        ];
+        $this
+            ->trunksClient
+            ->getUacRegistrationInfo($luuid)
+            ->willReturn($uacRegistrationInfo);
+    }
+}

--- a/web/rest/brand/app/config/api/raw/kam.yml
+++ b/web/rest/brand/app/config/api/raw/kam.yml
@@ -1,6 +1,10 @@
 ########################################
 ## Raw
 ########################################
+Ivoz\Kam\Domain\Model\TrunksUacreg\DdiProviderRegistrationStatus:
+  itemOperations: []
+  collectionOperations: []
+
 Ivoz\Kam\Domain\Model\UsersLocation\RegistrationStatus:
   itemOperations: []
   collectionOperations: []

--- a/web/rest/brand/app/config/api/raw/provider.yml
+++ b/web/rest/brand/app/config/api/raw/provider.yml
@@ -256,6 +256,12 @@ Ivoz\Provider\Domain\Model\DdiProvider\DdiProvider:
             transformationRuleSet: 'Ivoz\Provider\Domain\Model\TransformationRuleSet\TransformationRuleSet'
 
 Ivoz\Provider\Domain\Model\DdiProviderRegistration\DdiProviderRegistration:
+  collectionOperations:
+    get:
+      operation_normalization_context: 'detailedCollection'
+      normalization_context:
+        groups: ['detailedCollection']
+    post: ~
   attributes:
     access_control: '"ROLE_BRAND_ADMIN" in roles'
     read_access_control:

--- a/web/rest/brand/features/provider/ddiProviderRegistration/getDdiProviderRegistration.feature
+++ b/web/rest/brand/features/provider/ddiProviderRegistration/getDdiProviderRegistration.feature
@@ -15,7 +15,14 @@ Feature: Retrieve ddi provider registrations
     """
       [
           {
-              "id": 1
+              "username": "DDIRegistrationUsername",
+              "domain": "DDIRegistrationDomain",
+              "id": 1,
+              "status": {
+                  "registered": false,
+                  "inProgress": false,
+                  "expires": null
+              }
           }
       ]
     """


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->
Show DdiProviderRegistration status on API collection response

#### Type Of Change <!-- Mark one with X -->
- [X] New feature or enhancement

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
