### PR TITLE
Max daily usage

### DIFF
--- a/debian/ivozprovider-balances.install
+++ b/debian/ivozprovider-balances.install
@@ -1,2 +1,3 @@
 microservices/balances /opt/irontec/ivozprovider/microservices/
 debian/systemd/ivozprovider-balances.timer /lib/systemd/system
+debian/systemd/ivozprovider-counters.timer /lib/systemd/system

--- a/debian/ivozprovider-balances.ivozprovider-counters.service
+++ b/debian/ivozprovider-balances.ivozprovider-counters.service
@@ -1,0 +1,1 @@
+systemd/ivozprovider-counters.service

--- a/debian/ivozprovider.postinst
+++ b/debian/ivozprovider.postinst
@@ -162,6 +162,7 @@ function enable_services()
     /bin/systemctl enable ivozprovider-jwt.timer
     /bin/systemctl enable ivozprovider-recordings.timer
     /bin/systemctl enable ivozprovider-balances.timer
+    /bin/systemctl enable ivozprovider-counters.timer
     /bin/systemctl enable ivozprovider-scheduler.timer
     /bin/systemctl enable ivozprovider-cdrs.timer
     /bin/systemctl enable cgrates

--- a/debian/rules
+++ b/debian/rules
@@ -59,6 +59,7 @@ override_dh_systemd_enable:
 	dh_systemd_enable -p ivozprovider-web-rest        --name=ivozprovider-jwt                --no-enable
 	dh_systemd_enable -p ivozprovider-recordings      --name=ivozprovider-recordings         --no-enable
 	dh_systemd_enable -p ivozprovider-balances        --name=ivozprovider-balances           --no-enable
+	dh_systemd_enable -p ivozprovider-balances        --name=ivozprovider-counters           --no-enable
 	dh_systemd_enable -p ivozprovider-scheduler       --name=ivozprovider-scheduler          --no-enable
 	dh_systemd_enable -p ivozprovider-scheduler       --name=ivozprovider-cdrs               --no-enable
 
@@ -69,6 +70,7 @@ override_dh_systemd_start:
 	dh_systemd_start  -p ivozprovider-web-rest	       --name=ivozprovider-jwt                --no-restart-on-upgrade --no-start
 	dh_systemd_start  -p ivozprovider-recordings	   --name=ivozprovider-recordings         --no-restart-on-upgrade --no-start
 	dh_systemd_start  -p ivozprovider-balances	       --name=ivozprovider-balances           --no-restart-on-upgrade --no-start
+	dh_systemd_start  -p ivozprovider-balances	       --name=ivozprovider-counters           --no-restart-on-upgrade --no-start
 	dh_systemd_start  -p ivozprovider-scheduler	       --name=ivozprovider-scheduler          --no-restart-on-upgrade --no-start
 	dh_systemd_start  -p ivozprovider-scheduler        --name=ivozprovider-cdrs               --no-restart-on-upgrade --no-start
 

--- a/debian/systemd/ivozprovider-counters.service
+++ b/debian/systemd/ivozprovider-counters.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Ivozprovider Counter Reset
+
+[Service]
+Type=oneshot
+User=root
+ExecStart=/opt/irontec/ivozprovider/microservices/balances/bin/reset-daily-usage-counter

--- a/debian/systemd/ivozprovider-counters.timer
+++ b/debian/systemd/ivozprovider-counters.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=Run Ivozprovider Counter reset
+
+[Timer]
+OnCalendar=*-*-* 00:00:00
+
+[Install]
+WantedBy=timers.target

--- a/doc/sphinx/administration_portal/brand/billing/current_day_usages.rst
+++ b/doc/sphinx/administration_portal/brand/billing/current_day_usages.rst
@@ -1,0 +1,32 @@
+******************
+Current day usages
+******************
+
+This section lists current day usage for each client in the brand:
+
+.. glossary::
+
+    Type
+        Type of client (vPBX, retail, residential or wholesale).
+
+    Name
+        Client name.
+
+    Today usage
+        Amount of spent money in today's external calls.
+
+    Max daily usage
+        When this threshold is reached, account is disabled. At midnight, it will be re-enabled.
+
+    Status
+        Whether account has been disabled or not.
+
+
+.. note:: Client max daily usage is configured in **Clients configuration** with **Max daily usage** parameter.
+
+.. tip:: If an account is disabled, increasing its counter above current day usages re-enables it. Otherwise, it will be
+         re-enabled at midnight.
+
+
+.. error:: This is one of main :ref:`security` mechanisms available in IvozProvider. Use it to avoid toll fraud calls
+           (see :ref:`Current day max usage`).

--- a/doc/sphinx/administration_portal/brand/billing/index.rst
+++ b/doc/sphinx/administration_portal/brand/billing/index.rst
@@ -84,3 +84,4 @@ This topic will cover every topic involved in the billing process:
     destination_rates
     destinations
     prepaid_balances
+    current_day_usages

--- a/doc/sphinx/administration_portal/brand/clients/residential.rst
+++ b/doc/sphinx/administration_portal/brand/clients/residential.rst
@@ -54,11 +54,14 @@ These are the fields shown when **adding** a new residential client:
         Describes the way the client will "talk" and the way the client wants to be "talked".
 
     Max calls
-        Limits both client generated and external received calls to this value (0 for unlimited). Setting to 2 will allow
-        setting 2 outgoing calls and received 2 incoming calls (in parallel).
+        Limits both incoming and outgoing external calls (0 for unlimited).
 
     Filter by IP address
         If set, the platform will only allow calls coming from allowed IP addresses or network ranges.
+
+    Max daily usage
+        Limits external outbound calls when this limit is reached within a day. At midnight counters are reset and
+        accounts are re-enabled.
 
 
 When **editing** a client, these additional fields can be configured:
@@ -69,9 +72,6 @@ When **editing** a client, these additional fields can be configured:
     Invoice data
         All the fields in this group will be included in invoices generated for this client. This section also allows
         displaying invoices list in client's portal menu so they can download them.
-
-    Externally rater custom options
-        This field is for setting options for an optional external rating module.
 
     Outgoing DDI
         Fallback DDI for external outgoing calls (can be overridden at residential device level).

--- a/doc/sphinx/administration_portal/brand/clients/retail.rst
+++ b/doc/sphinx/administration_portal/brand/clients/retail.rst
@@ -78,11 +78,15 @@ These are the fields shown when **adding** a new retail client:
         Describes the way the client will "talk" and the way the client wants to be "talked".
 
     Max calls
-        Limits both client generated and external received calls to this value (0 for unlimited). Setting to 2 will allow
-        setting 2 outgoing calls and received 2 incoming calls (in parallel).
+        Limits both incoming and outgoing external calls (0 for unlimited).
 
     Filter by IP address
         If set, the platform will only allow calls coming from allowed IP addresses or network ranges.
+
+    Max daily usage
+        Limits external outbound calls when this limit is reached within a day. At midnight counters are reset and
+        accounts are re-enabled.
+
 
 When **editing** a client, these additional fields can be configured:
 
@@ -92,9 +96,6 @@ When **editing** a client, these additional fields can be configured:
     Invoice data
         All the fields in this group will be included in invoices generated for this client. This section also allows
         displaying invoices list in client's portal menu so they can download them.
-
-    Externally rater custom options
-        This field is for setting options for an optional external rating module.
 
     Outgoing DDI
         Fallback DDI for external outgoing calls (can be overridden at residential device level).

--- a/doc/sphinx/administration_portal/brand/clients/virtual_pbx.rst
+++ b/doc/sphinx/administration_portal/brand/clients/virtual_pbx.rst
@@ -30,16 +30,19 @@ that require feature-full call flows.
         Chosen currency will be used in price calculation, invoices, balance movements and
         remaining money operations of this client.
 
-    Security
-        Limits the external concurrent calls and source of calls for this client.
+    Max calls
+        Limits both incoming and outgoing external calls (0 for unlimited).
+
+    Filter by IP address
+        If set, the platform will only allow calls coming from allowed IP addresses or network ranges.
+
+    Max daily usage
+        Limits external outbound calls when this limit is reached within a day. At midnight counters are reset and
+        accounts are re-enabled.
 
     Invoice data
         Data included in invoices created by this brand. This section also allows displaying invoices list in
         client's portal menu so they can download them.
-
-    Externally rated options
-        For :ref:`Carriers` with externally rated enabled, this field can be used to store specific
-        information for this client.
 
     Notifications
         Configure the email :ref:`notification templates` to use for this client.

--- a/doc/sphinx/administration_portal/brand/clients/wholesale.rst
+++ b/doc/sphinx/administration_portal/brand/clients/wholesale.rst
@@ -55,8 +55,11 @@ These are the fields shown when **adding** a new wholesale client:
         Describes the way the client will "talk" and the way the client wants to be "talked".
 
     Max calls
-        Limits both client generated and external received calls to this value (0 for unlimited). Setting to 2 will allow
-        setting 2 outgoing calls and received 2 incoming calls (in parallel).
+        Limits outgoing external calls (0 for unlimited).
+
+    Max daily usage
+        Limits external outbound calls when this limit is reached within a day. At midnight counters are reset and
+        accounts are re-enabled.
 
 
 When **editing** a client, these additional fields can be configured:
@@ -67,9 +70,6 @@ When **editing** a client, these additional fields can be configured:
     Invoice data
         All the fields in this group will be included in invoices generated for this client. This section also allows
         displaying invoices list in client's portal menu so they can download them.
-
-    Externally rater custom options
-        This field is for setting options for an optional external rating module.
 
     Routing tags
         This field allows enabling routing tags for this specific client. Call preceded with this

