### PR TITLE
core: use client timezone in schedule checks

### DIFF
--- a/library/Ivoz/Provider/Domain/Model/CalendarPeriod/CalendarPeriod.php
+++ b/library/Ivoz/Provider/Domain/Model/CalendarPeriod/CalendarPeriod.php
@@ -54,7 +54,7 @@ class CalendarPeriod extends CalendarPeriodAbstract implements CalendarPeriodInt
         $company = $calendar->getCompany();
         $timezone = $company->getDefaultTimezone();
 
-        $now = new \DateTime('now', new \DateTimeZone('UTC'));
+        $now = new \DateTime('now', new \DateTimeZone($timezone->getTz()));
 
         $scheduleMatched = false;
         $calendarSchedules = $this->getRelSchedules();
@@ -62,11 +62,7 @@ class CalendarPeriod extends CalendarPeriodAbstract implements CalendarPeriodInt
             $schedule = $calendarSchedule->getSchedule();
 
             $scheduleMatched = $schedule
-                ->checkIsOnTimeRange(
-                    $now->format('l'),
-                    $now,
-                    new \DateTimeZone($timezone->getTz())
-                );
+                ->isOnSchedule($now);
 
             if ($scheduleMatched) {
                 break;

--- a/library/Ivoz/Provider/Domain/Model/ExternalCallFilter/ExternalCallFilter.php
+++ b/library/Ivoz/Provider/Domain/Model/ExternalCallFilter/ExternalCallFilter.php
@@ -174,7 +174,6 @@ class ExternalCallFilter extends ExternalCallFilterAbstract implements ExternalC
         }
 
         $scheduleMatched = false;
