### PR TITLE
CDRs: transport residentialDeviceId to kam_trunks_cdrs

### DIFF
--- a/asterisk/agi/src/Dialplan/Headers.php
+++ b/asterisk/agi/src/Dialplan/Headers.php
@@ -80,6 +80,12 @@ class Headers extends RouteHandlerAbstract
             if ($this->agi->getVariable("FAXFILE_ID") || $this->agi->getVariable("T38PASSTHROUGH")) {
                 $this->agi->setSIPHeader("X-Info-Special", "fax");
             }
+
+            // Get residentialDevice from channel variables
+            $residentialDeviceId = $this->agi->getVariable("RESIDENTIALDEVICEID");
+            if (!empty($residentialDeviceId)) {
+                $this->agi->setSIPHeader("X-Info-ResidentialDeviceId", $residentialDeviceId);
+            }
         }
 
         // Set recording header

--- a/asterisk/agi/src/Dialplan/Residentials.php
+++ b/asterisk/agi/src/Dialplan/Residentials.php
@@ -84,6 +84,7 @@ class Residentials extends RouteHandlerAbstract
 
         // Get residential from the endpoint.
         $residential = $this->endpointResolver->getResidentialFromEndpoint($endpointName);
+        $this->agi->setVariable("__RESIDENTIALDEVICEID", $residential->getId());
 
         // Set Company/Brand/Generic Music class
         $company = $residential->getCompany();

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -243,7 +243,7 @@ modparam("acc", "cdr_on_failed", 0)
 modparam("acc", "cdr_expired_dlg_enable", 1)
 modparam("acc", "cdr_start_on_confirmed", 1)
 modparam("acc", "cdr_facility", "LOG_LOCAL3")
-modparam("acc", "cdr_extra", "brandId=$dlg_var(brandId);companyId=$dlg_var(companyId);caller=$dlg_var(caller);callee=$dlg_var(callee);callid=$dlg_var(callid);callidHash=$dlg_var(cidhash);xcallid=$dlg_var(xcallid);diversion=$dlg_var(diversion);carrierId=$dlg_var(carrierId);direction=$dlg_var(direction);bounced=$dlg_var(bounced);cgrid=$dlg_var(cgrid);retailAccountId=$dlg_var(retailAccountId)")
+modparam("acc", "cdr_extra", "brandId=$dlg_var(brandId);companyId=$dlg_var(companyId);caller=$dlg_var(caller);callee=$dlg_var(callee);callid=$dlg_var(callid);callidHash=$dlg_var(cidhash);xcallid=$dlg_var(xcallid);diversion=$dlg_var(diversion);carrierId=$dlg_var(carrierId);direction=$dlg_var(direction);bounced=$dlg_var(bounced);cgrid=$dlg_var(cgrid);retailAccountId=$dlg_var(retailAccountId);residentialDeviceId=$dlg_var(residentialDeviceId)")
 modparam("acc", "cdr_extra_nullable", 1)
 
 # DIALOG
@@ -868,6 +868,14 @@ route[PARSE_X_HEADERS] {
         $dlg_var(retailAccountId) = $var(header-value);
     }
 
+    # Extract ResidentialDeviceId for cdr entry
+    $var(header) = 'X-Info-ResidentialDeviceId';
+    route(PARSE_OPTIONAL_X_HEADER);
+    if ($var(header-value) != '') {
+        xinfo("[$dlg_var(cidhash)] X-HEADERS-OTHER: '$var(header)' header found: $var(header-value)\n");
+        $dlg_var(residentialDeviceId) = $var(header-value);
+    }
+
     # Extract xcallid
     $var(header) = 'X-Call-Id';
     route(PARSE_OPTIONAL_X_HEADER);