--- a/doc/sphinx/security_and_maintenance/security/current_day_max_usage.rst
+++ b/doc/sphinx/security_and_maintenance/security/current_day_max_usage.rst
@@ -1,0 +1,12 @@
+#####################
+Current day max usage
+#####################
+
+CGRateS calculates price for every external outgoing call placed through non-externally-rated Carrier (see :ref:`Billing`).
+
+Total amount of money spent within a day can be limited using this feature, avoiding call toll fraud (or at least
+reducing damages).
+
+.. tip:: Set a reasonable limit for every client so that abnormal money usage is automatically blocked.
+
+More information at :ref:`current day usages`.

--- a/doc/sphinx/security_and_maintenance/security/index.rst
+++ b/doc/sphinx/security_and_maintenance/security/index.rst
@@ -14,3 +14,4 @@ installations maintained by `Irontec <https://www.irontec.com>`_) security mecha
     antiflooding
     authorized_ip_ranges
     concurrent_call_limit
+    current_day_max_usage

--- a/library/CoreBundle/Resources/config/services/infraestructure/cgrates.yml
+++ b/library/CoreBundle/Resources/config/services/infraestructure/cgrates.yml
@@ -17,6 +17,15 @@ services:
   Ivoz\Core\Infrastructure\Domain\Service\Cgrates\BillingService:
     public: true
 
+  Ivoz\Core\Infrastructure\Domain\Service\Cgrates\SetMaxUsageThresholdService:
+    public: true
+
+  Ivoz\Core\Infrastructure\Domain\Service\Cgrates\ReassembleTriggerService:
+    public: true
+
+  Ivoz\Core\Infrastructure\Domain\Service\Cgrates\EnableAccountService:
+    public: true
+
   Ivoz\Core\Infrastructure\Domain\Service\Cgrates\ReloadService:
     public: true
 

--- a/library/Ivoz/Cgr/Domain/Model/TpAccountAction/TpAccountActionRepository.php
+++ b/library/Ivoz/Cgr/Domain/Model/TpAccountAction/TpAccountActionRepository.php
@@ -7,5 +7,8 @@ use Doctrine\Common\Collections\Selectable;
 
 interface TpAccountActionRepository extends ObjectRepository, Selectable
 {
-
+    /**
+     * @param int $companyId
+     */
+    public function findByCompany(int $companyId);
 }

--- a/library/Ivoz/Cgr/Domain/Service/CgratesReloadNotificator.php
+++ b/library/Ivoz/Cgr/Domain/Service/CgratesReloadNotificator.php
@@ -36,16 +36,15 @@ abstract class CgratesReloadNotificator implements LifecycleEventHandlerInterfac
     }
 
     /**
-     * Set CGRateS safety key in redis for reloading
-     *
      * @param string $tpid
-     *
-     * @return void
+     * @param string|null $notifyThresholdForAccount
      */
-    protected function reload(string $tpid)
+    protected function reload(string $tpid, string $notifyThresholdForAccount = null)
     {
-        $this->cgratesReloadJob
+        $this
+            ->cgratesReloadJob
             ->setTpid($tpid)
+            ->setNotifyThresholdForAccount($notifyThresholdForAccount)
             ->send();
     }
 }

--- a/library/Ivoz/Cgr/Domain/Service/TpAccountAction/CreateByCarrier.php
+++ b/library/Ivoz/Cgr/Domain/Service/TpAccountAction/CreateByCarrier.php
@@ -53,6 +53,7 @@ class CreateByCarrier implements CarrierLifecycleEventHandlerInterface
             ->setTpid($brand->getCgrTenant())
             ->setCarrierId($carrier->getId())
             ->setTenant($brand->getCgrTenant())
+            ->setAllowNegative(1)
             ->setAccount($carrier->getCgrSubject());
 
         $this->entityTools->persistDto($accountActionDto, null);

--- a/library/Ivoz/Cgr/Domain/Service/TpAccountAction/UpdatedTpAccountActionNotificator.php
+++ b/library/Ivoz/Cgr/Domain/Service/TpAccountAction/UpdatedTpAccountActionNotificator.php
@@ -16,6 +16,17 @@ class UpdatedTpAccountActionNotificator extends CgratesReloadNotificator impleme
      */
     public function execute(TpAccountActionInterface $tpAccountAction)
     {
+        $company = $tpAccountAction->getCompany();
+
+        if ($company && $company->hasChanged('maxDailyUsage')) {
+            $this->reload(
+                $tpAccountAction->getTpid(),
+                $tpAccountAction->getAccount()
+            );
+
+            return;
+        }
+
         $this->reload($tpAccountAction->getTpid());
     }
 }

--- a/library/Ivoz/Cgr/Infrastructure/Persistence/Doctrine/TpAccountActionDoctrineRepository.php
+++ b/library/Ivoz/Cgr/Infrastructure/Persistence/Doctrine/TpAccountActionDoctrineRepository.php
@@ -19,4 +19,16 @@ class TpAccountActionDoctrineRepository extends ServiceEntityRepository implemen
     {
         parent::__construct($registry, TpAccountAction::class);
     }
+
+    /**
+     * @param int $companyId
+     */
+    public function findByCompany(int $companyId)
+    {
+        $criteria = [
+            'company' => $companyId
+        ];
+
+        return $this->findOneBy($criteria);
+    }
 }

--- a/library/Ivoz/Core/Infrastructure/Domain/Service/Cgrates/CarrierBalanceService.php
+++ b/library/Ivoz/Core/Infrastructure/Domain/Service/Cgrates/CarrierBalanceService.php
@@ -35,15 +35,7 @@ class CarrierBalanceService extends AbstractBalanceService implements CarrierBal
      */
     public function getBalances($brandId, array $carrierIds)
     {
-        $tenant = self::TENANT_PREFIX . $brandId;
-        $accountIds = array_map(
-            function ($carrierId) {
-                return self::ACCOUNT_PREFIX . $carrierId;
-            },
-            $carrierIds
-        );
-
-        return parent::getAccountsBalances($tenant, $accountIds);
+        return parent::getAccountsBalances($brandId, $carrierIds, self::ACCOUNT_PREFIX);
     }
 
     /**
@@ -55,7 +47,12 @@ class CarrierBalanceService extends AbstractBalanceService implements CarrierBal
         $carrierIds = [$carrierId];
         $payload = $this->getBalances($brandId, $carrierIds);
 
-        return $payload->result[$carrierId];
+        $balanceSum = [];
+        foreach ($payload->result as $balance) {
+            $balanceSum += $this->balanceReducer($balance);
+        }
+
+        return $balanceSum[$carrierId];
     }
 
     /**

--- a/library/Ivoz/Core/Infrastructure/Domain/Service/Cgrates/CompanyBalanceService.php
+++ b/library/Ivoz/Core/Infrastructure/Domain/Service/Cgrates/CompanyBalanceService.php
@@ -35,15 +35,15 @@ class CompanyBalanceService extends AbstractBalanceService implements CompanyBal
      */
     public function getBalances($brandId, array $companyIds)
     {
-        $tenant = self::TENANT_PREFIX . $brandId;
-        $accountIds = array_map(
-            function ($companyId) {
-                return self::ACCOUNT_PREFIX . $companyId;
-            },
-            $companyIds
-        );
+        $payload = parent::getAccountsBalances($brandId, $companyIds, self::ACCOUNT_PREFIX);
 
-        return parent::getAccountsBalances($tenant, $accountIds);
+        $balanceSum = [];
+        foreach ($payload->result as $balance) {
+            $balanceSum += $this->balanceReducer($balance);
+        }
+        $payload->result = $balanceSum;
+
+        return $payload;
     }
 
     /**
@@ -52,11 +52,64 @@ class CompanyBalanceService extends AbstractBalanceService implements CompanyBal
      */
     public function getBalance($brandId, $companyId)
     {
-        $companyIds = [$companyId];
-        $payload = $this->getBalances($brandId, $companyIds);
+        $payload = parent::getAccountsBalances($brandId, [$companyId], self::ACCOUNT_PREFIX);
 
-        return $payload->result[$companyId];
+        $balanceSum = [];
+        foreach ($payload->result as $balance) {
+            $balanceSum += $this->balanceReducer($balance);
+        }
+
+        return $balanceSum[$companyId];
     }
