### PR TITLE
Brand notification templates

### DIFF
--- a/asterisk/agi/src/Agi/Action/FaxReceiveStatusAction.php
+++ b/asterisk/agi/src/Agi/Action/FaxReceiveStatusAction.php
@@ -140,6 +140,7 @@ class FaxReceiveStatusAction
 
             // Get Fax Company
             $company = $fax->getCompany();
+            $brand = $company->getBrand();
 
             // Create attachment for PDF file
             $attach = \Swift_Attachment::fromPath($faxInDto->getFilePath(), 'application/pdf');
@@ -158,12 +159,17 @@ class FaxReceiveStatusAction
             // Get Company Notification Template for faxes
             $faxNotificationTemplate = $company->getFaxNotificationTemplate();
 
+            // If company has no template associated, fallback to brand notification template for faxes
+            if (!$faxNotificationTemplate) {
+                $faxNotificationTemplate = $brand->getFaxNotificationTemplate();
+            }
+
             // Get Generic Notification Template for faxes
             /** @var NotificationTemplateRepository $notificationTemplateRepository */
             $notificationTemplateRepository = $this->em->getRepository(NotificationTemplate::class);
             $genericFaxlNotificationTemplate = $notificationTemplateRepository->findGenericFaxTemplate();
 
-            // If no template is associated, fallback to generic notification template for voicemails
+            // If no template is associated, fallback to generic notification template for faxes
             if (!$faxNotificationTemplate) {
                 $faxNotificationTemplate = $genericFaxlNotificationTemplate;
             }

--- a/asterisk/agi/src/Voicemail/Sender.php
+++ b/asterisk/agi/src/Voicemail/Sender.php
@@ -99,6 +99,7 @@ class Sender extends RouteHandlerAbstract
 
         // Assume user has company and brand
         $company = $user->getCompany();
