### PR TITLE
cgrates: do not generate carrier CDRs unless calculateCost is enabled

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -1769,7 +1769,6 @@ route[CGRATES_AUTH_REQUEST] {
             \"cgr_account\":\"$dlg_var(cgrAccount)\",
             \"cgr_subject\":\"$dlg_var(cgrSubject)\",
             \"cgr_reqtype\":\"$dlg_var(cgrReqType)\",
-            \"carrierReqtype\":\"*rated\",
             \"cgr_destination\":\"$dlg_var(cgrDestination)\",
             \"cgr_setuptime\":\"$dlg_var(setupTime)\"}");
 
@@ -1874,12 +1873,6 @@ route[CGR_CALL_END] {
     $var(callDur) = $TS - $dlg(start_ts);
     $var(cgrCarrier) = 'cr' + $dlg_var(carrierId);
 
-    if ($dlg_var(calculateCost) == '1') {
-        $var(cgrDerivedReqType) = '*postpaid';
-    } else {
-        $var(cgrDerivedReqType) = '*rated';
-    }
-
     xnotice("[$dlg_var(cidhash)] CGR-CALL-END: Warn CGRates that call has ended (duration: $var(callDur))");
 
     evapi_relay("{\"event\":\"CGR_CALL_END\",
@@ -1894,7 +1887,7 @@ route[CGR_CALL_END] {
         \"cgr_duration\":\"$var(callDur)\",
         \"cgr_reqtype\":\"$dlg_var(cgrReqType)\",
         \"carrierId\":\"$var(cgrCarrier)\",
-        \"carrierReqtype\":\"$var(cgrDerivedReqType)\",
+        \"calculateCost\":\"$dlg_var(calculateCost)\",
         \"cgr_disconnectcause\":\"$T_reply_code\"}");
 }
 
@@ -1903,14 +1896,6 @@ route[CGR_CALL_FAILED] {
     if $sht(cgrconn=>cgr) == $null {
         xerr("[$dlg_var(cidhash)] CGR-CALL-FAILED: Charging controller unreachable");
         return;
-    }
-
-    $var(cgrCarrier) = 'cr' + $dlg_var(carrierId);
-
-    if ($dlg_var(calculateCost) == '1') {
-        $var(cgrDerivedReqType) = '*postpaid';
-    } else {
-        $var(cgrDerivedReqType) = '*rated';
     }
 
     xinfo("[$dlg_var(cidhash)] CGR-CALL-FAILED: Warn CGRates that call has failed (carrierId: $dlg_var(carrierId))");
@@ -1926,8 +1911,6 @@ route[CGR_CALL_FAILED] {
         \"cgr_answertime\":\"$dlg_var(setupTime)\",
         \"cgr_duration\":\"0\",
         \"cgr_reqtype\":\"$dlg_var(cgrReqType)\",
-        \"carrierId\":\"$var(cgrCarrier)\",
-        \"carrierReqtype\":\"$var(cgrDerivedReqType)\",
         \"cgr_disconnectcause\":\"$T_reply_code\"}");
 }
 

--- a/library/Ivoz/Cgr/Domain/Model/TpDerivedCharger/TpDerivedChargerAbstract.php
+++ b/library/Ivoz/Cgr/Domain/Model/TpDerivedCharger/TpDerivedChargerAbstract.php
@@ -63,13 +63,13 @@ abstract class TpDerivedChargerAbstract
      * column: run_filters
      * @var string
      */
-    protected $runFilters = 'carrierId';
+    protected $runFilters = '';
 
     /**
      * column: req_type_field
      * @var string
      */
-    protected $reqTypeField = 'carrierReqtype';
+    protected $reqTypeField = '^*postpaid';
 
     /**
      * column: direction_field

--- a/library/Ivoz/Cgr/Domain/Model/TpDerivedCharger/TpDerivedChargerDtoAbstract.php
+++ b/library/Ivoz/Cgr/Domain/Model/TpDerivedCharger/TpDerivedChargerDtoAbstract.php
@@ -58,12 +58,12 @@ abstract class TpDerivedChargerDtoAbstract implements DataTransferObjectInterfac
     /**
      * @var string
      */
-    private $runFilters = 'carrierId';
+    private $runFilters = '';
 
     /**
      * @var string
      */
-    private $reqTypeField = 'carrierReqtype';
+    private $reqTypeField = '^*postpaid';
 
     /**
      * @var string

--- a/library/Ivoz/Cgr/Infrastructure/Persistence/Doctrine/Mapping/TpDerivedCharger.TpDerivedChargerAbstract.orm.yml
+++ b/library/Ivoz/Cgr/Infrastructure/Persistence/Doctrine/Mapping/TpDerivedCharger.TpDerivedChargerAbstract.orm.yml
@@ -74,7 +74,7 @@ Ivoz\Cgr\Domain\Model\TpDerivedCharger\TpDerivedChargerAbstract:
       length: 32
       options:
         fixed: false
-        default: 'carrierId'
+        default: ''
       column: run_filters
     reqTypeField:
       type: string
@@ -82,7 +82,7 @@ Ivoz\Cgr\Domain\Model\TpDerivedCharger\TpDerivedChargerAbstract:
       length: 64
       options:
         fixed: false
-        default: 'carrierReqtype'
+        default: '^*postpaid'
       column: req_type_field
     directionField:
       type: string

--- a/schema/app/DoctrineMigrations/Version20190919120015.php
+++ b/schema/app/DoctrineMigrations/Version20190919120015.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20190919120015 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE tp_derived_chargers CHANGE run_filters run_filters VARCHAR(32) DEFAULT \'\' NOT NULL, CHANGE req_type_field req_type_field VARCHAR(64) DEFAULT \'^*postpaid\' NOT NULL');
+        $this->addSql("UPDATE tp_derived_chargers SET run_filters='',req_type_field='^*postpaid'");
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql("UPDATE tp_derived_chargers SET run_filters='carrierId',req_type_field='carrierReqtype'");
+        $this->addSql('ALTER TABLE tp_derived_chargers CHANGE run_filters run_filters VARCHAR(32) DEFAULT \'carrierId\' NOT NULL COLLATE utf8_unicode_ci, CHANGE req_type_field req_type_field VARCHAR(64) DEFAULT \'carrierReqtype\' NOT NULL COLLATE utf8_unicode_ci');
+    }
+}


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

Currently CGRateS inserts 3 entries per call:

- *raw
- *default
- carrier

This last entry is inserted even if selected carrier has calculateCost disabled. This generates lots of error log messages and makes tp_cdrs heavier than it should be.

#### Additional information

This PR needs cgr-engine to be upgraded with irontec/cgrates@4de71ee0f00adb15bfbf92be98705cf7bdfe0898 changes and reloading database info with cgr-loader command.
