### PR TITLE
Service split

### DIFF
--- a/library/Ivoz/Kam/Domain/Service/TrunksCdr/SetParsed.php
+++ b/library/Ivoz/Kam/Domain/Service/TrunksCdr/SetParsed.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Ivoz\Kam\Domain\Service\TrunksCdr;
+
+use Ivoz\Core\Application\Service\EntityTools;
+use Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdrDto;
+use Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdrInterface;
+
+class SetParsed
+{
+    protected $entityTools;
+
+    public function __construct(
+        EntityTools $entityTools
+    ) {
+        $this->entityTools = $entityTools;
+    }
+
+    /**
+     * @return void
+     */
+    public function execute(
+        TrunksCdrInterface $trunksCdr,
+        $dispatchImmediately = false
+    ) {
+        /**
+         * @var TrunksCdrDto $trunksCdrDto
+         */
+        $trunksCdrDto = $this->entityTools->entityToDto(
+            $trunksCdr
+        );
+        $trunksCdrDto->setParsed(true);
+        $this->entityTools->persistDto(
+            $trunksCdrDto,
+            $trunksCdr,
+            $dispatchImmediately
+        );
+    }
+}

--- a/library/Ivoz/Provider/Domain/Service/BalanceMovement/CreateByCarrier.php
+++ b/library/Ivoz/Provider/Domain/Service/BalanceMovement/CreateByCarrier.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Ivoz\Provider\Domain\Service\BalanceMovement;
+
+use Ivoz\Core\Application\Service\EntityTools;
+use Ivoz\Provider\Domain\Model\BalanceMovement\BalanceMovement;
+use Ivoz\Provider\Domain\Model\Carrier\CarrierInterface;
+
+class CreateByCarrier
+{
+    protected $entityTools;
+
+    public function __construct(
+        EntityTools $entityTools
+    ) {
+        $this->entityTools = $entityTools;
+    }
+
+    public function execute(
+        CarrierInterface $carrier,
+        $amount,
+        $balance
+    ) {
+        // Store this transaction in a BalanceMovement
+        $balanceMovementDto = BalanceMovement::createDto();
+        $balanceMovementDto
+            ->setCarrierId($carrier->getId())
+            ->setAmount($amount)
+            ->setBalance($balance);
+
+        $this->entityTools->persistDto(
+            $balanceMovementDto,
+            null,
+            true
+        );
+    }
+}

--- a/library/Ivoz/Provider/Domain/Service/BalanceMovement/CreateByCompany.php
+++ b/library/Ivoz/Provider/Domain/Service/BalanceMovement/CreateByCompany.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Ivoz\Provider\Domain\Service\BalanceMovement;
+
+use Ivoz\Core\Application\Service\EntityTools;
+use Ivoz\Provider\Domain\Model\BalanceMovement\BalanceMovement;
+use Ivoz\Provider\Domain\Model\Company\CompanyInterface;
+
+class CreateByCompany
+{
+    protected $entityTools;
+
+    public function __construct(
+        EntityTools $entityTools
+    ) {
+        $this->entityTools = $entityTools;
+    }
+
+    public function execute(
+        CompanyInterface $company,
+        $amount,
+        $balance
+    ) {
+        // Store this transaction in a BalanceMovement
+        $balanceMovementDto = BalanceMovement::createDto();
+        $balanceMovementDto
+            ->setCompanyId($company->getId())
+            ->setAmount($amount)
+            ->setBalance($balance);
+
+        $this->entityTools->persistDto(
+            $balanceMovementDto,
+            null,
+            true
+        );
+    }
+}

--- a/library/Ivoz/Provider/Domain/Service/BillableCall/MigrateFromTrunksCdr.php
+++ b/library/Ivoz/Provider/Domain/Service/BillableCall/MigrateFromTrunksCdr.php
@@ -5,12 +5,10 @@ namespace Ivoz\Provider\Domain\Service\BillableCall;
 use Ivoz\Core\Application\Service\EntityTools;
 use Ivoz\Core\Domain\Service\DomainEventPublisher;
 use Ivoz\Kam\Domain\Model\TrunksCdr\Event\TrunksCdrWasMigrated;
-use Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdrDto;
 use Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdrInterface;
-use Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdrRepository;
+use Ivoz\Kam\Domain\Service\TrunksCdr\SetParsed;
 use Ivoz\Provider\Domain\Model\BillableCall\BillableCallInterface;
 use Ivoz\Provider\Domain\Model\BillableCall\BillableCallRepository;
