### PR TITLE
core: filter billable calls with direction instead of carrierId

### DIFF
--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/BillableCallDoctrineRepository.php
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/BillableCallDoctrineRepository.php
@@ -306,8 +306,7 @@ class BillableCallDoctrineRepository extends ServiceEntityRepository implements 
             ['company', 'eq', $companyId],
             ['brand', 'eq', $brandId],
             ['startTime', 'gt', $startTime],
-            ['carrier', 'neq', null],
-            ['carrier', 'neq', ''],
+            ['direction', 'eq', BillableCallInterface::DIRECTION_OUTBOUND],
             'or' => [
                 ['price', 'isNull'],
                 ['price', 'lt', 0],


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

Call that should have price where guessed looking at _carrierId_ field. As incoming calls tarification is no longer supported, this PR stops looking at _carrierId_ and looks at outbound direction calls only.