### PR TITLE
core: removed deprecation warning

### DIFF
--- a/library/Ivoz/Core/Infrastructure/Symfony/DependencyInjection/Compiler/DomainServiceCompiler.php
+++ b/library/Ivoz/Core/Infrastructure/Symfony/DependencyInjection/Compiler/DomainServiceCompiler.php
@@ -2,7 +2,6 @@
 
 namespace Ivoz\Core\Infrastructure\Symfony\DependencyInjection\Compiler;
 
-use Ivoz\Core\Domain\Service\CommonLifecycleEventHandlerInterface;
 use Ivoz\Core\Domain\Service\DomainEventSubscriberInterface;
 use Ivoz\Core\Domain\Service\LifecycleServiceCollectionInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -79,7 +78,9 @@ class DomainServiceCompiler implements CompilerPassInterface
         $service->setAutowired(true);
 
         $tag = LifecycleServiceHelper::getServiceCollectionTag($fqdn);
-        $this->container->setAlias($tag, $fqdn);
+        $this->container
+            ->setAlias($tag, $fqdn)
+            ->setPublic(true);
     }
 
     /**


### PR DESCRIPTION
Made service_collection aliases public so that DoctrineEventSubscriber does not trigger warnings

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
