### PR TITLE
web/admin: filter outgoing ddis by brand on list screens

### DIFF
--- a/web/admin/application/configs/klear/CompaniesList.yaml
+++ b/web/admin/application/configs/klear/CompaniesList.yaml
@@ -69,11 +69,12 @@ production:
           balance: true
           country: true
           showInvoices: true
+          outgoingDdi: true
         order:
           name: true
           nif: true
           billingMethod: true
-          outgoingDdi: true
+          outgoingDdiE164: true
           domainUsers: true
           relFeatures: true
       options:
@@ -126,6 +127,7 @@ production:
           faxNotificationTemplate: true
           balance: true
           showInvoices: true
+          outgoingDdiE164: true
         order: &companiesOrder_Link
           id: true
           name: true
@@ -199,6 +201,7 @@ production:
           recordingsLimitMB: true
           recordingsLimitEmail: true
           recordingsDiskUsage: true
+          outgoingDdiE164: true
           balance: true
         whitelist:
           id: ${auth.isMainOperator}

--- a/web/admin/application/configs/klear/ResidentialClientsList.yaml
+++ b/web/admin/application/configs/klear/ResidentialClientsList.yaml
@@ -67,11 +67,12 @@ production:
           callCsvNotificationTemplate: true
           balance: true
           showInvoices: true
+          outgoingDdi: true
         order:
           name: true
           nif: true
           billingMethod: true
-          outgoingDdi: true
+          outgoingDdiE164: true
           relFeatures: true
       options:
         title: _("Options")
@@ -122,6 +123,7 @@ production:
           invoiceNotificationTemplate: true
           callCsvNotificationTemplate: true
           showInvoices: true
+          outgoingDdiE164: true
         order: &residentialClientsOrder_Link
           id: true
           name: true
@@ -192,6 +194,7 @@ production:
           countryName: ${auth.brandFeatures.invoices.disabled}
           outgoingDdiRule: true
           balance: true
+          outgoingDdiE164: true
         whitelist:
           id: ${auth.isMainOperator}
         order:

--- a/web/admin/application/configs/klear/RetailClientsList.yaml
+++ b/web/admin/application/configs/klear/RetailClientsList.yaml
@@ -56,11 +56,12 @@ production:
           showInvoices: true
           invoiceNotificationTemplate: true
           callCsvNotificationTemplate: true
+          outgoingDdi: true
         order:
           name: true
           nif: true
           billingMethod: true
-          outgoingDdi: true
+          outgoingDdiE164: true
           relRoutingTags: true
           relCodecs: true
       options:
@@ -101,6 +102,7 @@ production:
           showInvoices: true
           invoiceNotificationTemplate: true
           callCsvNotificationTemplate: true
+          outgoingDdiE164: true
         order: &retailClientsOrder_Link
           id: true
           name: true
@@ -171,6 +173,7 @@ production:
           town: ${auth.brandFeatures.invoices.disabled}
           province: ${auth.brandFeatures.invoices.disabled}
           countryName: ${auth.brandFeatures.invoices.disabled}
+          outgoingDdiE164: true
         whitelist:
           id: ${auth.isMainOperator}
         order:

--- a/web/admin/application/configs/klear/model/Companies.yaml
+++ b/web/admin/application/configs/klear/model/Companies.yaml
@@ -197,6 +197,12 @@ production:
           order:
             Ddi.ddie164: asc
         'null': _("Unassigned")
+    outgoingDdiE164:
+      title: _('Outgoing DDI')
+      type: ghost
+      source:
+        class: IvozProvider_Klear_Ghost_Companies
+        method: getDdiE164
     outgoingDdiRule:
       title: ngettext('Outgoing DDI Rule', 'Outgoing DDI Rules', 1)
       type: select

--- a/web/admin/application/configs/klear/model/ResidentialClients.yaml
+++ b/web/admin/application/configs/klear/model/ResidentialClients.yaml
@@ -197,6 +197,12 @@ production:
         icon: help
         text: _("Default outgoing DDI. This can be overriden in accounts's edit screen.")
         label: _("Need help?")
