### PR TITLE
web/admin: recover Externally rater custom options

### DIFF
--- a/web/admin/application/configs/klear/CompaniesList.yaml
+++ b/web/admin/application/configs/klear/CompaniesList.yaml
@@ -78,6 +78,7 @@ production:
           outgoingDdi: true
           maxDailyUsage: true
           allowRecordingRemoval: true
+          externallyExtraOpts: true
         order:
           name: true
           nif: true
@@ -125,6 +126,7 @@ production:
           countryName: true
           outgoingDdi: true
           outgoingDdiRule: true
+          externallyExtraOpts: true
           recordingsLimitMB: true
           recordingsLimitEmail: true
           recordingsDiskUsage: true
@@ -283,6 +285,12 @@ production:
             onDemandRecord: 6
             allowRecordingRemoval: 6
             onDemandRecordCode: 6
+        group6:
+          colsPerRow: 1
+          collapsed: true
+          label: _("Externally rater options")
+          fields:
+            externallyExtraOpts: 1
         group7:
           colsPerRow: 2
           collapsed: true

--- a/web/admin/application/configs/klear/CompanyBalancesList.yaml
+++ b/web/admin/application/configs/klear/CompanyBalancesList.yaml
@@ -74,6 +74,7 @@ production:
           accountStatus: true
           maxDailyUsage: true
           allowRecordingRemoval: true
+          externallyExtraOpts: true
         order:
           typeIcon: true
           name: true

--- a/web/admin/application/configs/klear/CurrentdayUsageList.yaml
+++ b/web/admin/application/configs/klear/CurrentdayUsageList.yaml
@@ -64,6 +64,7 @@ production:
           billingMethod: true
           maxDailyUsage: true
           allowRecordingRemoval: true
+          externallyExtraOpts: true
         order:
           typeIcon: true
           name: true

--- a/web/admin/application/configs/klear/ResidentialClientsList.yaml
+++ b/web/admin/application/configs/klear/ResidentialClientsList.yaml
@@ -73,6 +73,7 @@ production:
           outgoingDdi: true
           maxDailyUsage: true
           allowRecordingRemoval: true
+          externallyExtraOpts: true
         order:
           name: true
           nif: true
@@ -129,6 +130,7 @@ production:
           showInvoices: true
           outgoingDdiE164: true
           allowRecordingRemoval: true
+          externallyExtraOpts: true
         order: &residentialClientsOrder_Link
           id: true
           name: true
@@ -259,6 +261,12 @@ production:
             onDemandRecord: 6
             allowRecordingRemoval: 6
             onDemandRecordCode: 6
+        group6:
+          colsPerRow: 1
+          collapsed: true
+          label: _("Externally rater options")
+          fields:
+            externallyExtraOpts: 1
         group7:
           colsPerRow: 2
           collapsed: true

--- a/web/admin/application/configs/klear/RetailClientsList.yaml
+++ b/web/admin/application/configs/klear/RetailClientsList.yaml
@@ -62,6 +62,7 @@ production:
           outgoingDdi: true
           maxDailyUsage: true
           allowRecordingRemoval: true
+          externallyExtraOpts: true
         order:
           name: true
           nif: true
@@ -108,6 +109,7 @@ production:
           callCsvNotificationTemplate: true
           outgoingDdiE164: true
           allowRecordingRemoval: true
+          externallyExtraOpts: true
         order: &retailClientsOrder_Link
           id: true
           name: true
@@ -241,6 +243,12 @@ production:
           fields:
             invoiceNotificationTemplate: 1
             callCsvNotificationTemplate: 1
+        group6:
+          colsPerRow: 1
+          collapsed: true
+          label: _("Externally rater options")
+          fields:
+            externallyExtraOpts: 1
         group7:
           colsPerRow: 12
           collapsed: true

--- a/web/admin/application/configs/klear/WholesaleClientsList.yaml
+++ b/web/admin/application/configs/klear/WholesaleClientsList.yaml
@@ -60,6 +60,7 @@ production:
           invoiceNotificationTemplate: true
           callCsvNotificationTemplate: true
           maxDailyUsage: true
+          externallyExtraOpts: true
         order:
           name: true
           nif: true
@@ -104,6 +105,7 @@ production:
           showInvoices: true
           invoiceNotificationTemplate: true
           callCsvNotificationTemplate: true
+          externallyExtraOpts: true
         order: &wholesaleClientsOrder_Link
           id: true
           name: true