-        $now = new \DateTime('now', new \DateTimeZone('UTC'));
 
         /**
          * @var ExternalCallFilterRelSchedule $externalCallFilterRelSchedule
@@ -183,13 +182,10 @@ class ExternalCallFilter extends ExternalCallFilterAbstract implements ExternalC
             $schedule = $externalCallFilterRelSchedule->getSchedule();
             $company = $schedule->getCompany();
             $timezone = $company->getDefaultTimezone();
+            $now = new \DateTime('now', new \DateTimeZone($timezone->getTz()));
 
             $scheduleMatched = $schedule
-                ->checkIsOnTimeRange(
-                    $now->format('l'),
-                    $now,
-                    new \DateTimeZone($timezone->getTz())
-                );
+                ->isOnSchedule($now);
 
             if ($scheduleMatched) {
                 break;

--- a/library/Ivoz/Provider/Domain/Model/Schedule/Schedule.php
+++ b/library/Ivoz/Provider/Domain/Model/Schedule/Schedule.php
@@ -28,35 +28,12 @@ class Schedule extends ScheduleAbstract implements ScheduleInterface
         return $this->id;
     }
 
-    public function checkIsOnTimeRange($dayOfTheWeek, \DateTime $time, \DateTimeZone $timeZone)
-    {
-        if (!call_user_func(array($this, 'get' . $dayOfTheWeek))) {
-            return false;
-        }
-
-        $time = strtotime(
-            $time
-                ->setTimezone($timeZone)
-                ->format('H:i:s')
-        );
-
-        $timeIn = strtotime(
-            $this->getTimeIn()
-                ->format('H:i:s')
-        );
-
-        $timeOut = strtotime(
-            $this->getTimeout()
-                ->format('H:i:s')
-        );
-
-        $isInTimeRange =
-            ($time > $timeIn)
-            && ($time < $timeOut);
-
-        return $isInTimeRange;
-    }
-
+    /**
+     * Check if current time is inside Schedule
+     *
+     * @param \DateTime $time Current time in Client's Timezone
+     * @return bool
+     */
     public function isOnSchedule(\DateTime $time)
     {
         // Check if Day of The Week is enabled in the schedule
@@ -67,6 +44,8 @@ class Schedule extends ScheduleAbstract implements ScheduleInterface
 
         // Check if time is between begining and end
         $timezone = $time->getTimezone();
+
+        // Create new TimeIn/TimeOut with db times and client's timezone
         $timeIn = new \DateTime(
             $this->getTimeIn()->format('H:i:s'),
             $timezone
@@ -75,6 +54,7 @@ class Schedule extends ScheduleAbstract implements ScheduleInterface
             $this->getTimeOut()->format('H:i:s'),
             $timezone
         );
+
         $isOnSchedule = ($time >= $timeIn && $time < $timeOut);
 
         return $isOnSchedule;

--- a/library/Ivoz/Provider/Domain/Model/Schedule/ScheduleInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/Schedule/ScheduleInterface.php
@@ -12,8 +12,12 @@ interface ScheduleInterface extends LoggableEntityInterface
      */
     public function getChangeSet();
 
-    public function checkIsOnTimeRange($dayOfTheWeek, \DateTime $time, \DateTimeZone $timeZone);
-
+    /**
+     * Check if current time is inside Schedule
+     *
+     * @param \DateTime $time Current time in Client's Timezone
+     * @return bool
+     */
     public function isOnSchedule(\DateTime $time);
 
     /**

--- a/library/spec/Ivoz/Provider/Domain/Model/Schedule/ScheduleSpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Model/Schedule/ScheduleSpec.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace spec\Ivoz\Provider\Domain\Model\Schedule;
+
+use Ivoz\Provider\Domain\Model\Company\CompanyInterface;
+use Ivoz\Provider\Domain\Model\Schedule\Schedule;
+use Ivoz\Provider\Domain\Model\Schedule\ScheduleDto;
+use PhpSpec\ObjectBehavior;
+use spec\HelperTrait;
+
+class ScheduleSpec extends ObjectBehavior
+{
+    use HelperTrait;
+
+    /** @var ScheduleDto */
+    protected $dto;
+    protected $utc;
+    protected $europeMadrid;
+
+    protected $initialTimeIn = '20:00:00';
+
+    function let()
+    {
+        $this->dto = $dto = new ScheduleDto();
+
+        $this->utc = new \DateTimeZone('UTC');
+        $this->europeMadrid = new \DateTimeZone('Europe/Madrid');
+
+        $timeIn = new \DateTime(
+            $this->initialTimeIn,
+            $this->utc
+        );
+
+        $timeOut = new \DateTime(
+            '23:59:59',
+            $this->utc
+        );
+
+        $dto
+            ->setName('testSchedule')
+            ->setTimeIn($timeIn)
+            ->setTimeout($timeOut)
+            ->setMonday(true)
+            ->setTuesday(true)
+            ->setWednesday(true)
+            ->setThursday(true)
+            ->setFriday(true)
+            ->setSaturday(true)
+            ->setSunday(true);
+
+        $company = $this->getTestDouble(CompanyInterface::class);
+        $this->hydrate(
+            $dto,
+            [
+                'company' => $company->reveal(),
+            ]
+        );
+
+        $this->beConstructedThrough(
+            'fromDto',
+            [$dto, new \spec\DtoToEntityFakeTransformer()]
+        );
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(Schedule::class);
+    }
+
+    function it_tells_whether_is_on_schedule()
+    {
+        $time = new \DateTime(
+            $this->initialTimeIn,
+            $this->utc
+        );
+
+        $this
+            ->isOnSchedule($time)
+            ->shouldReturn(true);
+    }
+
+
+    function it_unifies_time_zones()
+    {
+        $time = new \DateTime(
+            '23:59:58',
+            $this->europeMadrid
+        );
+
+        $this
+            ->isOnSchedule($time)
+            ->shouldReturn(true);
+    }
+
+    function it_tells_whether_is_not_on_schedule()
+    {
+        $time = new \DateTime(
+            '19:00:00',
+            $this->utc
+        );
+
+        $this
+            ->isOnSchedule($time)
+            ->shouldReturn(false);
+    }
+
+    function it_checks_day_of_the_week()
+    {
+        $this->dto
+            ->setMonday(false)
+            ->setTuesday(false)
+            ->setWednesday(false)
+            ->setThursday(false)
+            ->setFriday(false)
+            ->setSaturday(false)
+            ->setSunday(false);
+
+        $time = new \DateTime(
+            $this->initialTimeIn,
+            $this->europeMadrid
+        );
+
+        $this
+            ->isOnSchedule($time)
+            ->shouldReturn(false);
+    }
+}


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
Refactor Schedule checks to use a single function that uses client timezone for comparisons.

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