+    outgoingDdiE164:
+      title: _('Outgoing DDI')
+      type: ghost
+      source:
+        class: IvozProvider_Klear_Ghost_Companies
+        method: getDdiE164
     language:
       title: _('Language')
       type: select

--- a/web/admin/application/configs/klear/model/RetailClients.yaml
+++ b/web/admin/application/configs/klear/model/RetailClients.yaml
@@ -237,6 +237,12 @@ production:
           order:
             Ddi.ddie164: asc
         'null': _("Unassigned")
+    outgoingDdiE164:
+      title: _('Outgoing DDI')
+      type: ghost
+      source:
+        class: IvozProvider_Klear_Ghost_Companies
+        method: getDdiE164
     showInvoices:
       title: _('Display Client Invoices section')
       type: select

--- a/web/admin/application/library/IvozProvider/Klear/Filter/OutgoingDDI.php
+++ b/web/admin/application/library/IvozProvider/Klear/Filter/OutgoingDDI.php
@@ -12,8 +12,18 @@ class IvozProvider_Klear_Filter_OutgoingDDI implements KlearMatrix_Model_Field_S
 
     public function setRouteDispatcher(KlearMatrix_Model_RouteDispatcher $routeDispatcher)
     {
-        // Do not apply filtering in list view
+        // Do not apply company based filtering in list view
         if ($routeDispatcher->getControllerName() == "list") {
+            $auth = Zend_Auth::getInstance();
+            if (!$auth->hasIdentity()) {
+                throw new Klear_Exception_Default("No company/brand emulated");
+            }
+            $currentBrandId = $auth->getIdentity()->brandId;
+            $this->_condition = [
+                'self::brand = :pk',
+                ['pk' => $currentBrandId]
+            ];
+
             return;
         }
 

--- a/web/admin/application/library/IvozProvider/Klear/Ghost/Companies.php
+++ b/web/admin/application/library/IvozProvider/Klear/Ghost/Companies.php
@@ -3,6 +3,8 @@
 use Ivoz\Core\Application\Service\DataGateway;
 use Ivoz\Provider\Domain\Model\Company\Company;
 use Ivoz\Provider\Domain\Model\Company\CompanyDto;
+use Ivoz\Provider\Domain\Model\Ddi\Ddi;
+use Ivoz\Provider\Domain\Model\Ddi\DdiDto;
 use Ivoz\Provider\Domain\Service\Company\CompanyBalanceServiceInterface;
 
 class IvozProvider_Klear_Ghost_Companies extends KlearMatrix_Model_Field_Ghost_Abstract
@@ -65,6 +67,32 @@ class IvozProvider_Klear_Ghost_Companies extends KlearMatrix_Model_Field_Ghost_A
             return sprintf("%s %s", $amount, $currencySymbol);
         } catch (Exception $exception) {
             return Klear_Model_Gettext::gettextCheck('_("Unavailable")');
+        }
+    }
+
+    /**
+     * @param CompanyDto $companyDto
+     * @return string
+     */
+    public function getDdiE164(CompanyDto $companyDto)
+    {
+        try {
+            if (!$companyDto->getOutgoingDdiId()) {
+                return Klear_Model_Gettext::gettextCheck('_("Unassigned")');
+            }
+
+            /** @var DataGateway $dataGateway */
+            $dataGateway = \Zend_Registry::get('data_gateway');
+
+            /** @var DdiDto $ddi */
+            $ddi = $dataGateway->find(
+                Ddi::class,
+                $companyDto->getOutgoingDdiId()
+            );
+
+            return $ddi->getDdie164();
+        } catch (Exception $exception) {
+            return Klear_Model_Gettext::gettextCheck('_("error")');
         }
     }
 }


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->
Fixed outgoing ddi filter on list screens. It was applying no filters and leading to out of memory exception when DDIs dataset was big enough (> 15000).

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