+
+    /**
+     * @see \Ivoz\Provider\Domain\Service\Company\CompanyBalanceServiceClientInterface::getCurrentDayUsage
+     * @inheritdoc
+     */
+    public function getCurrentDayUsage($brandId, $companyId)
+    {
+        $payload = parent::getAccountsBalances($brandId, [$companyId], self::ACCOUNT_PREFIX);
+
+        $balanceSum = [];
+        foreach ($payload->result as $balance) {
+            $balanceSum += $this->currentDayUsageReducer($balance);
+        }
+
+        return $balanceSum[$companyId];
+    }
+
+    /**
+     * @see \Ivoz\Provider\Domain\Service\Company\CompanyBalanceServiceClientInterface::getCurrentDayMaxUsage
+     * @inheritdoc
+     */
+    public function getCurrentDayMaxUsage($brandId, $companyId)
+    {
+        $payload = parent::getAccountsBalances($brandId, [$companyId], self::ACCOUNT_PREFIX);
+
+        $balanceSum = [];
+        foreach ($payload->result as $balance) {
+            $balanceSum += $this->currentDayMaxUsageReducer($balance);
+        }
+
+        return $balanceSum[$companyId];
+    }
+
+    /**
+     * @see \Ivoz\Provider\Domain\Service\Company\CompanyBalanceServiceClientInterface::getAccountStatus
+     * @inheritdoc
+     */
+    public function getAccountStatus($brandId, $companyId)
+    {
+        $payload = parent::getAccountsBalances($brandId, [$companyId], self::ACCOUNT_PREFIX);
+
+        $balanceSum = [];
+        foreach ($payload->result as $balance) {
+            $balanceSum += $this->accountStatusReducer($balance);
+        }
+
+        return $balanceSum[$companyId];
+    }
+
 
     /**
      * @param CompanyInterface $entity

--- a/library/Ivoz/Core/Infrastructure/Domain/Service/Cgrates/EnableAccountService.php
+++ b/library/Ivoz/Core/Infrastructure/Domain/Service/Cgrates/EnableAccountService.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Ivoz\Core\Infrastructure\Domain\Service\Cgrates;
+
+class EnableAccountService extends AbstractApiBasedService
+{
+    public function __construct(
+        CgrRpcClient $jsonRpcClient
+    ) {
+        parent::__construct(
+            $jsonRpcClient
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function execute(string $tenant, string $account)
+    {
+        $this->sendRequest(
+            'ApierV1.SetAccount',
+            [
+                'Tenant' => $tenant,
+                'Account' => $account,
+                'Disabled' => false
+            ]
+        );
+    }
+}

--- a/library/Ivoz/Core/Infrastructure/Domain/Service/Cgrates/ReassembleTriggerService.php
+++ b/library/Ivoz/Core/Infrastructure/Domain/Service/Cgrates/ReassembleTriggerService.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Ivoz\Core\Infrastructure\Domain\Service\Cgrates;
+
+class ReassembleTriggerService extends AbstractApiBasedService
+{
+    public function __construct(
+        CgrRpcClient $jsonRpcClient
+    ) {
+        parent::__construct(
+            $jsonRpcClient
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function execute(string $tenant, string $account, bool $reset = false)
+    {
+        $arguments = [
+            'Tenant' => $tenant,
+            'Account' => $account,
+            'ResetCounters' => $reset
+        ];
+
+        $this->sendRequest(
+            'ApierV1.ResetAccountActionTriggers',
+            $arguments
+        );
+    }
+}

--- a/library/Ivoz/Core/Infrastructure/Domain/Service/Cgrates/SetMaxUsageThresholdService.php
+++ b/library/Ivoz/Core/Infrastructure/Domain/Service/Cgrates/SetMaxUsageThresholdService.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Ivoz\Core\Infrastructure\Domain\Service\Cgrates;
+
+class SetMaxUsageThresholdService extends AbstractApiBasedService
+{
+    private $companyBalanceService;
+    private $reassembleTriggerService;
+    private $enableAccountService;
+
+    public function __construct(
+        CgrRpcClient $jsonRpcClient,
+        CompanyBalanceService $companyBalanceService,
+        ReassembleTriggerService $reassembleTriggerService,
+        EnableAccountService $enableAccountService
+    ) {
+        parent::__construct(
+            $jsonRpcClient
+        );
+
+        $this->companyBalanceService = $companyBalanceService;
+        $this->reassembleTriggerService = $reassembleTriggerService;
+        $this->enableAccountService = $enableAccountService;
+    }
+
+    /**
+     * @return void
+     */
+    public function execute(string $tenant, string $account, int $threshold)
+    {
+        $mustReassemble = $this->isReassembleNeeded(
+            $tenant,
+            $account,
+            $threshold
+        );
+
+        $this->setNewThreshold(
+            $tenant,
+            $account,
+            $threshold
+        );
+
+        if ($mustReassemble) {
+            $this->reassembleTriggerService->execute(
+                $tenant,
+                $account
+            );
+
+            $this->enableAccountService->execute(
+                $tenant,
+                $account
+            );
+        }
+    }
+
+    private function isReassembleNeeded(string $tenant, string $account, $threshold)
+    {
+        $brandId = substr($tenant, 1);
+        $companyId = substr($account, 1);
+
+        $currentDayUsage = $this->companyBalanceService->getCurrentDayUsage(
+            $brandId,
+            $companyId
+        );
+
+        return $threshold > $currentDayUsage;
+    }
+
+    /**
+     * @param string $tenant
+     * @param string $account
+     * @param int $threshold
+     */
+    private function setNewThreshold(string $tenant, string $account, int $threshold)
+    {
+        $payload = [
+            'Tenant' => $tenant,
+            'Account' => $account,
+            'UniqueID' => '*default',
+            'ThresholdValue' => $threshold
+        ];
+
+        $this->sendRequest(
+            'ApierV1.SetAccountActionTriggers',
+            $payload
+        );
+    }
+}

--- a/library/Ivoz/Core/Infrastructure/Domain/Service/Gearman/Jobs/Cgrates.php
+++ b/library/Ivoz/Core/Infrastructure/Domain/Service/Gearman/Jobs/Cgrates.php
@@ -14,6 +14,11 @@ class Cgrates extends AbstractJob
     protected $tpid;
 
     /**
+     * @var string | null
+     */
+    protected $notifyThresholdForAccount;
+
+    /**
      * @var string
      */
     protected $method = "WorkerCgrates~reload";
@@ -23,6 +28,7 @@ class Cgrates extends AbstractJob
      */
     protected $mainVariables = array(
         'tpid',
+        'notifyThresholdForAccount'
     );
 
     public function setTpid($tpid): self
@@ -34,6 +40,24 @@ class Cgrates extends AbstractJob
     public function getTpid(): string
     {
         return $this->tpid;
+    }
+
+    /**
+     * @return string | null
+     */
+    public function getNotifyThresholdForAccount()
+    {
+        return $this->notifyThresholdForAccount;
+    }
+
+    /**
+     * @param string | null $notifyThresholdForAccount
+     */
+    public function setNotifyThresholdForAccount($notifyThresholdForAccount)
+    {
+        $this->notifyThresholdForAccount = $notifyThresholdForAccount;
+
+        return $this;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/Company/CompanyAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Company/CompanyAbstract.php
@@ -47,6 +47,11 @@ abstract class CompanyAbstract
     protected $maxCalls = 0;
 
     /**
+     * @var integer
+     */
+    protected $maxDailyUsage = 1000000;
+
+    /**
      * @var string
      */
     protected $postalAddress;
@@ -205,6 +210,7 @@ abstract class CompanyAbstract
         $nif,
         $distributeMethod,
         $maxCalls,
+        $maxDailyUsage,
         $postalAddress,
         $postalCode,
         $town,
@@ -217,6 +223,7 @@ abstract class CompanyAbstract
         $this->setNif($nif);
         $this->setDistributeMethod($distributeMethod);
         $this->setMaxCalls($maxCalls);
+        $this->setMaxDailyUsage($maxDailyUsage);
         $this->setPostalAddress($postalAddress);
         $this->setPostalCode($postalCode);
         $this->setTown($town);
@@ -299,6 +306,7 @@ abstract class CompanyAbstract
             $dto->getNif(),
             $dto->getDistributeMethod(),
             $dto->getMaxCalls(),
+            $dto->getMaxDailyUsage(),
             $dto->getPostalAddress(),
             $dto->getPostalCode(),
             $dto->getTown(),
@@ -357,6 +365,7 @@ abstract class CompanyAbstract
             ->setNif($dto->getNif())
             ->setDistributeMethod($dto->getDistributeMethod())
             ->setMaxCalls($dto->getMaxCalls())
+            ->setMaxDailyUsage($dto->getMaxDailyUsage())
             ->setPostalAddress($dto->getPostalAddress())
             ->setPostalCode($dto->getPostalCode())
             ->setTown($dto->getTown())
@@ -406,6 +415,7 @@ abstract class CompanyAbstract
             ->setNif(self::getNif())
             ->setDistributeMethod(self::getDistributeMethod())
             ->setMaxCalls(self::getMaxCalls())
+            ->setMaxDailyUsage(self::getMaxDailyUsage())
             ->setPostalAddress(self::getPostalAddress())
             ->setPostalCode(self::getPostalCode())
             ->setTown(self::getTown())
@@ -449,6 +459,7 @@ abstract class CompanyAbstract
             'nif' => self::getNif(),
             'distributeMethod' => self::getDistributeMethod(),
             'maxCalls' => self::getMaxCalls(),
+            'maxDailyUsage' => self::getMaxDailyUsage(),
             'postalAddress' => self::getPostalAddress(),
             'postalCode' => self::getPostalCode(),
             'town' => self::getTown(),
@@ -655,6 +666,34 @@ abstract class CompanyAbstract
     public function getMaxCalls()
     {
         return $this->maxCalls;
+    }
+
+    /**
+     * Set maxDailyUsage
+     *
+     * @param integer $maxDailyUsage
+     *
+     * @return static
+     */
+    protected function setMaxDailyUsage($maxDailyUsage)
+    {
+        Assertion::notNull($maxDailyUsage, 'maxDailyUsage value "%s" is null, but non null value was expected.');
+        Assertion::integerish($maxDailyUsage, 'maxDailyUsage value "%s" is not an integer or a number castable to integer.');
+        Assertion::greaterOrEqualThan($maxDailyUsage, 0, 'maxDailyUsage provided "%s" is not greater or equal than "%s".');
+
+        $this->maxDailyUsage = (int) $maxDailyUsage;
+
+        return $this;
+    }
+
+    /**
+     * Get maxDailyUsage
+     *
+     * @return integer
+     */
+    public function getMaxDailyUsage()
+    {
+        return $this->maxDailyUsage;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/Company/CompanyDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Company/CompanyDtoAbstract.php
@@ -41,6 +41,11 @@ abstract class CompanyDtoAbstract implements DataTransferObjectInterface
     private $maxCalls = 0;
 
     /**
+     * @var integer
+     */
+    private $maxDailyUsage = 1000000;
+
+    /**
      * @var string
      */
     private $postalAddress;
@@ -269,6 +274,7 @@ abstract class CompanyDtoAbstract implements DataTransferObjectInterface
             'nif' => 'nif',
             'distributeMethod' => 'distributeMethod',
             'maxCalls' => 'maxCalls',
+            'maxDailyUsage' => 'maxDailyUsage',
             'postalAddress' => 'postalAddress',
             'postalCode' => 'postalCode',
             'town' => 'town',
@@ -314,6 +320,7 @@ abstract class CompanyDtoAbstract implements DataTransferObjectInterface
             'nif' => $this->getNif(),
             'distributeMethod' => $this->getDistributeMethod(),
             'maxCalls' => $this->getMaxCalls(),
+            'maxDailyUsage' => $this->getMaxDailyUsage(),
             'postalAddress' => $this->getPostalAddress(),
             'postalCode' => $this->getPostalCode(),
             'town' => $this->getTown(),
@@ -476,6 +483,26 @@ abstract class CompanyDtoAbstract implements DataTransferObjectInterface
     public function getMaxCalls()
     {
         return $this->maxCalls;
+    }
+
+    /**
+     * @param integer $maxDailyUsage
+     *
+     * @return static
+     */
+    public function setMaxDailyUsage($maxDailyUsage = null)
+    {
+        $this->maxDailyUsage = $maxDailyUsage;
+
+        return $this;
+    }
+
+    /**
+     * @return integer
+     */
+    public function getMaxDailyUsage()
+    {
+        return $this->maxDailyUsage;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/Company/CompanyInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/Company/CompanyInterface.php
@@ -191,6 +191,13 @@ interface CompanyInterface extends LoggableEntityInterface
     public function getMaxCalls();
 
     /**
+     * Get maxDailyUsage
+     *
+     * @return integer
+     */
+    public function getMaxDailyUsage();
+
+    /**
      * Get postalAddress
      *
      * @return string

--- a/library/Ivoz/Provider/Domain/Service/Company/CompanyBalanceServiceInterface.php
+++ b/library/Ivoz/Provider/Domain/Service/Company/CompanyBalanceServiceInterface.php
@@ -33,4 +33,18 @@ interface CompanyBalanceServiceInterface
      * @return mixed
      */
     public function getBalance($brandId, $companyId);
+
+    /**
+     * @param int $brandId
+     * @param int $companyId
+     * @return mixed
+     */
+    public function getCurrentDayUsage($brandId, $companyId);
+
+    /**
+     * @param int $brandId
+     * @param int $companyId
+     * @return mixed
+     */
+    public function getCurrentDayMaxUsage($brandId, $companyId);
 }

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/Company.CompanyAbstract.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/Company.CompanyAbstract.orm.yml
@@ -52,6 +52,13 @@ Ivoz\Provider\Domain\Model\Company\CompanyAbstract:
         unsigned: true
         default: 0
       column: maxCalls
+    maxDailyUsage:
+      type: integer
+      nullable: false
+      options:
+        unsigned: true
+        default: 1000000
+      column: maxDailyUsage
     postalAddress:
       type: string
       nullable: false

--- a/microservices/balances/app/MicroKernel.php
+++ b/microservices/balances/app/MicroKernel.php
@@ -44,6 +44,7 @@ class MicroKernel extends Kernel
         // kernel is a service that points to this class
         // optional 3rd argument is the route name
         $routes->add('/', 'kernel:sync');
+        $routes->add('/reset-counter', 'kernel:resetCounter');
     }
 
     public function sync()
@@ -61,7 +62,19 @@ class MicroKernel extends Kernel
         return new Response("Company and carrier balances updated successfully!\n");
     }
 
