### PR TITLE
Do not use entity setter on services

### DIFF
--- a/library/Ivoz/Cgr/Domain/Service/TpDestination/CreatedByDestination.php
+++ b/library/Ivoz/Cgr/Domain/Service/TpDestination/CreatedByDestination.php
@@ -5,6 +5,7 @@ namespace Ivoz\Cgr\Domain\Service\TpDestination;
 use Ivoz\Cgr\Domain\Model\TpDestination\TpDestination;
 use Ivoz\Cgr\Domain\Model\TpDestination\TpDestinationDto;
 use Ivoz\Core\Application\Service\EntityTools;
+use Ivoz\Provider\Domain\Model\Destination\DestinationDto;
 use Ivoz\Provider\Domain\Model\Destination\DestinationInterface;
 use Ivoz\Provider\Domain\Service\Destination\DestinationLifecycleEventHandlerInterface;
 
@@ -68,10 +69,19 @@ class CreatedByDestination implements DestinationLifecycleEventHandlerInterface
             true
         );
 
-        $destination
-            ->setTpDestination($tpDestination);
+        /** @var DestinationDto $destinationDto */
+        $destinationDto = $this->entityTools->entityToDto(
+            $destination
+        );
 
-        $this->entityTools
-            ->persist($destination);
+        $destinationDto
+            ->setTpDestination($tpDestinationDto);
+
+        $this
+            ->entityTools
+            ->persistDto(
+                $destinationDto,
+                $destination
+            );
     }
 }

--- a/library/Ivoz/Cgr/Domain/Service/TpDestinationRate/UpdatedByDestinationRate.php
+++ b/library/Ivoz/Cgr/Domain/Service/TpDestinationRate/UpdatedByDestinationRate.php
@@ -6,6 +6,7 @@ use Ivoz\Cgr\Domain\Model\TpDestinationRate\TpDestinationRate;
 use Ivoz\Cgr\Domain\Model\TpDestinationRate\TpDestinationRateDto;
 use Ivoz\Cgr\Domain\Service\TpRate\UpdatedByDestinationRate as TpRateUpdatedByDestinationRate;
 use Ivoz\Core\Application\Service\EntityTools;
+use Ivoz\Provider\Domain\Model\DestinationRate\DestinationRateDto;
 use Ivoz\Provider\Domain\Model\DestinationRate\DestinationRateInterface;
 use Ivoz\Provider\Domain\Service\DestinationRate\DestinationRateLifecycleEventHandlerInterface;
 
@@ -69,10 +70,21 @@ class UpdatedByDestinationRate implements DestinationRateLifecycleEventHandlerIn
             true
         );
 
-        $destinationRate
-            ->setTpDestinationRate($tpDestinationRate);
+        /** @var DestinationRateDto $destinationRateDto */
+        $destinationRateDto = $this
+            ->entityTools
+            ->entityToDto(
+                $destinationRate
+            );
 
-        $this->entityTools
-            ->persist($destinationRate);
+        $destinationRateDto
+            ->setTpDestinationRate($tpDestinationRateDto);
+
+        $this
+            ->entityTools
+            ->persistDto(
+                $destinationRateDto,
+                $destinationRate
+            );
     }
 }

--- a/library/Ivoz/Cgr/Domain/Service/TpRate/UpdatedByDestinationRate.php
+++ b/library/Ivoz/Cgr/Domain/Service/TpRate/UpdatedByDestinationRate.php
@@ -5,6 +5,7 @@ namespace Ivoz\Cgr\Domain\Service\TpRate;
 use Ivoz\Cgr\Domain\Model\TpRate\TpRate;
 use Ivoz\Cgr\Domain\Model\TpRate\TpRateDto;
 use Ivoz\Core\Application\Service\EntityTools;
+use Ivoz\Provider\Domain\Model\DestinationRate\DestinationRateDto;
 use Ivoz\Provider\Domain\Model\DestinationRate\DestinationRateInterface;
 use Ivoz\Provider\Domain\Service\DestinationRate\DestinationRateLifecycleEventHandlerInterface;
 
@@ -64,16 +65,29 @@ class UpdatedByDestinationRate implements DestinationRateLifecycleEventHandlerIn
             ->setRateIncrement($destinationRate->getRateIncrement())
             ->setGroupIntervalStart($destinationRate->getGroupIntervalStart());
 
