### PR TITLE
Fixed value objects

### DIFF
--- a/library/Ivoz/Provider/Domain/Model/Brand/BrandAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Brand/BrandAbstract.php
@@ -673,6 +673,11 @@ abstract class BrandAbstract
      */
     public function setLogo(Logo $logo)
     {
+        $isEqual = $this->logo && $this->logo->equals($logo);
+        if ($isEqual) {
+            return $this;
+        }
+
         $this->logo = $logo;
         return $this;
     }
@@ -696,6 +701,11 @@ abstract class BrandAbstract
      */
     public function setInvoice(Invoice $invoice)
     {
+        $isEqual = $this->invoice && $this->invoice->equals($invoice);
+        if ($isEqual) {
+            return $this;
+        }
+
         $this->invoice = $invoice;
         return $this;
     }

--- a/library/Ivoz/Provider/Domain/Model/Brand/Invoice.php
+++ b/library/Ivoz/Provider/Domain/Model/Brand/Invoice.php
@@ -68,6 +68,22 @@ class Invoice
         $this->setRegistryData($registryData);
     }
 
+    /**
+     * Equals
+     */
+    public function equals(self $invoice)
+    {
+        return
+            $this->getNif() === $invoice->getNif() &&
+            $this->getPostalAddress() === $invoice->getPostalAddress() &&
+            $this->getPostalCode() === $invoice->getPostalCode() &&
+            $this->getTown() === $invoice->getTown() &&
+            $this->getProvince() === $invoice->getProvince() &&
+            $this->getCountry() === $invoice->getCountry() &&
+            $this->getRegistryData() === $invoice->getRegistryData();
+    }
+
+
     // @codeCoverageIgnoreStart
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/Brand/Logo.php
+++ b/library/Ivoz/Provider/Domain/Model/Brand/Logo.php
@@ -41,6 +41,18 @@ class Logo
         $this->setBaseName($baseName);
     }
 
+    /**
+     * Equals
+     */
+    public function equals(self $logo)
+    {
+        return
+            $this->getFileSize() === $logo->getFileSize() &&
+            $this->getMimeType() === $logo->getMimeType() &&
+            $this->getBaseName() === $logo->getBaseName();
+    }
+
+
     // @codeCoverageIgnoreStart
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/CallCsvReport/CallCsvReportAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/CallCsvReport/CallCsvReportAbstract.php
@@ -448,6 +448,11 @@ abstract class CallCsvReportAbstract
      */
     public function setCsv(Csv $csv)
     {
+        $isEqual = $this->csv && $this->csv->equals($csv);
+        if ($isEqual) {
+            return $this;
+        }
+
         $this->csv = $csv;
         return $this;
     }

--- a/library/Ivoz/Provider/Domain/Model/CallCsvReport/Csv.php
+++ b/library/Ivoz/Provider/Domain/Model/CallCsvReport/Csv.php
@@ -41,6 +41,18 @@ class Csv
         $this->setBaseName($baseName);
     }
 
+    /**
+     * Equals
+     */
+    public function equals(self $csv)
+    {
+        return
+            $this->getFileSize() === $csv->getFileSize() &&
+            $this->getMimeType() === $csv->getMimeType() &&
+            $this->getBaseName() === $csv->getBaseName();
+    }
+
+
     // @codeCoverageIgnoreStart
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/Country/CountryAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Country/CountryAbstract.php
@@ -283,6 +283,11 @@ abstract class CountryAbstract
      */
     public function setName(Name $name)
     {
+        $isEqual = $this->name && $this->name->equals($name);
+        if ($isEqual) {
+            return $this;
+        }
+
         $this->name = $name;
         return $this;
     }
@@ -306,6 +311,11 @@ abstract class CountryAbstract
      */
     public function setZone(Zone $zone)
     {
+        $isEqual = $this->zone && $this->zone->equals($zone);
+        if ($isEqual) {
+            return $this;
+        }
+
         $this->zone = $zone;
         return $this;
     }