@@ -1178,7 +1186,7 @@ route[APPLY_TRANSFORMATION] {
 }
 
 route[GET_INFO_FROM_MATCHED_DDI] {
-    sql_xquery("cb", "SELECT c.mediaRelaySetsId, c.maxCalls AS maxCallsCompany, b.maxCalls AS maxCallsBrand, d.recordCalls, c.distributeMethod, AppS.ip AS asAddress FROM DDIs d JOIN Companies c ON d.companyId=c.id LEFT JOIN ApplicationServers AppS ON AppS.id=c.applicationServerId JOIN Brands b ON c.brandId=b.id WHERE d.DDIE164='$rU'", "ra");
+    sql_xquery("cb", "SELECT c.mediaRelaySetsId, c.maxCalls AS maxCallsCompany, b.maxCalls AS maxCallsBrand, d.recordCalls, c.distributeMethod, AppS.ip AS asAddress, d.routeType, d.residentialDeviceId, d.retailAccountId FROM DDIs d JOIN Companies c ON d.companyId=c.id LEFT JOIN ApplicationServers AppS ON AppS.id=c.applicationServerId JOIN Brands b ON c.brandId=b.id WHERE d.DDIE164='$rU'", "ra");
 
     # Matched DDI
     $dlg_var(maxCallsCompany) = $xavp(ra=>maxCallsCompany);
@@ -1194,6 +1202,13 @@ route[GET_INFO_FROM_MATCHED_DDI] {
     $avp(asAddress) = $xavp(ra=>asAddress);
 
     $dlg_var(mediaRelaySetsId) = $xavp(ra=>mediaRelaySetsId);
+
+    # Save endpointId for CDR accounting
+    if ($xavp(ra=>routeType) == 'retail' && $xavp(ra=>retailAccountId) != $null) {
+        $dlg_var(retailAccountId) = $xavp(ra=>retailAccountId);
+    } else if ($xavp(ra=>routeType) == 'residential' && $xavp(ra=>residentialDeviceId) != $null) {
+        $dlg_var(residentialDeviceId) = $xavp(ra=>residentialDeviceId);
+    }
 }
 
 route[GET_INFO_FROM_COMPANY] {
@@ -1318,11 +1333,8 @@ route[SETUP_KAMUSERS_CALL] {
     insert_hf("X-Info-Callee: $rU\r\n");
 
     # Update $ru using retail account username@domain
-    sql_xquery("cb", "SELECT RA.id, RA.name AS username, DS.domain AS domain FROM DDIs D INNER JOIN RetailAccounts RA ON D.retailAccountId=RA.id INNER JOIN Domains DS ON RA.domainId=DS.id WHERE DDIE164='$rU'", "ra");
+    sql_xquery("cb", "SELECT RA.name AS username, DS.domain AS domain FROM DDIs D INNER JOIN RetailAccounts RA ON D.retailAccountId=RA.id INNER JOIN Domains DS ON RA.domainId=DS.id WHERE DDIE164='$rU'", "ra");
     $ru = "sip:" + $xavp(ra=>username) + '@' + $xavp(ra=>domain);
-
-    # Save retailAccountId for cdr entry
-    $dlg_var(retailAccountId) = $xavp(ra=>id);
 }
 
 # Relay request

--- a/library/Ivoz/Kam/Domain/Model/TrunksCdr/TrunksCdrAbstract.php
+++ b/library/Ivoz/Kam/Domain/Model/TrunksCdr/TrunksCdrAbstract.php
@@ -105,6 +105,11 @@ abstract class TrunksCdrAbstract
      */
     protected $retailAccount;
 
+    /**
+     * @var \Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDeviceInterface | null
+     */
+    protected $residentialDevice;
+
 
     use ChangelogTrait;
 
@@ -213,6 +218,7 @@ abstract class TrunksCdrAbstract
             ->setCompany($fkTransformer->transform($dto->getCompany()))
             ->setCarrier($fkTransformer->transform($dto->getCarrier()))
             ->setRetailAccount($fkTransformer->transform($dto->getRetailAccount()))
+            ->setResidentialDevice($fkTransformer->transform($dto->getResidentialDevice()))
         ;
 
         $self->initChangelog();
@@ -249,7 +255,8 @@ abstract class TrunksCdrAbstract
             ->setBrand($fkTransformer->transform($dto->getBrand()))
             ->setCompany($fkTransformer->transform($dto->getCompany()))
             ->setCarrier($fkTransformer->transform($dto->getCarrier()))
-            ->setRetailAccount($fkTransformer->transform($dto->getRetailAccount()));
+            ->setRetailAccount($fkTransformer->transform($dto->getRetailAccount()))
+            ->setResidentialDevice($fkTransformer->transform($dto->getResidentialDevice()));
 
 
 
@@ -281,7 +288,8 @@ abstract class TrunksCdrAbstract
             ->setBrand(\Ivoz\Provider\Domain\Model\Brand\Brand::entityToDto(self::getBrand(), $depth))
             ->setCompany(\Ivoz\Provider\Domain\Model\Company\Company::entityToDto(self::getCompany(), $depth))
             ->setCarrier(\Ivoz\Provider\Domain\Model\Carrier\Carrier::entityToDto(self::getCarrier(), $depth))
-            ->setRetailAccount(\Ivoz\Provider\Domain\Model\RetailAccount\RetailAccount::entityToDto(self::getRetailAccount(), $depth));
+            ->setRetailAccount(\Ivoz\Provider\Domain\Model\RetailAccount\RetailAccount::entityToDto(self::getRetailAccount(), $depth))
+            ->setResidentialDevice(\Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDevice::entityToDto(self::getResidentialDevice(), $depth));
     }
 
     /**
@@ -307,7 +315,8 @@ abstract class TrunksCdrAbstract
             'brandId' => self::getBrand() ? self::getBrand()->getId() : null,
             'companyId' => self::getCompany() ? self::getCompany()->getId() : null,
             'carrierId' => self::getCarrier() ? self::getCarrier()->getId() : null,
-            'retailAccountId' => self::getRetailAccount() ? self::getRetailAccount()->getId() : null
+            'retailAccountId' => self::getRetailAccount() ? self::getRetailAccount()->getId() : null,
+            'residentialDeviceId' => self::getResidentialDevice() ? self::getResidentialDevice()->getId() : null
         ];
     }
     // @codeCoverageIgnoreStart
@@ -813,6 +822,30 @@ abstract class TrunksCdrAbstract
     public function getRetailAccount()
     {
         return $this->retailAccount;
+    }
+
+    /**
+     * Set residentialDevice
+     *
+     * @param \Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDeviceInterface $residentialDevice
+     *
+     * @return static
+     */
+    public function setResidentialDevice(\Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDeviceInterface $residentialDevice = null)
+    {
+        $this->residentialDevice = $residentialDevice;
+
+        return $this;
+    }
+
+    /**
+     * Get residentialDevice
+     *
+     * @return \Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDeviceInterface | null
+     */
+    public function getResidentialDevice()
+    {
+        return $this->residentialDevice;
     }
 
     // @codeCoverageIgnoreEnd

--- a/library/Ivoz/Kam/Domain/Model/TrunksCdr/TrunksCdrDtoAbstract.php
+++ b/library/Ivoz/Kam/Domain/Model/TrunksCdr/TrunksCdrDtoAbstract.php
@@ -105,6 +105,11 @@ abstract class TrunksCdrDtoAbstract implements DataTransferObjectInterface
      */
     private $retailAccount;
 
+    /**
+     * @var \Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDeviceDto | null
+     */
+    private $residentialDevice;
+
 
     use DtoNormalizer;
 
@@ -141,7 +146,8 @@ abstract class TrunksCdrDtoAbstract implements DataTransferObjectInterface
             'brandId' => 'brand',
             'companyId' => 'company',
             'carrierId' => 'carrier',
-            'retailAccountId' => 'retailAccount'
+            'retailAccountId' => 'retailAccount',
+            'residentialDeviceId' => 'residentialDevice'
         ];
     }
 