-        $tpRate = $this->entityTools->persistDto(
-            $tpRateDto,
-            $tpRate,
-            true
-        );
+        $tpRate = $this
+            ->entityTools
+            ->persistDto(
+                $tpRateDto,
+                $tpRate,
+                true
+            );
 
-        $destinationRate
-            ->setTpRate($tpRate);
+        /** @var DestinationRateDto $destinationRateDto */
+        $destinationRateDto = $this
+            ->entityTools
+            ->entityToDto(
+                $destinationRate
+            );
 
-        $this->entityTools
-            ->persist($destinationRate);
+        $destinationRateDto
+            ->setTpRate($tpRateDto);
+
+        $this
+            ->entityTools
+            ->persistDto(
+                $destinationRateDto,
+                $destinationRate
+            );
     }
 }

--- a/library/Ivoz/Kam/Domain/Service/TrunksAddress/UpdateByDdiProviderAddress.php
+++ b/library/Ivoz/Kam/Domain/Service/TrunksAddress/UpdateByDdiProviderAddress.php
@@ -4,6 +4,7 @@ namespace Ivoz\Kam\Domain\Service\TrunksAddress;
 
 use Ivoz\Core\Application\Service\EntityTools;
 use Ivoz\Kam\Domain\Model\TrunksAddress\TrunksAddressDto;
+use Ivoz\Provider\Domain\Model\DdiProviderAddress\DdiProviderAddressDto;
 use Ivoz\Provider\Domain\Model\DdiProviderAddress\DdiProviderAddressInterface;
 use Ivoz\Provider\Domain\Service\DdiProviderAddress\DdiProviderAddressLifecycleEventHandlerInterface;
 
@@ -56,10 +57,19 @@ class UpdateByDdiProviderAddress implements DdiProviderAddressLifecycleEventHand
             true
         );
 
-        $ddiProviderAddress
-            ->setTrunksAddress($trunksAddress);
+        /** @var DdiProviderAddressDto $ddiProviderAddressDto */
+        $ddiProviderAddressDto = $this->entityTools->entityToDto(
+            $ddiProviderAddress
+        );
 
-        $this->entityTools
-            ->persist($ddiProviderAddress);
+        $ddiProviderAddressDto
+            ->setTrunksAddress($trunksAddressDto);
+
+        $this
+            ->entityTools
+            ->persistDto(
+                $ddiProviderAddressDto,
+                $ddiProviderAddress
+            );
     }
 }

--- a/library/Ivoz/Kam/Domain/Service/TrunksLcrGateway/UpdateByCarrierServer.php
+++ b/library/Ivoz/Kam/Domain/Service/TrunksLcrGateway/UpdateByCarrierServer.php
@@ -5,6 +5,7 @@ namespace Ivoz\Kam\Domain\Service\TrunksLcrGateway;
 use Ivoz\Core\Application\Service\EntityTools;
 use Ivoz\Kam\Domain\Model\TrunksLcrGateway\TrunksLcrGateway;
 use Ivoz\Kam\Domain\Model\TrunksLcrGateway\TrunksLcrGatewayDto;
+use Ivoz\Provider\Domain\Model\CarrierServer\CarrierServerDto;
 use Ivoz\Provider\Domain\Model\CarrierServer\CarrierServerInterface;
 use Ivoz\Provider\Domain\Service\CarrierServer\CarrierServerLifecycleEventHandlerInterface;
 
@@ -52,13 +53,29 @@ class UpdateByCarrierServer implements CarrierServerLifecycleEventHandlerInterfa
             ->setTransport($carrierServer->getTransport())
             ->setCarrierServerId($carrierServer->getId());
 
-        $lcrGateway = $this->entityTools->persistDto(
-            $lcrGatewayDto,
-            $lcrGateway,
-            true
-        );
+        $this
+            ->entityTools
+            ->persistDto(
+                $lcrGatewayDto,
+                $lcrGateway,
+                true
+            );
 
-        $carrierServer->setLcrGateway($lcrGateway);
-        $this->entityTools->persist($carrierServer);
+        /** @var CarrierServerDto $carrierServerDto */
+        $carrierServerDto = $this
+            ->entityTools
+            ->entityToDto(
+                $carrierServer
+            );
+
+        $carrierServerDto
+            ->setLcrGateway($lcrGatewayDto);
+
+        $this
+            ->entityTools
+            ->persistDto(
+                $carrierServerDto,
+                $carrierServer
+            );
     }
 }