-use Psr\Log\LoggerInterface;
 
 class MigrateFromTrunksCdr
 {
@@ -18,17 +16,20 @@ class MigrateFromTrunksCdr
     protected $createOrUpdateBillableCallByTrunksCdr;
     protected $domainEventPublisher;
     protected $entityTools;
+    protected $setParsed;
 
     public function __construct(
         BillableCallRepository $billableCallRepository,
         CreateOrUpdateByTrunksCdr $createOrUpdateBillableCallByTrunksCdr,
         EntityTools $entityTools,
-        DomainEventPublisher $domainEventPublisher
+        DomainEventPublisher $domainEventPublisher,
+        SetParsed $setParsed
     ) {
         $this->billableCallRepository = $billableCallRepository;
         $this->createOrUpdateBillableCallByTrunksCdr = $createOrUpdateBillableCallByTrunksCdr;
         $this->domainEventPublisher = $domainEventPublisher;
         $this->entityTools = $entityTools;
+        $this->setParsed = $setParsed;
     }
 
     /**
@@ -55,15 +56,7 @@ class MigrateFromTrunksCdr
             $dispatchImmediately
         );
 
-        /**
-         * @var TrunksCdrDto $trunksCdrDto
-         */
-        $trunksCdrDto = $this->entityTools->entityToDto(
-            $trunksCdr
-        );
-        $trunksCdrDto->setParsed(true);
-        $this->entityTools->persistDto(
-            $trunksCdrDto,
+        $this->setParsed->execute(
             $trunksCdr,
             $dispatchImmediately
         );

--- a/library/Ivoz/Provider/Domain/Service/Brand/BrandLifecycleServiceCollection.php
+++ b/library/Ivoz/Provider/Domain/Service/Brand/BrandLifecycleServiceCollection.php
@@ -17,7 +17,7 @@ class BrandLifecycleServiceCollection implements LifecycleServiceCollectionInter
         [
             \Ivoz\Provider\Domain\Service\Domain\UpdateByBrand::class => 10,
             \Ivoz\Provider\Domain\Service\RoutingPattern\UpdateByBrand::class => 20,
-            \Ivoz\Provider\Domain\Service\Service\UpdateByBrand::class => 30,
+            \Ivoz\Provider\Domain\Service\BrandService\UpdateByBrand::class => 30,
             \Ivoz\Cgr\Domain\Service\TpDerivedCharger\CreatedByBrand::class => 200,
         ],
         "post_remove" =>

--- a/library/Ivoz/Provider/Domain/Service/BrandService/UpdateByBrand.php
+++ b/library/Ivoz/Provider/Domain/Service/BrandService/UpdateByBrand.php
@@ -1,4 +1,7 @@
 <?php
+
+// Move to Ivoz\Provider\Domain\BrandService\BrandService;
+
 namespace Ivoz\Provider\Domain\Service\Service;
 
 use Ivoz\Core\Application\Service\EntityTools;

--- a/library/Ivoz/Provider/Domain/Service/BrandService/UpdateByBrand.php
+++ b/library/Ivoz/Provider/Domain/Service/BrandService/UpdateByBrand.php
@@ -1,8 +1,6 @@
 <?php
 
-// Move to Ivoz\Provider\Domain\BrandService\BrandService;
-
-namespace Ivoz\Provider\Domain\Service\Service;
+namespace Ivoz\Provider\Domain\Service\BrandService;
 
 use Ivoz\Core\Application\Service\EntityTools;
 use Ivoz\Provider\Domain\Model\Brand\BrandInterface;

--- a/library/Ivoz/Provider/Domain/Service/CallCsvScheduler/SetExecutionError.php
+++ b/library/Ivoz/Provider/Domain/Service/CallCsvScheduler/SetExecutionError.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Ivoz\Provider\Domain\Service\CallCsvScheduler;
+
+use Ivoz\Core\Application\Service\EntityTools;
+use Ivoz\Provider\Domain\Model\CallCsvScheduler\CallCsvSchedulerDto;
+use Ivoz\Provider\Domain\Model\CallCsvScheduler\CallCsvSchedulerInterface;
+
+class SetExecutionError
+{
+    private $entityTools;
+
+    public function __construct(
+        EntityTools $entityTools
+    ) {
+        $this->entityTools = $entityTools;
+    }
+
+    /**
+     * @param CallCsvSchedulerInterface $scheduler
+     * @param string $error
+     *
+     * @return void
+     */
+    public function execute(CallCsvSchedulerInterface $scheduler, string $error)
+    {
+        /** @var CallCsvSchedulerDto $callCsvSchedulerDto */
+        $callCsvSchedulerDto = $this
+            ->entityTools
+            ->entityToDto($scheduler);
+
+        $callCsvSchedulerDto
+            ->setLastExecutionError($error);
+
+        $this->entityTools->updateEntityByDto(
+            $scheduler,
+            $callCsvSchedulerDto
+        );
+    }
+}

--- a/library/Ivoz/Provider/Domain/Service/CallCsvScheduler/UpdateLastExecutionDate.php
+++ b/library/Ivoz/Provider/Domain/Service/CallCsvScheduler/UpdateLastExecutionDate.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Ivoz\Provider\Domain\Service\CallCsvScheduler;
+
+use Ivoz\Core\Application\Service\EntityTools;
+use Ivoz\Provider\Domain\Model\CallCsvScheduler\CallCsvSchedulerDto;
+use Ivoz\Provider\Domain\Model\CallCsvScheduler\CallCsvSchedulerInterface;
+use Psr\Log\LoggerInterface;
+
+class UpdateLastExecutionDate
+{
+    private $entityTools;
+    protected $logger;
+
+    public function __construct(
+        EntityTools $entityTools,
+        LoggerInterface $logger
+    ) {
+        $this->entityTools = $entityTools;
+        $this->logger = $logger;
+    }
+
+    /**
+     * @param CallCsvSchedulerInterface $scheduler
+     * @return void
+     */
+    public function execute(
+        CallCsvSchedulerInterface $scheduler,
+        $dispatchImmediately = true
+    ) {
+        /** @var CallCsvSchedulerDto $callCsvSchedulerDto */
+        $callCsvSchedulerDto = $this
+            ->entityTools
+            ->entityToDto($scheduler);
+
+        $callCsvSchedulerDto
+            ->setLastExecution(
+                new \DateTime(
+                    null,
+                    new \DateTimeZone('UTC')
+                )
+            )
+            ->setLastExecutionError('');
+
+        $this->entityTools->persistDto(
+            $callCsvSchedulerDto,
+            $scheduler,
+            $dispatchImmediately
+        );
+    }
+}

--- a/library/Ivoz/Provider/Domain/Service/FixedCostsRelInvoice/CreateByScheduler.php
+++ b/library/Ivoz/Provider/Domain/Service/FixedCostsRelInvoice/CreateByScheduler.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Ivoz\Provider\Domain\Service\FixedCostsRelInvoice;
+
+use Ivoz\Core\Application\Service\EntityTools;
+use Ivoz\Provider\Domain\Model\FixedCostsRelInvoice\FixedCostsRelInvoice;
+use Ivoz\Provider\Domain\Model\FixedCostsRelInvoiceScheduler\FixedCostsRelInvoiceSchedulerInterface;
+use Ivoz\Provider\Domain\Model\Invoice\InvoiceInterface;
+use Ivoz\Provider\Domain\Model\InvoiceScheduler\InvoiceSchedulerInterface;
+use Psr\Log\LoggerInterface;
+
+class CreateByScheduler
+{
+    private $entityTools;
+
+    public function __construct(
+        EntityTools $entityTools
+    ) {
+        $this->entityTools = $entityTools;
+    }
+
+    /**
+     * @param InvoiceSchedulerInterface $scheduler
+     * @param InvoiceInterface $invoice
+     *
+     * @return void
+     */
+    public function execute(
+        InvoiceSchedulerInterface $scheduler,
+        InvoiceInterface $invoice
+    ) {
+        /** @var FixedCostsRelInvoiceSchedulerInterface[] $relFixedCosts */
+        $relFixedCosts = $scheduler->getRelFixedCosts();
+        foreach ($relFixedCosts as $relFixedCost) {
+            $fixedCostRelInvoice = FixedCostsRelInvoice::fromFixedCostsRelInvoiceScheduler(
+                $invoice,
+                $relFixedCost
+            );
+            $this->entityTools->persist($fixedCostRelInvoice);
+        }
+    }
+}

--- a/library/Ivoz/Provider/Domain/Service/InvoiceScheduler/SetExecutionError.php
+++ b/library/Ivoz/Provider/Domain/Service/InvoiceScheduler/SetExecutionError.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Ivoz\Provider\Domain\Service\InvoiceScheduler;
+
+use Ivoz\Core\Application\Service\EntityTools;
+use Ivoz\Provider\Domain\Model\InvoiceScheduler\InvoiceSchedulerDto;
+use Ivoz\Provider\Domain\Model\InvoiceScheduler\InvoiceSchedulerInterface;
+use Ivoz\Provider\Domain\Service\FixedCostsRelInvoice\CreateByScheduler as FixedCostsRelInvoiceByScheduler;
+use Psr\Log\LoggerInterface;
+
+class SetExecutionError
+{
+    private $entityTools;
+    protected $logger;
+    protected $fixedCostsRelInvoiceByScheduler;
+    protected $updateLastExecutionDate;
+
+    public function __construct(
+        EntityTools $entityTools,
+        LoggerInterface $logger,
+        FixedCostsRelInvoiceByScheduler $fixedCostsRelInvoiceByScheduler,
+        UpdateLastExecutionDate $updateLastExecutionDate
+    ) {
+        $this->entityTools = $entityTools;
+        $this->logger = $logger;
+        $this->fixedCostsRelInvoiceByScheduler = $fixedCostsRelInvoiceByScheduler;
+        $this->updateLastExecutionDate = $updateLastExecutionDate;
+    }
+
+    /**
+     * @param InvoiceSchedulerInterface $scheduler
+     * @param string $error
+     *
+     * @return void
+     */
+    public function execute(
+        InvoiceSchedulerInterface $scheduler,
+        string $error
+    ) {
+        /** @var InvoiceSchedulerDto $invoiceSchedulerDto */
+        $invoiceSchedulerDto = $this
+            ->entityTools
+            ->entityToDto($scheduler);
+
+        $invoiceSchedulerDto
+            ->setLastExecutionError($error);
+
+        $this->entityTools->updateEntityByDto(
+            $scheduler,
+            $invoiceSchedulerDto
+        );
+    }
+}

--- a/library/Ivoz/Provider/Domain/Service/InvoiceScheduler/UpdateLastExecutionDate.php
+++ b/library/Ivoz/Provider/Domain/Service/InvoiceScheduler/UpdateLastExecutionDate.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Ivoz\Provider\Domain\Service\InvoiceScheduler;
+
+use Ivoz\Core\Application\Service\EntityTools;
+use Ivoz\Provider\Domain\Model\InvoiceScheduler\InvoiceSchedulerDto;
+use Ivoz\Provider\Domain\Model\InvoiceScheduler\InvoiceSchedulerInterface;
+
+class UpdateLastExecutionDate
+{
+    private $entityTools;
+
+    public function __construct(
+        EntityTools $entityTools
+    ) {
+        $this->entityTools = $entityTools;
+    }
+
+    /**
+     * @param InvoiceSchedulerInterface $scheduler
+     * @return void
+     */
+    public function execute(
+        InvoiceSchedulerInterface $scheduler,
+        $dispatchImmediately = true
+    ) {
+        /** @var InvoiceSchedulerDto $invoiceSchedulerDto */
+        $invoiceSchedulerDto = $this
+            ->entityTools
+            ->entityToDto($scheduler);
+
+        $invoiceSchedulerDto
+            ->setLastExecution(
+                new \DateTime(
+                    null,
+                    new \DateTimeZone('UTC')
+                )
+            )
+            ->setLastExecutionError('');
+
+        $this->entityTools->persistDto(
+            $invoiceSchedulerDto,
+            $scheduler,
+            $dispatchImmediately
+        );
+    }
+}

--- a/library/Ivoz/Provider/Domain/Service/TransformationRuleSet/DisableGenerateRules.php
+++ b/library/Ivoz/Provider/Domain/Service/TransformationRuleSet/DisableGenerateRules.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Ivoz\Provider\Domain\Service\TransformationRuleSet;
+
+use Ivoz\Core\Application\Service\EntityTools;
+use Ivoz\Provider\Domain\Model\TransformationRuleSet\TransformationRuleSetDto;
+use Ivoz\Provider\Domain\Model\TransformationRuleSet\TransformationRuleSetInterface;
+
+class DisableGenerateRules
+{
+    protected $entityTools;
+
+    public function __construct(
+        EntityTools $entityTools
+    ) {
+        $this->entityTools = $entityTools;
+    }
+
+    /**
+     * @return void
+     */
+    public function execute(
+        TransformationRuleSetInterface $transformationRuleSet,
+        $dispatchImmediately = false
+    ) {
+        // Mark rules as generated
+        /** @var TransformationRuleSetDto $transformationRuleSetDto */
+        $transformationRuleSetDto = $this->entityTools->entityToDto($transformationRuleSet);
+
+        $transformationRuleSetDto->setGenerateRules(false);
+        $this->entityTools->persistDto(
+            $transformationRuleSetDto,
+            $transformationRuleSet,
+            $dispatchImmediately
+        );
+    }
+}

--- a/library/spec/Ivoz/Provider/Domain/Service/BillableCall/MigrateFromTrunksCdrSpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Service/BillableCall/MigrateFromTrunksCdrSpec.php
@@ -7,14 +7,12 @@ use Ivoz\Provider\Domain\Model\Brand\BrandInterface;
 use Ivoz\Provider\Domain\Service\BillableCall\CreateOrUpdateByTrunksCdr;
 use Ivoz\Provider\Domain\Service\BillableCall\MigrateFromTrunksCdr;
 use Ivoz\Core\Application\Service\EntityTools;
-use Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdr;
 use Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdrDto;
 use Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdrInterface;
-use Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdrRepository;
 use Ivoz\Provider\Domain\Model\BillableCall\BillableCallInterface;
 use Ivoz\Provider\Domain\Model\BillableCall\BillableCallRepository;
 use Ivoz\Core\Domain\Service\DomainEventPublisher;
-use Psr\Log\LoggerInterface;
+use Ivoz\Kam\Domain\Service\TrunksCdr\SetParsed;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use spec\HelperTrait;
@@ -27,23 +25,27 @@ class MigrateFromTrunksCdrSpec extends ObjectBehavior
     protected $createOrUpdateBillableCallByTrunksCdr;
     protected $domainEventPublisher;
     protected $entityTools;
+    protected $setParsed;
 
     public function let(
         BillableCallRepository $billableCallRepository,
         CreateOrUpdateByTrunksCdr $createOrUpdateBillableCallByTrunksCdr,
         EntityTools $entityTools,
-        DomainEventPublisher $domainEventPublisher
+        DomainEventPublisher $domainEventPublisher,
+        SetParsed $setParsed
     ) {
         $this->billableCallRepository = $billableCallRepository;
         $this->createOrUpdateBillableCallByTrunksCdr = $createOrUpdateBillableCallByTrunksCdr;
         $this->domainEventPublisher = $domainEventPublisher;
         $this->entityTools = $entityTools;
+        $this->setParsed = $setParsed;
 
         $this->beConstructedWith(
             $this->billableCallRepository,
             $this->createOrUpdateBillableCallByTrunksCdr,
             $this->entityTools,
-            $this->domainEventPublisher
+            $this->domainEventPublisher,
+            $this->setParsed
         );
     }
 
@@ -76,9 +78,8 @@ class MigrateFromTrunksCdrSpec extends ObjectBehavior
             ->shouldBeCalled();
 
         $this
-            ->entityTools
-            ->persistDto(
-                Argument::type(TrunksCdrDto::class),
+            ->setParsed
+            ->execute(
                 Argument::type(TrunksCdrInterface::class),
                 false
             )
@@ -126,13 +127,6 @@ class MigrateFromTrunksCdrSpec extends ObjectBehavior
                 Argument::type(BillableCallInterface::class)
             )
             ->willReturn($billableCall);
-
-        $this
-            ->entityTools
-            ->entityToDto(
-                Argument::type(TrunksCdrInterface::class)
-            )
-            ->willReturn($trunksCdrDto);
 
         $this
             ->entityTools

--- a/library/spec/Ivoz/Provider/Domain/Service/BrandService/UpdateByBrandSpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Service/BrandService/UpdateByBrandSpec.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace spec\Ivoz\Provider\Domain\Service\Service;
+namespace spec\Ivoz\Provider\Domain\Service\BrandService;
 
 use Ivoz\Core\Application\Service\EntityTools;
 use Ivoz\Provider\Domain\Model\Brand\BrandInterface;
@@ -8,7 +8,7 @@ use Ivoz\Provider\Domain\Model\BrandService\BrandServiceDto;
 use Ivoz\Provider\Domain\Model\BrandService\BrandServiceInterface;
 use Ivoz\Provider\Domain\Model\Service\ServiceInterface;
 use Ivoz\Provider\Domain\Model\Service\ServiceRepository;
-use Ivoz\Provider\Domain\Service\Service\UpdateByBrand;
+use Ivoz\Provider\Domain\Service\BrandService\UpdateByBrand;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 

--- a/library/spec/Ivoz/Provider/Domain/Service/Carrier/DecrementBalanceSpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Service/Carrier/DecrementBalanceSpec.php
@@ -14,69 +14,42 @@ use Ivoz\Core\Application\Service\EntityTools;
 use Ivoz\Provider\Domain\Model\Carrier\CarrierInterface;
 use Symfony\Bridge\Monolog\Logger;
 use Ivoz\Provider\Domain\Model\Carrier\CarrierRepository;
+use Ivoz\Provider\Domain\Service\BalanceMovement\CreateByCarrier;
 
 class DecrementBalanceSpec extends ObjectBehavior
 {
     use HelperTrait;
 
-    /**
-     * @var EntityTools
-     */
     protected $entityTools;
-
-    /**
-     * @var Logger
-     */
     protected $logger;
-
-    /**
-     * @var CarrierBalanceServiceInterface
-     */
     protected $client;
-
-    /**
-     * @var CarrierRepository
-     */
     protected $carrierRepository;
-
-    /**
-     * @var SyncBalances
-     */
     protected $syncBalanceService;
-
-    /**
-     * @var string
-     */
     protected $lastError;
+    protected $createBalanceMovementByCarrier;
 
-    /**
-     * IncrementBalance constructor.
-     *
-     * @param EntityTools $entityTools
-     * @param Logger $logger
-     * @param CarrierBalanceServiceInterface $client
-     * @param CarrierRepository $carrierRepository
-     * @param SyncBalances $syncBalanceService
-     */
     public function let(
         EntityTools $entityTools,
         Logger $logger,
         CarrierBalanceServiceInterface $client,
         CarrierRepository $carrierRepository,
-        SyncBalances $syncBalanceService
+        SyncBalances $syncBalanceService,
+        CreateByCarrier $createByCarrier
     ) {
         $this->entityTools = $entityTools;
         $this->logger = $logger;
         $this->client = $client;
         $this->carrierRepository = $carrierRepository;
         $this->syncBalanceService = $syncBalanceService;
+        $this->createBalanceMovementByCarrier = $createByCarrier;
 
         $this->beConstructedWith(
             $this->entityTools,
             $this->logger,
             $this->client,
             $this->carrierRepository,
-            $this->syncBalanceService
+            $this->syncBalanceService,
+            $createByCarrier
         );
     }
 
@@ -118,11 +91,11 @@ class DecrementBalanceSpec extends ObjectBehavior
         );
 
         $this
-            ->entityTools
-            ->persistDto(
-                Argument::type(BalanceMovementDto::class),
-                null,
-                true
+            ->createBalanceMovementByCarrier
+            ->execute(
+                $carrier,
+                Argument::any(),
+                Argument::any()
             )
             ->shouldBeCalled();
 

--- a/library/spec/Ivoz/Provider/Domain/Service/Carrier/IncrementBalanceSpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Service/Carrier/IncrementBalanceSpec.php
@@ -3,13 +3,13 @@
 namespace spec\Ivoz\Provider\Domain\Service\Carrier;
 
 use Ivoz\Core\Application\Service\EntityTools;
-use Ivoz\Provider\Domain\Model\BalanceMovement\BalanceMovementDto;
 use Ivoz\Provider\Domain\Model\Brand\BrandInterface;
 use Ivoz\Provider\Domain\Model\Carrier\CarrierInterface;
 use Ivoz\Provider\Domain\Model\Carrier\CarrierRepository;
 use Ivoz\Provider\Domain\Service\Carrier\CarrierBalanceServiceInterface;
 use Ivoz\Provider\Domain\Service\Carrier\IncrementBalance;
 use Ivoz\Provider\Domain\Service\Carrier\SyncBalances;
+use Ivoz\Provider\Domain\Service\BalanceMovement\CreateByCarrier;
 use Symfony\Bridge\Monolog\Logger;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
@@ -19,64 +19,38 @@ class IncrementBalanceSpec extends ObjectBehavior
 {
     use HelperTrait;
 
-    /**
-     * @var EntityTools
-     */
     protected $entityTools;
-
-    /**
-     * @var Logger
-     */
     protected $logger;
-
-    /**
-     * @var CarrierBalanceServiceInterface
-     */
     protected $client;
-
-    /**
-     * @var CarrierRepository
-     */
     protected $carrierRepository;
-
-    /**
-     * @var SyncBalances
-     */
     protected $syncBalanceService;
-
-    /**
-     * @var string
-     */
     protected $lastError;
+    protected $createBalanceMovementByCarrier;
 
-    /**
-     * IncrementBalance constructor.
-     *
-     * @param EntityTools $entityTools
-     * @param Logger $logger
-     * @param CarrierBalanceServiceInterface $client
-     * @param CarrierRepository $carrierRepository
-     * @param SyncBalances $syncBalanceService
-     */
+    const BALANCE = 100.45;
+
     public function let(
         EntityTools $entityTools,
         Logger $logger,
         CarrierBalanceServiceInterface $client,
         CarrierRepository $carrierRepository,
-        SyncBalances $syncBalanceService
+        SyncBalances $syncBalanceService,
+        CreateByCarrier $createByCarrier
     ) {
         $this->entityTools = $entityTools;
         $this->logger = $logger;
         $this->client = $client;
         $this->carrierRepository = $carrierRepository;
         $this->syncBalanceService = $syncBalanceService;
+        $this->createBalanceMovementByCarrier = $createByCarrier;
 
         $this->beConstructedWith(
             $this->entityTools,
             $this->logger,
             $this->client,
             $this->carrierRepository,
-            $this->syncBalanceService
+            $this->syncBalanceService,
+            $this->createBalanceMovementByCarrier
         );
     }
 
@@ -118,11 +92,11 @@ class IncrementBalanceSpec extends ObjectBehavior
         );
 
         $this
-            ->entityTools
-            ->persistDto(
-                Argument::type(BalanceMovementDto::class),
-                null,
-                true
+            ->createBalanceMovementByCarrier
+            ->execute(
+                $carrier,
+                10.15,
+                self::BALANCE
             )
             ->shouldBeCalled();
 
@@ -174,6 +148,6 @@ class IncrementBalanceSpec extends ObjectBehavior
                 Argument::type('numeric'),
                 Argument::type('numeric')
             )
-            ->willReturn(100.45);
+            ->willReturn(self::BALANCE);
     }
 }

--- a/library/spec/Ivoz/Provider/Domain/Service/Company/DecrementBalanceSpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Service/Company/DecrementBalanceSpec.php
@@ -14,69 +14,44 @@ use Ivoz\Core\Application\Service\EntityTools;
 use Ivoz\Provider\Domain\Model\Company\CompanyInterface;
 use Symfony\Bridge\Monolog\Logger;
 use Ivoz\Provider\Domain\Model\Company\CompanyRepository;
+use Ivoz\Provider\Domain\Service\BalanceMovement\CreateByCompany;
 
 class DecrementBalanceSpec extends ObjectBehavior
 {
     use HelperTrait;
 
-    /**
-     * @var EntityTools
-     */
+    const BALANCE = 100.45;
+
     protected $entityTools;
-
-    /**
-     * @var Logger
-     */
     protected $logger;
-
-    /**
-     * @var CompanyBalanceServiceInterface
-     */
     protected $client;
-
-    /**
-     * @var CompanyRepository
-     */
     protected $companyRepository;
-
-    /**
-     * @var SyncBalances
-     */
     protected $syncBalanceService;
-
-    /**
-     * @var string
-     */
     protected $lastError;
+    protected $createBalanceMovementByCompany;
 
-    /**
-     * IncrementBalance constructor.
-     *
-     * @param EntityTools $entityTools
-     * @param Logger $logger
-     * @param CompanyBalanceServiceInterface $client
-     * @param CompanyRepository $companyRepository
-     * @param SyncBalances $syncBalanceService
-     */
     public function let(
         EntityTools $entityTools,
         Logger $logger,
         CompanyBalanceServiceInterface $client,
         CompanyRepository $companyRepository,
-        SyncBalances $syncBalanceService
+        SyncBalances $syncBalanceService,
+        CreateByCompany $createByCompany
     ) {
         $this->entityTools = $entityTools;
         $this->logger = $logger;
         $this->client = $client;
         $this->companyRepository = $companyRepository;
         $this->syncBalanceService = $syncBalanceService;
+        $this->createBalanceMovementByCompany = $createByCompany;
 
         $this->beConstructedWith(
             $this->entityTools,
             $this->logger,
             $this->client,
             $this->companyRepository,
-            $this->syncBalanceService
+            $this->syncBalanceService,
+            $this->createBalanceMovementByCompany
         );
     }
 
@@ -118,11 +93,11 @@ class DecrementBalanceSpec extends ObjectBehavior
         );
 
         $this
-            ->entityTools
-            ->persistDto(
-                Argument::type(BalanceMovementDto::class),
-                null,
-                true
+            ->createBalanceMovementByCompany
+            ->execute(
+                $company,
+                -10.15,
+                self::BALANCE
             )
             ->shouldBeCalled();
 
@@ -174,6 +149,6 @@ class DecrementBalanceSpec extends ObjectBehavior
                 Argument::type('numeric'),
                 Argument::type('numeric')
             )
-            ->willReturn(100.45);
+            ->willReturn(self::BALANCE);
     }
 }

