### PR TITLE
core: skip cgrates calls on cdrmixer/invoicer if cgrates_mode is 1

### DIFF
--- a/library/Ivoz/Core/Infrastructure/Domain/Service/Cgrates/ProcessExternalCdr.php
+++ b/library/Ivoz/Core/Infrastructure/Domain/Service/Cgrates/ProcessExternalCdr.php
@@ -8,31 +8,15 @@ use Ivoz\Core\Application\Service\EntityTools;
 use Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdrDto;
 use Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdrInterface;
 use Psr\Log\LoggerInterface;
-use Zend\EventManager\Exception\DomainException;
 use Ivoz\Kam\Domain\Service\TrunksClientInterface;
 
 class ProcessExternalCdr
 {
     const DATE_FORMAT = 'Y-m-d\TH:i:s\Z';
 
-    /**
-     * @var ApiClient
-     */
     protected $apiClient;
-
-    /**
-     * @var EntityTools
-     */
     protected $entityTools;
-
-    /**
-     * @var TpCdrRepository
-     */
     protected $tpCdrRepository;
-
-    /**
-     * @var LoggerInterface
-     */
     protected $logger;
     protected $trunksClient;
 

--- a/library/Ivoz/Core/Infrastructure/Domain/Service/Cgrates/ProcessExternalCdr.php
+++ b/library/Ivoz/Core/Infrastructure/Domain/Service/Cgrates/ProcessExternalCdr.php
@@ -9,6 +9,7 @@ use Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdrDto;
 use Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdrInterface;
 use Psr\Log\LoggerInterface;
 use Zend\EventManager\Exception\DomainException;
+use Ivoz\Kam\Domain\Service\TrunksClientInterface;
 
 class ProcessExternalCdr
 {
@@ -33,17 +34,20 @@ class ProcessExternalCdr
      * @var LoggerInterface
      */
     protected $logger;
+    protected $trunksClient;
 
     public function __construct(
         ApiClient $apiClient,
         EntityTools $entityTools,
         TpCdrRepository $tpCdrRepository,
-        LoggerInterface $logger
+        LoggerInterface $logger,
+        TrunksClientInterface $trunksClient
     ) {
         $this->entityTools = $entityTools;
         $this->logger = $logger;
         $this->tpCdrRepository = $tpCdrRepository;
         $this->apiClient = $apiClient;
+        $this->trunksClient = $trunksClient;
     }
 
     /**
@@ -60,6 +64,10 @@ class ProcessExternalCdr
 
         $carrier = $trunksCdr->getCarrier();
         if ($carrier && $carrier->getExternallyRated()) {
+            return false;
+        }
+
+        if (!$this->trunksClient->isCgrEnabled()) {
             return false;
         }
 

--- a/library/Ivoz/Core/Infrastructure/Domain/Service/Cgrates/ReloadService.php
+++ b/library/Ivoz/Core/Infrastructure/Domain/Service/Cgrates/ReloadService.php
@@ -2,8 +2,6 @@
 
 namespace Ivoz\Core\Infrastructure\Domain\Service\Cgrates;
 
-use Ivoz\Kam\Domain\Service\TrunksCdr\RerateCallServiceInterface;
-
 class ReloadService extends AbstractApiBasedService
 {
     public function __construct(CgrRpcClient $jsonRpcClient)

--- a/library/Ivoz/Kam/Domain/Service/TrunksClientInterface.php
+++ b/library/Ivoz/Kam/Domain/Service/TrunksClientInterface.php
@@ -13,6 +13,7 @@ interface TrunksClientInterface
     const UAC_REG_INFO_ACTION = 'uac.reg_info';
     const DLG_PROFILE_GET_SIZE = 'dlg.profile_get_size';
     const RTPENGINE_RELOAD_ACTION = 'rtpengine.reload';
+    const CGRATES_ENABLED_ACTION = 'cfg.get';
 
     const TRUNKS_ACTIONS = [
         self::DIALPLAN_RELOAD_ACTION,
@@ -42,6 +43,8 @@ interface TrunksClientInterface
      * @return int
      */
     public function getPlatformActiveCalls();
+
+    public function isCgrEnabled();
 
     public function reloadDialplan();
 

--- a/library/Ivoz/Kam/Infrastructure/Kamailio/TrunksClient.php
+++ b/library/Ivoz/Kam/Infrastructure/Kamailio/TrunksClient.php
@@ -162,6 +162,23 @@ class TrunksClient implements TrunksClientInterface
         return $response->result;
     }
 
+    public function isCgrEnabled()
+    {
+        $response = $this->sendRequest(
+            self::CGRATES_ENABLED_ACTION,
+            [
+                'config',
+                'cgrates_mode'
+            ]
+        );
+
+        if (!isset($response->result)) {
+            return -1;
+        }
+
+        return $response->result === 0;
+    }
+
     /**
      * @param string $method
      * @param array $payload

--- a/library/Ivoz/Provider/Domain/Service/Invoice/AutoRateCalls.php
+++ b/library/Ivoz/Provider/Domain/Service/Invoice/AutoRateCalls.php
@@ -4,6 +4,7 @@ namespace Ivoz\Provider\Domain\Service\Invoice;
 
 use Ivoz\Core\Application\Service\EntityTools;
 use Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdrRepository;
+use Ivoz\Kam\Domain\Service\TrunksClientInterface;
 use Ivoz\Provider\Domain\Model\BillableCall\BillableCallRepository;
 use Ivoz\Provider\Domain\Model\Invoice\Invoice;
 use Ivoz\Provider\Domain\Model\Invoice\InvoiceInterface;
@@ -19,17 +20,20 @@ class AutoRateCalls implements InvoiceLifecycleEventHandlerInterface
     protected $rerateCallService;
     protected $migrateFromTrunksCdr;
     protected $entityTools;
+    protected $trunksClient;
 
     public function __construct(
         BillableCallRepository $billableCallRepository,
         RerateCallServiceInterface $rerateCallService,
         MigrateFromTrunksCdr $migrateFromTrunksCdr,
-        EntityTools $entityTools
+        EntityTools $entityTools,
+        TrunksClientInterface $trunksClient
     ) {
         $this->billableCallRepository = $billableCallRepository;
         $this->rerateCallService = $rerateCallService;
         $this->migrateFromTrunksCdr = $migrateFromTrunksCdr;
         $this->entityTools = $entityTools;
+        $this->trunksClient = $trunksClient;
     }
 
     public static function getSubscribedEvents()
@@ -45,6 +49,10 @@ class AutoRateCalls implements InvoiceLifecycleEventHandlerInterface
     public function execute(InvoiceInterface $invoice)
     {
         if (!$invoice->getScheduler()) {
+            return;
+        }
+
+        if (!$this->trunksClient->isCgrEnabled()) {
             return;
         }
 

--- a/library/Ivoz/Provider/Domain/Service/Invoice/AutoRateCalls.php
+++ b/library/Ivoz/Provider/Domain/Service/Invoice/AutoRateCalls.php
@@ -3,12 +3,9 @@
 namespace Ivoz\Provider\Domain\Service\Invoice;
 
 use Ivoz\Core\Application\Service\EntityTools;
-use Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdrRepository;
 use Ivoz\Kam\Domain\Service\TrunksClientInterface;
 use Ivoz\Provider\Domain\Model\BillableCall\BillableCallRepository;
-use Ivoz\Provider\Domain\Model\Invoice\Invoice;
 use Ivoz\Provider\Domain\Model\Invoice\InvoiceInterface;
-use Ivoz\Provider\Domain\Model\Invoice\InvoiceRepository;
 use Ivoz\Kam\Domain\Service\TrunksCdr\RerateCallServiceInterface;
 use Ivoz\Provider\Domain\Service\BillableCall\MigrateFromTrunksCdr;
 

--- a/library/spec/Ivoz/Core/Infrastructure/Domain/Service/Cgrates/ProcessExternalCdrSpec.php
+++ b/library/spec/Ivoz/Core/Infrastructure/Domain/Service/Cgrates/ProcessExternalCdrSpec.php
@@ -4,62 +4,49 @@ namespace spec\Ivoz\Core\Infrastructure\Domain\Service\Cgrates;
 
 use Ivoz\Cgr\Domain\Model\TpCdr\TpCdrInterface;
 use Ivoz\Cgr\Domain\Model\TpCdr\TpCdrRepository;
-use Ivoz\Cgr\Infrastructure\Persistence\Doctrine\TpCdrDoctrineRepository;
 use Ivoz\Core\Application\Service\EntityTools;
+use Ivoz\Core\Infrastructure\Domain\Service\Cgrates\ApiClient;
 use Ivoz\Core\Infrastructure\Domain\Service\Cgrates\ProcessExternalCdr;
 use Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdrDto;
+use Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdrInterface;
 use Ivoz\Provider\Domain\Model\Brand\BrandInterface;
 use Ivoz\Provider\Domain\Model\Carrier\CarrierInterface;
 use Ivoz\Provider\Domain\Model\Company\CompanyInterface;
+use Ivoz\Kam\Domain\Service\TrunksClientInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
-use Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdrInterface;
-use Graze\GuzzleHttp\JsonRpc\ClientInterface;
-use Prophecy\Prophet;
 use Psr\Log\LoggerInterface;
 use spec\HelperTrait;
-use Ivoz\Core\Infrastructure\Domain\Service\Cgrates\ApiClient;
 
 class ProcessExternalCdrSpec extends ObjectBehavior
 {
     use HelperTrait;
 
-    /**
-     * @var ApiClient
-     */
     protected $apiClient;
-
-    /**
-     * @var EntityTools
-     */
     protected $entityTools;
-
-    /**
-     * @var TpCdrRepository
-     */
     protected $tpCdrRepository;
-
-    /**
-     * @var LoggerInterface
-     */
     protected $logger;
+    protected $trunksClient;
 
     public function let(
         ApiClient $apiClient,
         EntityTools $entityTools,
         TpCdrRepository $tpCdrRepository,
-        LoggerInterface $logger
+        LoggerInterface $logger,
+        TrunksClientInterface $trunksClient
     ) {
         $this->apiClient = $apiClient;
         $this->entityTools = $entityTools;
         $this->tpCdrRepository = $tpCdrRepository;
         $this->logger = $logger;
+        $this->trunksClient = $trunksClient;
 
         $this->beConstructedWith(
             $apiClient,
             $entityTools,
             $tpCdrRepository,
-            $logger
+            $logger,
+            $trunksClient
         );
     }
 
@@ -303,6 +290,14 @@ class ProcessExternalCdrSpec extends ObjectBehavior
                 'getDuration' => '',
                 'getStartTime' => $startTime,
                 'isOutboundCall' => true
+            ],
+            false
+        );
+
+        $this->getterProphecy(
+            $this->trunksClient,
+            [
+                'isCgrEnabled' => true
             ],
             false
         );


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

cgrates_mode introduced in #1153 skip CGRateS from being called in KamTrunks. This PR gets that parameters value in order to skip CGRateS calls also in invoicer and cdr-mixer.
