### PR TITLE
rest: added deprecation warning on /api/brand/users_cdrs

### DIFF
--- a/web/rest/brand/app/config/api/raw/kam.yml
+++ b/web/rest/brand/app/config/api/raw/kam.yml
@@ -15,9 +15,13 @@ Ivoz\Kam\Domain\Model\UsersLocation\RegistrationStatus:
 
 Ivoz\Kam\Domain\Model\UsersCdr\UsersCdr:
   itemOperations:
-    get: ~
+    get:
+      swagger_context:
+        description: 'DEPRECTAED METHOD: Will be removed in the next release'
   collectionOperations:
-    get: ~
+    get:
+      swagger_context:
+        description: 'DEPRECTAED METHOD: Will be removed in the next release'
   attributes:
     access_control: '"ROLE_BRAND_ADMIN" in roles'
     read_access_control:


### PR DESCRIPTION
Set /api/brand/users_cdrs as deprecated

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