+        $brand = $company->getBrand();
 
         $substitution = array(
             '${VM_CATEGORY}' => $vmdata[self::VM_CATEGORY],
@@ -116,6 +117,11 @@ class Sender extends RouteHandlerAbstract
 
         // Get Company Notification Template for voicemails
         $vmNotificationTemplate = $company->getVoicemailNotificationTemplate();
+
+        // If company has no template associated, fallback to brand notification template for voicemails
+        if (!$vmNotificationTemplate) {
+            $vmNotificationTemplate = $brand->getVoicemailNotificationTemplate();
+        }
 
         // Get Generic Notification Template for voicemails
         /** @var NotificationTemplateRepository $notificationTemplateRepository */

--- a/doc/sphinx/administration_portal/brand/settings/notification_templates.rst
+++ b/doc/sphinx/administration_portal/brand/settings/notification_templates.rst
@@ -83,5 +83,7 @@ Configurable fields of each content:
 Assigning templates to clients
 ******************************
 
-Once the notification has been configured for the desired languages, Brand administrator must assign it to the
+Once the notification has been configured for the desired languages, Brand administrator can assign it to the
 client that will use it. This can be done in the Notification configuration section of each client.
+If client has no notification configured, brand notifications will be used for that client instead. If brand has no
+notification configured, default notifications will be used.

--- a/doc/sphinx/administration_portal/platform/brands.rst
+++ b/doc/sphinx/administration_portal/platform/brands.rst
@@ -43,6 +43,12 @@ This are the fields shown when a new brand is created:
     Locales
         Define default Timezone, Language and Currency for clients of this brand.
 
+    Notifications
+        Configure the email :ref:`notification templates` to use for this brand.
+        Clients configured to use generic notifications will use configured
+        brand notifications. If brand has no notification configured
+        :ref:`default notification templates` will be used.
+
 .. hint:: Some features are related to brand and cannot be assigned to clients.
     Other ones are also related to clients and lets the brand operator to
     assign them to its clients.

--- a/doc/sphinx/locale/es/LC_MESSAGES/administration_portal.po
+++ b/doc/sphinx/locale/es/LC_MESSAGES/administration_portal.po
@@ -4,12 +4,11 @@
 # package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: IvozProvider 2.7\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-09 11:39+0200\n"
+"POT-Creation-Date: 2019-10-21 11:27+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1696,6 +1695,7 @@ msgid ""
 msgstr ""
 
 #: ../../administration_portal/brand/clients/virtual_pbx.rst:43
+#: ../../administration_portal/platform/brands.rst:45
 msgid "Notifications"
 msgstr ""
 
@@ -3429,8 +3429,11 @@ msgstr ""
 #: ../../administration_portal/brand/settings/notification_templates.rst:86
 msgid ""
 "Once the notification has been configured for the desired languages, "
-"Brand administrator must assign it to the client that will use it. This "
-"can be done in the Notification configuration section of each client."
+"Brand administrator can assign it to the client that will use it. This "
+"can be done in the Notification configuration section of each client. If "
+"client has no notification configured, brand notifications will be used "
+"for that client instead. If brand has no notification configured, default"
+" notifications will be used."
 msgstr ""
 
 #: ../../administration_portal/brand/settings/numeric_transformations.rst:5
@@ -7789,57 +7792,65 @@ msgstr ""
 msgid "Define default Timezone, Language and Currency for clients of this brand."
 msgstr ""
 
-#: ../../administration_portal/platform/brands.rst:46
+#: ../../administration_portal/platform/brands.rst:47
+msgid ""
+"Configure the email :ref:`notification templates` to use for this brand. "
+"Clients configured to use generic notifications will use configured brand"
+" notifications. If brand has no notification configured :ref:`default "
+"notification templates` will be used."
+msgstr ""
+
+#: ../../administration_portal/platform/brands.rst:52
 msgid ""
 "Some features are related to brand and cannot be assigned to clients. "
 "Other ones are also related to clients and lets the brand operator to "
 "assign them to its clients."
 msgstr ""
 
-#: ../../administration_portal/platform/brands.rst:50
+#: ../../administration_portal/platform/brands.rst:56
 msgid ""
 "Disabling billing hides all related sections and assumes that an external"
 " element will set a price for calls (external tarification module is "
 "needed, ask for it!)."
 msgstr ""
 
-#: ../../administration_portal/platform/brands.rst:54
+#: ../../administration_portal/platform/brands.rst:60
 msgid ""
 "Disabling invoices hides related sections, assuming you will use an "
 "external tool to generate them."
 msgstr ""
 
-#: ../../administration_portal/platform/brands.rst:57
+#: ../../administration_portal/platform/brands.rst:63
 msgid ""
 "SIP domain is only visible for Brands with Retail or Residential features"
 " enabled."
 msgstr ""
 
-#: ../../administration_portal/platform/brands.rst:61
+#: ../../administration_portal/platform/brands.rst:67
 msgid "Brand operators"
 msgstr ""
 
-#: ../../administration_portal/platform/brands.rst:63
+#: ../../administration_portal/platform/brands.rst:69
 msgid ""
 "**List of brand operators** subsection allows adding/editing/deleting "
 "credentials for brand portal access."
 msgstr ""
 
-#: ../../administration_portal/platform/brands.rst:67
+#: ../../administration_portal/platform/brands.rst:73
 msgid "Brand Portals"
 msgstr ""
 
-#: ../../administration_portal/platform/brands.rst:69
+#: ../../administration_portal/platform/brands.rst:75
 msgid ""
 "**List of brand portals** subsection allows managing URLs to access to "
 "the different web portals available for a given brand."
 msgstr ""
 
-#: ../../administration_portal/platform/brands.rst:71
+#: ../../administration_portal/platform/brands.rst:77
 msgid "See :ref:`Client Portals` for further reference."
 msgstr ""
 
-#: ../../administration_portal/platform/brands.rst:73
+#: ../../administration_portal/platform/brands.rst:79
 msgid ""
 "URLs are assigned to brands. This means that through a given URL the "
 "brand can be guessed, but not the client. As a result, username collision"

--- a/library/Ivoz/Provider/Domain/Model/Brand/BrandAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Brand/BrandAbstract.php
@@ -69,6 +69,26 @@ abstract class BrandAbstract
      */
     protected $currency;
 
+    /**
+     * @var \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateInterface | null
+     */
+    protected $voicemailNotificationTemplate;
+
+    /**
+     * @var \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateInterface | null
+     */
+    protected $faxNotificationTemplate;
+
+    /**
+     * @var \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateInterface | null
+     */
+    protected $invoiceNotificationTemplate;
+
+    /**
+     * @var \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateInterface | null
+     */
+    protected $callCsvNotificationTemplate;
+
 
     use ChangelogTrait;
 
@@ -186,6 +206,10 @@ abstract class BrandAbstract
             ->setLanguage($fkTransformer->transform($dto->getLanguage()))
             ->setDefaultTimezone($fkTransformer->transform($dto->getDefaultTimezone()))
             ->setCurrency($fkTransformer->transform($dto->getCurrency()))
+            ->setVoicemailNotificationTemplate($fkTransformer->transform($dto->getVoicemailNotificationTemplate()))
+            ->setFaxNotificationTemplate($fkTransformer->transform($dto->getFaxNotificationTemplate()))
+            ->setInvoiceNotificationTemplate($fkTransformer->transform($dto->getInvoiceNotificationTemplate()))
+            ->setCallCsvNotificationTemplate($fkTransformer->transform($dto->getCallCsvNotificationTemplate()))
         ;
 
         $self->initChangelog();
@@ -231,7 +255,11 @@ abstract class BrandAbstract
             ->setDomain($fkTransformer->transform($dto->getDomain()))
             ->setLanguage($fkTransformer->transform($dto->getLanguage()))
             ->setDefaultTimezone($fkTransformer->transform($dto->getDefaultTimezone()))
-            ->setCurrency($fkTransformer->transform($dto->getCurrency()));
+            ->setCurrency($fkTransformer->transform($dto->getCurrency()))
+            ->setVoicemailNotificationTemplate($fkTransformer->transform($dto->getVoicemailNotificationTemplate()))
+            ->setFaxNotificationTemplate($fkTransformer->transform($dto->getFaxNotificationTemplate()))
+            ->setInvoiceNotificationTemplate($fkTransformer->transform($dto->getInvoiceNotificationTemplate()))
+            ->setCallCsvNotificationTemplate($fkTransformer->transform($dto->getCallCsvNotificationTemplate()));
 
 
 
@@ -264,7 +292,11 @@ abstract class BrandAbstract
             ->setDomain(\Ivoz\Provider\Domain\Model\Domain\Domain::entityToDto(self::getDomain(), $depth))
             ->setLanguage(\Ivoz\Provider\Domain\Model\Language\Language::entityToDto(self::getLanguage(), $depth))
             ->setDefaultTimezone(\Ivoz\Provider\Domain\Model\Timezone\Timezone::entityToDto(self::getDefaultTimezone(), $depth))
-            ->setCurrency(\Ivoz\Provider\Domain\Model\Currency\Currency::entityToDto(self::getCurrency(), $depth));
+            ->setCurrency(\Ivoz\Provider\Domain\Model\Currency\Currency::entityToDto(self::getCurrency(), $depth))
+            ->setVoicemailNotificationTemplate(\Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplate::entityToDto(self::getVoicemailNotificationTemplate(), $depth))
+            ->setFaxNotificationTemplate(\Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplate::entityToDto(self::getFaxNotificationTemplate(), $depth))
+            ->setInvoiceNotificationTemplate(\Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplate::entityToDto(self::getInvoiceNotificationTemplate(), $depth))
+            ->setCallCsvNotificationTemplate(\Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplate::entityToDto(self::getCallCsvNotificationTemplate(), $depth));
     }
 
     /**
@@ -291,7 +323,11 @@ abstract class BrandAbstract
             'domainId' => self::getDomain() ? self::getDomain()->getId() : null,
             'languageId' => self::getLanguage() ? self::getLanguage()->getId() : null,
             'defaultTimezoneId' => self::getDefaultTimezone() ? self::getDefaultTimezone()->getId() : null,
-            'currencyId' => self::getCurrency() ? self::getCurrency()->getId() : null
+            'currencyId' => self::getCurrency() ? self::getCurrency()->getId() : null,
+            'voicemailNotificationTemplateId' => self::getVoicemailNotificationTemplate() ? self::getVoicemailNotificationTemplate()->getId() : null,
+            'faxNotificationTemplateId' => self::getFaxNotificationTemplate() ? self::getFaxNotificationTemplate()->getId() : null,
+            'invoiceNotificationTemplateId' => self::getInvoiceNotificationTemplate() ? self::getInvoiceNotificationTemplate()->getId() : null,
+            'callCsvNotificationTemplateId' => self::getCallCsvNotificationTemplate() ? self::getCallCsvNotificationTemplate()->getId() : null
         ];
     }
     // @codeCoverageIgnoreStart
@@ -532,6 +568,102 @@ abstract class BrandAbstract
     public function getCurrency()
     {
         return $this->currency;
+    }
+
+    /**
+     * Set voicemailNotificationTemplate
+     *
+     * @param \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateInterface $voicemailNotificationTemplate
+     *
+     * @return static
+     */
+    public function setVoicemailNotificationTemplate(\Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateInterface $voicemailNotificationTemplate = null)
+    {
+        $this->voicemailNotificationTemplate = $voicemailNotificationTemplate;
+
+        return $this;
+    }
+
+    /**
+     * Get voicemailNotificationTemplate
+     *
+     * @return \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateInterface | null
+     */
+    public function getVoicemailNotificationTemplate()
+    {
+        return $this->voicemailNotificationTemplate;
+    }
+
+    /**
+     * Set faxNotificationTemplate
+     *
+     * @param \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateInterface $faxNotificationTemplate
+     *
+     * @return static
+     */
+    public function setFaxNotificationTemplate(\Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateInterface $faxNotificationTemplate = null)
+    {
+        $this->faxNotificationTemplate = $faxNotificationTemplate;
+
+        return $this;
+    }
+
+    /**
+     * Get faxNotificationTemplate
+     *
+     * @return \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateInterface | null
+     */
+    public function getFaxNotificationTemplate()
+    {
+        return $this->faxNotificationTemplate;
+    }
+
+    /**
+     * Set invoiceNotificationTemplate
+     *
+     * @param \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateInterface $invoiceNotificationTemplate
+     *
+     * @return static
+     */
+    public function setInvoiceNotificationTemplate(\Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateInterface $invoiceNotificationTemplate = null)
+    {
+        $this->invoiceNotificationTemplate = $invoiceNotificationTemplate;
+
+        return $this;
+    }
+
+    /**
+     * Get invoiceNotificationTemplate
+     *
+     * @return \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateInterface | null
+     */
+    public function getInvoiceNotificationTemplate()
+    {
+        return $this->invoiceNotificationTemplate;
+    }
+
+    /**
+     * Set callCsvNotificationTemplate
+     *
+     * @param \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateInterface $callCsvNotificationTemplate
+     *
+     * @return static
+     */
+    public function setCallCsvNotificationTemplate(\Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateInterface $callCsvNotificationTemplate = null)
+    {
+        $this->callCsvNotificationTemplate = $callCsvNotificationTemplate;
+
+        return $this;
+    }
+
+    /**
+     * Get callCsvNotificationTemplate
+     *
+     * @return \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateInterface | null
+     */
+    public function getCallCsvNotificationTemplate()
+    {
+        return $this->callCsvNotificationTemplate;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/Brand/BrandDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Brand/BrandDtoAbstract.php
@@ -111,6 +111,26 @@ abstract class BrandDtoAbstract implements DataTransferObjectInterface
     private $currency;
 
     /**
+     * @var \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateDto | null
+     */
+    private $voicemailNotificationTemplate;
+
+    /**
+     * @var \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateDto | null
+     */
+    private $faxNotificationTemplate;
+
+    /**
+     * @var \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateDto | null
+     */
+    private $invoiceNotificationTemplate;
+
+    /**
+     * @var \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateDto | null
+     */
+    private $callCsvNotificationTemplate;
+
+    /**
      * @var \Ivoz\Provider\Domain\Model\Company\CompanyDto[] | null
      */
     private $companies = null;
@@ -179,7 +199,11 @@ abstract class BrandDtoAbstract implements DataTransferObjectInterface
             'domainId' => 'domain',
             'languageId' => 'language',
             'defaultTimezoneId' => 'defaultTimezone',
-            'currencyId' => 'currency'
+            'currencyId' => 'currency',
+            'voicemailNotificationTemplateId' => 'voicemailNotificationTemplate',
+            'faxNotificationTemplateId' => 'faxNotificationTemplate',
+            'invoiceNotificationTemplateId' => 'invoiceNotificationTemplate',
+            'callCsvNotificationTemplateId' => 'callCsvNotificationTemplate'
         ];
     }
 
