### PR TITLE
kam: multiple minor changes

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -879,7 +879,10 @@ route[PARSE_X_HEADERS] {
     # Extract xcallid
     $var(header) = 'X-Call-Id';
     route(PARSE_OPTIONAL_X_HEADER);
-    if ($var(header-value) != '') $dlg_var(xcallid) = $var(header-value);
+    if ($var(header-value) != '') {
+        $dlg_var(xcallid) = $var(header-value);
+        xnotice("[$dlg_var(cidhash)] X-HEADERS-OTHER: Related leg: $dlg_var(xcallid)\n");
+    }
 
     if ($dlg_var(type) == 'wholesale' || $dlg_var(type) == 'retail') return;
 

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -345,8 +345,7 @@ request_route {
     route(IS_FROM_INSIDE);
 
     # Calculate cidhash if not set
-    if ($dlg_var(cidhash) == $null)
-        $dlg_var(cidhash) = $(ci{s.md5}{s.substr,0,8});
+    route(CIDHASH);
 
     if (is_method("OPTIONS")) {
         force_rport();
@@ -405,8 +404,7 @@ request_route {
     }
 
     # Calculate cidhash if not set
-    if ($dlg_var(cidhash) == $null)
-        $dlg_var(cidhash) = $(ci{s.md5}{s.substr,0,8});
+    route(CIDHASH);
 
     # Transformate numbers for calls from carriers
     if (!$var(is_from_inside)) {
@@ -500,6 +498,12 @@ route[IS_FROM_INSIDE] {
     } else {
         $var(is_from_inside) = 0; # carrier
     }
+}
+
+# Sets dlg_var(cidhash)
+route[CIDHASH] {
+    if ($dlg_var(cidhash) == $null)
+        $dlg_var(cidhash) = $(ci{s.md5}{s.substr,0,8});
 }
 
 route[CHECK_BOUNCE] {

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -1283,6 +1283,7 @@ route[DISPATCH] {
         # If t38Passthrough is off, route to KamUsers
         if ($xavp(rd=>t38Passthrough) == "no") {
             xinfo("[$dlg_var(cidhash)] DISPATCH: Calling to non-T.38 retail account, route to KamUsers\n");
+            insert_hf("X-Info-Skip-MediaRelay: yes\r\n");
             route(SETUP_KAMUSERS_CALL);
             return;
         } else {

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -1549,9 +1549,6 @@ failure_route[MANAGE_FAILURE_GW] {
     }
 
     xinfo("[$dlg_var(cidhash)] MANAGE-FAILURE-GW: Failure using carrier '$dlg_var(carrierId)' to place a call (reply code: $T_reply_code)\n");
-    if ($dlg_var(cgrid) != $null) {
-        route(CGR_CALL_FAILED);
-    }
 
     xinfo("[$dlg_var(cidhash)] MANAGE-FAILURE-GW: Try next GW\n");
     route(SELECT_NEXT_GW);
@@ -1931,29 +1928,6 @@ route[CGR_CALL_END] {
         \"cgr_reqtype\":\"$dlg_var(cgrReqType)\",
         \"carrierId\":\"$var(cgrCarrier)\",
         \"calculateCost\":\"$dlg_var(calculateCost)\",
-        \"cgr_disconnectcause\":\"$T_reply_code\"}");
-}
-
-# Inform CGRateS about a failed call establishment
-route[CGR_CALL_FAILED] {
-    if $sht(cgrconn=>cgr) == $null {
-        xerr("[$dlg_var(cidhash)] CGR-CALL-FAILED: Charging controller unreachable");
-        return;
-    }
-
-    xinfo("[$dlg_var(cidhash)] CGR-CALL-FAILED: Warn CGRates that call has failed (carrierId: $dlg_var(carrierId))");
-    $var(from_tag) = $dlg(from_tag) + ";failure_" + $TS;
-
-    evapi_relay("{\"event\":\"CGR_CALL_END\",
-        \"callid\":\"$dlg(callid)\",
-        \"from_tag\":\"$var(from_tag)\",
-        \"cgr_tenant\":\"$dlg_var(cgrTenant)\",
-        \"cgr_account\":\"$dlg_var(cgrAccount)\",
-        \"cgr_subject\":\"$dlg_var(cgrSubject)\",
-        \"cgr_destination\":\"$dlg_var(cgrDestination)\",
-        \"cgr_answertime\":\"$dlg_var(setupTime)\",
-        \"cgr_duration\":\"0\",
-        \"cgr_reqtype\":\"$dlg_var(cgrReqType)\",
         \"cgr_disconnectcause\":\"$T_reply_code\"}");
 }
 

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -1339,18 +1339,27 @@ route[PARSE_X_HEADERS] {
     route(PARSE_MANDATORY_X_HEADER);
     $dlg_var(callee) = $var(header-value);
 
-    if ($dlg_var(type) == 'retail') {
-        if (remove_hf("X-Info-Skip-MediaRelay")) {
-            $dlg_var(skipMediaRelay) = 'yes';
-        }
-        return;
+    if (remove_hf("X-Info-Skip-MediaRelay")) {
+        $dlg_var(skipMediaRelay) = 'yes';
     }
 
     # Extract xcallid
     $var(header) = 'X-Call-Id';
-    route(PARSE_MANDATORY_X_HEADER);
-    $dlg_var(xcallid) = $var(header-value);
-    xnotice("[$dlg_var(cidhash)] Related leg: $dlg_var(xcallid)\n");
+    route(PARSE_OPTIONAL_X_HEADER);
+    if ($var(header-value) != '') {
+        $dlg_var(xcallid) = $var(header-value);
+        xnotice("[$dlg_var(cidhash)] PARSE-X-HEADERS: Related leg: $dlg_var(xcallid)\n");
+    }
+}
+
+# Header might not be present and, if present, might be empty
+route[PARSE_OPTIONAL_X_HEADER] {
+    if (is_present_hf($var(header))) {
+        $var(header-value) = $hdr($var(header));
+        remove_hf($var(header));
+    } else {
+        $var(header-value) = '';
+    }
 }
 
 # Header MUST be present and with not null value

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -1045,6 +1045,9 @@ route[DISPATCH_TO_TRUNKS] {
             insert_hf("X-Info-Record: yes\r\n");
         }
     }
+
+    # No media handling for this proxy2proxy dialog
+    $dlg_var(skipMediaRelay) = 'yes';
 }
 
 route[DISPATCH_TO_AS] {
@@ -1336,7 +1339,12 @@ route[PARSE_X_HEADERS] {
     route(PARSE_MANDATORY_X_HEADER);
     $dlg_var(callee) = $var(header-value);
 
-    if ($dlg_var(type) == 'retail') return; # No X-Call-Id for retail calls
+    if ($dlg_var(type) == 'retail') {
+        if (remove_hf("X-Info-Skip-MediaRelay")) {
+            $dlg_var(skipMediaRelay) = 'yes';
+        }
+        return;
+    }
 
     # Extract xcallid
     $var(header) = 'X-Call-Id';
@@ -1997,7 +2005,7 @@ route[TRANSPORT_DETECT] {
 route[RTPENGINE] {
     if (!is_method("INVITE|UPDATE|ACK|BYE|CANCEL")) return;
     if (is_method("ACK") && !has_body("application/sdp")) return;
-    if ($dlg_var(type) == 'wholesale' || $dlg_var(type) == 'retail') return;
+    if ($dlg_var(skipMediaRelay) == 'yes') return;
     if ($avp(skip_mediarelay)) return;
 
     if ($(dlg_var(mediaRelaySetsId){s.len}) > 0 && $dlg_var(mediaRelaySetsId) != 0) {

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -538,15 +538,18 @@ route[ADAPT_RURI_OUT] {
 
     $var(number) = $rU;
     route(IS_INTERNAL);
-    if ($avp(is_internal) == '1') return;
+    if ($avp(is_internal) != '1') {
+        # Adapt external number
+        xinfo("[$dlg_var(cidhash)] ADAPT-RURI-OUT: Before -> $var(number)\n");
+        $var(transformation) = $dlg_var(tr_callee_out);
+        xinfo("[$dlg_var(cidhash)] ADAPT-RURI-OUT: Adapt '$var(number)' using rule '$var(transformation)'\n");
+        route(APPLY_TRANSFORMATION);
+        $rU = $var(transformated);
+        xinfo("[$dlg_var(cidhash)] ADAPT-RURI-OUT: After -> $var(transformated) (applied rule: '$avp(appliedrule)')\n");
+    }
 
-    # Adapt external number
-    xinfo("[$dlg_var(cidhash)] ADAPT-RURI-OUT: Before -> $var(number)\n");
-    $var(transformation) = $dlg_var(tr_callee_out);
-    xinfo("[$dlg_var(cidhash)] ADAPT-RURI-OUT: Adapt '$var(number)' using rule '$var(transformation)'\n");
-    route(APPLY_TRANSFORMATION);
-    $rU = $var(transformated);
-    xinfo("[$dlg_var(cidhash)] ADAPT-RURI-OUT: After -> $var(transformated) (applied rule: '$avp(appliedrule)')\n");
+    # Make To and R-URI equal to avoid problems with endpoints routing to To username
+    uac_replace_to("sip:" + $rU +"@" + $td);
 }
 
 route[ADAPT_RURI_IN] {

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -1381,7 +1381,11 @@ route[IS_INTERNAL] {
         } else {
             xinfo("[$dlg_var(cidhash)] IS-INTERNAL: $var(number) is a remote friend\n");
         }
-        $avp(is_internal) = '1';
+        if ($(var(number){s.substr,0,1}) == '+') {
+            xinfo("[$dlg_var(cidhash)] IS-INTERNAL: $var(number) not considered as internal as starts with +\n");
+        } else {
+            $avp(is_internal) = '1';
+        }
         return;
     }
 

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -459,8 +459,10 @@ request_route {
     # From now on, everything is for INVITEs: track dialog
     if (!is_known_dlg() || $si == $var(trunksAddress) || src_ip == myself) {
         dlg_manage();
-        route(CIDHASH);
     }
+
+    # Calculate cidhash if not set
+    route(CIDHASH);
 
     # Inspect new request
     route(CLASSIFY);


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
* 17937dfb7 - (HEAD -> kam-multiple-changes, origin/kam-multiple-changes, bleeding) kam: grab and store X-Call-Id if present 80 seconds ago ccruz
* e98d52faf - kam: skip mediarelay only when necessary 16 minutes ago ccruz
* a0da83b3b - kamusers: set To equal to R-URI in DDI_IN feature 4 hours ago ccruz
* 507410bea - kamusers: not consider friend value starting with + as internal 4 hours ago ccruz

4 unrelated Kamailio minor changes:

- Not consider friend value starting with + as internal so that it gets transformed properly.

- Set To username equal to R-URI username in DDI_IN feature.

- Avoid media relay skip for T.38 retail calls.

- Grab and store X-Call-Id if present.

- Make cidhash calculation logic equal between both proxies.