--- a/library/spec/Ivoz/Cgr/Domain/Service/TpDestination/CreatedByDestinationSpec.php
+++ b/library/spec/Ivoz/Cgr/Domain/Service/TpDestination/CreatedByDestinationSpec.php
@@ -7,6 +7,7 @@ use Ivoz\Cgr\Domain\Model\TpDestination\TpDestinationInterface;
 use Ivoz\Cgr\Domain\Service\TpDestination\CreatedByDestination;
 use Ivoz\Core\Application\Service\EntityTools;
 use Ivoz\Provider\Domain\Model\Brand\BrandInterface;
+use Ivoz\Provider\Domain\Model\Destination\DestinationDto;
 use Ivoz\Provider\Domain\Model\Destination\DestinationInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
@@ -19,6 +20,7 @@ class CreatedByDestinationSpec extends ObjectBehavior
     protected $entityTools;
 
     protected $destination;
+    protected $destinationDto;
     protected $brand;
     protected $tpDestination;
     protected $tpDestinationDto;
@@ -38,6 +40,11 @@ class CreatedByDestinationSpec extends ObjectBehavior
     {
         $this->destination = $destination = $this->getTestDouble(
             DestinationInterface::class,
+            true
+        );
+
+        $this->destinationDto = $destinationDto = $this->getTestDouble(
+            DestinationDto::class,
             true
         );
 
@@ -79,6 +86,11 @@ class CreatedByDestinationSpec extends ObjectBehavior
             ->entityTools
             ->entityToDto($tpDestination)
             ->willReturn($tpDestinationDto);
+
+        $this
+            ->entityTools
+            ->entityToDto($destination)
+            ->willReturn($destinationDto);
 
         $this
             ->entityTools
@@ -151,8 +163,16 @@ class CreatedByDestinationSpec extends ObjectBehavior
         $this->prepareExecution();
 
         $this
+            ->destinationDto
+            ->setTpDestination(
+                $this->tpDestinationDto
+            )
+            ->shouldBeCalled();
+
+        $this
             ->entityTools
-            ->persist(
+            ->persistDto(
+                Argument::type(DestinationDto::class),
                 Argument::type(DestinationInterface::class)
             )
             ->shouldBeCalled();

--- a/library/spec/Ivoz/Cgr/Domain/Service/TpDestinationRate/UpdatedByDestinationRateSpec.php
+++ b/library/spec/Ivoz/Cgr/Domain/Service/TpDestinationRate/UpdatedByDestinationRateSpec.php
@@ -7,6 +7,7 @@ use Ivoz\Cgr\Domain\Model\TpDestinationRate\TpDestinationRateInterface;
 use Ivoz\Cgr\Domain\Service\TpDestinationRate\UpdatedByDestinationRate;
 use Ivoz\Core\Application\Service\EntityTools;
 use Ivoz\Provider\Domain\Model\Brand\BrandInterface;
+use Ivoz\Provider\Domain\Model\DestinationRate\DestinationRateDto;
 use Ivoz\Provider\Domain\Model\DestinationRate\DestinationRateInterface;
 use Ivoz\Provider\Domain\Model\DestinationRateGroup\DestinationRateGroupInterface;
 use PhpSpec\ObjectBehavior;
@@ -19,6 +20,7 @@ class UpdatedByDestinationRateSpec extends ObjectBehavior
 
     protected $entityTools;
     protected $destinationRate;
+    protected $destinationRateDto;
     protected $destinationRateGroup;
     protected $brand;
     protected $tpDestinationRate;
@@ -40,6 +42,11 @@ class UpdatedByDestinationRateSpec extends ObjectBehavior
     {
         $this->destinationRate = $this->getTestDouble(
             DestinationRateInterface::class,
+            true
+        );
+
+        $this->destinationRateDto = $this->getTestDouble(
+            DestinationRateDto::class,
             true
         );
 
@@ -107,6 +114,15 @@ class UpdatedByDestinationRateSpec extends ObjectBehavior
         $this
             ->entityTools
             ->entityToDto(
+                $this->destinationRate
+            )
+            ->willReturn(
+                $this->destinationRateDto
+            );
+
+        $this
+            ->entityTools
+            ->entityToDto(
                 $this->tpDestinationRate
             )
             ->willReturn(
@@ -151,14 +167,15 @@ class UpdatedByDestinationRateSpec extends ObjectBehavior
         $this->prepareExecution();
 
         $this
-            ->destinationRate
+            ->destinationRateDto
             ->setTpDestinationRate(
-                $this->tpDestinationRate
+                $this->tpDestinationRateDto
             )
             ->shouldBeCalled();
 
         $this->entityTools
-            ->persist(
+            ->persistDto(
+                $this->destinationRateDto,
                 $this->destinationRate
             )
             ->shouldBeCalled();

--- a/library/spec/Ivoz/Cgr/Domain/Service/TpRate/UpdatedByDestinationRateSpec.php
+++ b/library/spec/Ivoz/Cgr/Domain/Service/TpRate/UpdatedByDestinationRateSpec.php
@@ -7,6 +7,7 @@ use Ivoz\Cgr\Domain\Model\TpRate\TpRateInterface;
 use Ivoz\Cgr\Domain\Service\TpRate\UpdatedByDestinationRate;
 use Ivoz\Core\Application\Service\EntityTools;
 use Ivoz\Provider\Domain\Model\Brand\BrandInterface;
+use Ivoz\Provider\Domain\Model\DestinationRate\DestinationRateDto;
 use Ivoz\Provider\Domain\Model\DestinationRate\DestinationRateInterface;
 use Ivoz\Provider\Domain\Model\DestinationRateGroup\DestinationRateGroupInterface;
 use PhpSpec\ObjectBehavior;
@@ -19,6 +20,7 @@ class UpdatedByDestinationRateSpec extends ObjectBehavior
 
     protected $entityTools;
     protected $destinationRate;
+    protected $destinationRateDto;
     protected $destinationRateGroup;
     protected $brand;
     protected $tpRate;
@@ -40,6 +42,11 @@ class UpdatedByDestinationRateSpec extends ObjectBehavior
     {
         $this->destinationRate = $this->getTestDouble(
             DestinationRateInterface::class,
+            true
+        );
+
+        $this->destinationRateDto = $this->getTestDouble(
+            DestinationRateDto::class,
             true
         );
 
@@ -112,6 +119,11 @@ class UpdatedByDestinationRateSpec extends ObjectBehavior
             ->entityTools
             ->entityToDto($this->tpRate)
             ->willReturn($this->tpRateDto);
+
+        $this
+            ->entityTools
+            ->entityToDto($this->destinationRate)
+            ->willReturn($this->destinationRateDto);
     }
 
     function it_is_initializable()
@@ -141,9 +153,18 @@ class UpdatedByDestinationRateSpec extends ObjectBehavior
         $this
             ->prepareExecution();
 
+        $this->destinationRateDto
+            ->setTpRate(
+                $this->tpRateDto
+            )
+        ->shouldbeCalled();
+
         $this
             ->entityTools
-            ->persist($this->destinationRate)
+            ->persistDto(
+                $this->destinationRateDto,
+                $this->destinationRate
+            )
             ->shouldBeCalled();
 
         $this->execute($this->destinationRate);

--- a/library/spec/Ivoz/Kam/Domain/Service/TrunksLcrGateway/UpdateByCarrierServerSpec.php
+++ b/library/spec/Ivoz/Kam/Domain/Service/TrunksLcrGateway/UpdateByCarrierServerSpec.php
@@ -5,6 +5,7 @@ namespace spec\Ivoz\Kam\Domain\Service\TrunksLcrGateway;
 use Ivoz\Core\Application\Service\EntityTools;
 use Ivoz\Kam\Domain\Model\TrunksLcrGateway\TrunksLcrGatewayDto;
 use Ivoz\Kam\Domain\Model\TrunksLcrGateway\TrunksLcrGatewayInterface;
+use Ivoz\Provider\Domain\Model\CarrierServer\CarrierServerDto;
 use Ivoz\Provider\Domain\Model\CarrierServer\CarrierServerInterface;
 use Ivoz\Kam\Domain\Service\TrunksLcrGateway\UpdateByCarrierServer;
 use PhpSpec\ObjectBehavior;
@@ -20,6 +21,9 @@ class UpdateByCarrierServerSpec extends ObjectBehavior
      */
     protected $entityTools;
 
+    protected $carrierServer;
+    protected $carrierServerDto;
+
     public function let(
         EntityTools $entityTools
     ) {
@@ -33,86 +37,114 @@ class UpdateByCarrierServerSpec extends ObjectBehavior
         $this->shouldHaveType(UpdateByCarrierServer::class);
     }
 
-    function it_creates_lcr_gateway_if_none(
-        CarrierServerInterface $entity,
-        TrunksLcrGatewayInterface $lcrGateway
+    private function prepareExecution(
+        TrunksLcrGatewayInterface $lcrGateway = null
     ) {
+        $this->carrierServer = $this->getTestDouble(
+            CarrierServerInterface::class
+        );
+
         $this->getterProphecy(
-            $entity,
+            $this->carrierServer,
             [
-                'getLcrGateway' => null,
-                'getName' => null,
-                'getIp' => null,
-                'getHostname' => null,
-                'getPort' => null,
-                'getUriScheme' => null,
-                'getTransport' => null,
-                'getId' => null
-            ]
+                'getLcrGateway' => $lcrGateway
+            ],
+            true
+        );
+
+        $this->carrierServerDto = $this->getTestDouble(
+            CarrierServerDto::class
         );
 
         $this
             ->entityTools
             ->persistDto(
                 Argument::type(TrunksLcrGatewayDto::class),
-                null,
+                $lcrGateway,
                 true
             )
-            ->willReturn($lcrGateway);
-
-        $entity
-            ->setLcrGateway($lcrGateway)
-            ->shouldBeCalled();
-
-        $this->entityTools
-            ->persist($entity)
-            ->shouldBeCalled();
-
-        $this->execute($entity);
-    }
-
-    function it_updates_lcr_gateway(
-        CarrierServerInterface $entity,
-        TrunksLcrGatewayInterface $lcrGateway
-    ) {
-        $this->getterProphecy(
-            $entity,
-            [
-                'getLcrGateway' => $lcrGateway,
-                'getName' => null,
-                'getIp' => null,
-                'getHostname' => null,
-                'getPort' => null,
-                'getUriScheme' => null,
-                'getTransport' => null,
-                'getId' => null
-            ]
-        );
-
-        $dto = new TrunksLcrGatewayDto();
-
-        $lcrGateway
-            ->toDto()
-            ->willReturn($dto)
             ->shouldBeCalled();
 
         $this
             ->entityTools
+            ->entityToDto(
+                $this->carrierServer
+            )
+            ->willReturn(
+                $this->carrierServerDto
+            );
+
+        $this
+            ->entityTools
             ->persistDto(
-                $dto,
+                $this->carrierServerDto,
+                $this->carrierServer
+            )
+            ->shouldBeCalled();
+    }
+
+    function it_creates_lcr_gateway_if_none()
+    {
+        $lcrGateway = null;
+        $this->prepareExecution(
+            $lcrGateway
+        );
+
+        $this
+            ->entityTools
+            ->persistDto(
+                Argument::type(TrunksLcrGatewayDto::class),
+                Argument::type(TrunksLcrGatewayinterface::class),
+                true
+            );
+
+        $this
+            ->carrierServerDto
+            ->setLcrGateway(
+                Argument::type(TrunksLcrGatewayDto::class)
+            )
+            ->shouldBeCalled();
+
+        $this->execute(
+            $this->carrierServer
+        );
+    }
+
+    function it_updates_lcr_gateway()
+    {
+        $lcrGateway = $this->getTestDouble(
+            TrunksLcrGatewayInterface::class,
+            false
+        );
+
+        $lcrGatewayDto = new TrunksLcrGatewayDto();
+        $lcrGateway
+            ->toDto()
+            ->willReturn($lcrGatewayDto)
+            ->shouldBeCalled();
+
+        $this->prepareExecution(
+            $lcrGateway
+        );
+
+        $this
+            ->entityTools
+            ->persistDto(
+                $lcrGatewayDto,
                 $lcrGateway,
                 true
             )
-            ->willReturn($lcrGateway);
-
-        $entity
-            ->setLcrGateway($lcrGateway)
             ->shouldBeCalled();
 
-        $this->entityTools
-            ->persist($entity)
+        $this
+            ->carrierServerDto
+            ->setLcrGateway(
+                $lcrGatewayDto
+            )
             ->shouldBeCalled();
 
-        $this->execute($entity);
+        $this->execute(
+            $this->carrierServer
+        );
     }
 }


### PR DESCRIPTION
Replace entity direct setters on services by dtos

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
