### PR TITLE
i18n: fix translations after unused model removal

### DIFF
--- a/web/admin/application/languages/ca_ES/ca_ES.po
+++ b/web/admin/application/languages/ca_ES/ca_ES.po
@@ -176,12 +176,6 @@ msgstr "Estàs segur que vols generar la factura?"
 msgid "Area code"
 msgstr "Codi d'àrea"
 
-msgid "As address"
-msgstr "Com adreça"
-
-msgid "As iden"
-msgstr "Com identificador"
-
 msgid "Assistant"
 msgstr "Assistent"
 
@@ -711,9 +705,6 @@ msgstr "Mostra nom"
 msgid "Distribute method"
 msgstr "Mètode de distribució"
 
-msgid "Diversion"
-msgstr "Desviació"
-
 msgid "Do not disturb"
 msgstr "No molestar"
 
@@ -830,9 +821,6 @@ msgstr "Habilitat"
 
 msgid "End date"
 msgstr "Data fi"
-
-msgid "End time"
-msgstr "Temps final"
 
 msgid "Endpoint id"
 msgstr "Dispositiu final Id"
@@ -1616,12 +1604,6 @@ msgstr ""
 "Els membres amb menys penalització seran trucats primer. Membres amb alta "
 "penalització seran trucats quan no hi hagi membres amb penalització"
 
-msgid "Metered"
-msgstr "Mesurat"
-
-msgid "Metering date"
-msgstr "Data de mesura"
-
 msgid ""
 "Minimal length 10, including 3 uppercase letters, 3 lowercase letters, 3 "
 "digits and one character in '+*_-'"
@@ -1866,9 +1848,6 @@ msgstr "Pagina"
 msgid "Parse file and import"
 msgstr "Analitza fitxer i importa"
 
-msgid "Parsed"
-msgstr "Analitzat"
-
 msgid "Party"
 msgstr "Festa"
 
@@ -1988,9 +1967,7 @@ msgid "Prevent missed calls"
 msgstr "Eviteu les trucades perdudes"
 
 msgid "Price"
-msgid_plural "Prices"
-msgstr[0] "Price"
-msgstr[1] "Prices"
+msgstr "Price"
 
 msgid "Prices Help"
 msgstr "Ajuda de preus"
@@ -2014,9 +1991,6 @@ msgstr[1] "Provinces"
 
 msgid "Provisioning Info"
 msgstr "Informació aprovisionament"
-
-msgid "Proxy"
-msgstr "Intermediari"
 
 msgid "Proxy Trunks"
 msgid_plural "Proxies Trunks"
@@ -2084,9 +2058,6 @@ msgid_plural "Rating plans"
 msgstr[0] "Rating plan"
 msgstr[1] "Rating plans"
 
-msgid "Re metering date"
-msgstr "Data de repetició de mesura"
-
 msgid "Realm"
 msgstr "Regne"
 
@@ -2106,12 +2077,6 @@ msgstr "Data de grabació"
 
 msgid "Recording extension"
 msgstr "Extensió gravada"
-
-msgid "Referee"
-msgstr "Àrbitre"
-
-msgid "Referrer"
-msgstr "Remitent"
 
 msgid "Register"
 msgstr "Registre"

--- a/web/admin/application/languages/en_US/en_US.po
+++ b/web/admin/application/languages/en_US/en_US.po
@@ -171,12 +171,6 @@ msgstr "Are you sure you want to generate the invoice?"
 msgid "Area code"
 msgstr "Area code"
 
-msgid "As address"
-msgstr "AS address"
-
-msgid "As iden"
-msgstr "AS iden"
-
 msgid "Assistant"
 msgstr "Assistant"
 
@@ -702,9 +696,6 @@ msgstr "Display name"
 msgid "Distribute method"
 msgstr "Distribute method"
 
-msgid "Diversion"
-msgstr "Diversion"
-
 msgid "Do not disturb"
 msgstr "Do not disturb"
 
@@ -821,9 +812,6 @@ msgstr "Enabled"
 
 msgid "End date"
 msgstr "End date"
-
-msgid "End time"
-msgstr "End time"
 
 msgid "Endpoint id"
 msgstr "Endpoint id"
