### PR TITLE
schema: update migrated MatchListPatterns regular expressions

### DIFF
--- a/schema/app/DoctrineMigrations/Version20191008111715.php
+++ b/schema/app/DoctrineMigrations/Version20191008111715.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20191008111715 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->addSql('UPDATE MatchListPatterns SET `regExp` = REPLACE(`regExp`, "^+", "^\\\\+")');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+    }
+}


### PR DESCRIPTION

<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
Artemis uses E.164 with plus, while Oasis used E.164 without plus, so regular expressions in patterns (Call ACLs and Match Lists) require some adaptation.


#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
