### PR TITLE
Scheduler dst bug

### DIFF
--- a/library/Ivoz/Provider/Domain/Model/CallCsvScheduler/CallCsvScheduler.php
+++ b/library/Ivoz/Provider/Domain/Model/CallCsvScheduler/CallCsvScheduler.php
@@ -56,6 +56,15 @@ class CallCsvScheduler extends CallCsvSchedulerAbstract implements SchedulerInte
         return $timeZone;
     }
 
+    public function getSchedulerDateTimeZone(): \DateTimeZone
+    {
+        $timezone = $this->getTimezone();
+
+        return new \DateTimeZone(
+            $timezone->getTz()
+        );
+    }
+
     /**
      * @return \DateInterval
      */

--- a/library/Ivoz/Provider/Domain/Model/CallCsvScheduler/CallCsvSchedulerInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/CallCsvScheduler/CallCsvSchedulerInterface.php
@@ -27,6 +27,8 @@ interface CallCsvSchedulerInterface extends SchedulerInterface, LoggableEntityIn
      */
     public function getTimezone();
 
+    public function getSchedulerDateTimeZone();
+
     /**
      * @return \DateInterval
      */

--- a/library/Ivoz/Provider/Domain/Model/InvoiceScheduler/InvoiceScheduler.php
+++ b/library/Ivoz/Provider/Domain/Model/InvoiceScheduler/InvoiceScheduler.php
@@ -51,6 +51,16 @@ class InvoiceScheduler extends InvoiceSchedulerAbstract implements SchedulerInte
         return parent::setFrequency($frequency);
     }
 
+
+    public function getSchedulerDateTimeZone(): \DateTimeZone
+    {
+        $timezone = $this->getBrand()->getDefaultTimezone();
+
+        return new \DateTimeZone(
+            $timezone->getTz()
+        );
+    }
+
     /**
      * @return \DateInterval
      */

--- a/library/Ivoz/Provider/Domain/Model/InvoiceScheduler/InvoiceSchedulerInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/InvoiceScheduler/InvoiceSchedulerInterface.php
@@ -30,6 +30,8 @@ interface InvoiceSchedulerInterface extends SchedulerInterface, LoggableEntityIn
      */
     public function setFrequency($frequency);
 
+    public function getSchedulerDateTimeZone();
+
     /**
      * @return \DateInterval
      */

--- a/library/Ivoz/Provider/Domain/Service/InvoiceScheduler/NextExecutionResolverTrait.php
+++ b/library/Ivoz/Provider/Domain/Service/InvoiceScheduler/NextExecutionResolverTrait.php
@@ -81,13 +81,18 @@ trait NextExecutionResolverTrait
         if (!$nextExecution) {
             return;
         }
+
         $nextExecution->setTimezone(
-            new \DateTimeZone('UTC')
+            $scheduler->getSchedulerDateTimeZone()
         );
 
         $nextExecution = DateTimeHelper::add(
             $nextExecution,
             $scheduler->getInterval()
+        );
+
+        $nextExecution->setTimezone(
+            new \DateTimeZone('UTC')
         );
 
         $this->setNextExecution(

--- a/library/spec/Ivoz/Provider/Domain/Service/InvoiceScheduler/NextExecutionResolverSpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Service/InvoiceScheduler/NextExecutionResolverSpec.php
@@ -105,6 +105,11 @@ class NextExecutionResolverSpec extends ObjectBehavior
             ->willReturn(false)
             ->shouldBeCalled();
 
+        $scheduler
+            ->getSchedulerDateTimeZone()
+            ->willReturn(new \DateTimeZone('Europe/Madrid'))
+            ->shouldBeCalled();
+
         $this
             ->entityTools
             ->entityToDto($scheduler)


### PR DESCRIPTION
This PR aims to fix daily scheduler issues on daylight saving time changes. 

Some scenarios cannot be avoided, for instance Europe/Madrid 2020-03-29 02:00:00 does not exist: 2020-03-28 02:00:00 will turn into 2020-03-29 03:00:00.

#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [X] Fixes an existing issue (Fixes #1216)