@@ -213,6 +237,10 @@ abstract class BrandDtoAbstract implements DataTransferObjectInterface
             'language' => $this->getLanguage(),
             'defaultTimezone' => $this->getDefaultTimezone(),
             'currency' => $this->getCurrency(),
+            'voicemailNotificationTemplate' => $this->getVoicemailNotificationTemplate(),
+            'faxNotificationTemplate' => $this->getFaxNotificationTemplate(),
+            'invoiceNotificationTemplate' => $this->getInvoiceNotificationTemplate(),
+            'callCsvNotificationTemplate' => $this->getCallCsvNotificationTemplate(),
             'companies' => $this->getCompanies(),
             'services' => $this->getServices(),
             'urls' => $this->getUrls(),
@@ -722,6 +750,190 @@ abstract class BrandDtoAbstract implements DataTransferObjectInterface
     public function getCurrencyId()
     {
         if ($dto = $this->getCurrency()) {
+            return $dto->getId();
+        }
+
+        return null;
+    }
+
+    /**
+     * @param \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateDto $voicemailNotificationTemplate
+     *
+     * @return static
+     */
+    public function setVoicemailNotificationTemplate(\Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateDto $voicemailNotificationTemplate = null)
+    {
+        $this->voicemailNotificationTemplate = $voicemailNotificationTemplate;
+
+        return $this;
+    }
+
+    /**
+     * @return \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateDto
+     */
+    public function getVoicemailNotificationTemplate()
+    {
+        return $this->voicemailNotificationTemplate;
+    }
+
+    /**
+     * @param mixed | null $id
+     *
+     * @return static
+     */
+    public function setVoicemailNotificationTemplateId($id)
+    {
+        $value = !is_null($id)
+            ? new \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateDto($id)
+            : null;
+
+        return $this->setVoicemailNotificationTemplate($value);
+    }
+
+    /**
+     * @return mixed | null
+     */
+    public function getVoicemailNotificationTemplateId()
+    {
+        if ($dto = $this->getVoicemailNotificationTemplate()) {
+            return $dto->getId();
+        }
+
+        return null;
+    }
+
+    /**
+     * @param \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateDto $faxNotificationTemplate
+     *
+     * @return static
+     */
+    public function setFaxNotificationTemplate(\Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateDto $faxNotificationTemplate = null)
+    {
+        $this->faxNotificationTemplate = $faxNotificationTemplate;
+
+        return $this;
+    }
+
+    /**
+     * @return \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateDto
+     */
+    public function getFaxNotificationTemplate()
+    {
+        return $this->faxNotificationTemplate;
+    }
+
+    /**
+     * @param mixed | null $id
+     *
+     * @return static
+     */
+    public function setFaxNotificationTemplateId($id)
+    {
+        $value = !is_null($id)
+            ? new \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateDto($id)
+            : null;
+
+        return $this->setFaxNotificationTemplate($value);
+    }
+
+    /**
+     * @return mixed | null
+     */
+    public function getFaxNotificationTemplateId()
+    {
+        if ($dto = $this->getFaxNotificationTemplate()) {
+            return $dto->getId();
+        }
+
+        return null;
+    }
+
+    /**
+     * @param \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateDto $invoiceNotificationTemplate
+     *
+     * @return static
+     */
+    public function setInvoiceNotificationTemplate(\Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateDto $invoiceNotificationTemplate = null)
+    {
+        $this->invoiceNotificationTemplate = $invoiceNotificationTemplate;
+
+        return $this;
+    }
+
+    /**
+     * @return \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateDto
+     */
+    public function getInvoiceNotificationTemplate()
+    {
+        return $this->invoiceNotificationTemplate;
+    }
+
+    /**
+     * @param mixed | null $id
+     *
+     * @return static
+     */
+    public function setInvoiceNotificationTemplateId($id)
+    {
+        $value = !is_null($id)
+            ? new \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateDto($id)
+            : null;
+
+        return $this->setInvoiceNotificationTemplate($value);
+    }
+
+    /**
+     * @return mixed | null
+     */
+    public function getInvoiceNotificationTemplateId()
+    {
+        if ($dto = $this->getInvoiceNotificationTemplate()) {
+            return $dto->getId();
+        }
+
+        return null;
+    }
+
+    /**
+     * @param \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateDto $callCsvNotificationTemplate
+     *
+     * @return static
+     */
+    public function setCallCsvNotificationTemplate(\Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateDto $callCsvNotificationTemplate = null)
+    {
+        $this->callCsvNotificationTemplate = $callCsvNotificationTemplate;
+
+        return $this;
+    }
+
+    /**
+     * @return \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateDto
+     */
+    public function getCallCsvNotificationTemplate()
+    {
+        return $this->callCsvNotificationTemplate;
+    }
+
+    /**
+     * @param mixed | null $id
+     *
+     * @return static
+     */
+    public function setCallCsvNotificationTemplateId($id)
+    {
+        $value = !is_null($id)
+            ? new \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateDto($id)
+            : null;
+
+        return $this->setCallCsvNotificationTemplate($value);
+    }
+
+    /**
+     * @return mixed | null
+     */
+    public function getCallCsvNotificationTemplateId()
+    {
+        if ($dto = $this->getCallCsvNotificationTemplate()) {
             return $dto->getId();
         }
 

--- a/library/Ivoz/Provider/Domain/Model/Brand/BrandInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/Brand/BrandInterface.php
@@ -170,6 +170,70 @@ interface BrandInterface extends FileContainerInterface, LoggableEntityInterface
     public function getCurrency();
 
     /**
+     * Set voicemailNotificationTemplate
+     *
+     * @param \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateInterface $voicemailNotificationTemplate
+     *
+     * @return static
+     */
+    public function setVoicemailNotificationTemplate(\Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateInterface $voicemailNotificationTemplate = null);
+
+    /**
+     * Get voicemailNotificationTemplate
+     *
+     * @return \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateInterface | null
+     */
+    public function getVoicemailNotificationTemplate();
+
+    /**
+     * Set faxNotificationTemplate
+     *
+     * @param \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateInterface $faxNotificationTemplate
+     *
+     * @return static
+     */
+    public function setFaxNotificationTemplate(\Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateInterface $faxNotificationTemplate = null);
+
+    /**
+     * Get faxNotificationTemplate
+     *
+     * @return \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateInterface | null
+     */
+    public function getFaxNotificationTemplate();
+
+    /**
+     * Set invoiceNotificationTemplate
+     *
+     * @param \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateInterface $invoiceNotificationTemplate
+     *
+     * @return static
+     */
+    public function setInvoiceNotificationTemplate(\Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateInterface $invoiceNotificationTemplate = null);
+
+    /**
+     * Get invoiceNotificationTemplate
+     *
+     * @return \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateInterface | null
+     */
+    public function getInvoiceNotificationTemplate();
+
+    /**
+     * Set callCsvNotificationTemplate
+     *
+     * @param \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateInterface $callCsvNotificationTemplate
+     *
+     * @return static
+     */
+    public function setCallCsvNotificationTemplate(\Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateInterface $callCsvNotificationTemplate = null);
+
+    /**
+     * Get callCsvNotificationTemplate
+     *
+     * @return \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateInterface | null
+     */
+    public function getCallCsvNotificationTemplate();
+
+    /**
      * Set logo
      *
      * @param \Ivoz\Provider\Domain\Model\Brand\Logo $logo

--- a/library/Ivoz/Provider/Domain/Service/Invoice/EmailSender.php
+++ b/library/Ivoz/Provider/Domain/Service/Invoice/EmailSender.php
@@ -129,9 +129,16 @@ class EmailSender implements InvoiceLifecycleEventHandlerInterface
     private function getNotificationTemplateContent(InvoiceInterface $invoice)
     {
         $company = $invoice->getCompany();
+        $brand = $company->getBrand();
 
-        // Get Company Notification Template for faxes
+        // Get Company Notification Template for invoices
         $invoiceNotificationTemplate = $company->getInvoiceNotificationTemplate();
+
+        // If company has no template associated, fallback to brand notification template for invoices
+        if (!$invoiceNotificationTemplate) {
+            $invoiceNotificationTemplate = $brand->getInvoiceNotificationTemplate();
+        }
+
         $genericInvoiceNotificationTemplate = $this->notificationTemplateRepository
             ->findGenericInvoiceTemplate();
 

--- a/library/Ivoz/Provider/Domain/Service/NotificationTemplateContent/CallCsvNotificationTemplateByCallCsvReport.php
+++ b/library/Ivoz/Provider/Domain/Service/NotificationTemplateContent/CallCsvNotificationTemplateByCallCsvReport.php
@@ -60,7 +60,12 @@ class CallCsvNotificationTemplateByCallCsvReport
     {
         $company = $callCsvReport->getCompany();
         if ($company) {
-            return $company->getCallCsvNotificationTemplate();
+            $callCsvNotificationTemplate = $company->getCallCsvNotificationTemplate();
+            if (!$callCsvNotificationTemplate) {
+                $brand = $company->getBrand();
+                $callCsvNotificationTemplate = $brand->getCallCsvNotificationTemplate();
+            }
+            return $callCsvNotificationTemplate;
         }
 
         $scheduler = $callCsvReport

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/Brand.BrandAbstract.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/Brand.BrandAbstract.orm.yml
@@ -92,3 +92,51 @@ Ivoz\Provider\Domain\Model\Brand\BrandAbstract:
           referencedColumnName: id
           onDelete: set null
       orphanRemoval: false
+    voicemailNotificationTemplate:
+      targetEntity: \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateInterface
+      cascade: {  }
+      fetch: LAZY
+      mappedBy: null
+      inversedBy: null
+      joinColumns:
+        vmNotificationTemplateId:
+          referencedColumnName: id
+          nullable: true
+          onDelete: set null
+      orphanRemoval: false
+    faxNotificationTemplate:
+      targetEntity: \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateInterface
+      cascade: {  }
+      fetch: LAZY
+      mappedBy: null
+      inversedBy: null
+      joinColumns:
+        faxNotificationTemplateId:
+          referencedColumnName: id
+          nullable: true
+          onDelete: set null
+      orphanRemoval: false
+    invoiceNotificationTemplate:
+      targetEntity: \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateInterface
+      cascade: {  }
+      fetch: LAZY
+      mappedBy: null
+      inversedBy: null
+      joinColumns:
+        invoiceNotificationTemplateId:
+          referencedColumnName: id
+          nullable: true
+          onDelete: set null
+      orphanRemoval: false
+    callCsvNotificationTemplate:
+      targetEntity: \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplateInterface
+      cascade: {  }
+      fetch: LAZY
+      mappedBy: null
+      inversedBy: null
+      joinColumns:
+        callCsvNotificationTemplateId:
+          referencedColumnName: id
+          nullable: true
+          onDelete: set null
+      orphanRemoval: false

--- a/library/spec/Ivoz/Provider/Domain/Service/NotificationTemplateContent/CallCsvNotificationTemplateByCallCsvReportSpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Service/NotificationTemplateContent/CallCsvNotificationTemplateByCallCsvReportSpec.php
@@ -206,13 +206,61 @@ class CallCsvNotificationTemplateByCallCsvReportSpec extends ObjectBehavior
         $this->execute($this->callCsvReport);
     }
 
-    public function it_uses_generic_notification_template_as_fallback()
+    public function it_uses_brand_notification_template_as_fallback()
     {
+        $brand = $this->getTestDouble(
+            BrandInterface::class
+        );
+
         $this
             ->company
             ->getCallCsvNotificationTemplate()
             ->willReturn(null)
             ->shouldBeCalled();
+
+        $this
+            ->company
+            ->getBrand()
+            ->willReturn($brand)
+            ->shouldBeCalled();
+
+        $this->getterProphecy(
+            $brand,
+            [
+                'getCallCsvNotificationTemplate' => $this->callCsvNotificationTemplate,
+            ],
+            true
+        );
+
+        $this->execute($this->callCsvReport);
+    }
+
+
+    public function it_uses_generic_notification_template_as_fallback()
+    {
+        $brand = $this->getTestDouble(
+            BrandInterface::class
+        );
+
+        $this
+            ->company
+            ->getCallCsvNotificationTemplate()
+            ->willReturn(null)
+            ->shouldBeCalled();
+
+        $this
+            ->company
+            ->getBrand()
+            ->willReturn($brand)
+            ->shouldBeCalled();
+
+        $this->getterProphecy(
+            $brand,
+            [
+                'getCallCsvNotificationTemplate' => null,
+            ],
+            true
+        );
 
         $this
             ->notificationTemplateRepository

--- a/schema/app/DoctrineMigrations/Version20191017111612.php
+++ b/schema/app/DoctrineMigrations/Version20191017111612.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20191017111612 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE Brands ADD vmNotificationTemplateId INT UNSIGNED DEFAULT NULL, ADD faxNotificationTemplateId INT UNSIGNED DEFAULT NULL, ADD invoiceNotificationTemplateId INT UNSIGNED DEFAULT NULL, ADD callCsvNotificationTemplateId INT UNSIGNED DEFAULT NULL');
+        $this->addSql('ALTER TABLE Brands ADD CONSTRAINT FK_790E41021BA12A15 FOREIGN KEY (vmNotificationTemplateId) REFERENCES NotificationTemplates (id) ON DELETE SET NULL');
+        $this->addSql('ALTER TABLE Brands ADD CONSTRAINT FK_790E4102E559D278 FOREIGN KEY (faxNotificationTemplateId) REFERENCES NotificationTemplates (id) ON DELETE SET NULL');
+        $this->addSql('ALTER TABLE Brands ADD CONSTRAINT FK_790E4102A29D8295 FOREIGN KEY (invoiceNotificationTemplateId) REFERENCES NotificationTemplates (id) ON DELETE SET NULL');
+        $this->addSql('ALTER TABLE Brands ADD CONSTRAINT FK_790E410274EE731B FOREIGN KEY (callCsvNotificationTemplateId) REFERENCES NotificationTemplates (id) ON DELETE SET NULL');
+        $this->addSql('CREATE INDEX IDX_790E41021BA12A15 ON Brands (vmNotificationTemplateId)');
+        $this->addSql('CREATE INDEX IDX_790E4102E559D278 ON Brands (faxNotificationTemplateId)');
+        $this->addSql('CREATE INDEX IDX_790E4102A29D8295 ON Brands (invoiceNotificationTemplateId)');
+        $this->addSql('CREATE INDEX IDX_790E410274EE731B ON Brands (callCsvNotificationTemplateId)');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE Brands DROP FOREIGN KEY FK_790E41021BA12A15');
+        $this->addSql('ALTER TABLE Brands DROP FOREIGN KEY FK_790E4102E559D278');
+        $this->addSql('ALTER TABLE Brands DROP FOREIGN KEY FK_790E4102A29D8295');
+        $this->addSql('ALTER TABLE Brands DROP FOREIGN KEY FK_790E410274EE731B');
+        $this->addSql('DROP INDEX IDX_790E41021BA12A15 ON Brands');
+        $this->addSql('DROP INDEX IDX_790E4102E559D278 ON Brands');
+        $this->addSql('DROP INDEX IDX_790E4102A29D8295 ON Brands');
+        $this->addSql('DROP INDEX IDX_790E410274EE731B ON Brands');
+        $this->addSql('ALTER TABLE Brands DROP vmNotificationTemplateId, DROP faxNotificationTemplateId, DROP invoiceNotificationTemplateId, DROP callCsvNotificationTemplateId');
+    }
+}

--- a/web/admin/application/configs/klear/BrandsList.yaml
+++ b/web/admin/application/configs/klear/BrandsList.yaml
@@ -44,6 +44,10 @@ production:
           language: true
           defaultTimezone: true
           currency: true
+          voicemailNotificationTemplate: true
+          faxNotificationTemplate: true
+          invoiceNotificationTemplate: true
+          callCsvNotificationTemplate: true
           recordingsLimitMB: true
           recordingsLimitEmail: true
           recordingsDiskUsage: true
@@ -91,6 +95,10 @@ production:
           invoice.province: true
           invoice.country: true
           invoice.registryData: true
+          voicemailNotificationTemplate: true
+          faxNotificationTemplate: true
+          invoiceNotificationTemplate: true
+          callCsvNotificationTemplate: true
           recordingsLimitMB: true
           recordingsDiskUsage: true
           recordingsDiskAvailable: true
@@ -130,6 +138,15 @@ production:
           label: _("SIP domain")
           fields:
             domain_users: 2
+        group5:
+          colsPerRow: 2
+          collapsed: true
+          label: _("Notification options")
+          fields:
+            voicemailNotificationTemplate: 1
+            faxNotificationTemplate: 1
+            invoiceNotificationTemplate: 1
+            callCsvNotificationTemplate: 1
 
     brandsEdit_screen: &brandsEdit_screenLink
       <<: *Brands

--- a/web/admin/application/configs/klear/model/Brands.yaml
+++ b/web/admin/application/configs/klear/model/Brands.yaml
@@ -219,8 +219,12 @@ production:
                   - recordingsLimitMB
                   - recordingsDiskUsage
                   - recordingsLimitEmail
+              faxes:
+                toggle:
+                  - faxNotificationTemplate
               invoices:
                 toggle:
+                  - invoiceNotificationTemplate
                   - invoice.PostalAddress
                   - invoice.PostalCode
                   - invoice.Town
@@ -229,6 +233,58 @@ production:
                   - invoice.RegistryData
           order:
             Feature.name: asc
+    voicemailNotificationTemplate:
+      title: ngettext('Voicemail Notification', 'Voicemail Notifications', 1)
+      type: select
+      source:
+        data: mapper
+        config:
+          entity: \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplate
+          filterClass: IvozProvider_Klear_Filter_NotificationTemplateVoicemail
+          fieldName:
+            fields:
+              - name
+            template: '%name%'
+        'null': _("Use generic template")
+    faxNotificationTemplate:
+      title: ngettext('Fax Notification', 'Fax Notifications', 1)
+      type: select
+      source:
+        data: mapper
+        config:
+          entity: \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplate
+          filterClass: IvozProvider_Klear_Filter_NotificationTemplateFax
+          fieldName:
+            fields:
+              - name
+            template: '%name%'
+        'null': _("Use generic template")
+    invoiceNotificationTemplate:
+      title: ngettext('Invoice Notification', 'Invoice Notifications', 1)
+      type: select
+      source:
+        data: mapper
+        config:
+          entity: \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplate
+          filterClass: IvozProvider_Klear_Filter_NotificationTemplateInvoice
+          fieldName:
+            fields:
+              - name
+            template: '%name%'
+        'null': _("Use generic template")
+    callCsvNotificationTemplate:
+      title: ngettext('Call CSV Notification', 'Call CSV Notifications', 1)
+      type: select
+      source:
+        data: mapper
+        config:
+          entity: \Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplate
+          filterClass: IvozProvider_Klear_Filter_NotificationTemplateCallCsv
+          fieldName:
+            fields:
+            - name
+            template: '%name%'
+        'null': _("Use generic template")
 staging:
   _extends: production
 testing:

--- a/web/admin/application/library/IvozProvider/Klear/Filter/Brand.php
+++ b/web/admin/application/library/IvozProvider/Klear/Filter/Brand.php
@@ -13,13 +13,26 @@ class IvozProvider_Klear_Filter_Brand implements KlearMatrix_Model_Field_Select_
 
     public function setRouteDispatcher(KlearMatrix_Model_RouteDispatcher $routeDispatcher)
     {
-        $auth = Zend_Auth::getInstance();
-        if (!$auth->hasIdentity()) {
-            throw new Klear_Exception_Default('No brand emulated');
-        }
 
-        $loggedUser = $auth->getIdentity();
-        $currentBrandyId = $loggedUser->brandId;
+        // Get ModelName and your Controller
+        $currentItemName = $routeDispatcher->getCurrentItemName();
+
+        $brandOwnedScreens = array(
+            "brandsList_screen",
+            "brandsEdit_screen",
+        );
+
+        if (in_array($currentItemName, $brandOwnedScreens)) {
+            $currentBrandyId =  $routeDispatcher->getParam("pk", false);
+        } else {
+            $auth = Zend_Auth::getInstance();
+            if (!$auth->hasIdentity()) {
+                throw new Klear_Exception_Default('No brand emulated');
+            }
+
+            $loggedUser = $auth->getIdentity();
+            $currentBrandyId = $loggedUser->brandId;
+        }
 
         $this->_condition[] = "self::brand = '" . $currentBrandyId . "'";
 


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
Add four new Brand fields to configure Clients notifications templates default values. If company has no template configured for a given notification, it will use the brand one. If brand has no template configured for a given notification, it will use the generic one.

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
