### PR TITLE
core: fix terminal model template backup overwrite

### DIFF
--- a/library/Ivoz/Provider/Domain/Service/TerminalModel/PersistTemplates.php
+++ b/library/Ivoz/Provider/Domain/Service/TerminalModel/PersistTemplates.php
@@ -90,6 +90,12 @@ class PersistTemplates implements TerminalModelLifecycleEventHandlerInterface
         $fileExists = $this->fs->exists($fileRoute);
 
         if ($fileExists) {
+            $backupExists = $this->fs->exists($fileRoute . '.back');
+            if ($backupExists) {
+                $this->fs->remove(
+                    $fileRoute . '.back'
+                );
+            }
             $this->fs->rename(
                 $fileRoute,
                 $fileRoute . '.back'

--- a/library/spec/Ivoz/Provider/Domain/Service/TerminalModel/PersistTemplatesSpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Service/TerminalModel/PersistTemplatesSpec.php
@@ -158,6 +158,46 @@ class PersistTemplatesSpec extends ObjectBehavior
 
         $this
             ->fs
+            ->exists($filePath . '.back')
+            ->willReturn(false);
+
+        $this
+            ->fs
+            ->rename(
+                $filePath,
+                $filePath . '.back'
+            )
+            ->shouldBeCalled();
+
+        $this->execute($entity);
+    }
+
+    function it_removes_old_generic_template_backup(
+        TerminalModelInterface $entity
+    ) {
+        $this->prepareNoChangesExampleBase($entity);
+        $this->prepareChangedTemplateExample($entity);
+
+        $filePath = $this->templateStoragePath . '/generic.phtml';
+        $this
+            ->fs
+            ->exists($filePath)
+            ->willReturn(true);
+
+        $this
+            ->fs
+            ->exists($filePath . '.back')
+            ->willReturn(true);
+
+        $this
+            ->fs
+            ->remove(
+                $filePath . '.back'
+            )
+            ->shouldBeCalled();
+
+        $this
+            ->fs
             ->rename(
                 $filePath,
                 $filePath . '.back'
@@ -195,6 +235,46 @@ class PersistTemplatesSpec extends ObjectBehavior
             ->fs
             ->exists($filePath)
             ->willReturn(true);
+
+        $this
+            ->fs
+            ->exists($filePath . '.back')
+            ->willReturn(false);
+
+        $this
+            ->fs
+            ->rename(
+                $filePath,
+                $filePath . '.back'
+            )
+            ->shouldBeCalled();
+
+        $this->execute($entity);
+    }
+
+    function it_removes_old_specific_template_backup(
+        TerminalModelInterface $entity
+    ) {
+        $this->prepareNoChangesExampleBase($entity);
+        $this->prepareChangedTemplateExample($entity, 'specific');
+
+        $filePath = $this->templateStoragePath . '/specific.phtml';
+        $this
+            ->fs
+            ->exists($filePath)
+            ->willReturn(true);
+
+        $this
+            ->fs
+            ->exists($filePath . '.back')
+            ->willReturn(true);
+
+        $this
+            ->fs
+            ->remove(
+                $filePath . '.back'
+            )
+            ->shouldBeCalled();
 
         $this
             ->fs


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
When a Terminal Model provisioning template is saved, the current template is renamed appending a .back to the file. If a file already exists with that name, an error raises because `rename()` is not able to overwrite files.

Following commit deletes the backup file before renaming current to .back, preventing the error.

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
