### PR TITLE
Solve maxDailyUsage threshold override

### DIFF
--- a/asterisk/agi/composer.lock
+++ b/asterisk/agi/composer.lock
@@ -1261,11 +1261,11 @@
         },
         {
             "name": "irontec/ivoz-core",
-            "version": "2.1.0.0",
+            "version": "2.1.1.0",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/irontec/ivoz-core",
-                "reference": "65ada582aac24efb5acd7e884adb6efca223d6b9",
+                "reference": "890f835828cdc82de16eb3c6b3befe6c3ec1b7ac",
                 "shasum": null
             },
             "require": {

--- a/library/Ivoz/Cgr/Domain/Service/CgratesReloadNotificator.php
+++ b/library/Ivoz/Cgr/Domain/Service/CgratesReloadNotificator.php
@@ -37,14 +37,13 @@ abstract class CgratesReloadNotificator implements LifecycleEventHandlerInterfac
 
     /**
      * @param string $tpid
-     * @param string|null $notifyThresholdForAccount
+     * @param bool $disableDestinations
      */
-    protected function reload(string $tpid, string $notifyThresholdForAccount = null, bool $disableDestinations = true)
+    protected function reload(string $tpid, bool $disableDestinations = true)
     {
         $this
             ->cgratesReloadJob
             ->setTpid($tpid)
-            ->setNotifyThresholdForAccount($notifyThresholdForAccount)
             ->setDisableDestinations($disableDestinations)
             ->send();
     }

--- a/library/Ivoz/Cgr/Domain/Service/TpAccountAction/CreateByCompany.php
+++ b/library/Ivoz/Cgr/Domain/Service/TpAccountAction/CreateByCompany.php
@@ -53,7 +53,7 @@ class CreateByCompany implements CompanyLifecycleEventHandlerInterface
                 ->setTpid($brand->getCgrTenant())
                 ->setCompanyId($company->getId())
                 ->setTenant($brand->getCgrTenant())
-                ->setActionTriggersTag('STANDARD_TRIGGERS')
+                ->setActionTriggersTag($company->getCgrSubject())
                 ->setAccount($company->getCgrSubject());
         } else {
             $accountAction = $this->tpAccountActionRepository

--- a/library/Ivoz/Cgr/Domain/Service/TpDestination/UpdatedTpDestinationNotificator.php
+++ b/library/Ivoz/Cgr/Domain/Service/TpDestination/UpdatedTpDestinationNotificator.php
@@ -20,7 +20,6 @@ class UpdatedTpDestinationNotificator extends CgratesReloadNotificator implement
 
         $this->reload(
             $tpDestination->getTpid(),
-            null,
             $isNotNew
         );
     }

--- a/library/Ivoz/Provider/Domain/Service/Company/CompanyLifecycleServiceCollection.php
+++ b/library/Ivoz/Provider/Domain/Service/Company/CompanyLifecycleServiceCollection.php
@@ -30,7 +30,7 @@ class CompanyLifecycleServiceCollection implements LifecycleServiceCollectionInt
         "on_commit" =>
         [
             \Ivoz\Provider\Domain\Service\Company\SearchBrokenThresholds::class => 10,
-            \Ivoz\Provider\Domain\Service\Company\SendCgratesReloadRequest::class => 200,
+            \Ivoz\Provider\Domain\Service\Company\SendCgratesUpdateRequest::class => 200,
             \Ivoz\Provider\Infrastructure\Domain\Service\Company\SendUsersAddressPermissionsReloadRequest::class => 200,
             \Ivoz\Provider\Infrastructure\Domain\Service\Company\SendUsersTrustedPermissionsReloadRequest::class => 200,
         ],

--- a/library/Ivoz/Provider/Domain/Service/Company/SendCgratesUpdateRequest.php
+++ b/library/Ivoz/Provider/Domain/Service/Company/SendCgratesUpdateRequest.php
@@ -4,19 +4,23 @@ namespace Ivoz\Provider\Domain\Service\Company;
 
 use Ivoz\Cgr\Domain\Model\TpAccountAction\TpAccountActionRepository;
 use Ivoz\Cgr\Domain\Service\CgratesReloadNotificator;
