### PR TITLE
Invoice templates fixes

### DIFF
--- a/schema/app/DoctrineMigrations/Version20191114115328.php
+++ b/schema/app/DoctrineMigrations/Version20191114115328.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20191114115328 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->addSql("UPDATE InvoiceTemplates SET templateHeader = REPLACE(templateHeader, 'brand.postalCode', 'brand.invoice.postalCode')");
+        $this->addSql("UPDATE InvoiceTemplates SET templateHeader = REPLACE(templateHeader, 'brand.town', 'brand.invoice.town')");
+        $this->addSql("UPDATE InvoiceTemplates SET templateHeader = REPLACE(templateHeader, 'brand.province', 'brand.invoice.province')");
+        $this->addSql("UPDATE InvoiceTemplates SET templateHeader = REPLACE(templateHeader, 'brand.postalAddress', 'brand.invoice.postalAddress')");
+        $this->addSql("UPDATE InvoiceTemplates SET templateHeader = REPLACE(templateHeader, 'brand.nif', 'brand.invoice.nif')");
+        $this->addSql("UPDATE InvoiceTemplates SET templateFooter = REPLACE(templateFooter, 'brand.registryData', 'brand.invoice.registryData')");
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+
+    }
+}

--- a/web/admin/application/configs/klear/DefaultInvoiceTemplatesList.yaml
+++ b/web/admin/application/configs/klear/DefaultInvoiceTemplatesList.yaml
@@ -74,7 +74,7 @@ production:
       fullWidth: true
       title: _("Edit %s %2s", ngettext('Invoice template', 'Invoice templates', 1), "[format| (%item%)]")
       forcedValues:
-        <<: *forcedBrand
+        "self::brand": null
       fixedPositions:
         <<: *defaultInvoiceTemplatesFixedPositions_Link
       <<: *invoiceTemplateHelp


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
This PR include two commits that addresses following bugs:
 - Administration portal default Invoice templates was assigned to emulated brand after being edited
 - Migrated Invoice Templates from 1.x didn't show Brand Invoice related data

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
