### PR TITLE
Add block routes to Outgoing Routings

### DIFF
--- a/doc/sphinx/administration_portal/brand/routing/outgoing_routings.rst
+++ b/doc/sphinx/administration_portal/brand/routing/outgoing_routings.rst
@@ -1,4 +1,4 @@
-.. _routes_metrics:
+.. _routes_weights:
 
 *****************
 Outgoing Routings
@@ -21,15 +21,15 @@ These are the fields that define an outgoing routing rule:
         This groups allows selecting if this rule applies for just one destination pattern, for a group or for faxes.
 
     Route type
-        There are two kind of rules: static and LCR. In static, only one carrier is selected. In LCR, multiple carriers
-        may be selected.
+        There are three kind of rules: static, LCR and block. In *static*, only one carrier is selected. In *LCR*, multiple carriers
+        may be selected. In *block*, no carrier is selected as call will be dropped.
 
     Priority
         If a call matches several routes, it will be placed using the outgoing
         route with lower priority, as long as it is available.
 
-    Metric
-        If a call matches several routes with equal priority, metric will determine
+    Weight
+        If a call matches several routes with equal priority, weight will determine
         the proportion of calls that will use one route or another.
 
 .. error:: **All clients rules apply to all clients**, even if they have specific matching rules. Matching specific rules and
@@ -39,44 +39,44 @@ These are the fields that define an outgoing routing rule:
 
 .. warning:: When placing a call to a given destination, rules with that pattern will be merged with rules of groups that contain that pattern.
 
-.. note:: In all this rule merging process, priority and metric determine the order.
+.. note:: In all this rule merging process, priority and weight determine the order.
 
 .. note:: Fax specific routes will apply first for both faxes sent via virtual faxing (see :ref:`faxes`) or T.38 capable devices. If no fax
           specific route found, remaining routes will apply as for a normal voice call to that destination.
 
 Last two fields, priority and order, are key parameters to achieve two interesting features too: **load-balancing** and **failover-routes**.
 
-Load balancing
-==============
+
+
+.. rubric:: Load balancing
 
 *Load-balancing* lets us distribute calls matching the same pattern using
 several valid outgoing routes.
 
-.. rubric:: Example 1
+- Example 1
 
-- Route A: priority 1, metric 1
-- Route B: priority 1, metric 1
+  - Route A: priority 1, weight 1
+  - Route B: priority 1, weight 1
 
 Call matching these routes will use route A for %50 of the calls and route B for
 %50 of the calls.
 
-.. rubric:: Example 2
+- Example 2
 
-- Route A: priority 1, metric 1
-- Route B: priority 1, metric 2
+  - Route A: priority 1, weight 1
+  - Route B: priority 1, weight 2
 
 Call matching these routes will use route A for %33 of the calls and route B for
 %66 of the calls.
 
-Failover routes
-===============
+.. rubric:: Failover routes
 
 Failover route lets us use another route whenever the main route fails.
 
-.. rubric:: Example
+- Example
 
-- Route A: priority 1, metric 1
-- Route B: priority 2, metric 1
+  - Route A: priority 1, weight 1
+  - Route B: priority 2, weight 1
 
 All calls matching these routes will try to use route A. In case the call fails,
 the call will be placed using route B.
@@ -93,7 +93,7 @@ given destination (for a 5 minutes duration) and will order them in increasing o
 .. note:: Carriers that cannot compute cost for a given destination are silently ignored (they are not used).
 
 LCR and static rules combined
-=============================
+-----------------------------
 
 Carrier election process can combine static and LCR rules:
 
@@ -104,3 +104,11 @@ Carrier election process can combine static and LCR rules:
 3. Carriers are ordered using priority (ascending order).
 
 4. Carrier's weight is used for load-balancing between carriers with same priority.
+
+Blocking routes
+===============
+
+Blocking routes are the only routes with **priority 0**. These enforcement makes them be **evaluated first**.
+
+.. tip:: Using these routes, it is easy to make a group with unwanted call prefixes and reject all calls to those
+         destinations for every client (or for one particular client).

--- a/doc/sphinx/locale/es/LC_MESSAGES/administration_portal.po
+++ b/doc/sphinx/locale/es/LC_MESSAGES/administration_portal.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: IvozProvider 2.7\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-21 11:27+0200\n"
+"POT-Creation-Date: 2019-10-08 18:01+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1695,7 +1695,6 @@ msgid ""
 msgstr ""
 
 #: ../../administration_portal/brand/clients/virtual_pbx.rst:43
-#: ../../administration_portal/platform/brands.rst:45
 msgid "Notifications"
 msgstr ""
 
