### PR TITLE
web/rest: do not join tables on zero depth responses (collections usu…

### DIFF
--- a/library/Ivoz/Api/Doctrine/Orm/Extension/DynamicLoadingExtension.php
+++ b/library/Ivoz/Api/Doctrine/Orm/Extension/DynamicLoadingExtension.php
@@ -157,7 +157,23 @@ final class DynamicLoadingExtension implements QueryItemExtensionInterface, Quer
         int &$joinCount = 0,
         int $currentDepth = null
     ) {
-        $currentDepth = $currentDepth > 0 ? $currentDepth - 1 : $currentDepth;
+        if (is_null($currentDepth)) {
+            $isCollection = isset($context['collection']) && $context['collection'] === 'collection';
+            $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
+
+            $currentDepth = isset($context['item_operation_name'])
+                ? $resourceMetadata->getItemOperationAttribute($context['item_operation_name'], 'depth', 1)
+                : $resourceMetadata->getCollectionOperationAttribute($context['collection_operation_name'], 'depth', 0);
+
+            if ($currentDepth < 1) {
+                return;
+            }
+        } else {
+            $currentDepth = $currentDepth > 0
+                ? $currentDepth - 1
+                : $currentDepth;
+        }
+
         $entityManager = $queryBuilder->getEntityManager();
         $classMetadata = $entityManager->getClassMetadata($resourceClass);
         $targetProperties = $this->getTargetPropertiesByContext($resourceClass, $context);

--- a/library/Ivoz/Api/Doctrine/Orm/Extension/UnpaginatedResultGeneratorExtension.php
+++ b/library/Ivoz/Api/Doctrine/Orm/Extension/UnpaginatedResultGeneratorExtension.php
@@ -2,25 +2,18 @@
 
 namespace Ivoz\Api\Doctrine\Orm\Extension;
 
-use ApiPlatform\Core\Bridge\Doctrine\Orm\AbstractPaginator;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Extension\ContextAwareQueryResultCollectionExtensionInterface;
-use ApiPlatform\Core\Bridge\Doctrine\Orm\Paginator;
-use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryChecker;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
-use ApiPlatform\Core\Exception\InvalidArgumentException;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
-use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\QueryBuilder;
-use Doctrine\ORM\Tools\Pagination\Paginator as DoctrineOrmPaginator;
-use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 final class UnpaginatedResultGeneratorExtension implements ContextAwareQueryResultCollectionExtensionInterface
 {
-    const BATCH_SIZE = 1000;
+    const BATCH_SIZE = 4000;
 
     private $requestStack;
     private $resourceMetadataFactory;
@@ -114,6 +107,7 @@ final class UnpaginatedResultGeneratorExtension implements ContextAwareQueryResu
 
             $query = $queryBuilder->getQuery();
             $results = $query->getResult();
+
             $continue = count($results) === self::BATCH_SIZE;
             $currentPage++;
 


### PR DESCRIPTION
- Do not join tables on zero depth responses (collections usually)
- Increase batch size on unpaginated requests

Some metrics (64000 BillableCall to csv through API):
251.2 sec - 43.3mb <-- original results
91.8 seg - 16.2 mb <- optimized queries
86.1 seg - 44.6 mb <- batch size from 1000 to 4000

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
