### PR TITLE
scheme: delete duplicates before trunks cdr unique callid index

### DIFF
--- a/schema/app/DoctrineMigrations/Version20190618171752.php
+++ b/schema/app/DoctrineMigrations/Version20190618171752.php
@@ -18,6 +18,7 @@ class Version20190618171752 extends AbstractMigration
         // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
+        $this->addSql('DELETE t1 FROM kam_trunks_cdrs t1 INNER JOIN kam_trunks_cdrs t2 WHERE t1.id > t2.id AND t1.callid=t2.callid AND t1.direction=t2.direction');
         $this->addSql('CREATE UNIQUE INDEX trunksCdr_callid_direction ON kam_trunks_cdrs (callid, direction)');
     }
 


### PR DESCRIPTION
This PR updates delta generated in e590fdf688694fa30c9ef83df271d48fbc35fef3 to avoid integrity errors while creating the unique index.


#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
This PR addresses one of the problems reported in #1141

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
