### PR TITLE
web/admin: filter timezone based on selected country

### DIFF
--- a/web/admin/application/configs/klear/CompaniesList.yaml
+++ b/web/admin/application/configs/klear/CompaniesList.yaml
@@ -155,8 +155,8 @@ production:
           colsPerRow: 3
           label: _("Geographic Configuration")
           fields:
-            defaultTimezone: 1
             country: 1
+            defaultTimezone: 1
             language: 1
             transformationRuleSet: 2
             currency: 1

--- a/web/admin/application/configs/klear/model/Companies.yaml
+++ b/web/admin/application/configs/klear/model/Companies.yaml
@@ -51,6 +51,8 @@ production:
             fields:
               - tz
             template: '%tz%'
+          extraDataAttributes:
+            country: countryId
           order:
             Timezone.tz: asc
     currency:
@@ -151,6 +153,8 @@ production:
       type: select
       defaultValue: 70
       required: true
+      attributes:
+        data-autofilter-select-by-data: "defaultTimezone:country"
       source:
         data: mapper
         config:

--- a/web/admin/application/configs/klear/model/ResidentialClients.yaml
+++ b/web/admin/application/configs/klear/model/ResidentialClients.yaml
@@ -45,6 +45,8 @@ production:
             fields:
               - tz
             template: '%tz%'
+          extraDataAttributes:
+            country: countryId
           order:
             Timezone.tz: asc
     currency:
@@ -145,6 +147,8 @@ production:
       type: select
       defaultValue: 70
       required: true
+      attributes:
+        data-autofilter-select-by-data: "defaultTimezone:country"
       source:
         data: mapper
         config:

--- a/web/admin/application/configs/klear/model/RetailClients.yaml
+++ b/web/admin/application/configs/klear/model/RetailClients.yaml
@@ -43,6 +43,8 @@ production:
             fields:
               - tz
             template: '%tz%'
+          extraDataAttributes:
+            country: countryId
           order:
             Timezone.tz: asc
     currency:
@@ -121,6 +123,8 @@ production:
       type: select
       defaultValue: 70
       required: true
+      attributes:
+        data-autofilter-select-by-data: "defaultTimezone:country"
       source:
         data: mapper
         config:

--- a/web/admin/application/configs/klear/model/WholesaleClients.yaml
+++ b/web/admin/application/configs/klear/model/WholesaleClients.yaml
@@ -43,6 +43,8 @@ production:
             fields:
               - tz
             template: '%tz%'
+          extraDataAttributes:
+            country: countryId
           order:
             Timezone.tz: asc
     currency:
@@ -106,6 +108,8 @@ production:
       type: select
       defaultValue: 70
       required: true
+      attributes:
+        data-autofilter-select-by-data: "defaultTimezone:country"
       source:
         data: mapper
         config:


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
This PR includes the configuration to filter timezone fields based on selected country in the same screen. This can only be applied in Client's screens because the rest of screens with timezone does not include a country field.

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
