### PR TITLE
Allow E.164 without plus as inbound number format

### DIFF
--- a/library/Ivoz/Provider/Domain/Service/TransformationRule/GenerateInRules.php
+++ b/library/Ivoz/Provider/Domain/Service/TransformationRule/GenerateInRules.php
@@ -44,7 +44,7 @@ class GenerateInRules
 
         $this->entityPersister->persistDto($ruleDto);
 
-        if (!empty($trunkPrefix)) {
+        if (strlen($trunkPrefix) > 0) {
             $ruleDto = new TransformationRuleDto();
             $ruleDto
                 ->setTransformationRuleSetId($entity->getId())
@@ -57,12 +57,12 @@ class GenerateInRules
             $this->entityPersister->persistDto($ruleDto);
         }
 
-        if (!empty($areaCode)) {
+        if (strlen($areaCode) > 0) {
             $ruleDto = new TransformationRuleDto();
             $ruleDto
                 ->setTransformationRuleSetId($entity->getId())
                 ->setType($type)
-                ->setDescription("From within national to e164")
+                ->setDescription("From within area national to e164")
                 ->setPriority(3)
                 ->setMatchExpr('^([0-9]{' . $nationalSubscriberLen . '})$')
                 ->setReplaceExpr($countryCode . $areaCode . '\1');
@@ -74,8 +74,19 @@ class GenerateInRules
         $ruleDto
             ->setTransformationRuleSetId($entity->getId())
             ->setType($type)
-            ->setDescription("From special national to e164")
+            ->setDescription("From national in e164 without plus to e164")
             ->setPriority(4)
+            ->setMatchExpr("^34([0-9]+)$")
+            ->setReplaceExpr($countryCode . '\1');
+
+        $this->entityPersister->persistDto($ruleDto);
+
+        $ruleDto = new TransformationRuleDto();
+        $ruleDto
+            ->setTransformationRuleSetId($entity->getId())
+            ->setType($type)
+            ->setDescription("From national to e164")
+            ->setPriority(5)
             ->setMatchExpr("^([0-9]+)$")
             ->setReplaceExpr($countryCode . '\1');
 

--- a/library/spec/Ivoz/Provider/Domain/Service/TransformationRule/GenerateInRulesSpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Service/TransformationRule/GenerateInRulesSpec.php
@@ -46,7 +46,7 @@ class GenerateInRulesSpec extends ObjectBehavior
         $this->execute($entity, 'callerin');
     }
 
-    function it_creates_specialNationalToE164_rule(
+    function it_creates_nationalToE164_rule(
         TransformationRuleSetInterface $entity,
         CountryInterface $country
     ) {
@@ -57,7 +57,7 @@ class GenerateInRulesSpec extends ObjectBehavior
             ->persistDto(Argument::any())
             ->willReturn(null);
 
-        $this->prepareSpecialNationalToE164Prophecy();
+        $this->prepareNationalToE164Prophecy();
 
         $this->execute($entity, 'callerin');
     }
@@ -98,7 +98,7 @@ class GenerateInRulesSpec extends ObjectBehavior
             ->persistDto(Argument::any())
             ->willReturn(null);
 
-        $this->prepareOutOfAreaNationalToE164Prophecy($trunkPrefix, false);
+        $this->prepareOutOfAreaNationalToE164Prophecy($trunkPrefix, true);
 
         $this->execute($entity, 'callerin');
     }
@@ -245,7 +245,7 @@ class GenerateInRulesSpec extends ObjectBehavior
         $nationalToE164
             ->setTransformationRuleSetId(1)
             ->setType('callerin')
-            ->setDescription("From within national to e164")
+            ->setDescription("From within area national to e164")
             ->setPriority(3)
             ->setMatchExpr('^([0-9]{' . $nationalSubscriberLen . '})$')
             ->setReplaceExpr('34' . $areaCode . '\1');
@@ -253,14 +253,14 @@ class GenerateInRulesSpec extends ObjectBehavior
         $this->setExpectedOutcome($nationalToE164, $shouldHappen);
     }
 
-    private function prepareSpecialNationalToE164Prophecy()
+    private function prepareNationalToE164Prophecy()
     {
         $nationalToE164 = new TransformationRuleDto();
         $nationalToE164
             ->setTransformationRuleSetId(1)
             ->setType('callerin')
-            ->setDescription("From special national to e164")
-            ->setPriority(4)
+            ->setDescription("From national to e164")
+            ->setPriority(5)
             ->setMatchExpr('^([0-9]+)$')
             ->setReplaceExpr('34\1');
 

--- a/schema/app/DoctrineMigrations/Version20191127124853.php
+++ b/schema/app/DoctrineMigrations/Version20191127124853.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20191127124853 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+
+        // Change current 4 priority to 5
+        $this->addSql('UPDATE TransformationRules TR
+                            INNER JOIN TransformationRuleSets TRS ON TRS.id = TR.transformationRuleSetId
+                            SET priority = 5
+                            WHERE TRS.brandId IS NULL
+                                AND TR.type LIKE "%in"
+                                AND TR.priority = 4');
+
+        // Insert new priority 4
+        $this->addSql("INSERT INTO TransformationRules (
+                                type,
+                                description,
+                                priority,
+                                matchExpr,
+                                replaceExpr,
+                                transformationRuleSetId
+                            ) SELECT
+                                'callerin',
+                                'From national in e164 without plus to e164',
+                                4,
+                                CONCAT('^', SUBSTR(C.countryCode,2), '([0-9]+)$'),
+                                CONCAT(C.countryCode, '\\\\1'),
+                                TRS.id
+                                FROM TransformationRuleSets TRS
+                                INNER JOIN Countries C ON C.id = TRS.countryId
+                                    WHERE brandId IS NULL"
+        );
+
+        $this->addSql("INSERT INTO TransformationRules (
+                                type,
+                                description,
+                                priority,
+                                matchExpr,
+                                replaceExpr,
+                                transformationRuleSetId
+                            ) SELECT
+                                'calleein',
+                                'From national in e164 without plus to e164',
+                                4,
+                                CONCAT('^', SUBSTR(C.countryCode,2), '([0-9]+)$'),
+                                CONCAT(C.countryCode, '\\\\1'),
+                                TRS.id
+                                FROM TransformationRuleSets TRS
+                                INNER JOIN Countries C ON C.id = TRS.countryId
+                                    WHERE brandId IS NULL"
+        );
+
+        // Fix descriptions
+        $this->addSql("UPDATE TransformationRules SET description='From national to e164' WHERE description='From special national to e164'");
+        $this->addSql("UPDATE TransformationRules SET description='From e164 to national' WHERE description='From e164 to special national'");
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('DELETE TR
+                            FROM TransformationRules TR
+                            INNER JOIN TransformationRuleSets TRS ON TRS.id = TR.transformationRuleSetId
+                            WHERE TRS.brandId IS NULL
+                                AND TR.type LIKE "%in"
+                                AND TR.priority = 4');
+        $this->addSql('UPDATE TransformationRules TR
+                            INNER JOIN TransformationRuleSets TRS ON TRS.id = TR.transformationRuleSetId
+                            SET priority = 4
+                            WHERE TRS.brandId IS NULL
+                                AND TR.type LIKE "%in"
+                                AND TR.priority = 5');
+
+        $this->addSql("UPDATE TransformationRules SET description='From special national to e164' WHERE description='From national to e164'");
+        $this->addSql("UPDATE TransformationRules SET description='From e164 to special national' WHERE description='From e164 to national'");
+    }
+}

--- a/web/admin/application/configs/klear/TransformationRulesList.yaml
+++ b/web/admin/application/configs/klear/TransformationRulesList.yaml
@@ -9,6 +9,10 @@ production:
   screens: &transformationRules_screensLink
     transformationRulesList_screen: &transformationRulesList_screenLink
       controller: list
+      order:
+        field:
+        - TransformationRule.priority
+        type: asc
       pagination:
         items: 25
       class: ui-silk-shape-rotate-anticlockwise


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

Calling in E.164 without + as national format caused transformations problems:

e.g. 34945945945 instead of 945945945 lead to +3434945945945

Current rules assumed that caller uses agreed formats, but some didn't. This new rules are more flexible.

#### Additional information

This PR changes both rules generators and predefined existing rules.