### PR TITLE
kamtrunks: 0 as default value for trunksCdr.parsed

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -644,8 +644,6 @@ route[CHECK_SPECIAL] {
         $dlg_var(parsed) = '1'; # Skip this call in CDRs
         $var(noRater) = 1; # Skip rater for this call
         $dlg_var(noRecording) = '1'; # Skip recording for this call
-    } else {
-        $dlg_var(parsed) = '0';
     }
 }
 
@@ -1487,6 +1485,9 @@ route[CLASSIFY] {
         send_reply("500", "Internal Server Error [UT]");
         exit;
     }
+
+    # Set parsed default value
+    $dlg_var(parsed) = '0';
 
     xinfo("[$dlg_var(cidhash)] CLASSIFY: '$dlg_var(type)' call (b$dlg_var(brandId):c$dlg_var(companyId))");
 

--- a/library/Ivoz/Kam/Infrastructure/Persistence/Doctrine/TrunksCdrDoctrineRepository.php
+++ b/library/Ivoz/Kam/Infrastructure/Persistence/Doctrine/TrunksCdrDoctrineRepository.php
@@ -75,10 +75,7 @@ class TrunksCdrDoctrineRepository extends ServiceEntityRepository implements Tru
 
         $qb = $this->createQueryBuilder('self');
         $qb->addCriteria(CriteriaHelper::fromArray([
-            'or' => [
-                ['parsed', 'eq', '0'],
-                ['parsed', 'isNull'],
-            ],
+            ['parsed', 'eq', '0'],
             ['parserScheduledAt', 'lte', $dateFrom->format('Y-m-d H:i:s')],
         ]));
         $qb->setMaxResults($batchSize);


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
7c8b3ef introduced parsed handling in cfg for special numbers.
    
 This PR forces 0 as default value directly in kamailio.cfg. Without this, NULL was inserted for inbound calls, causing not being parsed by the cdr-mixer.

#### Additional information

Changes introduced in 58cb8d204 are no longer needed.