### PR TITLE
kamusers: count outgoing calls in call waiting feature

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -998,8 +998,6 @@ route[MAXCALLS_USER] {
         xwarn("[$dlg_var(cidhash)] MAXCALLS-USER: Reject call\n");
         send_reply("486", "Maxcalls exceeded");
         exit;
-    } else {
-        $avp(AoR) = $tU + '@' + $td;
     }
 }
 
@@ -1243,6 +1241,9 @@ route[GET_INFO_FROM_CALLEE] {
     if ($dlg_var(type) == 'retail') {
         route(GET_RETAIL_CFW_SETTINGS);
     }
+
+    # Set AoR for maxcallsUser counting
+    $avp(AoR) = $tU + '@' + $td;
 }
 
 route[GET_RETAIL_CFW_SETTINGS] {
@@ -1296,6 +1297,9 @@ route[GET_INFO_FROM_FROM] {
     if ($xavp(ra=>onDemandRecord) != '0') {
         $dlg_var(onDemandRecord) = '1';
     }
+
+    # Set AoR for maxcallsUser counting
+    $avp(AoR) = $fU + '@' + $fd;
 }
 
 route[FILTER_BY_SCR_ADDR] {


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
Call waiting feature limits received simultaneous calls.

Currently, it only counts received calls.

After this commit, it will count both generated and received calls. It will
continue blocking just received calls when configured limit is reached.
