### PR TITLE
kamtrunks: handle incoming calls to T.38 retail accounts

### DIFF
--- a/asterisk/agi/src/Agi/Action/DdiAction.php
+++ b/asterisk/agi/src/Agi/Action/DdiAction.php
@@ -152,6 +152,7 @@ class DdiAction
             ->setRouteFriendDestination($ddi->getFriendValue())
             ->setRouteQueue($ddi->getQueue())
             ->setRouteResidential($ddi->getResidentialDevice())
+            ->setRouteRetail($ddi->getRetailAccount())
             ->setRouteConditional($ddi->getConditionalRoute())
             ->route();
     }

--- a/asterisk/agi/src/Agi/Action/RetailCallAction.php
+++ b/asterisk/agi/src/Agi/Action/RetailCallAction.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Agi\Action;
+
+use Agi\Wrapper;
+use Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface;
+
+class RetailCallAction
+{
+    /**
+     * @var Wrapper
+     */
+    protected $agi;
+
+    /**
+     * @var RetailAccountInterface
+     */
+    protected $retailAccount;
+
+    /**
+     * RetailCallAction constructor.
+     * @param Wrapper $agi
+     */
+    public function __construct(
+        Wrapper $agi
+    ) {
+        $this->agi = $agi;
+    }
+
+    /**
+     * @param RetailAccountInterface|null $retailAccount
+     * @return $this
+     */
+    public function setRetailAccount(RetailAccountInterface $retailAccount = null)
+    {
+        $this->retailAccount = $retailAccount;
+        return $this;
+    }
+
+    public function process()
+    {
+        // Local variables to improve readability
+        $retailAccount = $this->retailAccount;
+
+        if (is_null($retailAccount)) {
+            $this->agi->error("Retail Account is not properly defined. Check configuration.");
+            return;
+        }
+
+        // Get dialed number
+        $number =  $this->agi->getExtension();
+
+        // Some verbose dolan pls
+        $this->agi->notice("Preparing call to %s through account %s", $number, $retailAccount);
+
+        // Get device endpoint
+        $endpointName = $retailAccount->getSorcery();
+
+        // Configure Dial options
+        $timeout = "";
+        $options = "";
+
+        // Call the PSJIP endpoint
+        $this->agi->setVariable("DIAL_EXT", $number);
+        $this->agi->setVariable("DIAL_DST", "PJSIP/$endpointName");
+        $this->agi->setVariable("__DIAL_ENDPOINT", $endpointName);
+        $this->agi->setVariable("DIAL_TIMEOUT", $timeout);
+        $this->agi->setVariable("DIAL_OPTS", $options);
+
+        // Redirect to the calling dialplan context
+        $this->agi->redirect('call-retail', $number);
+    }
+}

--- a/asterisk/agi/src/Agi/Action/RouterAction.php
+++ b/asterisk/agi/src/Agi/Action/RouterAction.php
@@ -18,6 +18,7 @@ use Ivoz\Provider\Domain\Model\Friend\FriendInterface;
 use Ivoz\Provider\Domain\Model\HuntGroup\HuntGroupInterface;
 use Ivoz\Provider\Domain\Model\Ivr\IvrInterface;
 use Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDeviceInterface;
+use Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface;
 use Ivoz\Provider\Domain\Model\User\UserInterface;
 
 class RouterAction
@@ -37,6 +38,7 @@ class RouterAction
     const ConferenceRoom = 'conferenceRoom';
     const Queue          = 'queue';
     const Residential    = 'residential';
+    const Retail         = 'retail';
     const Conditional    = 'conditional';
 
     /**
@@ -120,6 +122,11 @@ class RouterAction
     protected $routeResidential;
 
     /**
+     * @var RetailAccountInterface
+     */
+    protected $routeRetail;
+
+    /**
      * @var ConditionalRouteInterface
      */
     protected $routeConditional;
@@ -185,6 +192,11 @@ class RouterAction
     protected $residentialCallAction;
 
     /**
+     * @var RetailCallAction
+     */
+    protected $retailCallAction;
+
+    /**
      * @var ServiceAction
      */
     protected $serviceAction;
