### PR TITLE
schema: avoid duplicate entries in userCdrs

### DIFF
--- a/library/DataFixtures/ORM/KamUsersCdr.php
+++ b/library/DataFixtures/ORM/KamUsersCdr.php
@@ -55,7 +55,7 @@ class KamUsersCdr extends Fixture implements DependentFixtureInterface
             $this->setDirection('outbound');
             $this->setCaller('102');
             $this->setCallee('+34676896561');
-            $this->setCallid('9297bdde-309cd48f@10.10.1.123');
+            $this->setCallid('8297bdde-309cd48f@10.10.1.123');
             $this->setCallidHash('517fa1eb');
         })->call($item2);
 

--- a/library/Ivoz/Kam/Infrastructure/Persistence/Doctrine/Mapping/UsersCdr.UsersCdrAbstract.orm.yml
+++ b/library/Ivoz/Kam/Infrastructure/Persistence/Doctrine/Mapping/UsersCdr.UsersCdrAbstract.orm.yml
@@ -1,5 +1,10 @@
 Ivoz\Kam\Domain\Model\UsersCdr\UsersCdrAbstract:
   type: mappedSuperclass
+  uniqueConstraints:
+    usersCdr_callid_direction:
+      columns:
+      - callid
+      - direction
   indexes:
     usersCdr_start_time_idx:
       columns:

--- a/schema/app/DoctrineMigrations/Version20191021113146.php
+++ b/schema/app/DoctrineMigrations/Version20191021113146.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20191021113146 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DELETE t1 FROM kam_users_cdrs t1 INNER JOIN kam_users_cdrs t2 WHERE t1.id > t2.id AND t1.callid=t2.callid AND t1.direction=t2.direction');
+        $this->addSql('CREATE UNIQUE INDEX usersCdr_callid_direction ON kam_users_cdrs (callid, direction)');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP INDEX usersCdr_callid_direction ON kam_users_cdrs');
+    }
+}

--- a/schema/tests/Kam/UsersCdr/UsersCdrRepositoryTest.php
+++ b/schema/tests/Kam/UsersCdr/UsersCdrRepositoryTest.php
@@ -63,7 +63,7 @@ class UsersCdrRepositoryTest extends KernelTestCase
             ->findByCallid('9297bdde-309cd48f@10.10.1.123');
 
         $this->assertCount(
-            2,
+            1,
             $result
         );
 


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

This PR avoids duplicate entries in kam_users_cdrs that may happen if database connection is lagged.