+use Ivoz\Core\Infrastructure\Domain\Service\Cgrates\SetMaxUsageThresholdService;
 use Ivoz\Core\Infrastructure\Domain\Service\Gearman\Jobs\Cgrates;
 use Ivoz\Provider\Domain\Model\Company\CompanyInterface;
 
-class SendCgratesReloadRequest extends CgratesReloadNotificator implements CompanyLifecycleEventHandlerInterface
+class SendCgratesUpdateRequest extends CgratesReloadNotificator implements CompanyLifecycleEventHandlerInterface
 {
 
     protected $tpAccountActionRepository;
+    protected $setMaxUsageThresholdService;
 
     public function __construct(
         TpAccountActionRepository $tpAccountActionRepository,
+        SetMaxUsageThresholdService $setMaxUsageThresholdService,
         Cgrates $cgratesReloadJob
     ) {
         $this->tpAccountActionRepository = $tpAccountActionRepository;
+        $this->setMaxUsageThresholdService = $setMaxUsageThresholdService;
         parent::__construct($cgratesReloadJob);
     }
 
@@ -25,13 +29,38 @@ class SendCgratesReloadRequest extends CgratesReloadNotificator implements Compa
      */
     public function execute(CompanyInterface $company)
     {
-        $changedMaxDailyUsage = $company->hasChanged('maxDailyUsage');
-        $changedBillingMethod = $company->hasChanged('billingMethod');
-
-        if (!$changedMaxDailyUsage && !$changedBillingMethod) {
+        if ($company->hasBeenDeleted()) {
             return;
         }
 
+        if ($company->isNew()) {
+            $this->sendReloadJob($company);
+            return;
+        }
+
+        $changedBillingMethod = $company->hasChanged('billingMethod');
+        if ($changedBillingMethod) {
+            $this->sendReloadJob($company);
+            return;
+        }
+
+        $changedMaxDailyUsage = $company->hasChanged('maxDailyUsage');
+        if (!$changedMaxDailyUsage) {
+            return;
+        }
+
+        $this
+            ->setMaxUsageThresholdService
+            ->execute(
+                $company->getBrand()->getCgrTenant(),
+                $company->getCgrSubject(),
+                $company->getMaxDailyUsage()
+            );
+    }
+
+    private function sendReloadJob(
+        CompanyInterface $company
+    ) {
         $tpAccountAction = $this
             ->tpAccountActionRepository
             ->findByCompany(
@@ -39,15 +68,6 @@ class SendCgratesReloadRequest extends CgratesReloadNotificator implements Compa
             );
 
         if (!$tpAccountAction) {
-            return;
-        }
-
-        if ($changedMaxDailyUsage) {
-            $this->reload(
-                $tpAccountAction->getTpid(),
-                $tpAccountAction->getAccount()
-            );
-
             return;
         }
 

--- a/library/composer.lock
+++ b/library/composer.lock
@@ -1799,16 +1799,16 @@
         },
         {
             "name": "irontec/ivoz-core",
-            "version": "2.1",
+            "version": "2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/irontec/ivoz-core.git",
-                "reference": "65ada582aac24efb5acd7e884adb6efca223d6b9"
+                "reference": "890f835828cdc82de16eb3c6b3befe6c3ec1b7ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/irontec/ivoz-core/zipball/65ada582aac24efb5acd7e884adb6efca223d6b9",
-                "reference": "65ada582aac24efb5acd7e884adb6efca223d6b9",
+                "url": "https://api.github.com/repos/irontec/ivoz-core/zipball/890f835828cdc82de16eb3c6b3befe6c3ec1b7ac",
+                "reference": "890f835828cdc82de16eb3c6b3befe6c3ec1b7ac",
                 "shasum": ""
             },
             "require": {
@@ -1849,7 +1849,7 @@
                 }
             ],
             "description": "Core library for ivozprovider",
-            "time": "2019-12-24T09:46:28+00:00"
+            "time": "2020-01-10T12:40:04+00:00"
         },
         {
             "name": "irontec/ivoz-core-bundle",

--- a/library/spec/Ivoz/Provider/Domain/Service/Company/SendCgratesUpdateRequestSpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Service/Company/SendCgratesUpdateRequestSpec.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace spec\Ivoz\Provider\Domain\Service\Company;
+
+use Ivoz\Provider\Domain\Model\Brand\Brandinterface;
+use Ivoz\Provider\Domain\Service\Company\SendCgratesUpdateRequest;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use spec\HelperTrait;
+use Ivoz\Cgr\Domain\Model\TpAccountAction\TpAccountActionRepository;
+use Ivoz\Core\Infrastructure\Domain\Service\Cgrates\SetMaxUsageThresholdService;
+use Ivoz\Core\Infrastructure\Domain\Service\Gearman\Jobs\Cgrates;
+use Ivoz\Provider\Domain\Model\Company\CompanyInterface;
+use Ivoz\Cgr\Domain\Model\TpAccountAction\TpAccountActionInterface;
+
+class SendCgratesUpdateRequestSpec extends ObjectBehavior
+{
+    use HelperTrait;
+
+    protected $tpAccountActionRepository;
+    protected $setMaxUsageThresholdService;
+    protected $cgratesReloadJob;
+
+
+    protected $company;
+
+    public function let(
+        TpAccountActionRepository $tpAccountActionRepository,
+        SetMaxUsageThresholdService $setMaxUsageThresholdService,
+        Cgrates $cgratesReloadJob
+    ) {
+        $this->tpAccountActionRepository = $tpAccountActionRepository;
+        $this->setMaxUsageThresholdService = $setMaxUsageThresholdService;
+        $this->cgratesReloadJob = $cgratesReloadJob;
+
+        $this->company = $this->getTestDouble(
+            CompanyInterface::class
+        );
+
+        $this->beConstructedWith(
+            $this->tpAccountActionRepository,
+            $this->setMaxUsageThresholdService,
+            $this->cgratesReloadJob
+        );
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(
+            SendCgratesUpdateRequest::class
+        );
+    }
+
+    function it_does_nothing_on_delete()
+    {
+        $this
+            ->company
+            ->hasBeenDeleted()
+            ->willReturn(true)
+            ->shouldBeCalled();
+
+        $this
+            ->company
+            ->isNew()
+            ->shouldNotBeCalled();
+
+        $this->execute(
+            $this->company
+        );
+    }
+
+    function it_triggers_reload_job_if_new()
+    {
+        $this->prepareExecution();
+
+        $this
+            ->company
+            ->isNew()
+            ->willReturn(true)
+            ->shouldbeCalled();
+
+        $this
+            ->cgratesReloadJob
+            ->send()
+            ->shouldbeCalled();
+
+        $this->execute(
+            $this->company
+        );
+    }
+
+    function it_triggers_reload_job_if_billingMethod_has_changed()
+    {
+        $this->prepareExecution();
+
+        $this
+            ->company
+            ->hasChanged('billingMethod')
+            ->willReturn(true)
+            ->shouldbeCalled();
+
+        $this
+            ->cgratesReloadJob
+            ->send()
+            ->shouldbeCalled();
+
+        $this->execute(
+            $this->company
+        );
+    }
+
+    function it_set_new_max_usage_if_changed()
+    {
+        $this->prepareExecution();
+
+        $this
+            ->company
+            ->hasChanged('maxDailyUsage')
+            ->willReturn(true)
+            ->shouldbeCalled();
+
+        $this
+            ->setMaxUsageThresholdService
+            ->execute(
+                Argument::type('string'),
+                Argument::type('string'),
+                Argument::type('numeric')
+            )
+            ->shouldBeCalled();
+
+        $this->execute(
+            $this->company
+        );
+    }
+
+    private function prepareExecution()
+    {
+        $companyId = 1;
+        $tpId = 'b1';
+        $company = $this->company;
+
+        $brand = $this->getTestDouble(
+            Brandinterface::class
+        );
+
+        $this->getterProphecy(
+            $brand,
+            [
+                'getCgrTenant' => 'b1'
+            ],
+            false
+        );
+
+        $this->getterProphecy(
+            $company,
+            [
+                'hasBeenDeleted' => false,
+                'isNew' => false,
+                'getId' => $companyId,
+                'getCgrSubject' => 'c1',
+                'getBrand' => $brand,
+                'getMaxDailyUsage' => 100
+            ],
+            false
+        );
+
+        $company
+            ->hasChanged('billingMethod')
+            ->willReturn(false);
+
+        $company
+            ->hasChanged('maxDailyUsage')
+            ->willReturn(false);
+
+        $tpAccountAction = $this->getTestDouble(
+            TpAccountActionInterface::class
+        );
+
+        $tpAccountAction
+            ->getTpid()
+            ->willReturn(
+                $tpId
+            );
+
+        $this
+            ->tpAccountActionRepository
+            ->findByCompany(
+                $companyId
+            )
+            ->willReturn(
+                $tpAccountAction
+            );
+
+        $this->fluentSetterProphecy(
+            $this->cgratesReloadJob,
+            [
+                'setTpid' => $tpId,
+                'setDisableDestinations' => Argument::any(),
+            ],
+            false
+        );
+    }
+}

--- a/microservices/balances/composer.lock
+++ b/microservices/balances/composer.lock
@@ -1261,11 +1261,11 @@
         },
         {
             "name": "irontec/ivoz-core",
-            "version": "2.1.0.0",
+            "version": "2.1.1.0",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/irontec/ivoz-core",
-                "reference": "65ada582aac24efb5acd7e884adb6efca223d6b9",
+                "reference": "890f835828cdc82de16eb3c6b3befe6c3ec1b7ac",
                 "shasum": null
             },
             "require": {

--- a/microservices/recordings/composer.lock
+++ b/microservices/recordings/composer.lock
@@ -1290,11 +1290,11 @@
         },
         {
             "name": "irontec/ivoz-core",
-            "version": "2.1.0.0",
+            "version": "2.1.1.0",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/irontec/ivoz-core",
-                "reference": "65ada582aac24efb5acd7e884adb6efca223d6b9",
+                "reference": "890f835828cdc82de16eb3c6b3befe6c3ec1b7ac",
                 "shasum": null
             },
             "require": {

--- a/microservices/scheduler/composer.lock
+++ b/microservices/scheduler/composer.lock
@@ -1261,11 +1261,11 @@
         },
         {
             "name": "irontec/ivoz-core",
-            "version": "2.1.0.0",
+            "version": "2.1.1.0",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/irontec/ivoz-core",
-                "reference": "65ada582aac24efb5acd7e884adb6efca223d6b9",
+                "reference": "890f835828cdc82de16eb3c6b3befe6c3ec1b7ac",
                 "shasum": null
             },
             "require": {

--- a/microservices/workers/composer.lock
+++ b/microservices/workers/composer.lock
@@ -1297,11 +1297,11 @@
         },
         {
             "name": "irontec/ivoz-core",
-            "version": "2.1.0.0",
+            "version": "2.1.1.0",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/irontec/ivoz-core",
-                "reference": "65ada582aac24efb5acd7e884adb6efca223d6b9",
+                "reference": "890f835828cdc82de16eb3c6b3befe6c3ec1b7ac",
                 "shasum": null
             },
             "require": {

--- a/schema/app/DoctrineMigrations/Version20200109172609.php
+++ b/schema/app/DoctrineMigrations/Version20200109172609.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Ivoz\Core\Infrastructure\Persistence\Doctrine\LoggableMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20200109172609 extends LoggableMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP VIEW `tp_action_triggers`');
+        $this->addSql('CREATE VIEW `tp_action_triggers` AS SELECT CONCAT("b", brandId) AS tpid, CONCAT("c", id) AS tag, "*default" AS unique_id, "*max_balance_counter" AS threshold_type, maxDailyUsage AS threshold_value, 1 AS recurrent, "*default" AS balance_tag, "*monetary" AS balance_type, "DISABLE_AND_LOG" AS actions_tag, 0.0 AS weight FROM Companies');
+
+        $this->addSql('UPDATE tp_account_actions SET action_triggers_tag=account WHERE companyId IS NOT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP VIEW `tp_action_triggers`');
+        $this->addSql('CREATE VIEW `tp_action_triggers` AS SELECT CONCAT("b", id) AS tpid, "STANDARD_TRIGGERS" AS tag, "*default" AS unique_id, "*max_balance_counter" AS threshold_type, 1000000 AS threshold_value, 1 AS recurrent, "*default" AS balance_tag, "*monetary" AS balance_type, "DISABLE_AND_LOG" AS actions_tag, 0.0 AS weight FROM Brands');
+
+        $this->addSql('UPDATE tp_account_actions SET action_triggers_tag="STANDARD_TRIGGERS" WHERE companyId IS NOT NULL');
+    }
+}