@@ -1602,12 +1590,6 @@ msgstr ""
 "métrica serán contactados cuando no exista ningún miembro de la métrica "
 "actual disponible."
 
-msgid "Metered"
-msgstr "Metered"
-
-msgid "Metering date"
-msgstr "Metering date"
-
 msgid ""
 "Minimal length 10, including 3 uppercase letters, 3 lowercase letters, 3 "
 "digits and one character in '+*_-'"
@@ -1850,9 +1832,6 @@ msgstr "Page"
 msgid "Parse file and import"
 msgstr "Parse file and import"
 
-msgid "Parsed"
-msgstr "Parsed"
-
 msgid "Party"
 msgstr "Party"
 
@@ -1972,9 +1951,7 @@ msgid "Prevent missed calls"
 msgstr "Prevent missed calls"
 
 msgid "Price"
-msgid_plural "Prices"
-msgstr[0] "Price"
-msgstr[1] "Prices"
+msgstr "Price"
 
 msgid "Prices Help"
 msgstr "Prices Help"
@@ -1998,9 +1975,6 @@ msgstr[1] "Provinces"
 
 msgid "Provisioning Info"
 msgstr "Provisioning Info"
-
-msgid "Proxy"
-msgstr "Proxy"
 
 msgid "Proxy Trunks"
 msgid_plural "Proxies Trunks"
@@ -2068,9 +2042,6 @@ msgid_plural "Rating plans"
 msgstr[0] "Rating plan"
 msgstr[1] "Rating plans"
 
-msgid "Re metering date"
-msgstr "Re metering date"
-
 msgid "Realm"
 msgstr "Realm"
 
@@ -2090,12 +2061,6 @@ msgstr "Recording data"
 
 msgid "Recording extension"
 msgstr "Recording extension"
-
-msgid "Referee"
-msgstr "Referee"
-
-msgid "Referrer"
-msgstr "Referrer"
 
 msgid "Register"
 msgstr "Register"

--- a/web/admin/application/languages/es_ES/es_ES.po
+++ b/web/admin/application/languages/es_ES/es_ES.po
@@ -176,12 +176,6 @@ msgstr "¿Desea generar la factura?"
 msgid "Area code"
 msgstr "Código de Area"
 
-msgid "As address"
-msgstr "Dirección Servidor de Aplicación"
-
-msgid "As iden"
-msgstr "Identificador Servidor de Aplicación"
-
 msgid "Assistant"
 msgstr "Asistente"
 
@@ -713,9 +707,6 @@ msgstr "Texto en pantalla"
 msgid "Distribute method"
 msgstr "Método de distribución"
 
-msgid "Diversion"
-msgstr "Enviar Diversion"
-
 msgid "Do not disturb"
 msgstr "No molestar"
 
@@ -833,9 +824,6 @@ msgid "Enabled"
 msgstr "Activado"
 
 msgid "End date"
-msgstr "Fecha fin"
-
-msgid "End time"
 msgstr "Fecha fin"
 
 msgid "Endpoint id"
@@ -1626,12 +1614,6 @@ msgstr ""
 "disponibles en una prioridad, se contactarán a los miembros de la siguiente "
 "prioridad."
 
-msgid "Metered"
-msgstr "Tarificado"
-
-msgid "Metering date"
-msgstr "Fecha de tarificación"
-
 msgid ""
 "Minimal length 10, including 3 uppercase letters, 3 lowercase letters, 3 "
 "digits and one character in '+*_-'"
@@ -1876,9 +1858,6 @@ msgstr "Páginas"
 msgid "Parse file and import"
 msgstr "Analizar fichero e importar"
 
-msgid "Parsed"
-msgstr "Parseada"
-
 msgid "Party"
 msgstr "Interlocutor"
 
@@ -2000,9 +1979,7 @@ msgid "Prevent missed calls"
 msgstr "Evitar llamadas perdidas"
 
 msgid "Price"
-msgid_plural "Prices"
-msgstr[0] "Precio"
-msgstr[1] "Precios"
+msgstr "Precio"
 
 msgid "Prices Help"
 msgstr "Ayuda Precios"
