### PR TITLE
Restrict user cdrs api methods

### DIFF
--- a/web/rest/brand/app/config/api/raw/kam.yml
+++ b/web/rest/brand/app/config/api/raw/kam.yml
@@ -14,8 +14,16 @@ Ivoz\Kam\Domain\Model\UsersLocation\RegistrationStatus:
       groups: ['']
 
 Ivoz\Kam\Domain\Model\UsersCdr\UsersCdr:
+  itemOperations:
+    get: ~
+  collectionOperations:
+    get: ~
   attributes:
     access_control: '"ROLE_BRAND_ADMIN" in roles'
+    read_access_control:
+      ROLE_BRAND_ADMIN:
+        brand:
+          eq: "user.getBrand().getId()"
 
 Ivoz\Kam\Domain\Model\UsersAddress\UsersAddress:
   attributes:

--- a/web/rest/brand/features/kam/usersCdr/getUsersCdrs.feature
+++ b/web/rest/brand/features/kam/usersCdr/getUsersCdrs.feature
@@ -1,0 +1,66 @@
+Feature: Retrieve users cdrs
+  In order to manage users cdrs
+  As a brand admin
+  I need to be able to retrieve them through the API.
+
+  @createSchema
+  Scenario: Retrieve the users cdrs json list
+    Given I add Brand Authorization header
+     When I add "Accept" header equal to "application/json"
+      And I send a "GET" request to "users_cdrs"
+     Then the response status code should be 200
+      And the response should be in JSON
+      And the header "Content-Type" should be equal to "application/json; charset=utf-8"
+      And the JSON should be equal to:
+    """
+      [
+          {
+              "startTime": "2018-11-22 17:54:49",
+              "endTime": "2018-11-22 17:54:54",
+              "duration": 4.539,
+              "direction": "outbound",
+              "caller": "102",
+              "callee": "+34676896561",
+              "id": 1
+          },
+          {
+              "startTime": "2018-11-23 17:54:49",
+              "endTime": "2018-11-23 18:54:49",
+              "duration": 3600,
+              "direction": "outbound",
+              "caller": "102",
+              "callee": "+34676896561",
+              "id": 2
+          }
+      ]
+    """
+
+  Scenario: Retrieve certain administrator json
+    Given I add Brand Authorization header
+     When I add "Accept" header equal to "application/json"
+      And I send a "GET" request to "users_cdrs/1"
+     Then the response status code should be 200
+      And the response should be in JSON
+      And the header "Content-Type" should be equal to "application/json; charset=utf-8"
+      And the JSON should be like:
+    """
+      {
+          "startTime": "2018-11-22 17:54:49",
+          "endTime": "2018-11-22 17:54:54",
+          "duration": 4.539,
+          "direction": "outbound",
+          "caller": "102",
+          "callee": "+34676896561",
+          "diversion": null,
+          "referee": null,
+          "referrer": null,
+          "callid": "9297bdde-309cd48f@10.10.1.123",
+          "callidHash": "517fa1eb",
+          "xcallid": null,
+          "id": 1,
+          "company": "~",
+          "friend": null,
+          "residentialDevice": null,
+          "retailAccount": null
+      }
+    """

--- a/web/rest/brand/features/kam/usersCdr/postUsersCdrs.feature
+++ b/web/rest/brand/features/kam/usersCdr/postUsersCdrs.feature
@@ -1,0 +1,32 @@
+Feature: Create users cdrs
+  In order to manage users cdrs
+  As a brand admin
+  I need to be able to create them through the API.
+
+  @createSchema
+  Scenario: Create an users cdrs
+    Given I add Brand Authorization header
+     When I add "Content-Type" header equal to "application/json"
+      And I add "Accept" header equal to "application/json"
+      And I send a "POST" request to "/users_cdrs" with body:
+    """
+      {
+          "startTime": "2018-11-22 17:54:49",
+          "endTime": "2018-11-22 17:54:54",
+          "duration": 4.539,
+          "direction": "outbound",
+          "caller": "102",
+          "callee": "+34676896561",
+          "diversion": null,
+          "referee": null,
+          "referrer": null,
+          "callid": "9297bdde-309cd48f@10.10.1.123",
+          "callidHash": "517fa1eb",
+          "xcallid": null,
+          "company": 1,
+          "friend": null,
+          "residentialDevice": null,
+          "retailAccount": null
+      }
+    """
+    Then the response status code should be 405

--- a/web/rest/brand/features/kam/usersCdr/putUsersCdrs.feature
+++ b/web/rest/brand/features/kam/usersCdr/putUsersCdrs.feature
@@ -1,0 +1,32 @@
+Feature: Update users cdrs
+  In order to manage users cdrs
+  As a brand admin
+  I need to be able to update them through the API.
+
+  @createSchema
+  Scenario: Update an users cdrs
+    Given I add Brand Authorization header
+     When I add "Content-Type" header equal to "application/json"
+      And I add "Accept" header equal to "application/json"
+      And I send a "PUT" request to "/users_cdrs/1" with body:
+    """
+      {
+          "startTime": "2019-11-22 17:54:49",
+          "endTime": "2019-11-22 17:54:54",
+          "duration": 4.539,
+          "direction": "outbound",
+          "caller": "102",
+          "callee": "+34676896561",
+          "diversion": null,
+          "referee": null,
+          "referrer": null,
+          "callid": "9297bdde-309cd48f@10.10.1.123",
+          "callidHash": "517fa1eb",
+          "xcallid": null,
+          "company": 1,
+          "friend": null,
+          "residentialDevice": null,
+          "retailAccount": null
+      }
+    """
+    Then the response status code should be 405

--- a/web/rest/brand/features/kam/usersCdr/removeUsersCdrs.feature
+++ b/web/rest/brand/features/kam/usersCdr/removeUsersCdrs.feature
@@ -1,0 +1,12 @@
+Feature: Manage users cdrs
+  In order to manage users cdrs
+  As a brand admin
+  I need to be able to delete them through the API.
+
+  @createSchema
+  Scenario: Remove a administrator
+    Given I add Brand Authorization header
+     When I add "Content-Type" header equal to "application/json"
+      And I add "Accept" header equal to "application/json"
+      And I send a "DELETE" request to "/users_cdrs/1"
+     Then the response status code should be 405

--- a/web/rest/brand/tests/DataAccessControl/Kam/UsersAddressTest.php
+++ b/web/rest/brand/tests/DataAccessControl/Kam/UsersAddressTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\DataAccessControl\Provider;
+
+use Ivoz\Api\Core\Security\DataAccessControlParser;
+use Ivoz\Kam\Domain\Model\UsersAddress\UsersAddress;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class UsersAddressTest extends KernelTestCase
+{
+    use \Ivoz\Tests\AccessControlTestHelperTrait;
+
+    protected function getResourceClass()
+    {
+        return UsersAddress::class;
+    }
+
+    protected function getAdminCriteria(): array
+    {
+        return ['username' => 'test_brand_admin'];
+    }
+
+    /**
+     * @test
+     */
+    function it_has_read_access_control()
+    {
+        $accessControl = $this
+            ->dataAccessControlParser
+            ->get(
+                DataAccessControlParser::READ_ACCESS_CONTROL_ATTRIBUTE
+            );
+
+        $this->assertEquals(
+            $accessControl,
+            [
+                ['company', 'in', 'companyRepository.getSupervisedCompanyIdsByAdmin(user)'],
+            ]
+        );
+    }
+
+    /**
+     * @test
+     */
+    function it_has_write_access_control()
+    {
+        $accessControl = $this
+            ->dataAccessControlParser
+            ->get(
+                DataAccessControlParser::WRITE_ACCESS_CONTROL_ATTRIBUTE
+            );
+
+        $this->assertEquals(
+            $accessControl,
+            [
+                ['company', 'in', 'companyRepository.getSupervisedCompanyIdsByAdmin(user)'],
+            ]
+        );
+    }
+}

--- a/web/rest/brand/tests/DataAccessControl/Kam/UsersCdrTest.php
+++ b/web/rest/brand/tests/DataAccessControl/Kam/UsersCdrTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\DataAccessControl\Provider;
+
+use Ivoz\Api\Core\Security\DataAccessControlParser;
+use Ivoz\Kam\Domain\Model\UsersCdr\UsersCdr;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class UsersCdrTest extends KernelTestCase
+{
+    use \Ivoz\Tests\AccessControlTestHelperTrait;
+
+    protected function getResourceClass()
+    {
+        return UsersCdr::class;
+    }
+
+    protected function getAdminCriteria(): array
+    {
+        return ['username' => 'test_brand_admin'];
+    }
+
+    /**
+     * @test
+     */
+    function it_has_read_access_control()
+    {
+        $accessControl = $this
+            ->dataAccessControlParser
+            ->get(
+                DataAccessControlParser::READ_ACCESS_CONTROL_ATTRIBUTE
+            );
+
+        $this->assertEquals(
+            $accessControl,
+            [
+                ['brand', 'eq', 'user.getBrand().getId()'],
+            ]
+        );
+    }
+
+    /**
+     * @test
+     */
+    function it_has_write_access_control()
+    {
+        $accessControl = $this
+            ->dataAccessControlParser
+            ->get(
+                DataAccessControlParser::WRITE_ACCESS_CONTROL_ATTRIBUTE
+            );
+
+        $this->assertEquals(
+            $accessControl,
+            [
+                ['brand', 'eq', 'user.getBrand().getId()'],
+            ]
+        );
+    }
+}


### PR DESCRIPTION
Allow GET operations only on users cdr

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