--- a/library/spec/Ivoz/Provider/Domain/Service/Company/IncrementBalanceSpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Service/Company/IncrementBalanceSpec.php
@@ -10,6 +10,7 @@ use Ivoz\Provider\Domain\Model\Company\CompanyRepository;
 use Ivoz\Provider\Domain\Service\Company\CompanyBalanceServiceInterface;
 use Ivoz\Provider\Domain\Service\Company\IncrementBalance;
 use Ivoz\Provider\Domain\Service\Company\SyncBalances;
+use Ivoz\Provider\Domain\Service\BalanceMovement\CreateByCompany;
 use Symfony\Bridge\Monolog\Logger;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
@@ -19,64 +20,38 @@ class IncrementBalanceSpec extends ObjectBehavior
 {
     use HelperTrait;
 
-    /**
-     * @var EntityTools
-     */
+    const BALANCE = 100.45;
+
     protected $entityTools;
-
-    /**
-     * @var Logger
-     */
     protected $logger;
-
-    /**
-     * @var CompanyBalanceServiceInterface
-     */
     protected $client;
-
-    /**
-     * @var CompanyRepository
-     */
     protected $companyRepository;
-
-    /**
-     * @var SyncBalances
-     */
     protected $syncBalanceService;
-
-    /**
-     * @var string
-     */
     protected $lastError;
+    protected $createBalanceMovementByCompany;
 
-    /**
-     * IncrementBalance constructor.
-     *
-     * @param EntityTools $entityTools
-     * @param Logger $logger
-     * @param CompanyBalanceServiceInterface $client
-     * @param CompanyRepository $companyRepository
-     * @param SyncBalances $syncBalanceService
-     */
     public function let(
         EntityTools $entityTools,
         Logger $logger,
         CompanyBalanceServiceInterface $client,
         CompanyRepository $companyRepository,
-        SyncBalances $syncBalanceService
+        SyncBalances $syncBalanceService,
+        CreateByCompany $createByCompany
     ) {
         $this->entityTools = $entityTools;
         $this->logger = $logger;
         $this->client = $client;
         $this->companyRepository = $companyRepository;
         $this->syncBalanceService = $syncBalanceService;
+        $this->createBalanceMovementByCompany = $createByCompany;
 
         $this->beConstructedWith(
             $this->entityTools,
             $this->logger,
             $this->client,
             $this->companyRepository,
-            $this->syncBalanceService
+            $this->syncBalanceService,
+            $this->createBalanceMovementByCompany
         );
     }
 
@@ -118,11 +93,11 @@ class IncrementBalanceSpec extends ObjectBehavior
         );
 
         $this
-            ->entityTools
-            ->persistDto(
-                Argument::type(BalanceMovementDto::class),
-                null,
-                true
+            ->createBalanceMovementByCompany
+            ->execute(
+                $company,
+                10.15,
+                self::BALANCE
             )
             ->shouldBeCalled();
 
@@ -174,6 +149,6 @@ class IncrementBalanceSpec extends ObjectBehavior
                 Argument::type('numeric'),
                 Argument::type('numeric')
             )
-            ->willReturn(100.45);
+            ->willReturn(self::BALANCE);
     }
 }

--- a/library/spec/Ivoz/Provider/Domain/Service/TransformationRule/GenerateRulesSpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Service/TransformationRule/GenerateRulesSpec.php
@@ -10,34 +10,27 @@ use Ivoz\Provider\Domain\Model\TransformationRuleSet\TransformationRuleSetInterf
 use Ivoz\Provider\Domain\Service\TransformationRule\GenerateInRules;
 use Ivoz\Provider\Domain\Service\TransformationRule\GenerateOutRules;
 use Ivoz\Provider\Domain\Service\TransformationRule\GenerateRules;
+use Ivoz\Provider\Domain\Service\TransformationRuleSet\DisableGenerateRules;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
 class GenerateRulesSpec extends ObjectBehavior
 {
-    /**
-     * @var EntityTools
-     */
     protected $entityTools;
-
-    /**
-     * @var GenerateInRules
-     */
     protected $generateInRules;
-
-    /**
-     * @var GenerateOutRules
-     */
     protected $generateOutRules;
+    protected $disableGenerateRules;
 
     function let(
         EntityTools $entityTools,
         GenerateInRules $generateInRules,
-        GenerateOutRules $generateOutRules
+        GenerateOutRules $generateOutRules,
+        DisableGenerateRules $disableGenerateRules
     ) {
         $this->entityTools = $entityTools;
         $this->generateInRules = $generateInRules;
         $this->generateOutRules = $generateOutRules;
+        $this->disableGenerateRules = $disableGenerateRules;
 
         $this->beConstructedWith(...func_get_args());
     }
@@ -86,20 +79,6 @@ class GenerateRulesSpec extends ObjectBehavior
                 Argument::any(),
                 Argument::any()
             )
-            ->shouldBeCalled();
-
-        $this
-            ->entityTools
-            ->entityToDto($transformationRuleSet)
-            ->willReturn($transformationRuleSetDto);
-
-        $transformationRuleSetDto
-            ->setGenerateRules(false)
-            ->shouldBeCalled();
-
-        $this
-            ->entityTools
-            ->persistDto($transformationRuleSetDto, $transformationRuleSet, false)
             ->shouldBeCalled();
 
         $this


### PR DESCRIPTION
Slit services so that there are no persist operations out of their entity service folder

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
