### PR TITLE
pkg: add italian and catalan to install screens

### DIFF
--- a/debian/ivozprovider-profile-portal.templates
+++ b/debian/ivozprovider-profile-portal.templates
@@ -22,6 +22,8 @@ Description-es.UTF-8:
 Template: ivozprovider/language
 Type: select
 Default: en
-Choices: en, es
-Choices-en.UTF8: English, Spanish
-Choices-es.UTF8: Inglés, Español
+Choices: en, es, it, ca
+Choices-en.UTF8: English, Spanish, Italian, Catalan
+Choices-es.UTF8: Inglés, Español, Italiano, Catalán
+Choices-it.UTF8: Inglese, Spagnolo, Italiano, Catalano
+Choices-ca.UTF8: Anglès, Castellà, Italià, Català


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
Added Italian and Catalan languages to portals profile menu  default language 

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
