### PR TITLE
kamtrunks: cgrates_mode runtime parameter

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -34,18 +34,23 @@
 # Maximum call duration: 3 hours
 #!define MAX_DIALOG_TIMEOUT 10800
 
-# Allow calls when billing engine is down
+# CGRateS mode:
 #
-# By default (after service restart) it is off. To enable, execute:
-# kamcmd-proxytrunks cfg.set config allow_calls_without_cgrates 1
+# (0) Ask CGRateS for acceptance for all calls. If CGRateS is down, allow only
+#     within-country calls. Default mode.
 #
-# To disable again:
-# kamcmd-proxytrunks cfg.set config allow_calls_without_cgrates 0
+# (1) Disable CGRateS: CGRateS won't be used for any call.
+#
+# To skip rater in all calls, set 1:
+# kamcmd-proxytrunks cfg.set config cgrates_mode 1
+#
+# To go back to default mode, set 0:
+# kamcmd-proxytrunks cfg.set config cgrates_mode 0
 #
 # To see current value:
-# kamcmd-proxytrunks cfg.get config allow_calls_without_cgrates
+# kamcmd-proxytrunks cfg.get config cgrates_mode
 
-config.allow_calls_without_cgrates = 0
+config.cgrates_mode = 0
 
 # Enable/disable debug logs
 dolog.rpc    = 0 desc "If 1, debug RPC"
@@ -448,9 +453,7 @@ request_route {
             # From now on, only executed if CGRateS is DOWN
             route(IS_WITHIN_COUNTRY);
 
-            if ($sel(cfg_get.config.allow_calls_without_cgrates) == 1) {
-                xwarn("[$dlg_var(cidhash)] Allow call despite CGRateS being down");
-            } else if ($var(is_within_country)) {
+            if ($var(is_within_country)) {
                 xwarn("[$dlg_var(cidhash)] Allow within country call despite CGRateS being down");
             } else {
                 xerr("[$dlg_var(cidhash)] Drop call as CGRateS is down");
@@ -590,9 +593,14 @@ route[LOAD_GWS] {
 }
 
 route[CHECK_RATER] {
-    # Loop over $avp(gw_uri_avp): if non-externally-rating GW found, set $var(needsRater) to 1 and leave
     $var(needsRater) = 0;
 
+    if ($sel(cfg_get.config.cgrates_mode) == 1) {
+        xwarn("[$dlg_var(cidhash)] CHECK-RATER: Skip rater for all calls (cgrates_mode: 1)");
+        return;
+    }
+
+    # Loop over $avp(gw_uri_avp): if non-externally-rating GW found, set $var(needsRater) to 1 and leave
     $var(m) = 0;
     while(is_avp_set("$(avp(gw_uri_avp)[$var(m)])")) {
         $var(carrierServerId) = $(avp(gw_uri_avp)[$var(m)]{s.select,10,|});
@@ -607,7 +615,11 @@ route[CHECK_RATER] {
         $var(m) = $var(m) + 1;
     }
 
-    xinfo("[$dlg_var(cidhash)] CHECK-RATER: needsRater -> $var(needsRater)");
+    if ($var(needsRater)) {
+        xinfo("[$dlg_var(cidhash)] CHECK-RATER: Rater will be used for this call");
+    } else {
+        xinfo("[$dlg_var(cidhash)] CHECK-RATER: Rater won't be used for this call");
+    }
 }
 
 # This route calls ADD_LCR_CARRIER for each Carrier in $avp(carriers)
@@ -731,19 +743,18 @@ route[SELECT_NEXT_GW] {
     if ( $(xavp(ra=>carrierId){s.len}) ) {
         $dlg_var(carrierId) = $xavp(ra=>carrierId);
         $dlg_var(calculateCost) = $xavp(ra=>calculateCost);
-        xinfo("[$dlg_var(cidhash)] SELECT-NEXT-GW: carrierId: $dlg_var(carrierId)\n");
+        xinfo("[$dlg_var(cidhash)] SELECT-NEXT-GW: carrierId: $dlg_var(carrierId) (externallyRated: $xavp(ra=>externallyRated))\n");
     } else {
         xerr("[$dlg_var(cidhash)] SELECT-NEXT-GW: Error obtaining 'carrierId' for carrierServerId '$avp(carrierServerId)'\n");
         send_reply("500", "Server Internal Error");
         exit;
     }
 
-    if ($xavp(ra=>externallyRated) == '1') {
-        # Externally rating GW
-        $dlg_var(cgrid) = $null;
-        dlg_set_timeout(MAX_DIALOG_TIMEOUT);
-    } else if ($sht(cgrconn=>cgr) == $null) {
-        xwarn("[$dlg_var(cidhash)] SELECT-NEXT-GW: Charging controller unreachable, treat as externally rated");
+    if ($xavp(ra=>externallyRated) == '1' || $sel(cfg_get.config.cgrates_mode) == 1 || $sht(cgrconn=>cgr) == $null) {
+        # 3 exceptional cases:
+        # - Externally rated GW
+        # - CGRateS is disabled with cgrates_mode
+        # - CGRateS is down and call is national
         $dlg_var(cgrid) = $null;
         dlg_set_timeout(MAX_DIALOG_TIMEOUT);
     } else {


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
<!-- Describe your changes in detail -->
Introduce _cgrates_mode_ runtime parameter that replaces _allow_calls_without_cgrates_.

- allow_calls_without_cgrates:

    Only applied when CGRateS was down:

    * If set, calls were allowed.

    * If not set, calls were declined (unless they were national).

- cgrates_mode:

    Applies no matter CGRateS is down:

    * If set, CGRateS is disabled for every call (equals to enabling externallyRated
    for all carriers).

    * If not set, CGRateS is asked for every call:

        1. If it is up, CGRateS will allow/decline calls.
        2. If it is down, only national calls are allowed.

The difference is that CGRateS is skipped no matter if it is up or down. National
calls continue being allowed in CGRateS down scenarios.