### PR TITLE
Friends disable directmedia

### DIFF
--- a/library/Ivoz/Ast/Domain/Service/PsEndpoint/UpdateByFriend.php
+++ b/library/Ivoz/Ast/Domain/Service/PsEndpoint/UpdateByFriend.php
@@ -4,6 +4,7 @@ namespace Ivoz\Ast\Domain\Service\PsEndpoint;
 
 use Ivoz\Ast\Domain\Model\PsEndpoint\PsEndpoint;
 use Ivoz\Ast\Domain\Model\PsEndpoint\PsEndpointDto;
+use Ivoz\Ast\Domain\Model\PsEndpoint\PsEndpointInterface;
 use Ivoz\Ast\Domain\Model\PsEndpoint\PsEndpointRepository;
 use Ivoz\Core\Domain\Service\EntityPersisterInterface;
 use Ivoz\Provider\Domain\Model\Friend\Friend;
@@ -80,18 +81,11 @@ class UpdateByFriend implements FriendLifecycleEventHandlerInterface
             ->setAors($entity->getSorcery())
             ->setDisallow($entity->getDisallow())
             ->setAllow($entity->getAllow())
-            ->setDirectmediaMethod($entity->getDirectmediaMethod())
             ->setTrustIdInbound('yes')
             ->setOutboundProxy('sip:users.ivozprovider.local^3Blr')
             ->setT38Udptl($entity->getT38Passthrough())
-            ->setDirectMediaMethod('invite');
-
-        // Disable direct media for T.38 capable devices
-        if ($entity->getT38Passthrough() === FriendInterface::T38PASSTHROUGH_YES) {
-            $endPointDto->setDirectMedia('no');
-        } else {
-            $endPointDto->setDirectMedia('yes');
-        }
+            ->setDirectMedia('no')
+            ->setDirectMediaMethod(PsEndpointInterface::DIRECTMEDIAMETHOD_INVITE);
 
         $this->entityPersister->persistDto($endPointDto, $endpoint, true);
     }

--- a/schema/app/DoctrineMigrations/Version20200127120901.php
+++ b/schema/app/DoctrineMigrations/Version20200127120901.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Ivoz\Core\Infrastructure\Persistence\Doctrine\LoggableMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20200127120901 extends LoggableMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('UPDATE ast_ps_endpoints SET direct_media="no" WHERE friendId IS NOT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('UPDATE ast_ps_endpoints SET direct_media="yes" WHERE friendId IS NOT NULL');
+    }
+}


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

Directmedia in friends call may cause no audio issues if SIP endpoint on the other side does not handle media liberation correctly.

This PR disables direcmedia for every friend to prevent these problems.