--- a/library/Ivoz/Provider/Domain/Model/Country/Name.php
+++ b/library/Ivoz/Provider/Domain/Model/Country/Name.php
@@ -47,6 +47,19 @@ class Name
         $this->setIt($it);
     }
 
+    /**
+     * Equals
+     */
+    public function equals(self $name)
+    {
+        return
+            $this->getEn() === $name->getEn() &&
+            $this->getEs() === $name->getEs() &&
+            $this->getCa() === $name->getCa() &&
+            $this->getIt() === $name->getIt();
+    }
+
+
     // @codeCoverageIgnoreStart
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/Country/Zone.php
+++ b/library/Ivoz/Provider/Domain/Model/Country/Zone.php
@@ -47,6 +47,19 @@ class Zone
         $this->setIt($it);
     }
 
+    /**
+     * Equals
+     */
+    public function equals(self $zone)
+    {
+        return
+            $this->getEn() === $zone->getEn() &&
+            $this->getEs() === $zone->getEs() &&
+            $this->getCa() === $zone->getCa() &&
+            $this->getIt() === $zone->getIt();
+    }
+
+
     // @codeCoverageIgnoreStart
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/Currency/CurrencyAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Currency/CurrencyAbstract.php
@@ -250,6 +250,11 @@ abstract class CurrencyAbstract
      */
     public function setName(Name $name)
     {
+        $isEqual = $this->name && $this->name->equals($name);
+        if ($isEqual) {
+            return $this;
+        }
+
         $this->name = $name;
         return $this;
     }

--- a/library/Ivoz/Provider/Domain/Model/Currency/Name.php
+++ b/library/Ivoz/Provider/Domain/Model/Currency/Name.php
@@ -47,6 +47,19 @@ class Name
         $this->setIt($it);
     }
 
+    /**
+     * Equals
+     */
+    public function equals(self $name)
+    {
+        return
+            $this->getEn() === $name->getEn() &&
+            $this->getEs() === $name->getEs() &&
+            $this->getCa() === $name->getCa() &&
+            $this->getIt() === $name->getIt();
+    }
+
+
     // @codeCoverageIgnoreStart
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/Destination/DestinationAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Destination/DestinationAbstract.php
@@ -278,6 +278,11 @@ abstract class DestinationAbstract
      */
     public function setName(Name $name)
     {
+        $isEqual = $this->name && $this->name->equals($name);
+        if ($isEqual) {
+            return $this;
+        }
+
         $this->name = $name;
         return $this;
     }

--- a/library/Ivoz/Provider/Domain/Model/Destination/Name.php
+++ b/library/Ivoz/Provider/Domain/Model/Destination/Name.php
@@ -47,6 +47,19 @@ class Name
         $this->setIt($it);
     }
 
+    /**
+     * Equals
+     */
+    public function equals(self $name)
+    {
+        return
+            $this->getEn() === $name->getEn() &&
+            $this->getEs() === $name->getEs() &&
+            $this->getCa() === $name->getCa() &&
+            $this->getIt() === $name->getIt();
+    }
+
+
     // @codeCoverageIgnoreStart
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/DestinationRateGroup/Description.php
+++ b/library/Ivoz/Provider/Domain/Model/DestinationRateGroup/Description.php
@@ -47,6 +47,19 @@ class Description
         $this->setIt($it);
     }
 
+    /**
+     * Equals
+     */
+    public function equals(self $description)
+    {
+        return
+            $this->getEn() === $description->getEn() &&
+            $this->getEs() === $description->getEs() &&
+            $this->getCa() === $description->getCa() &&
+            $this->getIt() === $description->getIt();
+    }
+
+
     // @codeCoverageIgnoreStart
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/DestinationRateGroup/DestinationRateGroupAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/DestinationRateGroup/DestinationRateGroupAbstract.php
@@ -352,6 +352,11 @@ abstract class DestinationRateGroupAbstract
      */
     public function setName(Name $name)
     {
+        $isEqual = $this->name && $this->name->equals($name);
+        if ($isEqual) {
+            return $this;
+        }
+
         $this->name = $name;
         return $this;
     }