@@ -223,6 +225,12 @@ production:
           label: _("Platform data")
           fields:
             mediaRelaySets: 4
+        group6:
+          colsPerRow: 1
+          collapsed: true
+          label: _("Externally rater options")
+          fields:
+            externallyExtraOpts: 1
         group7:
           colsPerRow: 2
           collapsed: true

--- a/web/admin/application/configs/klear/model/Companies.yaml
+++ b/web/admin/application/configs/klear/model/Companies.yaml
@@ -507,6 +507,9 @@ production:
         icon: help
         text: _("Enable this option to display a section in Client's portal to download generated invoices.")
         label: _("Need help?")
+    externallyExtraOpts:
+      title: _('Externally rater custom options')
+      type: textarea
 staging:
   _extends: production
 testing:

--- a/web/admin/application/configs/klear/model/ResidentialClients.yaml
+++ b/web/admin/application/configs/klear/model/ResidentialClients.yaml
@@ -421,6 +421,9 @@ production:
         icon: help
         text: _("Enable this option to display a section in Client's portal to download generated invoices.")
         label: _("Need help?")
+    externallyExtraOpts:
+      title: _('Externally rater custom options')
+      type: textarea
 staging:
   _extends: production
 testing:

--- a/web/admin/application/configs/klear/model/RetailClients.yaml
+++ b/web/admin/application/configs/klear/model/RetailClients.yaml
@@ -341,6 +341,9 @@ production:
         icon: help
         text: _("Enable this option to display delete button in Client's portal call recordings section.")
         label: _("Need help?")
+    externallyExtraOpts:
+      title: _('Externally rater custom options')
+      type: textarea
 staging:
   _extends: production
 testing:

--- a/web/admin/application/configs/klear/model/WholesaleClients.yaml
+++ b/web/admin/application/configs/klear/model/WholesaleClients.yaml
@@ -264,6 +264,9 @@ production:
             - name
             template: '%name%'
         'null': _("Use generic template")
+    externallyExtraOpts:
+      title: _('Externally rater custom options')
+      type: textarea
 staging:
   _extends: production
 testing:

--- a/web/admin/application/languages/ca_ES/ca_ES.po
+++ b/web/admin/application/languages/ca_ES/ca_ES.po
@@ -920,6 +920,12 @@ msgstr ""
 "Tarifació externa no pot ser deshabilitada ja que alguns DDI d'entrada "
 "demanen ser facturats."
 
+msgid "Externally rater custom options"
+msgstr "Opcions especials de tarifació externa"
+
+msgid "Externally rater options"
+msgstr "Opcions de tarifació externa"
+
 msgid "Extra Configuration"
 msgstr "Configuració extra"
 

--- a/web/admin/application/languages/en_US/en_US.po
+++ b/web/admin/application/languages/en_US/en_US.po
@@ -910,6 +910,12 @@ msgid ""
 msgstr ""
 "Externally rated cannot be disabled as some DDIs wants to bill inbound calls."
 
+msgid "Externally rater custom options"
+msgstr "Externally rater custom options"
+
+msgid "Externally rater options"
+msgstr "Externally rater options"
+
 msgid "Extra Configuration"
 msgstr "Extra Configuration"
 

--- a/web/admin/application/languages/es_ES/es_ES.po
+++ b/web/admin/application/languages/es_ES/es_ES.po
@@ -925,6 +925,12 @@ msgstr ""
 "La tarificación externa no puede ser deshabilitada ya que hay DDIs con "
 "tarificacion entrante."
 
+msgid "Externally rater custom options"
+msgstr "Opciones adicionales tarificación externa"
+
+msgid "Externally rater options"
+msgstr "Opciones Tarificación externa"
+
 msgid "Extra Configuration"
 msgstr "Configuración adicional"
 

--- a/web/admin/application/languages/it_IT/it_IT.po
+++ b/web/admin/application/languages/it_IT/it_IT.po
@@ -927,6 +927,12 @@ msgstr ""
 "La tariffazione esterna non può essere disabilitata poiché alcuni DDI "
 "richiedono fatturazione delle chiamate in entrata."
 
+msgid "Externally rater custom options"
+msgstr "Opzioni personalizzate Tariffatore Esterno"
+
+msgid "Externally rater options"
+msgstr "Externally rater options"
+
 msgid "Extra Configuration"
 msgstr "Configurazione extra"
 


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

Display Externally Rater custom options field in edit screens for vPBX/residential/retail/wholesale clientes.