### PR TITLE
microservices: recover disableDestination logic

### DIFF
--- a/microservices/workers/src/Worker/Rates.php
+++ b/microservices/workers/src/Worker/Rates.php
@@ -349,9 +349,14 @@ class Rates
             $this->logger->debug('About to insert DestinationRates');
             $tpDestinationRateChunks = array_chunk($destinationRates, self::CHUNK_SIZE);
             foreach ($tpDestinationRateChunks as $destinationRates) {
-                $this
+                $affectedRows = $this
                     ->destinationRateRepository
                     ->insertIgnoreFromArray($destinationRates);
+
+                // Reload CGRateS destinations only if new prefixes have been added
+                if ($affectedRows > 0) {
+                    $disableDestinations = false;
+                }
             }
 
             /**


### PR DESCRIPTION
Restores logic implemented in 3027797 and deleted in 0120f85

<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
<!-- Describe your changes in detail -->

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
