### PR TITLE
Api expose cost on billable calls rate

### DIFF
--- a/library/Ivoz/Provider/Domain/Model/BillableCall/BillableCallDto.php
+++ b/library/Ivoz/Provider/Domain/Model/BillableCall/BillableCallDto.php
@@ -16,6 +16,7 @@ class BillableCallDto extends BillableCallDtoAbstract
         if ($context === self::CONTEXT_RATING_INTERNAL) {
             return [
                 'price' => 'price',
+                'cost' => 'cost',
                 'destinationName' => 'destinationName',
                 'destinationId' => 'destination',
                 'ratingPlanName' => 'ratingPlanName',
@@ -26,6 +27,7 @@ class BillableCallDto extends BillableCallDtoAbstract
         if ($context === self::CONTEXT_RATING) {
             return [
                 'price' => 'price',
+                'cost' => 'cost',
                 'destinationName' => 'destinationName',
                 'ratingPlanName' => 'ratingPlanName'
             ];

--- a/web/rest/brand/features/provider/billableCalls/putBillableCalls.feature
+++ b/web/rest/brand/features/provider/billableCalls/putBillableCalls.feature
@@ -19,6 +19,7 @@ Feature: Update billable calls
     """
       {
           "price": 2.2,
+          "cost": 1.1,
           "destinationName": "Rate test",
           "ratingPlanName": "RatingPlan Test"
       }
@@ -34,7 +35,7 @@ Feature: Update billable calls
           "duration": 0,
           "caller": "+34633646464",
           "callee": "+34633656565",
-          "cost": null,
+          "cost": 1.1,
           "price": 2.2,
           "carrierName": null,
           "destinationName": "Rate test",

--- a/web/rest/brand/src/Controller/Provider/PutBillableCallRatingAction.php
+++ b/web/rest/brand/src/Controller/Provider/PutBillableCallRatingAction.php
@@ -60,13 +60,6 @@ class PutBillableCallRatingAction
             []
         );
 
-        if (!isset($data['price'])) {
-            throw new \DomainException(
-                'Price is required',
-                500
-            );
-        }
-
         if (isset($data['destinationName'])) {
             $data['destination'] = null;
         }

--- a/web/rest/platform/features/provider/billableCalls/putBillableCalls.feature
+++ b/web/rest/platform/features/provider/billableCalls/putBillableCalls.feature
@@ -19,6 +19,7 @@ Feature: Update billable calls
     """
       {
           "price": 2.2,
+          "cost": 1.1,
           "destinationName": "Rate test",
           "ratingPlanName": "RatingPlan Test"
       }
@@ -34,7 +35,7 @@ Feature: Update billable calls
           "duration": 0,
           "caller": "+34633646464",
           "callee": "+34633656565",
-          "cost": null,
+          "cost": 1.1,
           "price": 2.2,
           "priceDetails": [],
           "carrierName": null,

--- a/web/rest/platform/src/Controller/Provider/PutBillableCallRatingAction.php
+++ b/web/rest/platform/src/Controller/Provider/PutBillableCallRatingAction.php
@@ -50,13 +50,6 @@ class PutBillableCallRatingAction
             []
         );
 
-        if (!isset($data['price'])) {
-            throw new \DomainException(
-                'Price is required',
-                500
-            );
-        }
-
         if (isset($data['destinationName'])) {
             $data['destination'] = null;
         }


### PR DESCRIPTION
Allow to set cost on /billable_calls/callid/rate API endpoint

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