@@ -208,6 +220,7 @@ class RouterAction
         IvrAction $ivrAction,
         QueueAction $queueAction,
         ResidentialCallAction $residentialCallAction,
+        RetailCallAction $retailCallAction,
         ServiceAction $serviceAction,
         VoiceMailAction $voiceMailAction
     ) {
@@ -224,6 +237,7 @@ class RouterAction
         $this->ivrAction = $ivrAction;
         $this->queueAction = $queueAction;
         $this->residentialCallAction = $residentialCallAction;
+        $this->retailCallAction = $retailCallAction;
         $this->serviceAction = $serviceAction;
         $this->voiceMailAction = $voiceMailAction;
     }
@@ -335,6 +349,12 @@ class RouterAction
         return $this;
     }
 
+    public function setRouteRetail(RetailAccountInterface $routeRetail = null)
+    {
+        $this->routeRetail = $routeRetail;
+        return $this;
+    }
+
     public function setRouteFax(FaxInterface $routeFax = null)
     {
         $this->routeFax = $routeFax;
@@ -377,6 +397,9 @@ class RouterAction
                 break;
             case RouterAction::Residential:
                 $this->routeToResidentialDevice();
+                break;
+            case RouterAction::Retail:
+                $this->routeToRetailAccount();
                 break;
             case RouterAction::Conditional:
                 $this->routeToConditionalRoute();
@@ -480,6 +503,13 @@ class RouterAction
     {
         $this->residentialCallAction
             ->setResidentialDevice($this->routeResidential)
+            ->process();
+    }
+
+    protected function routeToRetailAccount()
+    {
+        $this->retailCallAction
+            ->setRetailAccount($this->routeRetail)
             ->process();
     }
 

--- a/asterisk/config/dialplan/default.conf
+++ b/asterisk/config/dialplan/default.conf
@@ -98,6 +98,11 @@ exten => _[+*0-9]!,1,NoOp(Calling ${EXTEN} through ${DIAL_ENDPOINT})
     same => n,Dial(${DIAL_DST},${DIAL_TIMEOUT},${DIAL_OPTS}b(add-headers^${EXTEN}^1))
     same => n,AGI(agi://127.0.0.1:4573/fastagi-runner.php?command=dialplan/residentialstatus)
 
+;; Context for calling through a retail account
+[call-retail]
+exten => _[+*0-9]!,1,NoOp(Calling ${EXTEN} through ${DIAL_ENDPOINT})
+    same => n,Dial(${DIAL_DST},${DIAL_TIMEOUT},${DIAL_OPTS}b(add-headers^${EXTEN}^1))
+
 ;;---------------------------------------------------------------------------------------------------
 ;;------------------------------------[      Subroutines      ]--------------------------------------
 ;;---------------------------------------------------------------------------------------------------

--- a/doc/sphinx/administration_portal/client/retail/retail_accounts.rst
+++ b/doc/sphinx/administration_portal/client/retail/retail_accounts.rst
@@ -98,6 +98,8 @@ This external called will be called whenever the retail account cannot be reache
 
 - Accounts using SIP register: when no answer is received from last contact address or when no active register is found.
 
+.. warning:: Retail accounts marked as T.38 won't have any call forward settings.
+
 Asterisk as a retail account
 ============================
 

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -471,7 +471,6 @@ request_route {
             route(GET_INFO_FROM_MATCHED_DDI);
             route(CONTROL_MAXCALLS);
             route(DISPATCH);
-            route(SETUP_KAMUSERS_CALL);
             route(RTPENGINE);
             route(RELAY);
         } else {
@@ -1257,9 +1256,23 @@ route[WITHINDLG] {
 
 route[DISPATCH] {
     if ($dlg_var(type) == 'retail') {
-        # No AS in retail calls, send to kamusers
-        $du = "sip:users.ivozprovider.local";
-        return;
+        sql_xquery("cb", "SELECT D.retailAccountId, RA.t38Passthrough FROM DDIs D LEFT JOIN RetailAccounts RA ON D.retailAccountId=RA.id WHERE D.DDIE164='$rU'", "rd");
+
+        # Reject call if DDI does not point to any retail account
+        if ($xavp(rd=>retailAccountId) == $null) {
+            xwarn("[$dlg_var(cidhash)] DISPATCH: $rU is not routed to any retail account\n");
+            send_reply("404", "Not Here");
+            exit;
+        }
+
+        # If t38Passthrough is off, route to KamUsers
+        if ($xavp(rd=>t38Passthrough) == "no") {
+            xinfo("[$dlg_var(cidhash)] DISPATCH: Calling to non-T.38 retail account, route to KamUsers\n");
+            route(SETUP_KAMUSERS_CALL);
+            return;
+        } else {
+            xinfo("[$dlg_var(cidhash)] DISPATCH: Calling to T.38 retail account, route to AS\n");
+        }
     }
 
     # Insert header with LogTag
@@ -1295,7 +1308,8 @@ route[DISPATCH] {
 }
 
 route[SETUP_KAMUSERS_CALL] {
-    if ($dlg_var(type) != 'retail') return;
+    # No AS in retail calls, send to kamusers
+    $du = "sip:users.ivozprovider.local";
 
     # Insert X-Info headers for kamusers
     insert_hf("X-Info-BrandId: $dlg_var(brandId)\r\n");

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -1238,7 +1238,7 @@ route[GET_INFO_FROM_CALLEE] {
 }
 
 route[GET_RETAIL_CFW_SETTINGS] {
-    sql_xquery("cb", "SELECT RA.name, D.domain, CONCAT(C.countryCode, CFS.numberValue) AS CfwTarget FROM RetailAccounts RA INNER JOIN Domains D ON RA.domainId=D.id INNER JOIN CallForwardSettings CFS ON CFS.retailAccountId=RA.id INNER JOIN Countries C ON C.id=CFS.numberCountryId WHERE CFS.enabled=1 AND CFS.callForwardType='userNotRegistered' AND RA.id='$dlg_var(retailAccountId)'", "ra");
+    sql_xquery("cb", "SELECT RA.name, D.domain, CONCAT(C.countryCode, CFS.numberValue) AS CfwTarget, RA.t38passthrough FROM RetailAccounts RA INNER JOIN Domains D ON RA.domainId=D.id INNER JOIN CallForwardSettings CFS ON CFS.retailAccountId=RA.id INNER JOIN Countries C ON C.id=CFS.numberCountryId WHERE CFS.enabled=1 AND CFS.callForwardType='userNotRegistered' AND RA.t38passthrough='no' AND RA.id='$dlg_var(retailAccountId)'", "ra");
 
     # Leave if no call forward configured
     if ($xavp(ra=>CfwTarget) == $null) return;

--- a/web/admin/application/configs/klear/RetailAccountsList.yaml
+++ b/web/admin/application/configs/klear/RetailAccountsList.yaml
@@ -177,6 +177,7 @@ production:
       <<: *callForwardSettingsList_screenLink
       filterField: retailAccount
       parentOptionCustomizer:
+        - IvozProvider_Klear_Options_OptionsCustomizer
         - recordCount
       forcedValues:
         callTypeFilter: both

--- a/web/admin/application/library/IvozProvider/Klear/Options/OptionsCustomizer.php
+++ b/web/admin/application/library/IvozProvider/Klear/Options/OptionsCustomizer.php
@@ -121,6 +121,9 @@ class IvozProvider_Klear_Options_OptionsCustomizer implements \KlearMatrix_Model
             case "balanceMovementsList_screen":
                 $show = $this->_parentModel->getCalculateCost();
                 break;
+            case "callForwardSettingsList_screen":
+                $show = $this->_parentModel->getT38Passthrough() == 'no';
+                break;
             case "tarificateCall_dialog":
                 $direction = $this->_parentModel->getDirection();
                 $isOutboundCall = $direction === BillableCallInterface::DIRECTION_OUTBOUND;


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [x] Fixes an existing issue (Fixes #1199)

#### Description

2 changes here:

- If matching DDI belongs to a retail client but is not pointing to any retail
  account, drop call.

- If points to a retail account in T.38 mode, route to AS. Otherwise, route
  to KamUsers directly.
