### PR TITLE
core: keep Commands in memory through cdr mixer loops

### DIFF
--- a/library/CoreBundle/Resources/config/logger.yml
+++ b/library/CoreBundle/Resources/config/logger.yml
@@ -6,6 +6,7 @@ monolog:
      action_level: error
      priority: 1
      handler: fingers_crossed_handler
+     buffer_size: 100
      channels:
       - !changelog
       - !provisioning
@@ -14,6 +15,7 @@ monolog:
      ident: onError
      type: syslog
      level: info
+     buffer_size: 100
 
    changelog_handler:
      ident: changelog

--- a/library/Ivoz/Provider/Domain/Service/BillableCall/MigrateFromUnparsedTrunksCdr.php
+++ b/library/Ivoz/Provider/Domain/Service/BillableCall/MigrateFromUnparsedTrunksCdr.php
@@ -3,13 +3,8 @@
 namespace Ivoz\Provider\Domain\Service\BillableCall;
 
 use Ivoz\Core\Application\Service\EntityTools;
-use Ivoz\Core\Domain\Service\DomainEventPublisher;
-use Ivoz\Kam\Domain\Model\TrunksCdr\Event\TrunksCdrWasMigrated;
-use Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdrDto;
-use Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdrInterface;
 use Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdrRepository;
-use Ivoz\Provider\Domain\Model\BillableCall\BillableCallInterface;
-use Ivoz\Provider\Domain\Model\BillableCall\BillableCallRepository;
+use Ivoz\Provider\Domain\Model\Commandlog\Commandlog;
 use Psr\Log\LoggerInterface;
 
 class MigrateFromUnparsedTrunksCdr
@@ -55,7 +50,10 @@ class MigrateFromUnparsedTrunksCdr
 
             try {
                 $this->entityTools->dispatchQueuedOperations();
-                $this->entityTools->clear();
+                $this->entityTools->clearExcept(
+                    Commandlog::class
+                );
+
                 $cdrCount += count($trunks);
             } catch (\Exception $e) {
                 $this->logger->error('BillableCall migration service error:: ' . $e->getMessage());


### PR DESCRIPTION
Do not clear Commands from unit of work unit cdr mixer is done

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