@@ -169,7 +175,8 @@ abstract class TrunksCdrDtoAbstract implements DataTransferObjectInterface
             'brand' => $this->getBrand(),
             'company' => $this->getCompany(),
             'carrier' => $this->getCarrier(),
-            'retailAccount' => $this->getRetailAccount()
+            'retailAccount' => $this->getRetailAccount(),
+            'residentialDevice' => $this->getResidentialDevice()
         ];
     }
 
@@ -651,6 +658,52 @@ abstract class TrunksCdrDtoAbstract implements DataTransferObjectInterface
     public function getRetailAccountId()
     {
         if ($dto = $this->getRetailAccount()) {
+            return $dto->getId();
+        }
+
+        return null;
+    }
+
+    /**
+     * @param \Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDeviceDto $residentialDevice
+     *
+     * @return static
+     */
+    public function setResidentialDevice(\Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDeviceDto $residentialDevice = null)
+    {
+        $this->residentialDevice = $residentialDevice;
+
+        return $this;
+    }
+
+    /**
+     * @return \Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDeviceDto
+     */
+    public function getResidentialDevice()
+    {
+        return $this->residentialDevice;
+    }
+
+    /**
+     * @param mixed | null $id
+     *
+     * @return static
+     */
+    public function setResidentialDeviceId($id)
+    {
+        $value = !is_null($id)
+            ? new \Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDeviceDto($id)
+            : null;
+
+        return $this->setResidentialDevice($value);
+    }
+
+    /**
+     * @return mixed | null
+     */
+    public function getResidentialDeviceId()
+    {
+        if ($dto = $this->getResidentialDevice()) {
             return $dto->getId();
         }
 

--- a/library/Ivoz/Kam/Domain/Model/TrunksCdr/TrunksCdrInterface.php
+++ b/library/Ivoz/Kam/Domain/Model/TrunksCdr/TrunksCdrInterface.php
@@ -169,4 +169,20 @@ interface TrunksCdrInterface extends EntityInterface
      * @return \Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface | null
      */
     public function getRetailAccount();
+
+    /**
+     * Set residentialDevice
+     *
+     * @param \Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDeviceInterface $residentialDevice
+     *
+     * @return static
+     */
+    public function setResidentialDevice(\Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDeviceInterface $residentialDevice = null);
+
+    /**
+     * Get residentialDevice
+     *
+     * @return \Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDeviceInterface | null
+     */
+    public function getResidentialDevice();
 }

