### PR TITLE
Kam: minor fixes

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -978,7 +978,7 @@ route[PARSE_X_HEADERS] {
         xnotice("[$dlg_var(cidhash)] X-HEADERS-OTHER: Related leg: $dlg_var(xcallid)\n");
     }
 
-    if ($dlg_var(type) == 'wholesale' || $dlg_var(type) == 'retail') return;
+    if ($dlg_var(type) == 'wholesale') return;
 
     # Extract X-Info-Special header
     $var(header) = 'X-Info-Special';

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -987,20 +987,6 @@ route[PARSE_X_HEADERS] {
         xinfo("[$dlg_var(cidhash)] X-HEADERS-OTHER: X-Info-Special header found (value: fax)\n");
         $avp(fax) = '1';
     }
-
-    # -- xcallid is mandatory for every vPBX/residential call.
-    #    Check if X-Info-Special header is present with 'fax' value (current only exception)
-    if ($(dlg_var(xcallid){s.len}) == 0) {
-        if ($avp(fax) == '1') {
-            xinfo("[$dlg_var(cidhash)] X-HEADERS-OTHER: Special case without xcallid: fax\n");
-        } else {
-            xerr("[$dlg_var(cidhash)] X-HEADERS-OTHER: Invalid $var(header) value ($var(header-value)) for call without xcallid\n");
-            send_reply("500", "x-callid is missing");
-            exit;
-        }
-    } else {
-        xnotice("[$dlg_var(cidhash)] X-HEADERS-OTHER: Related leg: $dlg_var(xcallid)\n");
-    }
 }
 
 # Header might not be present and, if present, might be empty

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -1391,6 +1391,7 @@ route[IS_INTERNAL] {
     }
 
     # Is extension in Extensions?
+    $xavp(ra) = $null;
     sql_xquery("cb", "SELECT COUNT(*) > 0 AS isExtension FROM Extensions E WHERE number='$var(number)' AND companyId='$dlg_var(companyId)'", "ra");
     if ($xavp(ra=>isExtension) == '1') {
         xinfo("[$dlg_var(cidhash)] IS-INTERNAL: $var(number) is an internal extension\n");
@@ -1399,6 +1400,7 @@ route[IS_INTERNAL] {
     }
 
     # Is a friend?
+    $xavp(rd) = $null;
     sql_xquery("cb", "SELECT F.id, F.directConnectivity, F.interCompanyId FROM FriendsPatterns FP JOIN Friends F ON FP.friendId=F.id WHERE F.companyId='$dlg_var(companyId)' AND '$var(number)' REGEXP `regExp` ORDER BY F.priority ASC LIMIT 1", "rd");
     if ($xavp(rd=>directConnectivity) != $null) {
         if ($xavp(rd=>directConnectivity) == 'intervpbx') {


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

3 minor fixes here:

- KamTrunks dropped calls if X-Call-Id was missing. This is not done anymore, as has no effect in call establishment.

- KamTrunks parsed X-Info-Special header for fax route detection. Retails calls can also contain this header now (since T.38 passthrough was added).

- KamUsers IS_INTERNAL detected wrong internal numbers in some call bouncing scenarios due to XAVP inheritance. This PR empties XAVPs to avoid this situation.