@@ -3429,11 +3428,8 @@ msgstr ""
 #: ../../administration_portal/brand/settings/notification_templates.rst:86
 msgid ""
 "Once the notification has been configured for the desired languages, "
-"Brand administrator can assign it to the client that will use it. This "
-"can be done in the Notification configuration section of each client. If "
-"client has no notification configured, brand notifications will be used "
-"for that client instead. If brand has no notification configured, default"
-" notifications will be used."
+"Brand administrator must assign it to the client that will use it. This "
+"can be done in the Notification configuration section of each client."
 msgstr ""
 
 #: ../../administration_portal/brand/settings/numeric_transformations.rst:5
@@ -7792,65 +7788,57 @@ msgstr ""
 msgid "Define default Timezone, Language and Currency for clients of this brand."
 msgstr ""
 
-#: ../../administration_portal/platform/brands.rst:47
-msgid ""
-"Configure the email :ref:`notification templates` to use for this brand. "
-"Clients configured to use generic notifications will use configured brand"
-" notifications. If brand has no notification configured :ref:`default "
-"notification templates` will be used."
-msgstr ""
-
-#: ../../administration_portal/platform/brands.rst:52
+#: ../../administration_portal/platform/brands.rst:46
 msgid ""
 "Some features are related to brand and cannot be assigned to clients. "
 "Other ones are also related to clients and lets the brand operator to "
 "assign them to its clients."
 msgstr ""
 
-#: ../../administration_portal/platform/brands.rst:56
+#: ../../administration_portal/platform/brands.rst:50
 msgid ""
 "Disabling billing hides all related sections and assumes that an external"
 " element will set a price for calls (external tarification module is "
 "needed, ask for it!)."
 msgstr ""
 
-#: ../../administration_portal/platform/brands.rst:60
+#: ../../administration_portal/platform/brands.rst:54
 msgid ""
 "Disabling invoices hides related sections, assuming you will use an "
 "external tool to generate them."
 msgstr ""
 
-#: ../../administration_portal/platform/brands.rst:63
+#: ../../administration_portal/platform/brands.rst:57
 msgid ""
 "SIP domain is only visible for Brands with Retail or Residential features"
 " enabled."
 msgstr ""
 
-#: ../../administration_portal/platform/brands.rst:67
+#: ../../administration_portal/platform/brands.rst:61
 msgid "Brand operators"
 msgstr ""
 
-#: ../../administration_portal/platform/brands.rst:69
+#: ../../administration_portal/platform/brands.rst:63
 msgid ""
 "**List of brand operators** subsection allows adding/editing/deleting "
 "credentials for brand portal access."
 msgstr ""
 
-#: ../../administration_portal/platform/brands.rst:73
+#: ../../administration_portal/platform/brands.rst:67
 msgid "Brand Portals"
 msgstr ""
 
-#: ../../administration_portal/platform/brands.rst:75
+#: ../../administration_portal/platform/brands.rst:69
 msgid ""
 "**List of brand portals** subsection allows managing URLs to access to "
 "the different web portals available for a given brand."
 msgstr ""
 
-#: ../../administration_portal/platform/brands.rst:77
+#: ../../administration_portal/platform/brands.rst:71
 msgid "See :ref:`Client Portals` for further reference."
 msgstr ""
 
-#: ../../administration_portal/platform/brands.rst:79
+#: ../../administration_portal/platform/brands.rst:73
 msgid ""
 "URLs are assigned to brands. This means that through a given URL the "
 "brand can be guessed, but not the client. As a result, username collision"

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -567,8 +567,16 @@ route[LOAD_GWS] {
             $var(rule_id) = $(avp(gw_uri_avp)[$var(i)]{s.select,-1,|});
             $var(gw_hostname) = $(avp(gw_uri_avp)[$var(i)]{s.select,6,|});
             if ($var(gw_hostname) == "dummy.ivozprovider.local") {
-                xinfo("[$dlg_var(cidhash)] REPLACE-DUMMY-GWS: Dummy GW found, replace it with LCR gateways");
-                route(ADD_LCR_CARRIERS);
+                sql_xquery("cb", "SELECT O.routingMode FROM kam_trunks_lcr_rules K JOIN OutgoingRouting O ON O.id=K.outgoingRoutingId WHERE K.id=$var(rule_id)", "rr");
+                if ($xavp(rr=>routingMode) == 'block') {
+                    xinfo("[$dlg_var(cidhash)] LOAD-GWS: Blocking route found, drop call");
+                    send_reply("403","Forbidden");
+                    exit;
+                } else {
+                    # routing_mode == 'lcr'
+                    xinfo("[$dlg_var(cidhash)] LOAD-GWS: LCR route found, replace it with LCR gateways");
+                    route(ADD_LCR_CARRIERS);
+                }
             } else {
                 $avp(new_gw_uri_avp) = $(avp(gw_uri_avp)[$var(i)]);
             }

--- a/library/Ivoz/Kam/Domain/Service/TrunksLcrRuleTarget/TrunksLcrRuleTargetFactory.php
+++ b/library/Ivoz/Kam/Domain/Service/TrunksLcrRuleTarget/TrunksLcrRuleTargetFactory.php
@@ -65,6 +65,11 @@ class TrunksLcrRuleTargetFactory
                 $lcrGateways[] = $this->trunksLcrGatewayRepository->findDummyGateway();
                 break;
 
+            case OutgoingRoutingInterface::ROUTINGMODE_BLOCK:
+                // Blocking Rules use special dummy gateway
+                $lcrGateways[] = $this->trunksLcrGatewayRepository->findDummyGateway();
+                break;
+
             default:
                 throw new \DomainException('Invalid Routing mode');
         }