@@ -375,6 +380,11 @@ abstract class DestinationRateGroupAbstract
      */
     public function setDescription(Description $description)
     {
+        $isEqual = $this->description && $this->description->equals($description);
+        if ($isEqual) {
+            return $this;
+        }
+
         $this->description = $description;
         return $this;
     }
@@ -398,6 +408,11 @@ abstract class DestinationRateGroupAbstract
      */
     public function setFile(File $file)
     {
+        $isEqual = $this->file && $this->file->equals($file);
+        if ($isEqual) {
+            return $this;
+        }
+
         $this->file = $file;
         return $this;
     }

--- a/library/Ivoz/Provider/Domain/Model/DestinationRateGroup/File.php
+++ b/library/Ivoz/Provider/Domain/Model/DestinationRateGroup/File.php
@@ -52,6 +52,19 @@ class File
         $this->setImporterArguments($importerArguments);
     }
 
+    /**
+     * Equals
+     */
+    public function equals(self $file)
+    {
+        return
+            $this->getFileSize() === $file->getFileSize() &&
+            $this->getMimeType() === $file->getMimeType() &&
+            $this->getBaseName() === $file->getBaseName() &&
+            $this->getImporterArguments() === $file->getImporterArguments();
+    }
+
+
     // @codeCoverageIgnoreStart
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/DestinationRateGroup/Name.php
+++ b/library/Ivoz/Provider/Domain/Model/DestinationRateGroup/Name.php
@@ -47,6 +47,19 @@ class Name
         $this->setIt($it);
     }
 
+    /**
+     * Equals
+     */
+    public function equals(self $name)
+    {
+        return
+            $this->getEn() === $name->getEn() &&
+            $this->getEs() === $name->getEs() &&
+            $this->getCa() === $name->getCa() &&
+            $this->getIt() === $name->getIt();
+    }
+
+
     // @codeCoverageIgnoreStart
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/FaxesInOut/FaxesInOutAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/FaxesInOut/FaxesInOutAbstract.php
@@ -471,6 +471,11 @@ abstract class FaxesInOutAbstract
      */
     public function setFile(File $file)
     {
+        $isEqual = $this->file && $this->file->equals($file);
+        if ($isEqual) {
+            return $this;
+        }
+
         $this->file = $file;
         return $this;
     }

--- a/library/Ivoz/Provider/Domain/Model/FaxesInOut/File.php
+++ b/library/Ivoz/Provider/Domain/Model/FaxesInOut/File.php
@@ -41,6 +41,18 @@ class File
         $this->setBaseName($baseName);
     }
 
+    /**
+     * Equals
+     */
+    public function equals(self $file)
+    {
+        return
+            $this->getFileSize() === $file->getFileSize() &&
+            $this->getMimeType() === $file->getMimeType() &&
+            $this->getBaseName() === $file->getBaseName();
+    }
+
+
     // @codeCoverageIgnoreStart
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/Feature/FeatureAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Feature/FeatureAbstract.php
@@ -213,6 +213,11 @@ abstract class FeatureAbstract
      */
     public function setName(Name $name)
     {
+        $isEqual = $this->name && $this->name->equals($name);
+        if ($isEqual) {
+            return $this;
+        }
+
         $this->name = $name;
         return $this;
     }

--- a/library/Ivoz/Provider/Domain/Model/Feature/Name.php
+++ b/library/Ivoz/Provider/Domain/Model/Feature/Name.php
@@ -47,6 +47,19 @@ class Name
         $this->setIt($it);
     }
 
+    /**
+     * Equals
+     */
+    public function equals(self $name)
+    {
+        return
+            $this->getEn() === $name->getEn() &&
+            $this->getEs() === $name->getEs() &&
+            $this->getCa() === $name->getCa() &&
+            $this->getIt() === $name->getIt();
+    }
+
+
     // @codeCoverageIgnoreStart
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/Invoice/InvoiceAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Invoice/InvoiceAbstract.php
@@ -660,6 +660,11 @@ abstract class InvoiceAbstract
      */
     public function setPdf(Pdf $pdf)
     {
+        $isEqual = $this->pdf && $this->pdf->equals($pdf);
+        if ($isEqual) {
+            return $this;
+        }
+
         $this->pdf = $pdf;
         return $this;
     }

