### PR TITLE
web/admin: country code in residential external filter screens

### DIFF
--- a/web/admin/application/configs/klear/ExternalCallFiltersResidentialList.yaml
+++ b/web/admin/application/configs/klear/ExternalCallFiltersResidentialList.yaml
@@ -70,9 +70,24 @@ production:
       forcedValues:
         outOfScheduleTargetType: number
         <<: *forcedCompany
+      defaultValues:
+        outOfScheduleNumberCountry: ${auth.companyCountryId}
       fields:
         blacklist:
           <<: *externalCallFiltersResidential_blacklistLink
+      fixedPositions: &externalCallFiltersResidential_fixedPositionsLink
+        group0:
+          label: _("Basic Info")
+          colsPerRow: 2
+          fields:
+            name: 1
+        group1:
+          label: _("Filtering info")
+          colsPerRow: 6
+          fields:
+            outOfScheduleNumberCountry: 2
+            outOfScheduleNumberValue: 2
+
     externalCallFiltersResidentialEdit_screen: &externalCallFiltersResidentialEdit_screenLink
       <<: *ExternalCallFiltersResidential
       controller: edit
@@ -84,6 +99,9 @@ production:
       fields:
         blacklist:
           <<: *externalCallFiltersResidential_blacklistLink
+      fixedPositions:
+        <<: *externalCallFiltersResidential_fixedPositionsLink
+
   dialogs: &externalCallFiltersResidential_dialogsLink
     externalCallFiltersResidentialDel_dialog: &externalCallFiltersResidentialDel_dialogLink
       <<: *ExternalCallFiltersResidential

--- a/web/admin/application/configs/klear/model/ExternalCallFiltersResidential.yaml
+++ b/web/admin/application/configs/klear/model/ExternalCallFiltersResidential.yaml
@@ -35,6 +35,21 @@ production:
             title: ngettext('Extension', 'Extensions', 1)
           'voicemail':
             title: ngettext('Voicemail', 'Voicemails', 1)
+    outOfScheduleNumberCountry:
+      title: ngettext('Country', 'Countries', 1)
+      type: select
+      required: true
+      source:
+        data: mapper
+        config:
+          entity: \Ivoz\Provider\Domain\Model\Country\Country
+          fieldName:
+            fields:
+              - name${lang}
+              - countryCode
+            template: '%name${lang}% (%countryCode%)'
+          order:
+            Country.name.${lang}: asc
     outOfScheduleNumberValue:
       title: _('External Filter destination')
       type: text


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
Enable the country listbox in Residential External Call filter screens. Previously only the number input was enabled making impossible to convert the destination to E.164

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