-    private function registerCommand()
+    public function resetCounter()
+    {
+        $this->registerCommand('reset-counter');
+
+        $resetDailyUsageCounters = $this->container->get(
+            \Services\ResetDailyUsageCounters::class
+        );
+        $resetDailyUsageCounters->execute();
+
+        return new Response("Company daily usage counters reset successfully!\n");
+    }
+
+    private function registerCommand($method = 'sync')
     {
         /** @var DomainEventPublisher $eventPublisher */
         $eventPublisher = $this->container->get(
@@ -76,7 +89,7 @@ class MicroKernel extends Kernel
         $event = new CommandWasExecuted(
             $requestId->toString(),
             'Balances',
-            'sync',
+            $method,
             [],
             []
         );

--- a/microservices/balances/app/config/services.yml
+++ b/microservices/balances/app/config/services.yml
@@ -8,4 +8,7 @@ services:
   _defaults:
     autowire: true
     autoconfigure: true
-    public: false
+    public: true
+
+  Services\:
+    resource: '../../src/Services/*'

--- a/microservices/balances/bin/reset-daily-usage-counter
+++ b/microservices/balances/bin/reset-daily-usage-counter
@@ -1,0 +1,20 @@
+#!/usr/bin/env php
+<?php
+
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\HttpFoundation\Request;
+
+// require Composer's autoloader
+require __DIR__.'/../vendor/autoload.php';
+
+require __DIR__.'/../app/MicroKernel.php';
+
+$input = new ArgvInput();
+$env = $input->getParameterOption(['--env', '-e'], getenv('SYMFONY_ENV') ?: 'dev');
+
+$kernel = new MicroKernel($env, false);
+$request = new Request([], [], [], [], [], ['REQUEST_URI' => '/reset-counter']);
+
+$response = $kernel->handle($request);
+$response->send();
+$kernel->terminate($request, $response);

--- a/microservices/balances/src/Services/ResetDailyUsageCounters.php
+++ b/microservices/balances/src/Services/ResetDailyUsageCounters.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Services;
+
+use Ivoz\Core\Infrastructure\Domain\Service\Cgrates\ReassembleTriggerService;
+use Ivoz\Core\Infrastructure\Domain\Service\Cgrates\EnableAccountService;
+use Ivoz\Provider\Domain\Model\Brand\BrandInterface;
+use Ivoz\Provider\Domain\Model\Brand\BrandRepository;
+
+class ResetDailyUsageCounters
+{
+    private $reassembleTriggerService;
+    private $enableAccountService;
+    private $brandRepository;
+
+    public function __construct(
+        ReassembleTriggerService $reassembleTriggerService,
+        EnableAccountService $enableAccountService,
+        BrandRepository $brandRepository
+    ) {
+        $this->reassembleTriggerService = $reassembleTriggerService;
+        $this->enableAccountService = $enableAccountService;
+        $this->brandRepository = $brandRepository;
+    }
+
+    /**
+     * @return void
+     */
+    public function execute()
+    {
+        /** @var BrandInterface[] $brands */
+        $brands = $this->brandRepository->findAll();
+        foreach ($brands as $brand) {
+            $companies = $brand->getCompanies();
+            foreach ($companies as $company) {
+                $tenant = $brand->getCgrTenant();
+                $account = $company->getCgrSubject();
+
+                $this->reassembleTriggerService->execute(
+                    $tenant,
+                    $account,
+                    true
+                );
+
+                $this->enableAccountService->execute(
+                    $tenant,
+                    $account
+                );
+            }
+        }
+    }
+}

--- a/microservices/workers/src/Worker/Cgrates.php
+++ b/microservices/workers/src/Worker/Cgrates.php
@@ -5,11 +5,14 @@ namespace Worker;
 use GearmanJob;
 use Ivoz\Core\Infrastructure\Domain\Service\Cgrates\ReloadService;
 use Ivoz\Core\Infrastructure\Domain\Service\Gearman\Jobs\Cgrates as CgratesJob;
+use Ivoz\Provider\Domain\Model\Company\CompanyInterface;
+use Ivoz\Provider\Domain\Model\Company\CompanyRepository;
 use Mmoreram\GearmanBundle\Driver\Gearman;
 use Psr\Log\LoggerInterface;
 use Ivoz\Core\Domain\Service\DomainEventPublisher;
 use Ivoz\Core\Application\RequestId;
 use Ivoz\Core\Application\RegisterCommandTrait;
+use Ivoz\Core\Infrastructure\Domain\Service\Cgrates\SetMaxUsageThresholdService;
 
 /**
  * @Gearman\Work(
@@ -26,17 +29,23 @@ class Cgrates
     private $eventPublisher;
     private $requestId;
     private $reloadService;
+    private $setMaxUsageThresholdService;
+    private $companyRepository;
     private $logger;
 
     public function __construct(
         DomainEventPublisher $eventPublisher,
         RequestId $requestId,
         ReloadService $reloadService,
+        SetMaxUsageThresholdService $setMaxUsageThresholdService,
+        CompanyRepository $companyRepository,
         LoggerInterface $logger
     ) {
         $this->eventPublisher = $eventPublisher;
         $this->requestId = $requestId;
         $this->reloadService = $reloadService;
+        $this->setMaxUsageThresholdService = $setMaxUsageThresholdService;
+        $this->companyRepository = $companyRepository;
         $this->logger = $logger;
     }
 
@@ -62,13 +71,44 @@ class Cgrates
         /** @var CgratesJob $job */
         $job = igbinary_unserialize($serializedJob->workload());
 
-        $cgratesTpid = $job->getTpid();
+        $this->logger->info(
+            'ApierV1.LoadTariffPlanFromStorDb GEARMAN payload ' . var_export($job, true)
+        );
 
-        $this->logger->info(sprintf("Reloading Tpid %s through CGRateS API", $cgratesTpid));
+        $cgratesTpid = $job->getTpid();
+        $notifyThresholdForAccount = $job->getNotifyThresholdForAccount();
+
+        $this->logger->info(sprintf("ApierV1.LoadTariffPlanFromStorDb GEARMAN Reloading Tpid %s through CGRateS API", $cgratesTpid));
 
         $this->reloadService
             ->execute($cgratesTpid);
 
+        if ($notifyThresholdForAccount) {
+
+            /** @var CompanyInterface $company */
+            $company = $this->companyRepository->find(
+                substr($notifyThresholdForAccount, 1)
+            );
+
+
+            if (!$company) {
+                $this->logger->error(
+                    'Not company found for account ' . $notifyThresholdForAccount
+                );
+
+                return false;
+            }
+
+            $this
+                ->setMaxUsageThresholdService
+                ->execute(
+                    $cgratesTpid,
+                    $notifyThresholdForAccount,
+                    $company->getMaxDailyUsage()
+                );
+        }
+
+        $this->logger->info(sprintf("ApierV1.LoadTariffPlanFromStorDb GEARMAN Reloaded Tpid %s through CGRateS API", $cgratesTpid));
         // Done!
         return true;
     }

--- a/schema/app/DoctrineMigrations/Version20191023153740.php
+++ b/schema/app/DoctrineMigrations/Version20191023153740.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20191023153740 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        // New CGRateS tables for max daily usage
+        $this->addSql('CREATE VIEW `tp_action_triggers` AS SELECT CONCAT("b", id) AS tpid, "STANDARD_TRIGGERS" AS tag, "*default" AS unique_id, "*max_balance_counter" AS threshold_type, 1000000 AS threshold_value, 1 AS recurrent, "*default" AS balance_tag, "*monetary" AS balance_type, "DISABLE_AND_LOG" AS actions_tag, 0.0 AS weight FROM Brands');
+        $this->addSql('CREATE VIEW `tp_actions` AS SELECT CONCAT("b", id) AS tpid, "DISABLE_AND_LOG" AS tag, "*disable_account" AS action, "*default" AS balance_tag, "*monetary" AS balance_type FROM Brands UNION SELECT CONCAT("b", id) AS tpid, "DISABLE_AND_LOG" AS tag, "*log" AS action, "*default" AS balance_tag, "*monetary" AS balance_type FROM Brands');
+
+        // Allow negative except for non-prepaid clients
+        $this->addSql('UPDATE tp_account_actions SET allow_negative=1 WHERE carrierId IS NOT NULL');
+        $this->addSql('UPDATE tp_account_actions t JOIN Companies C ON C.id=t.companyId SET allow_negative=0 WHERE C.billingMethod!=\'postpaid\'');
+
+        // Default max daily usage
+        $this->addSql('ALTER TABLE Companies ADD maxDailyUsage INT UNSIGNED DEFAULT 1000000 NOT NULL');
+
+        // Enable daily usage counters
+        $this->addSql('UPDATE tp_account_actions SET action_triggers_tag="STANDARD_TRIGGERS" WHERE companyId IS NOT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('UPDATE tp_account_actions SET action_triggers_tag=NULL');
+
+        $this->addSql('ALTER TABLE Companies DROP maxDailyUsage');
+
+        $this->addSql('UPDATE tp_account_actions SET allow_negative=0');
+
+        $this->addSql('DROP VIEW tp_action_triggers');
+        $this->addSql('DROP VIEW tp_actions');
+    }
+}