--- a/library/Ivoz/Provider/Domain/Model/Invoice/Pdf.php
+++ b/library/Ivoz/Provider/Domain/Model/Invoice/Pdf.php
@@ -41,6 +41,18 @@ class Pdf
         $this->setBaseName($baseName);
     }
 
+    /**
+     * Equals
+     */
+    public function equals(self $pdf)
+    {
+        return
+            $this->getFileSize() === $pdf->getFileSize() &&
+            $this->getMimeType() === $pdf->getMimeType() &&
+            $this->getBaseName() === $pdf->getBaseName();
+    }
+
+
     // @codeCoverageIgnoreStart
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/Language/LanguageAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Language/LanguageAbstract.php
@@ -213,6 +213,11 @@ abstract class LanguageAbstract
      */
     public function setName(Name $name)
     {
+        $isEqual = $this->name && $this->name->equals($name);
+        if ($isEqual) {
+            return $this;
+        }
+
         $this->name = $name;
         return $this;
     }

--- a/library/Ivoz/Provider/Domain/Model/Language/Name.php
+++ b/library/Ivoz/Provider/Domain/Model/Language/Name.php
@@ -47,6 +47,19 @@ class Name
         $this->setIt($it);
     }
 
+    /**
+     * Equals
+     */
+    public function equals(self $name)
+    {
+        return
+            $this->getEn() === $name->getEn() &&
+            $this->getEs() === $name->getEs() &&
+            $this->getCa() === $name->getCa() &&
+            $this->getIt() === $name->getIt();
+    }
+
+
     // @codeCoverageIgnoreStart
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/Locution/EncodedFile.php
+++ b/library/Ivoz/Provider/Domain/Model/Locution/EncodedFile.php
@@ -41,6 +41,18 @@ class EncodedFile
         $this->setBaseName($baseName);
     }
 
+    /**
+     * Equals
+     */
+    public function equals(self $encodedFile)
+    {
+        return
+            $this->getFileSize() === $encodedFile->getFileSize() &&
+            $this->getMimeType() === $encodedFile->getMimeType() &&
+            $this->getBaseName() === $encodedFile->getBaseName();
+    }
+
+
     // @codeCoverageIgnoreStart
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/Locution/LocutionAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Locution/LocutionAbstract.php
@@ -318,6 +318,11 @@ abstract class LocutionAbstract
      */
     public function setEncodedFile(EncodedFile $encodedFile)
     {
+        $isEqual = $this->encodedFile && $this->encodedFile->equals($encodedFile);
+        if ($isEqual) {
+            return $this;
+        }
+
         $this->encodedFile = $encodedFile;
         return $this;
     }
@@ -341,6 +346,11 @@ abstract class LocutionAbstract
      */
     public function setOriginalFile(OriginalFile $originalFile)
     {
+        $isEqual = $this->originalFile && $this->originalFile->equals($originalFile);
+        if ($isEqual) {
+            return $this;
+        }
+
         $this->originalFile = $originalFile;
         return $this;
     }

--- a/library/Ivoz/Provider/Domain/Model/Locution/OriginalFile.php
+++ b/library/Ivoz/Provider/Domain/Model/Locution/OriginalFile.php
@@ -41,6 +41,18 @@ class OriginalFile
         $this->setBaseName($baseName);
     }
 
+    /**
+     * Equals
+     */
+    public function equals(self $originalFile)
+    {
+        return
+            $this->getFileSize() === $originalFile->getFileSize() &&
+            $this->getMimeType() === $originalFile->getMimeType() &&
+            $this->getBaseName() === $originalFile->getBaseName();
+    }
+
+
     // @codeCoverageIgnoreStart
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/MusicOnHold/EncodedFile.php
+++ b/library/Ivoz/Provider/Domain/Model/MusicOnHold/EncodedFile.php
@@ -41,6 +41,18 @@ class EncodedFile
         $this->setBaseName($baseName);
     }
 
