### PR TITLE
core: fix routing pattern creation/edition logic

### DIFF
--- a/library/Ivoz/Kam/Domain/Service/TrunksLcrRule/UpdateByRoutingPattern.php
+++ b/library/Ivoz/Kam/Domain/Service/TrunksLcrRule/UpdateByRoutingPattern.php
@@ -57,6 +57,10 @@ class UpdateByRoutingPattern implements RoutingPatternLifecycleEventHandlerInter
      */
     public function execute(RoutingPatternInterface $routingPattern)
     {
+        if ($routingPattern->isNew()) {
+            return;
+        }
+
         if (!$routingPattern->hasChanged('prefix')) {
             return;
         }

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/OutgoingRoutingDoctrineRepository.php
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/OutgoingRoutingDoctrineRepository.php
@@ -32,7 +32,8 @@ class OutgoingRoutingDoctrineRepository extends ServiceEntityRepository implemen
             ->select('self')
             ->innerJoin('self.routingPatternGroup', 'routingPatternGroup')
             ->innerJoin('routingPatternGroup.relPatterns', 'relPattern')
-            ->innerJoin('relPattern.routingPattern', 'routingPattern')
+            ->where('relPattern.routingPattern = :routingPatternId')
+            ->setParameter(':routingPatternId', $routingPattern->getId())
             ->groupBy('self.id')
             ->getQuery();
 


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

Two fixes:

- Prefix creation should not trigger any LCR logics.

- Getting OutgoingRoutings using a routing pattern through a group was wrong (missing where condition).

#### Additional information

Missing where condition may have inserted wrong underlying LcrRules.