--- a/library/Ivoz/Kam/Infrastructure/Persistence/Doctrine/Mapping/TrunksCdr.TrunksCdrAbstract.orm.yml
+++ b/library/Ivoz/Kam/Infrastructure/Persistence/Doctrine/Mapping/TrunksCdr.TrunksCdrAbstract.orm.yml
@@ -156,3 +156,14 @@ Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdrAbstract:
           referencedColumnName: id
           onDelete: set null
       orphanRemoval: false
+    residentialDevice:
+      targetEntity: \Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDeviceInterface
+      cascade: {  }
+      fetch: LAZY
+      mappedBy: null
+      inversedBy: null
+      joinColumns:
+        residentialDeviceId:
+          referencedColumnName: id
+          onDelete: set null
+      orphanRemoval: false

--- a/library/Ivoz/Provider/Domain/Service/BillableCall/CreateOrUpdateByTrunksCdr.php
+++ b/library/Ivoz/Provider/Domain/Service/BillableCall/CreateOrUpdateByTrunksCdr.php
@@ -97,6 +97,12 @@ class CreateOrUpdateByTrunksCdr
                 ->setEndpointId($trunksCdrDto->getRetailAccountId());
         }
 
+        if ($trunksCdrDto->getResidentialDeviceId()) {
+            $billableCallDto
+                ->setEndpointType('ResidentialDevice')
+                ->setEndpointId($trunksCdrDto->getResidentialDeviceId());
+        }
+
         /** @var BillableCallInterface $billableCall */
         $billableCall = $this->entityTools->persistDto(
             $billableCallDto,

--- a/schema/app/DoctrineMigrations/Version20191220152436.php
+++ b/schema/app/DoctrineMigrations/Version20191220152436.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20191220152436 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE kam_trunks_cdrs ADD residentialDeviceId INT UNSIGNED DEFAULT NULL');
+        $this->addSql('ALTER TABLE kam_trunks_cdrs ADD CONSTRAINT FK_92E58EB68B329DCD FOREIGN KEY (residentialDeviceId) REFERENCES ResidentialDevices (id) ON DELETE SET NULL');
+        $this->addSql('CREATE INDEX IDX_92E58EB68B329DCD ON kam_trunks_cdrs (residentialDeviceId)');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE kam_trunks_cdrs DROP FOREIGN KEY FK_92E58EB68B329DCD');
+        $this->addSql('DROP INDEX IDX_92E58EB68B329DCD ON kam_trunks_cdrs');
+        $this->addSql('ALTER TABLE kam_trunks_cdrs DROP residentialDeviceId');
+    }
+}


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

#737 transported _retailAccountId_ to _kam_trunks_cdrs_ table. This PR does the same with _residentialDeviceId_.

#### Additional information

_kam_trunks_cdrs.residentialDeviceId_ is exported to _BillableCalls_ in _endpointType_ and _endpointId_ fields.