--- a/schema/composer.lock
+++ b/schema/composer.lock
@@ -1710,11 +1710,11 @@
         },
         {
             "name": "irontec/ivoz-core",
-            "version": "2.1.0.0",
+            "version": "2.1.1.0",
             "dist": {
                 "type": "path",
                 "url": "../library/vendor/irontec/ivoz-core",
-                "reference": "65ada582aac24efb5acd7e884adb6efca223d6b9",
+                "reference": "890f835828cdc82de16eb3c6b3befe6c3ec1b7ac",
                 "shasum": null
             },
             "require": {

--- a/web/rest/brand/composer.lock
+++ b/web/rest/brand/composer.lock
@@ -1639,11 +1639,11 @@
         },
         {
             "name": "irontec/ivoz-core",
-            "version": "2.1.0.0",
+            "version": "2.1.1.0",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/irontec/ivoz-core",
-                "reference": "65ada582aac24efb5acd7e884adb6efca223d6b9",
+                "reference": "890f835828cdc82de16eb3c6b3befe6c3ec1b7ac",
                 "shasum": null
             },
             "require": {

--- a/web/rest/client/composer.lock
+++ b/web/rest/client/composer.lock
@@ -1639,11 +1639,11 @@
         },
         {
             "name": "irontec/ivoz-core",
-            "version": "2.1.0.0",
+            "version": "2.1.1.0",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/irontec/ivoz-core",
-                "reference": "65ada582aac24efb5acd7e884adb6efca223d6b9",
+                "reference": "890f835828cdc82de16eb3c6b3befe6c3ec1b7ac",
                 "shasum": null
             },
             "require": {

--- a/web/rest/platform/composer.lock
+++ b/web/rest/platform/composer.lock
@@ -1639,11 +1639,11 @@
         },
         {
             "name": "irontec/ivoz-core",
-            "version": "2.1.0.0",
+            "version": "2.1.1.0",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/irontec/ivoz-core",
-                "reference": "65ada582aac24efb5acd7e884adb6efca223d6b9",
+                "reference": "890f835828cdc82de16eb3c6b3befe6c3ec1b7ac",
                 "shasum": null
             },
             "require": {


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

_tp_action_triggers_ was introduced in #1166 with a row per brand with 1000000 default threshold. This threshold was overridden using cgrates API with wanted value per Client.

This runtime threshold are lost when CGRateS tariff plans are reloaded for some accounts (those with no BalanceMap).

This PR changes _tp_action_triggers_ so that is has one entry per client with wanted threshold.

**Pending:**

- [x] Remove cgr-reload + threshold logic.
- [x] On client removal: do nothing.
- [x] On client creation: just cgr-reload.
- [x] On client edition if BillingMethod changes: just cgr-reload.
- [x] On client edit with threshold change: just update threshold via API
- [ ] New tests for all these logic.