--- a/library/Ivoz/Provider/Domain/Model/OutgoingRouting/OutgoingRouting.php
+++ b/library/Ivoz/Provider/Domain/Model/OutgoingRouting/OutgoingRouting.php
@@ -69,6 +69,10 @@ class OutgoingRouting extends OutgoingRoutingAbstract implements OutgoingRouting
             case self::MODE_LCR:
                 $this->setCarrier(null);
                 break;
+            case self::ROUTINGMODE_BLOCK:
+                $this->setCarrier(null);
+                $this->setPriority(0);
+                break;
             default:
                 throw new \DomainException('Incorrect Outgoing Routing Mode');
         }

--- a/library/Ivoz/Provider/Domain/Model/OutgoingRouting/OutgoingRoutingAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/OutgoingRouting/OutgoingRoutingAbstract.php
@@ -29,7 +29,7 @@ abstract class OutgoingRoutingAbstract
     protected $weight = 1;
 
     /**
-     * comment: enum:static|lcr
+     * comment: enum:static|lcr|block
      * @var string | null
      */
     protected $routingMode = 'static';
@@ -362,7 +362,8 @@ abstract class OutgoingRoutingAbstract
             Assertion::maxLength($routingMode, 25, 'routingMode value "%s" is too long, it should have no more than %d characters, but has %d characters.');
             Assertion::choice($routingMode, [
                 OutgoingRoutingInterface::ROUTINGMODE_STATIC,
-                OutgoingRoutingInterface::ROUTINGMODE_LCR
+                OutgoingRoutingInterface::ROUTINGMODE_LCR,
+                OutgoingRoutingInterface::ROUTINGMODE_BLOCK
             ], 'routingModevalue "%s" is not an element of the valid values: %s');
         }
 