--- a/schema/tests/Cgr/TpAccountAction/TpAccountActionRepositoryTest.php
+++ b/schema/tests/Cgr/TpAccountAction/TpAccountActionRepositoryTest.php
@@ -32,4 +32,19 @@ class TpAccountActionRepositoryTest extends KernelTestCase
             $repository
         );
     }
+
+    public function its_finds_by_company()
+    {
+        /** @var TpAccountActionRepository $repository */
+        $repository = $this
+            ->em
+            ->getRepository(TpAccountAction::class);
+
+        $tpAccountAction = $repository->findOneBy(1);
+
+        $this->assertInstanceOf(
+            TpAccountAction::class,
+            $tpAccountAction
+        );
+    }
 }

--- a/schema/tests/Provider/Carrier/CarrierLifeCycleTest.php
+++ b/schema/tests/Provider/Carrier/CarrierLifeCycleTest.php
@@ -166,6 +166,7 @@ class CarrierLifeCycleTest extends KernelTestCase
             'loadid' => 'DATABASE',
             'tenant' => 'b1',
             'account' => 'cr3',
+            'allow_negative' => 1,
             'carrierId' => 3,
             'id' => 3
         ];

--- a/web/admin/application/configs/klear/BrandResidentialDevicesList.yaml
+++ b/web/admin/application/configs/klear/BrandResidentialDevicesList.yaml
@@ -39,6 +39,9 @@ production:
           language: true
           status: true
           ddiIn: true
+          t38Passthrough: true
+          outgoingDdi: true
+          maxCalls: true
         order:
           company: true
           name: true

--- a/web/admin/application/configs/klear/BrandRetailAccountsList.yaml
+++ b/web/admin/application/configs/klear/BrandRetailAccountsList.yaml
@@ -31,6 +31,8 @@ production:
           port: true
           status: true
           ddiIn: true
+          outgoingDdi: true
+          t38Passthrough: true
         order:
           company: true
           name: true

--- a/web/admin/application/configs/klear/BrandsList.yaml
+++ b/web/admin/application/configs/klear/BrandsList.yaml
@@ -11,6 +11,10 @@ production:
   screens:
     brandsList_screen: &brandsList_screenLink
       controller: list
+      order:
+        field:
+        - Brand.name
+        type: asc
       pagination:
         items: 25
       <<: *Brands

--- a/web/admin/application/configs/klear/CompaniesList.yaml
+++ b/web/admin/application/configs/klear/CompaniesList.yaml
@@ -61,15 +61,18 @@ production:
           recordingsLimitMB: true
           recordingsLimitEmail: true
           recordingsDiskUsage: true
-          externallyExtraOpts: true
           voicemailNotificationTemplate: true
           faxNotificationTemplate: true
           invoiceNotificationTemplate: true
           callCsvNotificationTemplate: true
           balance: true
+          currentDayUsage: true
+          currentDayMaxUsage: true
+          accountStatus: true
           country: true
           showInvoices: true
           outgoingDdi: true
+          maxDailyUsage: true
         order:
           name: true
           nif: true
@@ -117,7 +120,6 @@ production:
           countryName: true
           outgoingDdi: true
           outgoingDdiRule: true
-          externallyExtraOpts: true
           recordingsLimitMB: true
           recordingsLimitEmail: true
           recordingsDiskUsage: true
@@ -128,16 +130,19 @@ production:
           balance: true
           showInvoices: true
           outgoingDdiE164: true
+          currentDayUsage: true
+          currentDayMaxUsage: true
+          accountStatus: true
         order: &companiesOrder_Link
           id: true
           name: true
           maxCalls: true
+          maxDialyUsage: true
           language: true
           outgoingDdi: true
           showInvoices: true
           onDemandRecord: true
           voicemailNotificationTemplate: true
-          externallyExtraOpts: true
       fixedPositions:
         group0:
           colsPerRow: 6
@@ -148,11 +153,12 @@ production:
             relFeatures: 3
             billingMethod: 3
         group1:
-          colsPerRow: 2
+          colsPerRow: 3
           label: _("Security")
           fields:
             maxCalls: 1
             ipFilter: 1
+            maxDailyUsage: 1
         group2:
           colsPerRow: 3
           label: _("Geographic Configuration")
@@ -203,6 +209,8 @@ production:
           recordingsDiskUsage: true
           outgoingDdiE164: true
           balance: true
+          currentDayUsage: true
+          currentDayMaxUsage: true
         whitelist:
           id: ${auth.isMainOperator}
         order:
@@ -222,11 +230,12 @@ production:
             relFeatures: 3
             billingMethod: 3
         group1:
-          colsPerRow: 2
+          colsPerRow: 3
           label: _("Security")
           fields:
             maxCalls: 1
             ipFilter: 1
+            maxDailyUsage: 1
         group2:
           colsPerRow: 3
           label: _("Geographic Configuration")
@@ -266,12 +275,6 @@ production:
           fields:
             onDemandRecord: 6
             onDemandRecordCode: 6
-        group6:
-          colsPerRow: 1
-          collapsed: true
-          label: _("Externally rater options")
-          fields:
-            externallyExtraOpts: 1
         group7:
           colsPerRow: 2
           collapsed: true

--- a/web/admin/application/configs/klear/CompaniesList.yaml
+++ b/web/admin/application/configs/klear/CompaniesList.yaml
@@ -14,6 +14,10 @@ production:
   screens: &companies_screensLink
     companiesList_screen: &companiesList_screenLink
       controller: list
+      order:
+        field:
+        - Company.name
+        type: asc
       pagination:
         items: 25
       <<: *Companies
@@ -204,6 +208,7 @@ production:
           town: ${auth.brandFeatures.invoices.disabled}
           province: ${auth.brandFeatures.invoices.disabled}
           countryName: ${auth.brandFeatures.invoices.disabled}
+          invoiceNotificationTemplate: ${auth.brandFeatures.invoices.disabled}
           recordingsLimitMB: true
           recordingsLimitEmail: true
           recordingsDiskUsage: true

--- a/web/admin/application/configs/klear/CompanyBalancesList.yaml
+++ b/web/admin/application/configs/klear/CompanyBalancesList.yaml
@@ -11,6 +11,10 @@ production:
   screens: &companyBalances_screensLink
     companyBalancesList_screen: &companyBalancesList_screenLink
       controller: list
+      order:
+        field:
+        - Company.name
+        type: asc
       rawCondition: "Company.billingMethod in ('prepaid', 'pseudoprepaid')"
       pagination:
         items: 25
@@ -68,7 +72,7 @@ production:
           currentDayUsage: true
           currentDayMaxUsage: true
           accountStatus: true
-          maxDialyUsage: true
+          maxDailyUsage: true
         order:
           typeIcon: true
           name: true

--- a/web/admin/application/configs/klear/CompanyBalancesList.yaml
+++ b/web/admin/application/configs/klear/CompanyBalancesList.yaml
@@ -39,6 +39,7 @@ production:
           province: true
           countryName: true
           outgoingDdi: true
+          outgoingDdiE164: true
           outgoingDdiRule: true
           registryData: true
           maxCalls: true
@@ -54,7 +55,6 @@ production:
           recordingsLimitMB: true
           recordingsLimitEmail: true
           recordingsDiskUsage: true
-          externallyExtraOpts: true
           voicemailNotificationTemplate: true
           faxNotificationTemplate: true
           invoiceNotificationTemplate: true
@@ -65,6 +65,10 @@ production:
           domainUsers: true
           relFeatures: true
           showInvoices: true
+          currentDayUsage: true
+          currentDayMaxUsage: true
+          accountStatus: true
+          maxDialyUsage: true
         order:
           typeIcon: true
           name: true

