### PR TITLE
Set retailAccountId for T.38 retail outbound calls

### DIFF
--- a/asterisk/agi/src/Dialplan/Headers.php
+++ b/asterisk/agi/src/Dialplan/Headers.php
@@ -86,6 +86,12 @@ class Headers extends RouteHandlerAbstract
             if (!empty($residentialDeviceId)) {
                 $this->agi->setSIPHeader("X-Info-ResidentialDeviceId", $residentialDeviceId);
             }
+
+            // Get retailAccount from channel variables
+            $retailAccountId = $this->agi->getVariable("RETAILACCOUNTID");
+            if (!empty($retailAccountId)) {
+                $this->agi->setSIPHeader("X-Info-RetailAccount", $retailAccountId);
+            }
         }
 
         // Set recording header

--- a/asterisk/agi/src/Dialplan/Retails.php
+++ b/asterisk/agi/src/Dialplan/Retails.php
@@ -65,6 +65,7 @@ class Retails extends RouteHandlerAbstract
 
         // Get retailAccount from the endpoint.
         $retailAccount = $this->endpointResolver->getRetailFromEndpoint($endpointName);
+        $this->agi->setVariable("__RETAILACCOUNTID", $retailAccount->getId());
 
         // Set Company/Brand/Generic Music class
         $company = $retailAccount->getCompany();

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -1409,16 +1409,6 @@ route[CLASSIFY] {
         $var(header) = 'X-Info-Type';
         route(PARSE_MANDATORY_X_HEADER);
         $dlg_var(type) = $var(header-value);
-
-        # Get retailAccountId for retail call-forward calls through AS (MUST have Diversion header)
-        if ($dlg_var(type) == 'retail' && !is_present_hf("X-Info-RetailAccountId")) {
-            if (is_present_hf("Diversion")) {
-                sql_xquery("cb", "SELECT RA.id FROM DDIs D INNER JOIN RetailAccounts RA ON D.retailAccountId=RA.id WHERE DDIE164='$(di{uri.user})'", "rp");
-                $dlg_var(retailAccountId) = $xavp(rp=>id);
-            } else {
-                xwarn("[$dlg_var(cidhash)] CLASSIFY: retail call without X-Info-RetailAccountId nor Diversion");
-            }
-        }
     } else {
         sql_xquery("cb", "SELECT C.brandId, C.id AS companyId, C.type FROM DDIs D JOIN Companies C ON D.companyId=C.id WHERE DDIE164='$rU'", "rp");
         $dlg_var(brandId) = $xavp(rp=>brandId);


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

T.38 retail account outbound calls traverse Application Servers. In this traverse retailAccountId was lost.

This PR sets X-Info-RetailAccountId as KamUsers does for non-T.38 retail accounts.