### PR TITLE
agis: fix CalendarPeriod checking in ExternalCallFilter

### DIFF
--- a/asterisk/agi/src/Agi/Action/DdiAction.php
+++ b/asterisk/agi/src/Agi/Action/DdiAction.php
@@ -108,6 +108,7 @@ class DdiAction
                 /** @var CalendarPeriod $calendarPeriod */
                 $calendarPeriod = $externalCallFilter->getCalendarPeriodForToday();
                 if (!empty($calendarPeriod)) {
+                    $this->agi->verbose("DDI %s has %s for today.", $ddi, $calendarPeriod);
                     if ($calendarPeriod->isOutOfSchedule()) {
                         $this->agi->verbose("DDI %s is on %s Out of Schedule.", $ddi, $calendarPeriod);
                         $this->externalFilterAction

--- a/library/Ivoz/Provider/Domain/Model/ExternalCallFilter/ExternalCallFilter.php
+++ b/library/Ivoz/Provider/Domain/Model/ExternalCallFilter/ExternalCallFilter.php
@@ -156,8 +156,10 @@ class ExternalCallFilter extends ExternalCallFilterAbstract implements ExternalC
                 CriteriaHelper::fromArray($criteria)
             );
 
-            // Return the first calendar period that matched
-            return array_shift($calendarPeriods);
+            if (!empty($calendarPeriods)) {
+                // Return the first calendar period that matched
+                return array_shift($calendarPeriods);
+            }
         }
 
         return null;


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
When multiple calendars are selected in a single ExternalCallFilter,
the logic should loop searching a calendar period in all of them,
but instead it only looks for calendar periods in the first calendar.

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