@@ -2026,9 +2003,6 @@ msgstr[1] "Provincias"
 
 msgid "Provisioning Info"
 msgstr "Provisioning"
-
-msgid "Proxy"
-msgstr "Proxy"
 
 msgid "Proxy Trunks"
 msgid_plural "Proxies Trunks"
@@ -2096,9 +2070,6 @@ msgid_plural "Rating plans"
 msgstr[0] "Plan de precio"
 msgstr[1] "Planes de precios"
 
-msgid "Re metering date"
-msgstr "Fecha de retarificación"
-
 msgid "Realm"
 msgstr "Realm"
 
@@ -2118,12 +2089,6 @@ msgstr "Grabaciones"
 
 msgid "Recording extension"
 msgstr "Extensión de grabado"
-
-msgid "Referee"
-msgstr "Referee"
-
-msgid "Referrer"
-msgstr "Referrer"
 
 msgid "Register"
 msgstr "Registro"

--- a/web/admin/application/languages/it_IT/it_IT.po
+++ b/web/admin/application/languages/it_IT/it_IT.po
@@ -178,12 +178,6 @@ msgstr "Sei sicuro di voler generare la fattura?"
 msgid "Area code"
 msgstr "Area code"
 
-msgid "As address"
-msgstr "Come indirizzo"
-
-msgid "As iden"
-msgstr "Come iden"
-
 msgid "Assistant"
 msgstr "Assistente"
 
@@ -716,9 +710,6 @@ msgstr "Nome visualizzato"
 msgid "Distribute method"
 msgstr "Metodo di distribuzione"
 
-msgid "Diversion"
-msgstr "Deviazione"
-
 msgid "Do not disturb"
 msgstr "Non disturbare"
 
@@ -835,9 +826,6 @@ msgstr "Abilitato"
 
 msgid "End date"
 msgstr "End date"
-
-msgid "End time"
-msgstr "Ora fine"
 
 msgid "Endpoint id"
 msgstr "Endpoint id"
@@ -1626,12 +1614,6 @@ msgstr ""
 "penalità maggioresaranno contattati quando non ci sono membri con penalità "
 "attuale disponibili."
 
-msgid "Metered"
-msgstr "Misurati"
-
-msgid "Metering date"
-msgstr "Data misurazione"
-
 msgid ""
 "Minimal length 10, including 3 uppercase letters, 3 lowercase letters, 3 "
 "digits and one character in '+*_-'"
@@ -1878,9 +1860,6 @@ msgstr "Pagina"
 msgid "Parse file and import"
 msgstr "Analizza file e importa"
 
-msgid "Parsed"
-msgstr "Analizzato"
-
 msgid "Party"
 msgstr "Party"
 
@@ -2002,9 +1981,7 @@ msgid "Prevent missed calls"
 msgstr "Prevenire le chiamate perse"
 
 msgid "Price"
-msgid_plural "Prices"
-msgstr[0] "Prezzo"
-msgstr[1] "Prezzi"
+msgstr "Prezzo"
 
 msgid "Prices Help"
 msgstr "Guida ai prezzi"
@@ -2028,9 +2005,6 @@ msgstr[1] "Province"
 
 msgid "Provisioning Info"
 msgstr "Informazioni di provisioning"
-
-msgid "Proxy"
-msgstr "Proxy"
 
 msgid "Proxy Trunks"
 msgid_plural "Proxies Trunks"
@@ -2098,9 +2072,6 @@ msgid_plural "Rating plans"
 msgstr[0] "Piano di tariffazione"
 msgstr[1] "Piani di tariffazione"
 
-msgid "Re metering date"
-msgstr "Data Rivalorizzazione"
-
 msgid "Realm"
 msgstr "Realm"
 
@@ -2120,12 +2091,6 @@ msgstr "Registrazione dei dati"
 
 msgid "Recording extension"
 msgstr "Interno di registrazione"
-
-msgid "Referee"
-msgstr "Riferito"
-
-msgid "Referrer"
-msgstr "Referente"
 
 msgid "Register"
 msgstr "Register"


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
KamAccCdrsBrand.yaml removal in 6d98d6287745869640e5d1876f376c0397a14b69 broke translations tests.

This PR aims to fix it.