### PR TITLE
web/admin: hide call registry for non vpbx

### DIFF
--- a/doc/sphinx/administration_portal/client/residential/calls/call_registry.rst
+++ b/doc/sphinx/administration_portal/client/residential/calls/call_registry.rst
@@ -1,1 +1,0 @@
-.. include:: ../../vpbx/calls/call_registry.rst

--- a/doc/sphinx/administration_portal/client/residential/calls/index.rst
+++ b/doc/sphinx/administration_portal/client/residential/calls/index.rst
@@ -8,7 +8,6 @@ These are the call-list sections for residential clients:
     :maxdepth: 1
     :titlesonly:
 
-    call_registry
     external_calls
     call_csv_schedulers
     call_recordings

--- a/doc/sphinx/administration_portal/client/retail/calls/call_registry.rst
+++ b/doc/sphinx/administration_portal/client/retail/calls/call_registry.rst
@@ -1,1 +1,0 @@
-.. include:: ../../vpbx/calls/call_registry.rst

--- a/doc/sphinx/administration_portal/client/retail/calls/index.rst
+++ b/doc/sphinx/administration_portal/client/retail/calls/index.rst
@@ -8,7 +8,6 @@ These are the call-list sections for retail clients:
     :maxdepth: 1
     :titlesonly:
 
-    call_registry
     external_calls
     call_csv_schedulers
     call_recordings

--- a/web/admin/application/configs/klear/klear.yaml
+++ b/web/admin/application/configs/klear/klear.yaml
@@ -457,7 +457,7 @@ production:
               title: _('Call registry')
               class: ui-silk-application-view-list-telephone
               description: _("List of %s", ngettext('Call', 'Calls', 0))
-              showOnlyIf: ${auth.companyNotWholesale}
+              showOnlyIf: ${auth.companyVPBX}
             BillableCallsClientList:
               title: ngettext('External call', 'External calls', 0)
               description: _("List of %s", ngettext('External call', 'External calls', 0))


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

_kam_users_cdrs_ stores client side CDRs. For wholesale, retail and residential clients this information is nearly redundant with that in _kam_trunks_cdrs_, as they have no internal call concept.

This PR hides just hide _Call Registries_ web sections. An upcoming PR will avoid this information being stored at all.
