### PR TITLE
No cascade delete on calls

### DIFF
--- a/library/Ivoz/Kam/Domain/Model/TrunksCdr/TrunksCdrAbstract.php
+++ b/library/Ivoz/Kam/Domain/Model/TrunksCdr/TrunksCdrAbstract.php
@@ -86,12 +86,12 @@ abstract class TrunksCdrAbstract
     protected $cgrid;
 
     /**
-     * @var \Ivoz\Provider\Domain\Model\Brand\BrandInterface
+     * @var \Ivoz\Provider\Domain\Model\Brand\BrandInterface | null
      */
     protected $brand;
 
     /**
-     * @var \Ivoz\Provider\Domain\Model\Company\CompanyInterface
+     * @var \Ivoz\Provider\Domain\Model\Company\CompanyInterface | null
      */
     protected $company;
 
@@ -745,7 +745,7 @@ abstract class TrunksCdrAbstract
     /**
      * Get brand
      *
-     * @return \Ivoz\Provider\Domain\Model\Brand\BrandInterface
+     * @return \Ivoz\Provider\Domain\Model\Brand\BrandInterface | null
      */
     public function getBrand()
     {
@@ -769,7 +769,7 @@ abstract class TrunksCdrAbstract
     /**
      * Get company
      *
-     * @return \Ivoz\Provider\Domain\Model\Company\CompanyInterface
+     * @return \Ivoz\Provider\Domain\Model\Company\CompanyInterface | null
      */
     public function getCompany()
     {

--- a/library/Ivoz/Kam/Domain/Model/TrunksCdr/TrunksCdrInterface.php
+++ b/library/Ivoz/Kam/Domain/Model/TrunksCdr/TrunksCdrInterface.php
@@ -118,7 +118,7 @@ interface TrunksCdrInterface extends EntityInterface
     /**
      * Get brand
      *
-     * @return \Ivoz\Provider\Domain\Model\Brand\BrandInterface
+     * @return \Ivoz\Provider\Domain\Model\Brand\BrandInterface | null
      */
     public function getBrand();
 
@@ -134,7 +134,7 @@ interface TrunksCdrInterface extends EntityInterface
     /**
      * Get company
      *
-     * @return \Ivoz\Provider\Domain\Model\Company\CompanyInterface
+     * @return \Ivoz\Provider\Domain\Model\Company\CompanyInterface | null
      */
     public function getCompany();
 

--- a/library/Ivoz/Kam/Domain/Model/UsersCdr/UsersCdrAbstract.php
+++ b/library/Ivoz/Kam/Domain/Model/UsersCdr/UsersCdrAbstract.php
@@ -76,12 +76,12 @@ abstract class UsersCdrAbstract
     protected $xcallid;
 
     /**
-     * @var \Ivoz\Provider\Domain\Model\Brand\BrandInterface
+     * @var \Ivoz\Provider\Domain\Model\Brand\BrandInterface | null
      */
     protected $brand;
 
     /**
-     * @var \Ivoz\Provider\Domain\Model\Company\CompanyInterface
+     * @var \Ivoz\Provider\Domain\Model\Company\CompanyInterface | null
      */
     protected $company;
 
@@ -667,7 +667,7 @@ abstract class UsersCdrAbstract
     /**
      * Get brand
      *
-     * @return \Ivoz\Provider\Domain\Model\Brand\BrandInterface
+     * @return \Ivoz\Provider\Domain\Model\Brand\BrandInterface | null
      */
     public function getBrand()
     {
@@ -691,7 +691,7 @@ abstract class UsersCdrAbstract
     /**
      * Get company
      *
-     * @return \Ivoz\Provider\Domain\Model\Company\CompanyInterface
+     * @return \Ivoz\Provider\Domain\Model\Company\CompanyInterface | null
      */
     public function getCompany()
     {

--- a/library/Ivoz/Kam/Domain/Model/UsersCdr/UsersCdrInterface.php
+++ b/library/Ivoz/Kam/Domain/Model/UsersCdr/UsersCdrInterface.php
@@ -112,7 +112,7 @@ interface UsersCdrInterface extends EntityInterface
     /**
      * Get brand
      *
-     * @return \Ivoz\Provider\Domain\Model\Brand\BrandInterface
+     * @return \Ivoz\Provider\Domain\Model\Brand\BrandInterface | null
      */
     public function getBrand();
 
@@ -128,7 +128,7 @@ interface UsersCdrInterface extends EntityInterface
     /**
      * Get company
      *
-     * @return \Ivoz\Provider\Domain\Model\Company\CompanyInterface
+     * @return \Ivoz\Provider\Domain\Model\Company\CompanyInterface | null
      */
     public function getCompany();
 

--- a/library/Ivoz/Kam/Infrastructure/Persistence/Doctrine/Mapping/TrunksCdr.TrunksCdrAbstract.orm.yml
+++ b/library/Ivoz/Kam/Infrastructure/Persistence/Doctrine/Mapping/TrunksCdr.TrunksCdrAbstract.orm.yml
@@ -121,7 +121,7 @@ Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdrAbstract:
       joinColumns:
         brandId:
           referencedColumnName: id
-          onDelete: cascade
+          onDelete: set null
       orphanRemoval: false
     company:
       targetEntity: \Ivoz\Provider\Domain\Model\Company\CompanyInterface
@@ -132,7 +132,7 @@ Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdrAbstract:
       joinColumns:
         companyId:
           referencedColumnName: id
-          onDelete: cascade
+          onDelete: set null
       orphanRemoval: false
     carrier:
       targetEntity: \Ivoz\Provider\Domain\Model\Carrier\CarrierInterface

--- a/library/Ivoz/Kam/Infrastructure/Persistence/Doctrine/Mapping/UsersCdr.UsersCdrAbstract.orm.yml
+++ b/library/Ivoz/Kam/Infrastructure/Persistence/Doctrine/Mapping/UsersCdr.UsersCdrAbstract.orm.yml
@@ -121,7 +121,7 @@ Ivoz\Kam\Domain\Model\UsersCdr\UsersCdrAbstract:
       joinColumns:
         brandId:
           referencedColumnName: id
-          onDelete: cascade
+          onDelete: set null
       orphanRemoval: false
     company:
       targetEntity: \Ivoz\Provider\Domain\Model\Company\CompanyInterface
@@ -132,7 +132,7 @@ Ivoz\Kam\Domain\Model\UsersCdr\UsersCdrAbstract:
       joinColumns:
         companyId:
           referencedColumnName: id
-          onDelete: cascade
+          onDelete: set null
       orphanRemoval: false
     user:
       targetEntity: \Ivoz\Provider\Domain\Model\User\UserInterface

--- a/library/Ivoz/Provider/Domain/Model/BillableCall/BillableCallAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/BillableCall/BillableCallAbstract.php
@@ -85,12 +85,12 @@ abstract class BillableCallAbstract
     protected $direction = 'outbound';
 
     /**
-     * @var \Ivoz\Provider\Domain\Model\Brand\BrandInterface
+     * @var \Ivoz\Provider\Domain\Model\Brand\BrandInterface | null
      */
     protected $brand;
 
     /**
-     * @var \Ivoz\Provider\Domain\Model\Company\CompanyInterface
+     * @var \Ivoz\Provider\Domain\Model\Company\CompanyInterface | null
      */
     protected $company;
 
@@ -743,7 +743,7 @@ abstract class BillableCallAbstract
      *
      * @return static
      */
-    public function setBrand(\Ivoz\Provider\Domain\Model\Brand\BrandInterface $brand)
+    public function setBrand(\Ivoz\Provider\Domain\Model\Brand\BrandInterface $brand = null)
     {
         $this->brand = $brand;
 
@@ -753,7 +753,7 @@ abstract class BillableCallAbstract
     /**
      * Get brand
      *
-     * @return \Ivoz\Provider\Domain\Model\Brand\BrandInterface
+     * @return \Ivoz\Provider\Domain\Model\Brand\BrandInterface | null
      */
     public function getBrand()
     {
@@ -767,7 +767,7 @@ abstract class BillableCallAbstract
      *
      * @return static
      */
-    public function setCompany(\Ivoz\Provider\Domain\Model\Company\CompanyInterface $company)
+    public function setCompany(\Ivoz\Provider\Domain\Model\Company\CompanyInterface $company = null)
     {
         $this->company = $company;
 
@@ -777,7 +777,7 @@ abstract class BillableCallAbstract
     /**
      * Get company
      *
-     * @return \Ivoz\Provider\Domain\Model\Company\CompanyInterface
+     * @return \Ivoz\Provider\Domain\Model\Company\CompanyInterface | null
      */
     public function getCompany()
     {

--- a/library/Ivoz/Provider/Domain/Model/BillableCall/BillableCallInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/BillableCall/BillableCallInterface.php
@@ -123,12 +123,12 @@ interface BillableCallInterface extends LoggableEntityInterface
      *
      * @return static
      */
-    public function setBrand(\Ivoz\Provider\Domain\Model\Brand\BrandInterface $brand);
+    public function setBrand(\Ivoz\Provider\Domain\Model\Brand\BrandInterface $brand = null);
 
     /**
      * Get brand
      *
-     * @return \Ivoz\Provider\Domain\Model\Brand\BrandInterface
+     * @return \Ivoz\Provider\Domain\Model\Brand\BrandInterface | null
      */
     public function getBrand();
 
@@ -139,12 +139,12 @@ interface BillableCallInterface extends LoggableEntityInterface
      *
      * @return static
      */
-    public function setCompany(\Ivoz\Provider\Domain\Model\Company\CompanyInterface $company);
+    public function setCompany(\Ivoz\Provider\Domain\Model\Company\CompanyInterface $company = null);
 
     /**
      * Get company
      *
-     * @return \Ivoz\Provider\Domain\Model\Company\CompanyInterface
+     * @return \Ivoz\Provider\Domain\Model\Company\CompanyInterface | null
      */
     public function getCompany();
 

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/BillableCall.BillableCallAbstract.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/BillableCall.BillableCallAbstract.orm.yml
@@ -115,8 +115,8 @@ Ivoz\Provider\Domain\Model\BillableCall\BillableCallAbstract:
       joinColumns:
         brandId:
           referencedColumnName: id
-          nullable: false
-          onDelete: cascade
+          nullable: true
+          onDelete: set null
       orphanRemoval: false
     company:
       targetEntity: \Ivoz\Provider\Domain\Model\Company\CompanyInterface
@@ -127,8 +127,8 @@ Ivoz\Provider\Domain\Model\BillableCall\BillableCallAbstract:
       joinColumns:
         companyId:
           referencedColumnName: id
-          nullable: false
-          onDelete: cascade
+          nullable: true
+          onDelete: set null
       orphanRemoval: false
     carrier:
       targetEntity: \Ivoz\Provider\Domain\Model\Carrier\CarrierInterface

--- a/schema/app/DoctrineMigrations/Version20200113080213.php
+++ b/schema/app/DoctrineMigrations/Version20200113080213.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Ivoz\Core\Infrastructure\Persistence\Doctrine\LoggableMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20200113080213 extends LoggableMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        // BillableCalls
+        $this->addSql('ALTER TABLE BillableCalls DROP FOREIGN KEY FK_E6F2DA352480E723');
+        $this->addSql('ALTER TABLE BillableCalls DROP FOREIGN KEY FK_E6F2DA359CBEC244');
+
+        $this->addSql('ALTER TABLE BillableCalls MODIFY `companyId` int(10) unsigned DEFAULT NULL');
+        $this->addSql('ALTER TABLE BillableCalls MODIFY `brandId` int(10) unsigned DEFAULT NULL');
+
+        $this->addSql('ALTER TABLE BillableCalls ADD CONSTRAINT FK_E6F2DA352480E723 FOREIGN KEY (companyId) REFERENCES Companies (id) ON DELETE SET NULL');
+        $this->addSql('ALTER TABLE BillableCalls ADD CONSTRAINT FK_E6F2DA359CBEC244 FOREIGN KEY (brandId) REFERENCES Brands (id) ON DELETE SET NULL');
+
+        // kam_trunks_cdrs
+        $this->addSql('ALTER TABLE kam_trunks_cdrs DROP FOREIGN KEY FK_92E58EB62480E723');
+        $this->addSql('ALTER TABLE kam_trunks_cdrs DROP FOREIGN KEY FK_92E58EB69CBEC244');
+
+        $this->addSql('ALTER TABLE kam_trunks_cdrs ADD CONSTRAINT FK_92E58EB62480E723 FOREIGN KEY (companyId) REFERENCES Companies (id) ON DELETE SET NULL');
+        $this->addSql('ALTER TABLE kam_trunks_cdrs ADD CONSTRAINT FK_92E58EB69CBEC244 FOREIGN KEY (brandId) REFERENCES Brands (id) ON DELETE SET NULL');
+
+        // kam_users_cdrs
+        $this->addSql('ALTER TABLE kam_users_cdrs DROP FOREIGN KEY FK_238F735B2480E723');
+        $this->addSql('ALTER TABLE kam_users_cdrs DROP FOREIGN KEY FK_238F735B9CBEC244');
+
+        $this->addSql('ALTER TABLE kam_users_cdrs ADD CONSTRAINT FK_238F735B2480E723 FOREIGN KEY (companyId) REFERENCES Companies (id) ON DELETE SET NULL');
+        $this->addSql('ALTER TABLE kam_users_cdrs ADD CONSTRAINT FK_238F735B9CBEC244 FOREIGN KEY (brandId) REFERENCES Brands (id) ON DELETE SET NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE BillableCalls DROP FOREIGN KEY FK_E6F2DA352480E723');
+        $this->addSql('ALTER TABLE BillableCalls DROP FOREIGN KEY FK_E6F2DA359CBEC244');
+
+        $this->addSql('ALTER TABLE BillableCalls MODIFY `companyId` int(10) unsigned NOT NULL');
+        $this->addSql('ALTER TABLE BillableCalls MODIFY `brandId` int(10) unsigned NOT NULL');
+
+        $this->addSql('ALTER TABLE BillableCalls ADD CONSTRAINT FK_E6F2DA359CBEC244 FOREIGN KEY (brandId) REFERENCES Brands (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE BillableCalls ADD CONSTRAINT FK_E6F2DA352480E723 FOREIGN KEY (companyId) REFERENCES Companies (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE kam_trunks_cdrs DROP FOREIGN KEY FK_92E58EB69CBEC244');
+        $this->addSql('ALTER TABLE kam_trunks_cdrs DROP FOREIGN KEY FK_92E58EB62480E723');
+        $this->addSql('ALTER TABLE kam_trunks_cdrs ADD CONSTRAINT FK_92E58EB69CBEC244 FOREIGN KEY (brandId) REFERENCES Brands (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE kam_trunks_cdrs ADD CONSTRAINT FK_92E58EB62480E723 FOREIGN KEY (companyId) REFERENCES Companies (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE kam_users_cdrs DROP FOREIGN KEY FK_238F735B9CBEC244');
+        $this->addSql('ALTER TABLE kam_users_cdrs DROP FOREIGN KEY FK_238F735B2480E723');
+        $this->addSql('ALTER TABLE kam_users_cdrs ADD CONSTRAINT FK_238F735B9CBEC244 FOREIGN KEY (brandId) REFERENCES Brands (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE kam_users_cdrs ADD CONSTRAINT FK_238F735B2480E723 FOREIGN KEY (companyId) REFERENCES Companies (id) ON DELETE CASCADE');
+    }
+}


### PR DESCRIPTION
Removing on cascade billable calls and trunks/users cdrs when a company/brand is deleted may cause high database load. Remove them asynchronously instead.

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
