### PR TITLE
schema: added index into tp_cdrs.answer_time

### DIFF
--- a/library/Ivoz/Cgr/Infrastructure/Persistence/Doctrine/Mapping/TpCdr.TpCdrAbstract.orm.yml
+++ b/library/Ivoz/Cgr/Infrastructure/Persistence/Doctrine/Mapping/TpCdr.TpCdrAbstract.orm.yml
@@ -13,6 +13,9 @@ Ivoz\Cgr\Domain\Model\TpCdr\TpCdrAbstract:
     tpCdr_cgrid_idx:
       columns:
         - cgrid
+    tpCdr_answerTime_idx:
+      columns:
+      - answer_time
   fields:
     cgrid:
       type: string

--- a/schema/app/DoctrineMigrations/Version20200113155612.php
+++ b/schema/app/DoctrineMigrations/Version20200113155612.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Ivoz\Core\Infrastructure\Persistence\Doctrine\LoggableMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20200113155612 extends LoggableMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('CREATE INDEX tpCdr_answerTime_idx ON tp_cdrs (answer_time)');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP INDEX tpCdr_answerTime_idx ON tp_cdrs');
+    }
+}


### PR DESCRIPTION
Add an index into tp_cdrs.answer_time so that it can be rotated

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally

