### PR TITLE
Improved changelog

### DIFF
--- a/library/Ivoz/Core/Infrastructure/Domain/Service/Lifecycle/CommandPersister.php
+++ b/library/Ivoz/Core/Infrastructure/Domain/Service/Lifecycle/CommandPersister.php
@@ -47,6 +47,14 @@ class CommandPersister
      */
     public function persistEvents()
     {
+        $entityEvents = $this
+            ->entityEventSubscriber
+            ->getEvents();
+
+        if (empty($entityEvents)) {
+            return;
+        }
+
         $commandNum = $this
             ->commandEventSubscriber
             ->countEvents();
@@ -84,10 +92,6 @@ class CommandPersister
 
             $commandlog = $this->latestCommandlog;
         }
-
-        $entityEvents = $this
-            ->entityEventSubscriber
-            ->getEvents();
 
         $this
             ->entityEventSubscriber

--- a/library/Ivoz/Provider/Domain/Model/Terminal/Terminal.php
+++ b/library/Ivoz/Provider/Domain/Model/Terminal/Terminal.php
@@ -16,7 +16,10 @@ class Terminal extends TerminalAbstract implements TerminalInterface
      */
     public function getChangeSet()
     {
-        return parent::getChangeSet();
+        $response = parent::getChangeSet();
+        unset($response['lastProvisionDate']);
+
+        return $response;
     }
 
     /**


### PR DESCRIPTION
Don't register terminal.lastProvisionDate changes on changelog

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
