### PR TITLE
core: bump symfony/symfony from 3.4.32 to 3.4.36

### DIFF
--- a/asterisk/agi/composer.lock
+++ b/asterisk/agi/composer.lock
@@ -2175,11 +2175,11 @@
         },
         {
             "name": "psr/log",
-            "version": "1.1.0.0",
+            "version": "1.1.1.0",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/psr/log",
-                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
+                "reference": "bf73deb2b3b896a9d9c75f3f0d88185d2faa27e2",
                 "shasum": null
             },
             "require": {
@@ -2188,7 +2188,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
@@ -3120,11 +3120,11 @@
         },
         {
             "name": "symfony/symfony",
-            "version": "3.4.32.0",
+            "version": "3.4.36.0",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/symfony/symfony",
-                "reference": "2815d1fa34d417b8b87450667f166edbefff3177",
+                "reference": "0a6fccb5772ad2467253e6849d589bd09d9eb195",
                 "shasum": null
             },
             "require": {
@@ -3146,6 +3146,7 @@
                 "twig/twig": "^1.41|^2.10"
             },
             "conflict": {
+                "monolog/monolog": ">=2",
                 "phpdocumentor/reflection-docblock": "<3.0||>=3.2.0,<3.2.2",
                 "phpdocumentor/type-resolver": "<0.3.0",
                 "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"

--- a/library/composer.lock
+++ b/library/composer.lock
@@ -3856,16 +3856,16 @@
         },
         {
             "name": "symfony/symfony",
-            "version": "v3.4.32",
+            "version": "v3.4.36",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/symfony.git",
-                "reference": "2815d1fa34d417b8b87450667f166edbefff3177"
+                "reference": "0a6fccb5772ad2467253e6849d589bd09d9eb195"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/symfony/zipball/2815d1fa34d417b8b87450667f166edbefff3177",
-                "reference": "2815d1fa34d417b8b87450667f166edbefff3177",
+                "url": "https://api.github.com/repos/symfony/symfony/zipball/0a6fccb5772ad2467253e6849d589bd09d9eb195",
+                "reference": "0a6fccb5772ad2467253e6849d589bd09d9eb195",
                 "shasum": ""
             },
             "require": {
@@ -3887,6 +3887,7 @@
                 "twig/twig": "^1.41|^2.10"
             },
             "conflict": {
+                "monolog/monolog": ">=2",
                 "phpdocumentor/reflection-docblock": "<3.0||>=3.2.0,<3.2.2",
                 "phpdocumentor/type-resolver": "<0.3.0",
                 "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
@@ -4007,7 +4008,7 @@
             "keywords": [
                 "framework"
             ],
-            "time": "2019-10-07T14:42:16+00:00"
+            "time": "2019-12-01T13:50:53+00:00"
         },
         {
             "name": "twig/twig",
@@ -5029,6 +5030,7 @@
             ],
             "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
             "homepage": "https://github.com/container-interop/container-interop",