+    /**
+     * Equals
+     */
+    public function equals(self $encodedFile)
+    {
+        return
+            $this->getFileSize() === $encodedFile->getFileSize() &&
+            $this->getMimeType() === $encodedFile->getMimeType() &&
+            $this->getBaseName() === $encodedFile->getBaseName();
+    }
+
+
     // @codeCoverageIgnoreStart
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/MusicOnHold/MusicOnHoldAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/MusicOnHold/MusicOnHoldAbstract.php
@@ -351,6 +351,11 @@ abstract class MusicOnHoldAbstract
      */
     public function setOriginalFile(OriginalFile $originalFile)
     {
+        $isEqual = $this->originalFile && $this->originalFile->equals($originalFile);
+        if ($isEqual) {
+            return $this;
+        }
+
         $this->originalFile = $originalFile;
         return $this;
     }
@@ -374,6 +379,11 @@ abstract class MusicOnHoldAbstract
      */
     public function setEncodedFile(EncodedFile $encodedFile)
     {
+        $isEqual = $this->encodedFile && $this->encodedFile->equals($encodedFile);
+        if ($isEqual) {
+            return $this;
+        }
+
         $this->encodedFile = $encodedFile;
         return $this;
     }

--- a/library/Ivoz/Provider/Domain/Model/MusicOnHold/OriginalFile.php
+++ b/library/Ivoz/Provider/Domain/Model/MusicOnHold/OriginalFile.php
@@ -41,6 +41,18 @@ class OriginalFile
         $this->setBaseName($baseName);
     }
 
+    /**
+     * Equals
+     */
+    public function equals(self $originalFile)
+    {
+        return
+            $this->getFileSize() === $originalFile->getFileSize() &&
+            $this->getMimeType() === $originalFile->getMimeType() &&
+            $this->getBaseName() === $originalFile->getBaseName();
+    }
+
+
     // @codeCoverageIgnoreStart
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/RatingPlanGroup/Description.php
+++ b/library/Ivoz/Provider/Domain/Model/RatingPlanGroup/Description.php
@@ -47,6 +47,19 @@ class Description
         $this->setIt($it);
     }
 
+    /**
+     * Equals
+     */
+    public function equals(self $description)
+    {
+        return
+            $this->getEn() === $description->getEn() &&
+            $this->getEs() === $description->getEs() &&
+            $this->getCa() === $description->getCa() &&
+            $this->getIt() === $description->getIt();
+    }
+
+
     // @codeCoverageIgnoreStart
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/RatingPlanGroup/Name.php
+++ b/library/Ivoz/Provider/Domain/Model/RatingPlanGroup/Name.php
@@ -47,6 +47,19 @@ class Name
         $this->setIt($it);
     }
 
+    /**
+     * Equals
+     */
+    public function equals(self $name)
+    {
+        return
+            $this->getEn() === $name->getEn() &&
+            $this->getEs() === $name->getEs() &&
+            $this->getCa() === $name->getCa() &&
+            $this->getIt() === $name->getIt();
+    }
+
+
     // @codeCoverageIgnoreStart
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/RatingPlanGroup/RatingPlanGroupAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/RatingPlanGroup/RatingPlanGroupAbstract.php
@@ -275,6 +275,11 @@ abstract class RatingPlanGroupAbstract
      */
     public function setName(Name $name)
     {
+        $isEqual = $this->name && $this->name->equals($name);
+        if ($isEqual) {
+            return $this;
+        }
+
         $this->name = $name;
         return $this;
     }
@@ -298,6 +303,11 @@ abstract class RatingPlanGroupAbstract
      */
     public function setDescription(Description $description)
     {
+        $isEqual = $this->description && $this->description->equals($description);
+        if ($isEqual) {
+            return $this;
+        }
+
         $this->description = $description;
         return $this;
     }

