### PR TITLE
core: fixed schema dependecy for LoggableMigrations

### DIFF
--- a/schema/composer.json
+++ b/schema/composer.json
@@ -69,10 +69,10 @@
         "ramsey/uuid": "^3.7",
         "symfony/monolog-bundle": "3.1.*",
         "symfony/swiftmailer-bundle": "^3.1",
-        "symfony/symfony": "3.4.*"
+        "symfony/symfony": "3.4.*",
+        "beberlei/assert": "2.9.*"
     },
     "require-dev": {
-        "beberlei/assert": "2.9.*",
         "docteurklein/test-double-bundle": "^1.0",
         "doctrine/doctrine-fixtures-bundle": "^3.0",
         "phpunit/phpunit": "^6.0",

--- a/schema/composer.lock
+++ b/schema/composer.lock
@@ -4,8 +4,78 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "a97f61d47387eb16f7ce051ea86441a1",
+    "content-hash": "37799e3afa209d8d6a77441fae52978b",
     "packages": [
+        {
+            "name": "beberlei/assert",
+            "version": "2.9.9.0",
+            "dist": {
+                "type": "path",
+                "url": "../library/vendor/beberlei/assert",
+                "reference": "124317de301b7c91d5fce34c98bba2c6925bec95",
+                "shasum": null
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.1.1",
+                "phpunit/phpunit": "^4.8.35|^5.7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Assert\\": "lib/Assert"
+                },
+                "files": [
+                    "lib/Assert/functions.php"
+                ]
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "Assert\\Tests\\": "tests/Assert/Tests"
+                },
+                "files": [
+                    "tests/Assert/Tests/Fixtures/functions.php"
+                ]
+            },
+            "scripts": {
+                "assert:generate-docs": [
+                    "php bin/generate_method_docs.php"
+                ],
+                "assert:cs-lint": [
+                    "php-cs-fixer fix --diff -vvv --dry-run"
+                ],
+                "assert:cs-fix": [
+                    "php-cs-fixer fix . -vvv || true"
+                ]
+            },
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Richard Quadling",
+                    "email": "rquadling@gmail.com",
+                    "role": "Collaborator"
+                }
+            ],
+            "description": "Thin assertion library for input validation in business models.",
+            "keywords": [
+                "assert",
+                "assertion",
+                "validation"
+            ],
+            "transport-options": {
+                "symlink": true
+            }
+        },
         {
             "name": "doctrine/annotations",
             "version": "1.4.0.0",
@@ -3449,76 +3519,6 @@
         }
     ],
     "packages-dev": [
-        {
-            "name": "beberlei/assert",
-            "version": "2.9.9.0",
-            "dist": {
-                "type": "path",
-                "url": "../library/vendor/beberlei/assert",
-                "reference": "124317de301b7c91d5fce34c98bba2c6925bec95",
-                "shasum": null
-            },
-            "require": {
-                "ext-mbstring": "*",
-                "php": ">=5.3"
-            },
-            "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.1.1",
-                "phpunit/phpunit": "^4.8.35|^5.7"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Assert\\": "lib/Assert"
-                },
-                "files": [
-                    "lib/Assert/functions.php"
-                ]
-            },
-            "autoload-dev": {
-                "psr-4": {
-                    "Assert\\Tests\\": "tests/Assert/Tests"
-                },
-                "files": [
-                    "tests/Assert/Tests/Fixtures/functions.php"
-                ]
-            },
-            "scripts": {
-                "assert:generate-docs": [
-                    "php bin/generate_method_docs.php"
-                ],
-                "assert:cs-lint": [
-                    "php-cs-fixer fix --diff -vvv --dry-run"
-                ],
-                "assert:cs-fix": [
-                    "php-cs-fixer fix . -vvv || true"
-                ]
-            },
-            "license": [
-                "BSD-2-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Benjamin Eberlei",
-                    "email": "kontakt@beberlei.de",
-                    "role": "Lead Developer"
-                },
-                {
-                    "name": "Richard Quadling",
-                    "email": "rquadling@gmail.com",
-                    "role": "Collaborator"
-                }
-            ],
-            "description": "Thin assertion library for input validation in business models.",
-            "keywords": [
-                "assert",
-                "assertion",
-                "validation"
-            ],
-            "transport-options": {
-                "symlink": true
-            }
-        },
         {
             "name": "docteurklein/test-double-bundle",
             "version": "1.0.0.0",


### PR DESCRIPTION
Moved beberlei/assert schema dependecy from dev to all that LoggableMigrations do not end on error

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [X] Fixes an existing issue (Fixes #1141) <!-- Replace XXXX with issue id -->