--- a/web/admin/application/configs/klear/CurrentdayUsageList.yaml
+++ b/web/admin/application/configs/klear/CurrentdayUsageList.yaml
@@ -1,0 +1,81 @@
+#include conf.d/mapperList.yaml
+#include conf.d/actions.yaml
+#include conf.d/documentationLink.yaml
+#include BalanceNotificationsList.yaml
+#include BalanceMovementsList.yaml
+
+production:
+  main:
+    module: klearMatrix
+    defaultScreen: companyBalancesList_screen
+  screens: &companyBalances_screensLink
+    companyBalancesList_screen: &companyBalancesList_screenLink
+      controller: list
+      order:
+        field:
+        - Company.name
+        type: asc
+      pagination:
+        items: 25
+      <<: *Companies
+      class: ui-silk-building
+      title: _("List of %s %2s", ngettext('Current Day Usage', 'Current Day Usages', 0), "[format| (%parent%)]")
+      info:
+        <<: *documentationLink
+        href: "/doc/en/administration_portal/brand/billing/current_day_usages.html"
+      forcedValues:
+        <<: *forcedBrand
+      fields:
+        blacklist:
+          transformationRuleSet: true
+          postalAddress: true
+          postalCode: true
+          town: true
+          province: true
+          countryName: true
+          outgoingDdi: true
+          outgoingDdiE164: true
+          outgoingDdiRule: true
+          registryData: true
+          maxCalls: true
+          defaultTimezone: true
+          currency: true
+          distributeMethod: true
+          applicationServer: true
+          mediaRelaySets: true
+          ipFilter: true
+          language: true
+          onDemandRecord: true
+          onDemandRecordCode: true
+          recordingsLimitMB: true
+          recordingsLimitEmail: true
+          recordingsDiskUsage: true
+          voicemailNotificationTemplate: true
+          faxNotificationTemplate: true
+          invoiceNotificationTemplate: true
+          callCsvNotificationTemplate: true
+          language: true
+          nif: true
+          country: true
+          domainUsers: true
+          relFeatures: true
+          showInvoices: true
+          balance: true
+          billingMethod: true
+          maxDailyUsage: true
+        order:
+          typeIcon: true
+          name: true
+          billingMethod: true
+          currentDayUsage: true
+          currentDayMaxUsage: true
+          accountStatus: true
+
+staging:
+  _extends: production
+testing:
+  _extends: production
+development:
+  _extends: production
+localdev:
+  _extends: production

--- a/web/admin/application/configs/klear/ResidentialClientsList.yaml
+++ b/web/admin/application/configs/klear/ResidentialClientsList.yaml
@@ -59,7 +59,6 @@ production:
           language: true
           onDemandRecord: true
           onDemandRecordCode: true
-          externallyExtraOpts: true
           type: true
           voicemailNotificationTemplate: true
           faxNotificationTemplate: true
@@ -68,6 +67,7 @@ production:
           balance: true
           showInvoices: true
           outgoingDdi: true
+          maxDailyUsage: true
         order:
           name: true
           nif: true
@@ -116,7 +116,6 @@ production:
           applicationServer: true
           maxCalls: false
           outgoingDdiRule: true
-          externallyExtraOpts: true
           balance: true
           voicemailNotificationTemplate: true
           faxNotificationTemplate: true
@@ -128,12 +127,12 @@ production:
           id: true
           name: true
           maxCalls: true
+          maxDailyUsage: true
           language: true
           showInvoices: true
           onDemandRecord: true
           voicemailNotificationTemplate: true
           mediaRelaySets: true
-          externallyExtraOpts: true
       fixedPositions: &residentialClientsFixedPositions_Link
         group0:
           colsPerRow: 6
@@ -153,11 +152,12 @@ production:
             transformationRuleSet: 8
             currency: 4
         group2:
-          colsPerRow: 2
+          colsPerRow: 3
           label: _("Security")
           fields:
             maxCalls: 1
             ipFilter: 1
+            maxDailyUsage: 1
       class: ui-silk-add
       label: true
       multiInstance: true
@@ -218,11 +218,12 @@ production:
             transformationRuleSet: 8
             currency: 4
         group2:
-          colsPerRow: 2
+          colsPerRow: 3
           label: _("Security")
           fields:
             maxCalls: 1
             ipFilter: 1
+            maxDailyUsage: 1
         group3:
           colsPerRow: 12
           collapsed: true
@@ -250,12 +251,6 @@ production:
           fields:
             onDemandRecord: 6
             onDemandRecordCode: 6
-        group6:
-          colsPerRow: 1
-          collapsed: true
-          label: _("Externally rater options")
-          fields:
-            externallyExtraOpts: 1
         group7:
           colsPerRow: 2
           collapsed: true

--- a/web/admin/application/configs/klear/ResidentialClientsList.yaml
+++ b/web/admin/application/configs/klear/ResidentialClientsList.yaml
@@ -13,6 +13,10 @@ production:
   screens: &residentialClients_screensLink
     residentialClientsList_screen: &residentialClientsList_screenLink
       controller: list
+      order:
+        field:
+        - Company.name
+        type: asc
       pagination:
         items: 25
       <<: *ResidentialClients
@@ -192,6 +196,7 @@ production:
           town: ${auth.brandFeatures.invoices.disabled}
           province: ${auth.brandFeatures.invoices.disabled}
           countryName: ${auth.brandFeatures.invoices.disabled}
+          invoiceNotificationTemplate: ${auth.brandFeatures.invoices.disabled}
           outgoingDdiRule: true
           balance: true
           outgoingDdiE164: true

--- a/web/admin/application/configs/klear/ResidentialDevicesList.yaml
+++ b/web/admin/application/configs/klear/ResidentialDevicesList.yaml
@@ -10,6 +10,10 @@ production:
   screens: &residentialDevices_screensLink
     residentialDevicesList_screen: &residentialDevicesList_screenLink
       controller: list
+      order:
+        field:
+        - ResidentialDevice.name
+        type: asc
       pagination:
         items: 25
       <<: *ResidentialDevices

--- a/web/admin/application/configs/klear/RetailAccountsList.yaml
+++ b/web/admin/application/configs/klear/RetailAccountsList.yaml
@@ -11,6 +11,10 @@ production:
   screens: &retailAccounts_screensLink
     retailAccountsList_screen: &retailAccountsList_screenLink
       controller: list
+      order:
+        field:
+        - RetailAccount.name
+        type: asc
       pagination:
         items: 25
       <<: *RetailAccounts

--- a/web/admin/application/configs/klear/RetailClientsList.yaml
+++ b/web/admin/application/configs/klear/RetailClientsList.yaml
@@ -12,6 +12,10 @@ production:
   screens: &retailClients_screensLink
     retailClientsList_screen: &retailClientsList_screenLink
       controller: list
+      order:
+        field:
+        - Company.name
+        type: asc
       pagination:
         items: 25
       <<: *RetailClients
@@ -173,6 +177,7 @@ production:
           town: ${auth.brandFeatures.invoices.disabled}
           province: ${auth.brandFeatures.invoices.disabled}
           countryName: ${auth.brandFeatures.invoices.disabled}
+          invoiceNotificationTemplate: ${auth.brandFeatures.invoices.disabled}
           outgoingDdiE164: true
         whitelist:
           id: ${auth.isMainOperator}

--- a/web/admin/application/configs/klear/RetailClientsList.yaml
+++ b/web/admin/application/configs/klear/RetailClientsList.yaml
@@ -52,11 +52,11 @@ production:
           maxCalls: true
           recordingsDiskUsage: true
           country: true
-          externallyExtraOpts: true
           showInvoices: true
           invoiceNotificationTemplate: true
           callCsvNotificationTemplate: true
           outgoingDdi: true
+          maxDailyUsage: true
         order:
           name: true
           nif: true
@@ -98,7 +98,6 @@ production:
           countryName: true
           mediaRelaySets: true
           maxCalls: false
-          externallyExtraOpts: true
           showInvoices: true
           invoiceNotificationTemplate: true
           callCsvNotificationTemplate: true
@@ -107,13 +106,13 @@ production:
           id: true
           name: true
           maxCalls: true
+          maxDailyUsage: true
           language: true
           relRoutingTags: true
           showInvoices: true
           onDemandRecord: true
           invoiceNotificationTemplate: true
           mediaRelaySets: true
-          externallyExtraOpts: true
       fixedPositions: &retailClientsFixedPositions_Link
         group0:
           colsPerRow: 12
@@ -124,11 +123,12 @@ production:
             outgoingDdi: 6
             relFeatures: 3
         group1:
-          colsPerRow: 2
+          colsPerRow: 3
           label: _("Security")
           fields:
             maxCalls: 1
             ipFilter: 1
+            maxDailyUsage: 1
         group2:
           colsPerRow: 12
           label: _("Geographic Configuration")
@@ -197,11 +197,12 @@ production:
             transformationRuleSet: 8
             currency: 4
         group2:
-          colsPerRow: 2
+          colsPerRow: 3
           label: _("Security")
           fields:
             maxCalls: 1
             ipFilter: 1
+            maxDailyUsage: 1
         group3:
           colsPerRow: 12
           label: _("Retail specific")
@@ -233,12 +234,6 @@ production:
           label: _("Platform data")
           fields:
             mediaRelaySets: 4
-        group6:
-          colsPerRow: 1
-          collapsed: true
-          label: _("Externally rater options")
-          fields:
-            externallyExtraOpts: 1
       class: ui-silk-pencil
       label: false
       title: _("Edit %s %2s", ngettext('Retail Client', 'Retail Clients', 1), "[format| (%item%)]")

--- a/web/admin/application/configs/klear/TerminalsList.yaml
+++ b/web/admin/application/configs/klear/TerminalsList.yaml
@@ -11,6 +11,10 @@ production:
   screens: &terminals_screensLink
     terminalsList_screen: &terminalsList_screenLink
       controller: list
+      order:
+        field:
+        - Terminal.name
+        type: asc
       pagination:
         items: 25
       <<: *Terminals

--- a/web/admin/application/configs/klear/WholesaleClientsList.yaml
+++ b/web/admin/application/configs/klear/WholesaleClientsList.yaml
@@ -52,10 +52,10 @@ production:
           balance: true
           maxCalls: true
           recordingsDiskUsage: true
-          externallyExtraOpts: true
           showInvoices: true
           invoiceNotificationTemplate: true
           callCsvNotificationTemplate: true
+          maxDailyUsage: true
         order:
           name: true
           nif: true
@@ -97,7 +97,6 @@ production:
           countryName: true
           mediaRelaySets: true
           maxCalls: false
-          externallyExtraOpts: true
           showInvoices: true
           invoiceNotificationTemplate: true
           callCsvNotificationTemplate: true
@@ -105,13 +104,13 @@ production:
           id: true
           name: true
           maxCalls: true
+          maxDailyUsage: true
           language: true
           relRoutingTags: true
           showInvoices: true
           onDemandRecord: true
           invoiceNotificationTemplate: true
           mediaRelaySets: true
-          externallyExtraOpts: true
       fixedPositions: &wholesaleClientsFixedPositions_Link
         group0:
           colsPerRow: 6
@@ -124,6 +123,7 @@ production:
           label: _("Security")
           fields:
             maxCalls: 1
+            maxDailyUsage: 1
         group2:
           colsPerRow: 12
           label: _("Geographic Configuration")
@@ -184,6 +184,7 @@ production:
           label: _("Security")
           fields:
             maxCalls: 1
+            maxDailyUsage: 1
         group2:
           colsPerRow: 12
           label: _("Geographic Configuration")
@@ -217,12 +218,6 @@ production:
           label: _("Platform data")
           fields:
             mediaRelaySets: 4
-        group6:
-          colsPerRow: 1
-          collapsed: true
-          label: _("Externally rater options")
-          fields:
-            externallyExtraOpts: 1
         group7:
           colsPerRow: 2
           collapsed: true

--- a/web/admin/application/configs/klear/WholesaleClientsList.yaml
+++ b/web/admin/application/configs/klear/WholesaleClientsList.yaml
@@ -12,6 +12,10 @@ production:
   screens: &wholesaleClients_screensLink
     wholesaleClientsList_screen: &wholesaleClientsList_screenLink
       controller: list
+      order:
+        field:
+        - Company.name
+        type: asc
       pagination:
         items: 25
       <<: *WholesaleClients
@@ -168,6 +172,7 @@ production:
           town: ${auth.brandFeatures.invoices.disabled}
           province: ${auth.brandFeatures.invoices.disabled}
           countryName: ${auth.brandFeatures.invoices.disabled}
+          invoiceNotificationTemplate: ${auth.brandFeatures.invoices.disabled}
         whitelist:
           id: ${auth.isMainOperator}
         order:

--- a/web/admin/application/configs/klear/klear.yaml
+++ b/web/admin/application/configs/klear/klear.yaml
@@ -204,6 +204,10 @@ production:
               title: ngettext('Prepaid Balance', 'Prepaid Balances', 0)
               class: ui-silk-money-yen
               description: _("List of %s", ngettext('Prepaid Balance', 'Prepaid Balances', 0))
+            CurrentdayUsageList:
+              title: ngettext('Current Day Usage', 'Current Day Usages', 0)
+              class: ui-silk-newspaper
+              description: _("List of %s", ngettext('Current Day Usage', 'Current Day Usages', 0))
         Invoicing:
           title: _('Invoicing')
           class: ui-silk-report

--- a/web/admin/application/configs/klear/model/Companies.yaml
+++ b/web/admin/application/configs/klear/model/Companies.yaml
@@ -118,6 +118,20 @@ production:
         icon: help
         text: _("Limits external incoming and outgoing calls to this value (0 for unlimited).")
         label: _("Need help?")
+    maxDailyUsage:
+      title: _('Max daily usage')
+      type: number
+      defaultValue: 1000000
+      source:
+        control: Spinner
+        min: 1
+        minStep: 50
+      info:
+        type: box
+        position: left
+        icon: help
+        text: _("Limit max daily usage.")
+        label: _("Need help?")
     postalAddress:
       title: _('Postal address')
       type: text
@@ -299,9 +313,6 @@ production:
       maxLength: 3
       prefix: '<span class="asterisc">*</span>'
       pattern: '[0-9*]+'
-    externallyExtraOpts:
-      title: _('Externally rater custom options')
-      type: textarea
     recordingsLimitMB:
       title: _("Max disk usage (in MB)")
       type: number
@@ -432,6 +443,28 @@ production:
       source:
         class: IvozProvider_Klear_Ghost_Companies
         method: getBalance
+    currentDayUsage:
+      title: _('Today usage')
+      type: ghost
+      readonly: true
+      source:
+        class: IvozProvider_Klear_Ghost_Companies
+        method: getCurrentDayUsage
+    accountStatus:
+      title: _('Status')
+      type: ghost
+      readonly: true
+      dirty: true
+      source:
+        class: IvozProvider_Klear_Ghost_Companies
+        method: getAccountStatus
+    currentDayMaxUsage:
+      title: _('Max daily usage')
+      type: ghost
+      readonly: true
+      source:
+        class: IvozProvider_Klear_Ghost_Companies
+        method: getCurrentDayMaxUsage
     typeIcon:
       title: _('Type')
       type: ghost

--- a/web/admin/application/configs/klear/model/ResidentialClients.yaml
+++ b/web/admin/application/configs/klear/model/ResidentialClients.yaml
@@ -112,6 +112,19 @@ production:
         icon: help
         text: _("Limits external incoming and outgoing calls to this value (0 for unlimited).")
         label: _("Need help?")
+    maxDailyUsage:
+      title: _('Max daily usage')
+      type: number
+      defaultValue: 100
+      source:
+        control: Spinner
+        min: 1
+      info:
+        type: box
+        position: left
+        icon: help
+        text: _("Limit max daily usage.")
+        label: _("Need help?")
     postalAddress:
       title: _('Postal address')
       type: text
@@ -279,9 +292,6 @@ production:
       maxLength: 3
       prefix: '<span class="asterisc">*</span>'
       pattern: '[0-9*]+'
-    externallyExtraOpts:
-      title: _('Externally rater custom options')
-      type: textarea
     relFeatures:
       title: _('Features')
       type: multiselect

--- a/web/admin/application/configs/klear/model/RetailClients.yaml
+++ b/web/admin/application/configs/klear/model/RetailClients.yaml
@@ -73,6 +73,19 @@ production:
         icon: help
         text: _("Limits external incoming and outgoing calls to this value (0 for unlimited).")
         label: _("Need help?")
+    maxDailyUsage:
+      title: _('Max daily usage')
+      type: number
+      defaultValue: 100
+      source:
+        control: Spinner
+        min: 1
+      info:
+        type: box
+        position: left
+        icon: help
+        text: _("Limit max daily usage.")
+        label: _("Need help?")
     postalAddress:
       title: _('Postal address')
       type: text
@@ -136,9 +149,6 @@ production:
             template: '%name${lang}% (%countryCode%)'
           order:
             Country.name.${lang}: asc
-    externallyExtraOpts:
-      title: _('Externally rater custom options')
-      type: textarea
     mediaRelaySets:
       title: _('Media relay Set')
       type: select

--- a/web/admin/application/configs/klear/model/WholesaleClients.yaml
+++ b/web/admin/application/configs/klear/model/WholesaleClients.yaml
@@ -73,6 +73,19 @@ production:
         icon: help
         text: _("Limits external incoming and outgoing calls to this value (0 for unlimited).")
         label: _("Need help?")
+    maxDailyUsage:
+      title: _('Max daily usage')
+      type: number
+      defaultValue: 100
+      source:
+        control: Spinner
+        min: 1
+      info:
+        type: box
+        position: left
+        icon: help
+        text: _("Limit max daily usage.")
+        label: _("Need help?")
     postalAddress:
       title: _('Postal address')
       type: text
@@ -121,9 +134,6 @@ production:
             template: '%name${lang}% (%countryCode%)'
           order:
             Country.name.${lang}: asc
-    externallyExtraOpts:
-      title: _('Externally rater custom options')
-      type: textarea
     language:
       title: _('Language')
       type: select

--- a/web/admin/application/languages/ca_ES/ca_ES.po
+++ b/web/admin/application/languages/ca_ES/ca_ES.po
@@ -569,6 +569,11 @@ msgid_plural "Currencies"
 msgstr[0] "Moneda"
 msgstr[1] "Monedes"
 
+msgid "Current Day Usage"
+msgid_plural "Current Day Usages"
+msgstr[0] "Consum dia en curs"
+msgstr[1] "Consums dia en curs"
+
 msgid "Custom"
 msgstr "Personalitzat"
 
@@ -904,12 +909,6 @@ msgid ""
 msgstr ""
 "Tarifació externa no pot ser deshabilitada ja que alguns DDI d'entrada "
 "demanen ser facturats."
-
-msgid "Externally rater custom options"
-msgstr "Opcions especials de tarifació externa"
-
-msgid "Externally rater options"
-msgstr "Opcions de tarifació externa"
 
 msgid "Extra Configuration"
 msgstr "Configuració extra"
@@ -1386,6 +1385,9 @@ msgstr "Deixa en blanc per enviar al camp Amfitrió"
 msgid "Leave empty to use the suggested default"
 msgstr "Deixar en blanc per utilitzar els per defectes suggerits"
 
+msgid "Limit max daily usage."
+msgstr "Limitar diari màxim de consum."
+
 msgid ""
 "Limits external incoming and outgoing calls to this value (0 for unlimited)."
 msgstr ""
@@ -1519,6 +1521,9 @@ msgstr "Tipus de coincidència"
 
 msgid "Max calls"
 msgstr "Trucades màximes"
+
+msgid "Max daily usage"
+msgstr "Màxim diari consum"
 
 msgid "Max digits"
 msgstr "Dígits màxims"
@@ -2617,6 +2622,9 @@ msgstr "Tipus de temporització"
 
 msgid "To address"
 msgstr "Adreça destí"
+
+msgid "Today usage"
+msgstr "Consum d’hui"
 
 msgid "Toggle extension"
 msgstr "Commuta extensió"

--- a/web/admin/application/languages/en_US/en_US.po
+++ b/web/admin/application/languages/en_US/en_US.po
@@ -564,6 +564,11 @@ msgid_plural "Currencies"
 msgstr[0] "Currency"
 msgstr[1] "Currencies"
 
+msgid "Current Day Usage"
+msgid_plural "Current Day Usages"
+msgstr[0] "Current Day Usage"
+msgstr[1] "Current Day Usages"
+
 msgid "Custom"
 msgstr "Custom"
 
@@ -894,12 +899,6 @@ msgid ""
 "Externally rated cannot be disabled as some DDIs wants to bill inbound calls."
 msgstr ""
 "Externally rated cannot be disabled as some DDIs wants to bill inbound calls."
-
-msgid "Externally rater custom options"
-msgstr "Externally rater custom options"
-
-msgid "Externally rater options"
-msgstr "Externally rater options"
 
 msgid "Extra Configuration"
 msgstr "Extra Configuration"
@@ -1373,6 +1372,9 @@ msgstr "Leave empty to send to Host field"
 msgid "Leave empty to use the suggested default"
 msgstr "Leave empty to use the suggested default"
 
+msgid "Limit max daily usage."
+msgstr "Limit max daily usage."
+
 msgid ""
 "Limits external incoming and outgoing calls to this value (0 for unlimited)."
 msgstr ""
@@ -1505,6 +1507,9 @@ msgstr "Matching type"
 
 msgid "Max calls"
 msgstr "Max calls"
+
+msgid "Max daily usage"
+msgstr "Max daily usage"
 
 msgid "Max digits"
 msgstr "Max digits"
@@ -2599,6 +2604,9 @@ msgstr "Timing type"
 
 msgid "To address"
 msgstr "To address"
+
+msgid "Today usage"
+msgstr "Today usage"
 
 msgid "Toggle extension"
 msgstr "Toggle extension"

--- a/web/admin/application/languages/es_ES/es_ES.po
+++ b/web/admin/application/languages/es_ES/es_ES.po
@@ -571,6 +571,11 @@ msgid_plural "Currencies"
 msgstr[0] "Divisa"
 msgstr[1] "Divisas"
 
+msgid "Current Day Usage"
+msgid_plural "Current Day Usages"
+msgstr[0] "Consumo Día En Curso"
+msgstr[1] "Consumos Día En Curso"
+
 msgid "Custom"
 msgstr "A medida"
 
@@ -908,12 +913,6 @@ msgid ""
 msgstr ""
 "La tarificación externa no puede ser deshabilitada ya que hay DDIs con "
 "tarificacion entrante."
-
-msgid "Externally rater custom options"
-msgstr "Opciones adicionales tarificación externa"
-
-msgid "Externally rater options"
-msgstr "Opciones Tarificación externa"
 
 msgid "Extra Configuration"
 msgstr "Configuración adicional"
@@ -1391,6 +1390,9 @@ msgstr "Dejar vacío para enviar al campo Host"
 msgid "Leave empty to use the suggested default"
 msgstr "Dejar vacío para emplear la sugerencia por defecto"
 
+msgid "Limit max daily usage."
+msgstr "Limitar máximo consumo diario."
+
 msgid ""
 "Limits external incoming and outgoing calls to this value (0 for unlimited)."
 msgstr ""
@@ -1526,6 +1528,9 @@ msgstr "Tipo coincidencia"
 
 msgid "Max calls"
 msgstr "Límite llamadas"
+
+msgid "Max daily usage"
+msgstr "Máximo consumo diario"
 
 msgid "Max digits"
 msgstr "Longitud máxima"
@@ -2630,6 +2635,9 @@ msgstr "Tipo de timing"
 
 msgid "To address"
 msgstr "Dirección destino"
+
+msgid "Today usage"
+msgstr "Consumo día en curso"
 
 msgid "Toggle extension"
 msgstr "Código conmutar"

--- a/web/admin/application/languages/it_IT/it_IT.po
+++ b/web/admin/application/languages/it_IT/it_IT.po
@@ -574,6 +574,11 @@ msgid_plural "Currencies"
 msgstr[0] "Currency"
 msgstr[1] "Currencies"
 
+msgid "Current Day Usage"
+msgid_plural "Current Day Usages"
+msgstr[0] "Consumo di giorno corrente"
+msgstr[1] "Consumi del giorno corrente"
+
 msgid "Custom"
 msgstr "Custom"
 
@@ -911,12 +916,6 @@ msgid ""
 msgstr ""
 "La tariffazione esterna non può essere disabilitata poiché alcuni DDI "
 "richiedono fatturazione delle chiamate in entrata."
-
-msgid "Externally rater custom options"
-msgstr "Opzioni personalizzate Tariffatore Esterno"
-
-msgid "Externally rater options"
-msgstr "Externally rater options"
 
 msgid "Extra Configuration"
 msgstr "Configurazione extra"
@@ -1392,6 +1391,9 @@ msgstr "Lascia vuoto per inviare al campo Host"
 msgid "Leave empty to use the suggested default"
 msgstr "Lascia vuoto per usare l'impostazione predefinita suggerita"
 
+msgid "Limit max daily usage."
+msgstr "Limitare il consumo giornaliero"
+
 msgid ""
 "Limits external incoming and outgoing calls to this value (0 for unlimited)."
 msgstr ""
@@ -1527,6 +1529,9 @@ msgstr "Confronta tipo"
 
 msgid "Max calls"
 msgstr "Massimo Chiamates"
+
+msgid "Max daily usage"
+msgstr "Consumo giornaliero"
 
 msgid "Max digits"
 msgstr "Massimo Cifre"
@@ -2635,6 +2640,9 @@ msgstr "Timing type"
 msgid "To address"
 msgstr "Indirizzo To"
 
+msgid "Today usage"
+msgstr "Il consumo oggi"
+
 msgid "Toggle extension"
 msgstr "Attiva / disattiva estensione"
 
@@ -2969,11 +2977,3 @@ msgstr "condiviso"
 
 msgid "unlimited"
 msgstr "illimitato"
-
-#~ msgid "Company's default"
-#~ msgstr "Impostazione predefinita Company"
-
-#~ msgid ""
-#~ "Limits the number of concurrent received calls. Set 0 for unlimited calls."
-#~ msgstr ""
-#~ "Limits the number of concurrent received calls. Set 0 for unlimited calls."

--- a/web/admin/application/library/IvozProvider/Klear/Ghost/Companies.php
+++ b/web/admin/application/library/IvozProvider/Klear/Ghost/Companies.php
@@ -74,6 +74,84 @@ class IvozProvider_Klear_Ghost_Companies extends KlearMatrix_Model_Field_Ghost_A
      * @param CompanyDto $companyDto
      * @return string
      */
+    public function getCurrentDayUsage(CompanyDto $companyDto)
+    {
+        try {
+            /** @var DataGateway $dataGateway */
+            $dataGateway = \Zend_Registry::get('data_gateway');
+
+            $amount = $this->fetchCompanyBalance->getCurrentDayUsage(
+                $companyDto->getBrandId(),
+                $companyDto->getId()
+            );
+
+            $currencySymbol = $dataGateway->remoteProcedureCall(
+                Company::class,
+                $companyDto->getId(),
+                'getCurrencySymbol',
+                []
+            );
+
+            return sprintf("%s %s", $amount, $currencySymbol);
+        } catch (Exception $exception) {
+            return Klear_Model_Gettext::gettextCheck('_("Unavailable")');
+        }
+    }
+
+    /**
+     * @param CompanyDto $companyDto
+     * @return string
+     */
+    public function getCurrentDayMaxUsage(CompanyDto $companyDto)
+    {
+        try {
+            /** @var DataGateway $dataGateway */
+            $dataGateway = \Zend_Registry::get('data_gateway');
+
+            $amount = $this->fetchCompanyBalance->getCurrentDayMaxUsage(
+                $companyDto->getBrandId(),
+                $companyDto->getId()
+            );
+
+            $currencySymbol = $dataGateway->remoteProcedureCall(
+                Company::class,
+                $companyDto->getId(),
+                'getCurrencySymbol',
+                []
+            );
+
+            return sprintf("%s %s", $amount, $currencySymbol);
+        } catch (Exception $exception) {
+            return Klear_Model_Gettext::gettextCheck('_("Unavailable")');
+        }
+    }
+
+    /**
+     * @param CompanyDto $companyDto
+     * @return string
+     */
+    public function getAccountStatus(CompanyDto $companyDto)
+    {
+        try {
+            $disabled = $this->fetchCompanyBalance->getAccountStatus(
+                $companyDto->getBrandId(),
+                $companyDto->getId()
+            );
+
+            if (!$disabled) {
+                return '<span class="ui-silk inline ui-silk-accept" title="Active"></span>';
+            }
+
+            return '<span class="ui-silk inline ui-silk-delete" title="Inactive"></span>';
+        } catch (Exception $exception) {
+            return Klear_Model_Gettext::gettextCheck('_("Unavailable")');
+        }
+    }
+
+    /**
+     * @param CompanyDto $companyDto
+     * @return string
+     */
     public function getDdiE164(CompanyDto $companyDto)
     {
         try {


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [ ] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [ ] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

This new feature allows setting a maximum daily usage at client level:

- If maximum usage is reached, client's CGRateS account is disabled (no external outgoing calls will be allowed, unless placed through externally rated carriers).

- To re-enable client's account, max daily usage threshold must be increased until it exceeds current day's usage.

- At midnight all counters are reset and all CGRateS accounts are enabled.

#### Additional information

- Default value for existing clients: 1000000 € (equals to no-limit).

- *Current day usage* section lists information about this feature.

- No notifications yet.