--- a/library/Ivoz/Provider/Domain/Model/Recording/RecordedFile.php
+++ b/library/Ivoz/Provider/Domain/Model/Recording/RecordedFile.php
@@ -41,6 +41,18 @@ class RecordedFile
         $this->setBaseName($baseName);
     }
 
+    /**
+     * Equals
+     */
+    public function equals(self $recordedFile)
+    {
+        return
+            $this->getFileSize() === $recordedFile->getFileSize() &&
+            $this->getMimeType() === $recordedFile->getMimeType() &&
+            $this->getBaseName() === $recordedFile->getBaseName();
+    }
+
+
     // @codeCoverageIgnoreStart
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/Recording/RecordingAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Recording/RecordingAbstract.php
@@ -482,6 +482,11 @@ abstract class RecordingAbstract
      */
     public function setRecordedFile(RecordedFile $recordedFile)
     {
+        $isEqual = $this->recordedFile && $this->recordedFile->equals($recordedFile);
+        if ($isEqual) {
+            return $this;
+        }
+
         $this->recordedFile = $recordedFile;
         return $this;
     }

--- a/library/Ivoz/Provider/Domain/Model/RoutingPattern/Description.php
+++ b/library/Ivoz/Provider/Domain/Model/RoutingPattern/Description.php
@@ -47,6 +47,19 @@ class Description
         $this->setIt($it);
     }
 
+    /**
+     * Equals
+     */
+    public function equals(self $description)
+    {
+        return
+            $this->getEn() === $description->getEn() &&
+            $this->getEs() === $description->getEs() &&
+            $this->getCa() === $description->getCa() &&
+            $this->getIt() === $description->getIt();
+    }
+
+
     // @codeCoverageIgnoreStart
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/RoutingPattern/Name.php
+++ b/library/Ivoz/Provider/Domain/Model/RoutingPattern/Name.php
@@ -47,6 +47,19 @@ class Name
         $this->setIt($it);
     }
 
+    /**
+     * Equals
+     */
+    public function equals(self $name)
+    {
+        return
+            $this->getEn() === $name->getEn() &&
+            $this->getEs() === $name->getEs() &&
+            $this->getCa() === $name->getCa() &&
+            $this->getIt() === $name->getIt();
+    }
+
+
     // @codeCoverageIgnoreStart
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/RoutingPattern/RoutingPatternAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/RoutingPattern/RoutingPatternAbstract.php
@@ -282,6 +282,11 @@ abstract class RoutingPatternAbstract
      */
     public function setName(Name $name)
     {
+        $isEqual = $this->name && $this->name->equals($name);
+        if ($isEqual) {
+            return $this;
+        }
+
         $this->name = $name;
         return $this;
     }
@@ -305,6 +310,11 @@ abstract class RoutingPatternAbstract
      */
     public function setDescription(Description $description)
     {
+        $isEqual = $this->description && $this->description->equals($description);
+        if ($isEqual) {
+            return $this;
+        }
+
         $this->description = $description;
         return $this;
     }

--- a/library/Ivoz/Provider/Domain/Model/Service/Description.php
+++ b/library/Ivoz/Provider/Domain/Model/Service/Description.php
@@ -47,6 +47,19 @@ class Description
         $this->setIt($it);
     }
 
+    /**
+     * Equals
+     */
+    public function equals(self $description)
+    {
+        return
+            $this->getEn() === $description->getEn() &&
+            $this->getEs() === $description->getEs() &&
+            $this->getCa() === $description->getCa() &&
+            $this->getIt() === $description->getIt();
+    }
+
+
     // @codeCoverageIgnoreStart
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/Service/Name.php
+++ b/library/Ivoz/Provider/Domain/Model/Service/Name.php
@@ -47,6 +47,19 @@ class Name
         $this->setIt($it);
     }
 