+            "abandoned": "psr/container",
             "time": "2017-02-14T19:40:03+00:00"
         },
         {

--- a/microservices/balances/composer.lock
+++ b/microservices/balances/composer.lock
@@ -2099,11 +2099,11 @@
         },
         {
             "name": "psr/log",
-            "version": "1.1.0.0",
+            "version": "1.1.1.0",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/psr/log",
-                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
+                "reference": "bf73deb2b3b896a9d9c75f3f0d88185d2faa27e2",
                 "shasum": null
             },
             "require": {
@@ -2112,7 +2112,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
@@ -3044,11 +3044,11 @@
         },
         {
             "name": "symfony/symfony",
-            "version": "3.4.32.0",
+            "version": "3.4.36.0",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/symfony/symfony",
-                "reference": "2815d1fa34d417b8b87450667f166edbefff3177",
+                "reference": "0a6fccb5772ad2467253e6849d589bd09d9eb195",
                 "shasum": null
             },
             "require": {
@@ -3070,6 +3070,7 @@
                 "twig/twig": "^1.41|^2.10"
             },
             "conflict": {
+                "monolog/monolog": ">=2",
                 "phpdocumentor/reflection-docblock": "<3.0||>=3.2.0,<3.2.2",
                 "phpdocumentor/type-resolver": "<0.3.0",
                 "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"

--- a/microservices/recordings/composer.lock
+++ b/microservices/recordings/composer.lock
@@ -2128,11 +2128,11 @@
         },
         {
             "name": "psr/log",
-            "version": "1.1.0.0",
+            "version": "1.1.1.0",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/psr/log",
-                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
+                "reference": "bf73deb2b3b896a9d9c75f3f0d88185d2faa27e2",
                 "shasum": null
             },
             "require": {
@@ -2141,7 +2141,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
@@ -3073,11 +3073,11 @@
         },
         {
             "name": "symfony/symfony",
-            "version": "3.4.32.0",
+            "version": "3.4.36.0",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/symfony/symfony",
-                "reference": "2815d1fa34d417b8b87450667f166edbefff3177",
+                "reference": "0a6fccb5772ad2467253e6849d589bd09d9eb195",
                 "shasum": null
             },
             "require": {
@@ -3099,6 +3099,7 @@
                 "twig/twig": "^1.41|^2.10"
             },
             "conflict": {
+                "monolog/monolog": ">=2",
                 "phpdocumentor/reflection-docblock": "<3.0||>=3.2.0,<3.2.2",
                 "phpdocumentor/type-resolver": "<0.3.0",
                 "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"

--- a/microservices/scheduler/composer.lock
+++ b/microservices/scheduler/composer.lock
@@ -2099,11 +2099,11 @@
         },
         {
             "name": "psr/log",
-            "version": "1.1.0.0",
+            "version": "1.1.1.0",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/psr/log",
-                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
+                "reference": "bf73deb2b3b896a9d9c75f3f0d88185d2faa27e2",
                 "shasum": null
             },
             "require": {
@@ -2112,7 +2112,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
@@ -3044,11 +3044,11 @@
         },
         {
             "name": "symfony/symfony",
-            "version": "3.4.32.0",
+            "version": "3.4.36.0",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/symfony/symfony",
-                "reference": "2815d1fa34d417b8b87450667f166edbefff3177",
+                "reference": "0a6fccb5772ad2467253e6849d589bd09d9eb195",
                 "shasum": null
             },
             "require": {
@@ -3070,6 +3070,7 @@
                 "twig/twig": "^1.41|^2.10"
             },
             "conflict": {
+                "monolog/monolog": ">=2",
                 "phpdocumentor/reflection-docblock": "<3.0||>=3.2.0,<3.2.2",
                 "phpdocumentor/type-resolver": "<0.3.0",
                 "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"

--- a/microservices/workers/composer.lock
+++ b/microservices/workers/composer.lock
@@ -2309,11 +2309,11 @@
         },
         {
             "name": "psr/log",
-            "version": "1.1.0.0",
+            "version": "1.1.1.0",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/psr/log",
-                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
+                "reference": "bf73deb2b3b896a9d9c75f3f0d88185d2faa27e2",
                 "shasum": null
             },
             "require": {
@@ -2322,7 +2322,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
@@ -3254,11 +3254,11 @@
         },
         {
             "name": "symfony/symfony",
-            "version": "3.4.32.0",
+            "version": "3.4.36.0",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/symfony/symfony",
-                "reference": "2815d1fa34d417b8b87450667f166edbefff3177",
+                "reference": "0a6fccb5772ad2467253e6849d589bd09d9eb195",
                 "shasum": null
             },
             "require": {
@@ -3280,6 +3280,7 @@
                 "twig/twig": "^1.41|^2.10"
             },
             "conflict": {
+                "monolog/monolog": ">=2",
                 "phpdocumentor/reflection-docblock": "<3.0||>=3.2.0,<3.2.2",
                 "phpdocumentor/type-resolver": "<0.3.0",
                 "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"

--- a/schema/composer.json
+++ b/schema/composer.json
@@ -61,7 +61,7 @@
         "php": ">=7.0.19",
         "doctrine/doctrine-migrations-bundle": "^1.2",
         "doctrine/orm": "^2.5",
-        "gesdinet/jwt-refresh-token-bundle": "^0.4.0",
+        "gesdinet/jwt-refresh-token-bundle": "^0.6.2",
         "graze/guzzle-jsonrpc": "3.2.*",
         "guzzlehttp/guzzle": "^6.3",
         "incenteev/composer-parameter-handler": "^2.0",

--- a/schema/composer.lock
+++ b/schema/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "37799e3afa209d8d6a77441fae52978b",
+    "content-hash": "3913b3a9fbd04cae61473e9986416daf",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -1135,23 +1135,24 @@
         },
         {
             "name": "gesdinet/jwt-refresh-token-bundle",
-            "version": "0.4.0.0",
+            "version": "0.6.2.0",
             "dist": {
                 "type": "path",
                 "url": "../library/vendor/gesdinet/jwt-refresh-token-bundle",
-                "reference": "95292f16e25b06a8d5a5e70c0dc38b2214df8849",
+                "reference": "9b9a9f8cf5fdc48dacb012929dc01cdf05b6badf",
                 "shasum": null
             },
             "require": {
-                "doctrine/doctrine-bundle": "~1.4",
-                "doctrine/orm": "^2.4.8",
                 "lexik/jwt-authentication-bundle": "^1.1|^2.0@dev",
-                "php": ">=5.3.3",
-                "symfony/framework-bundle": "~3.3|~4.0",
-                "symfony/validator": "~3.3|~4.0"
+                "php": "^5.5.9|>=7.0.8",
+                "symfony/framework-bundle": "~3.4|~4.0",
+                "symfony/validator": "~3.4|~4.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^4.0"
+                "doctrine/doctrine-bundle": "~1.4",
+                "doctrine/mongodb-odm-bundle": "^3.4",
+                "doctrine/orm": "^2.4.8",
+                "phpspec/phpspec": "^3.0|^4.0"
             },
             "type": "symfony-bundle",
             "extra": {
@@ -2199,11 +2200,11 @@
         },
         {
             "name": "psr/log",
-            "version": "1.1.0.0",
+            "version": "1.1.1.0",
             "dist": {
                 "type": "path",
                 "url": "../library/vendor/psr/log",
-                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
+                "reference": "bf73deb2b3b896a9d9c75f3f0d88185d2faa27e2",
                 "shasum": null
             },
             "require": {
@@ -2212,7 +2213,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
@@ -3144,11 +3145,11 @@
         },
         {
             "name": "symfony/symfony",
-            "version": "3.4.32.0",
+            "version": "3.4.36.0",
             "dist": {
                 "type": "path",
                 "url": "../library/vendor/symfony/symfony",
-                "reference": "2815d1fa34d417b8b87450667f166edbefff3177",
+                "reference": "0a6fccb5772ad2467253e6849d589bd09d9eb195",
                 "shasum": null
             },
             "require": {
@@ -3170,6 +3171,7 @@
                 "twig/twig": "^1.41|^2.10"
             },
             "conflict": {
+                "monolog/monolog": ">=2",
                 "phpdocumentor/reflection-docblock": "<3.0||>=3.2.0,<3.2.2",
                 "phpdocumentor/type-resolver": "<0.3.0",
                 "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
@@ -5027,11 +5029,11 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.1.0",
+            "version": "3.3.2.0",
             "dist": {
                 "type": "path",
                 "url": "../library/vendor/squizlabs/php_codesniffer",
-                "reference": "82cd0f854ceca17731d6d019c7098e3755c45060",
+                "reference": "6ad28354c04b364c3c71a34e4a18b629cc3b231e",
                 "shasum": null
             },
             "require": {
@@ -5063,7 +5065,7 @@
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "homepage": "http://www.squizlabs.com/php-codesniffer",
             "keywords": [
                 "phpcs",
                 "standards"
@@ -5079,11 +5081,11 @@
         },
         {
             "name": "symfony/phpunit-bridge",
-            "version": "dev-master",
+            "version": "3.4.35.0",
             "dist": {
                 "type": "path",
                 "url": "../library/vendor/symfony/phpunit-bridge",
-                "reference": "76e013a98031356604e5a730c9eb22713dc4dda4",
+                "reference": "cbea8818e9f34e4e9d780bd22bdda21b57d4d5c7",
                 "shasum": null
             },
             "require": {
@@ -5093,7 +5095,6 @@
                 "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
             },
             "suggest": {
-                "ext-zip": "Zip support is required when using bin/simple-phpunit",
                 "symfony/debug": "For tracking deprecated interfaces usages at runtime with DebugClassLoader"
             },
             "bin": [

--- a/web/rest/brand/composer.lock
+++ b/web/rest/brand/composer.lock
@@ -2531,11 +2531,11 @@
         },
         {
             "name": "psr/log",
-            "version": "1.1.0.0",
+            "version": "1.1.1.0",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/psr/log",
-                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
+                "reference": "bf73deb2b3b896a9d9c75f3f0d88185d2faa27e2",
                 "shasum": null
             },
             "require": {
@@ -2544,7 +2544,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
@@ -3566,11 +3566,11 @@
         },
         {
             "name": "symfony/symfony",
-            "version": "3.4.32.0",
+            "version": "3.4.36.0",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/symfony/symfony",
-                "reference": "2815d1fa34d417b8b87450667f166edbefff3177",
+                "reference": "0a6fccb5772ad2467253e6849d589bd09d9eb195",
                 "shasum": null
             },
             "require": {
@@ -3592,6 +3592,7 @@
                 "twig/twig": "^1.41|^2.10"
             },
             "conflict": {
+                "monolog/monolog": ">=2",
                 "phpdocumentor/reflection-docblock": "<3.0||>=3.2.0,<3.2.2",
                 "phpdocumentor/type-resolver": "<0.3.0",
                 "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
@@ -6588,7 +6589,7 @@
         },
         {
             "name": "symfony/phpunit-bridge",
-            "version": "3.4.32.0",
+            "version": "3.4.35.0",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/symfony/phpunit-bridge",

--- a/web/rest/client/composer.lock
+++ b/web/rest/client/composer.lock
@@ -2531,11 +2531,11 @@
         },
         {
             "name": "psr/log",
-            "version": "1.1.0.0",
+            "version": "1.1.1.0",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/psr/log",
-                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
+                "reference": "bf73deb2b3b896a9d9c75f3f0d88185d2faa27e2",
                 "shasum": null
             },
             "require": {
@@ -2544,7 +2544,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
@@ -3566,11 +3566,11 @@
         },
         {
             "name": "symfony/symfony",
-            "version": "3.4.32.0",
+            "version": "3.4.36.0",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/symfony/symfony",
-                "reference": "2815d1fa34d417b8b87450667f166edbefff3177",
+                "reference": "0a6fccb5772ad2467253e6849d589bd09d9eb195",
                 "shasum": null
             },
             "require": {
@@ -3592,6 +3592,7 @@
                 "twig/twig": "^1.41|^2.10"
             },
             "conflict": {
+                "monolog/monolog": ">=2",
                 "phpdocumentor/reflection-docblock": "<3.0||>=3.2.0,<3.2.2",
                 "phpdocumentor/type-resolver": "<0.3.0",
                 "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
@@ -6588,7 +6589,7 @@
         },
         {
             "name": "symfony/phpunit-bridge",
-            "version": "3.4.32.0",
+            "version": "3.4.35.0",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/symfony/phpunit-bridge",

--- a/web/rest/platform/composer.lock
+++ b/web/rest/platform/composer.lock
@@ -2531,11 +2531,11 @@
         },
         {
             "name": "psr/log",
-            "version": "1.1.0.0",
+            "version": "1.1.1.0",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/psr/log",
-                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
+                "reference": "bf73deb2b3b896a9d9c75f3f0d88185d2faa27e2",
                 "shasum": null
             },
             "require": {
@@ -2544,7 +2544,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
@@ -3566,11 +3566,11 @@
         },
         {
             "name": "symfony/symfony",
-            "version": "3.4.32.0",
+            "version": "3.4.36.0",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/symfony/symfony",
-                "reference": "2815d1fa34d417b8b87450667f166edbefff3177",
+                "reference": "0a6fccb5772ad2467253e6849d589bd09d9eb195",
                 "shasum": null
             },
             "require": {
@@ -3592,6 +3592,7 @@
                 "twig/twig": "^1.41|^2.10"
             },
             "conflict": {
+                "monolog/monolog": ">=2",
                 "phpdocumentor/reflection-docblock": "<3.0||>=3.2.0,<3.2.2",
                 "phpdocumentor/type-resolver": "<0.3.0",
                 "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
@@ -6588,7 +6589,7 @@
         },
         {
             "name": "symfony/phpunit-bridge",
-            "version": "3.4.32.0",
+            "version": "3.4.35.0",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/symfony/phpunit-bridge",


### PR DESCRIPTION
Fixes some vulnerabilities 
- https://github.com/advisories/GHSA-xhh6-956q-4q69
- https://github.com/advisories/GHSA-79gr-58r3-pwm3

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