--- a/library/Ivoz/Provider/Domain/Model/OutgoingRouting/OutgoingRoutingInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/OutgoingRouting/OutgoingRoutingInterface.php
@@ -10,6 +10,7 @@ interface OutgoingRoutingInterface extends LoggableEntityInterface
 {
     const ROUTINGMODE_STATIC = 'static';
     const ROUTINGMODE_LCR = 'lcr';
+    const ROUTINGMODE_BLOCK = 'block';
 
 
     /**

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/OutgoingRouting.OutgoingRoutingAbstract.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/OutgoingRouting.OutgoingRoutingAbstract.orm.yml
@@ -25,7 +25,7 @@ Ivoz\Provider\Domain\Model\OutgoingRouting\OutgoingRoutingAbstract:
       length: 25
       options:
         fixed: false
-        comment: '[enum:static|lcr]'
+        comment: '[enum:static|lcr|block]'
         default: 'static'
       column: routingMode
     prefix:

--- a/schema/app/DoctrineMigrations/Version20191021131531.php
+++ b/schema/app/DoctrineMigrations/Version20191021131531.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20191021131531 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE OutgoingRouting CHANGE routingMode routingMode VARCHAR(25) DEFAULT \'static\' COMMENT \'[enum:static|lcr|block]\'');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE OutgoingRouting CHANGE routingMode routingMode VARCHAR(25) DEFAULT \'static\' COLLATE utf8_general_ci COMMENT \'[enum:static|lcr]\'');
+    }
+}

--- a/web/admin/application/configs/klear/OutgoingRoutingList.yaml
+++ b/web/admin/application/configs/klear/OutgoingRoutingList.yaml
@@ -72,6 +72,10 @@ production:
         blacklist:
           target: true
           carriersGhost: true
+          prefix: true
+          forceClid: true
+          clid: true
+          clidCountry: true
         order:
           <<: *outgoingRouting_fieldsOrder
       fixedPositions: &outgoingRoutingFixedPositions_Link

--- a/web/admin/application/configs/klear/model/OutgoingRouting.yaml
+++ b/web/admin/application/configs/klear/model/OutgoingRouting.yaml
@@ -144,6 +144,11 @@ production:
             visualFilter:
               show: [ relCarriers ]
               hide: [ carrier, prefix, forceClid, clidCountry, clid ]
+          'block':
+            title: _("Block")
+            visualFilter:
+              show: [ ]
+              hide: [ carrier, prefix, forceClid, clidCountry, clid, relCarriers, weight, priority]
     company:
       title: ngettext('Client', 'Clients', 1)
       type: select

--- a/web/admin/application/languages/ca_ES/ca_ES.po
+++ b/web/admin/application/languages/ca_ES/ca_ES.po
@@ -251,6 +251,9 @@ msgstr "Mètode de facturació"
 msgid "Black Lists"
 msgstr "Llista negra"
 
+msgid "Block"
+msgstr "Bloquejar"
+
 msgid "Body"
 msgstr "Cos"
 

--- a/web/admin/application/languages/en_US/en_US.po
+++ b/web/admin/application/languages/en_US/en_US.po
@@ -246,6 +246,9 @@ msgstr "Billing method"
 msgid "Black Lists"
 msgstr "Black Lists"
 
+msgid "Block"
+msgstr "Block"
+
 msgid "Body"
 msgstr "Body"
 

--- a/web/admin/application/languages/es_ES/es_ES.po
+++ b/web/admin/application/languages/es_ES/es_ES.po
@@ -251,6 +251,9 @@ msgstr "Método tarificación"
 msgid "Black Lists"
 msgstr "Listas negras"
 
+msgid "Block"
+msgstr "Bloquear"
+
 msgid "Body"
 msgstr "Cuerpo"
 

--- a/web/admin/application/languages/it_IT/it_IT.po
+++ b/web/admin/application/languages/it_IT/it_IT.po
@@ -253,6 +253,9 @@ msgstr "Metodo di fatturazione"
 msgid "Black Lists"
 msgstr "Black Lists"
 
+msgid "Block"
+msgstr "Blocco"
+
 msgid "Body"
 msgstr "Corpo"
 

--- a/web/admin/application/library/IvozProvider/Klear/Filter/OutgoingRoutingMode.php
+++ b/web/admin/application/library/IvozProvider/Klear/Filter/OutgoingRoutingMode.php
@@ -61,9 +61,15 @@ class IvozProvider_Klear_Filter_OutgoingRoutingMode implements KlearMatrix_Model
             switch ($this->outgoingRouting->getRoutingMode()) {
                 case OutgoingRouting::MODE_LCR:
                     $excludedRoutingModes[] = OutgoingRouting::MODE_STATIC;
+                    $excludedRoutingModes[] = OutgoingRouting::ROUTINGMODE_BLOCK;
                     break;
                 case OutgoingRouting::MODE_STATIC:
                     $excludedRoutingModes[] = OutgoingRouting::MODE_LCR;
+                    $excludedRoutingModes[] = OutgoingRouting::ROUTINGMODE_BLOCK;
+                    break;
+                case OutgoingRouting::ROUTINGMODE_BLOCK:
+                    $excludedRoutingModes[] = OutgoingRouting::ROUTINGMODE_STATIC;
+                    $excludedRoutingModes[] = OutgoingRouting::ROUTINGMODE_LCR;
                     break;
             }
         }

--- a/web/admin/application/library/IvozProvider/Klear/Ghost/OutgoingRouting.php
+++ b/web/admin/application/library/IvozProvider/Klear/Ghost/OutgoingRouting.php
@@ -41,6 +41,8 @@ class IvozProvider_Klear_Ghost_OutgoingRouting extends KlearMatrix_Model_Field_G
                     $outgoingRoutingRelCarriers
                 );
                 break;
+            case OutgoingRouting::ROUTINGMODE_BLOCK:
+                return "";
             default:
                 return Klear_Model_Gettext::gettextCheck('_("Invalid route mode")');
         }


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
Add **Block routes** concept to _Outgoing Routings_.

#### Additional information

They are evaluated first (because they are enforced to have 0 priority) and make it easy to block wanted prefixed for all clients with a unique blocking route.