+    /**
+     * Equals
+     */
+    public function equals(self $name)
+    {
+        return
+            $this->getEn() === $name->getEn() &&
+            $this->getEs() === $name->getEs() &&
+            $this->getCa() === $name->getCa() &&
+            $this->getIt() === $name->getIt();
+    }
+
+
     // @codeCoverageIgnoreStart
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/Service/ServiceAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Service/ServiceAbstract.php
@@ -323,6 +323,11 @@ abstract class ServiceAbstract
      */
     public function setName(Name $name)
     {
+        $isEqual = $this->name && $this->name->equals($name);
+        if ($isEqual) {
+            return $this;
+        }
+
         $this->name = $name;
         return $this;
     }
@@ -346,6 +351,11 @@ abstract class ServiceAbstract
      */
     public function setDescription(Description $description)
     {
+        $isEqual = $this->description && $this->description->equals($description);
+        if ($isEqual) {
+            return $this;
+        }
+
         $this->description = $description;
         return $this;
     }

--- a/library/Ivoz/Provider/Domain/Model/Timezone/Label.php
+++ b/library/Ivoz/Provider/Domain/Model/Timezone/Label.php
@@ -47,6 +47,19 @@ class Label
         $this->setIt($it);
     }
 
+    /**
+     * Equals
+     */
+    public function equals(self $label)
+    {
+        return
+            $this->getEn() === $label->getEn() &&
+            $this->getEs() === $label->getEs() &&
+            $this->getCa() === $label->getCa() &&
+            $this->getIt() === $label->getIt();
+    }
+
+
     // @codeCoverageIgnoreStart
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/Timezone/TimezoneAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Timezone/TimezoneAbstract.php
@@ -286,6 +286,11 @@ abstract class TimezoneAbstract
      */
     public function setLabel(Label $label)
     {
+        $isEqual = $this->label && $this->label->equals($label);
+        if ($isEqual) {
+            return $this;
+        }
+
         $this->label = $label;
         return $this;
     }

--- a/library/Ivoz/Provider/Domain/Model/TransformationRuleSet/Name.php
+++ b/library/Ivoz/Provider/Domain/Model/TransformationRuleSet/Name.php
@@ -47,6 +47,19 @@ class Name
         $this->setIt($it);
     }
 
+    /**
+     * Equals
+     */
+    public function equals(self $name)
+    {
+        return
+            $this->getEn() === $name->getEn() &&
+            $this->getEs() === $name->getEs() &&
+            $this->getCa() === $name->getCa() &&
+            $this->getIt() === $name->getIt();
+    }
+
+
     // @codeCoverageIgnoreStart
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/TransformationRuleSet/TransformationRuleSetAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/TransformationRuleSet/TransformationRuleSetAbstract.php
@@ -470,6 +470,11 @@ abstract class TransformationRuleSetAbstract
      */
     public function setName(Name $name)
     {
+        $isEqual = $this->name && $this->name->equals($name);
+        if ($isEqual) {
+            return $this;
+        }
+
         $this->name = $name;
         return $this;
     }

--- a/library/Ivoz/Provider/Domain/Model/WebPortal/Logo.php
+++ b/library/Ivoz/Provider/Domain/Model/WebPortal/Logo.php
@@ -41,6 +41,18 @@ class Logo
         $this->setBaseName($baseName);
     }
 
+    /**
+     * Equals
+     */
+    public function equals(self $logo)
+    {
+        return
+            $this->getFileSize() === $logo->getFileSize() &&
+            $this->getMimeType() === $logo->getMimeType() &&
+            $this->getBaseName() === $logo->getBaseName();
+    }
+
+
     // @codeCoverageIgnoreStart
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/WebPortal/WebPortalAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/WebPortal/WebPortalAbstract.php
@@ -400,6 +400,11 @@ abstract class WebPortalAbstract
      */
     public function setLogo(Logo $logo)
     {
+        $isEqual = $this->logo && $this->logo->equals($logo);
+        if ($isEqual) {
+            return $this;
+        }
+
         $this->logo = $logo;
         return $this;
     }

--- a/library/bin/composer-update
+++ b/library/bin/composer-update
@@ -1,45 +1,43 @@
 #!/bin/bash
 
 pushd /opt/irontec/ivozprovider/library
-    rm -fr composer.lock vendor
+    composer update $*
 popd
 
 pushd /opt/irontec/ivozprovider/asterisk/agi
-    rm -fr composer.lock vendor
+    composer update $*
 popd
 
 pushd /opt/irontec/ivozprovider/microservices/recordings
-    rm -fr composer.lock vendor
+    composer update $*
 popd
 
 pushd /opt/irontec/ivozprovider/microservices/workers
-    rm -fr composer.lock vendor
+    composer update $*
 popd
 
 pushd /opt/irontec/ivozprovider/microservices/balances
-    rm -fr composer.lock vendor
+    composer update $*
 popd
 
 pushd /opt/irontec/ivozprovider/microservices/scheduler
-    rm -fr composer.lock vendor
+    composer update $*
 popd
 
 pushd /opt/irontec/ivozprovider/schema
-    rm -fr composer.lock vendor
+    composer update $*
 popd
 
 pushd /opt/irontec/ivozprovider/web/rest/platform
-    rm -fr composer.lock vendor
+    composer update $*
 popd
 
 pushd /opt/irontec/ivozprovider/web/rest/brand
-    rm -fr composer.lock vendor
+    composer update $*
 popd
 
 pushd /opt/irontec/ivozprovider/web/rest/client
-    rm -fr composer.lock vendor
+    composer update $*
 popd
 
-pushd /opt/irontec/ivozprovider/library
-    bin/composer-install $*
-popd
+

--- a/library/composer.lock
+++ b/library/composer.lock
@@ -1904,16 +1904,16 @@
         },
         {
             "name": "irontec/ivoz-dev-tools",
-            "version": "2.2.2",
+            "version": "2.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/irontec/ivoz-dev-tools.git",
-                "reference": "6bdf7d6eb193963e0b7dca913e019d6c7c0319b2"
+                "reference": "1887c2210838032bb4995e385ec12763fa0ba2bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/irontec/ivoz-dev-tools/zipball/6bdf7d6eb193963e0b7dca913e019d6c7c0319b2",
-                "reference": "6bdf7d6eb193963e0b7dca913e019d6c7c0319b2",
+                "url": "https://api.github.com/repos/irontec/ivoz-dev-tools/zipball/1887c2210838032bb4995e385ec12763fa0ba2bc",
+                "reference": "1887c2210838032bb4995e385ec12763fa0ba2bc",
                 "shasum": ""
             },
             "require": {
@@ -1947,7 +1947,7 @@
                 }
             ],
             "description": "DevTools for ivozprovider",
-            "time": "2020-01-15T12:08:18+00:00"
+            "time": "2020-01-22T09:21:12+00:00"
         },
         {
             "name": "jdorn/sql-formatter",
@@ -4433,6 +4433,7 @@
             ],
             "description": "Handlebars processor for php",
             "homepage": "https://github.com/XaminProject/handlebars.php",
+            "abandoned": true,
             "time": "2016-12-12T13:51:02+00:00"
         },
         {

--- a/schema/composer.lock
+++ b/schema/composer.lock
@@ -1807,11 +1807,11 @@
         },
         {
             "name": "irontec/ivoz-dev-tools",
-            "version": "2.2.2.0",
+            "version": "2.3.1.0",
             "dist": {
                 "type": "path",
                 "url": "../library/vendor/irontec/ivoz-dev-tools",
-                "reference": "6bdf7d6eb193963e0b7dca913e019d6c7c0319b2",
+                "reference": "1887c2210838032bb4995e385ec12763fa0ba2bc",
                 "shasum": null
             },
             "require": {


### PR DESCRIPTION
Value object instances are replaced every time entity::updateFromDto is executed, this triggers unnecessary lifecycle events because doctrine compares non scalar values by reference. Do not replace them if value is equal.

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
