### PR TITLE
pkg: changes on postinstall scripts

### DIFF
--- a/debian/ivozprovider-profile-common.postinst
+++ b/debian/ivozprovider-profile-common.postinst
@@ -11,7 +11,4 @@ if [ -z "$2" ]; then
     echo >> /root/.bashrc
 fi
 
-# Change storage perms
-chmod 777 -R /opt/irontec/ivozprovider/storage
-
 :

--- a/debian/ivozprovider-schema.postinst
+++ b/debian/ivozprovider-schema.postinst
@@ -53,7 +53,7 @@ function schema_migrations()
     cd /opt/irontec/ivozprovider/schema
     bin/console cache:clear --no-warmup -q -n
     bin/console doctrine:migrations:status
-    bin/console doctrine:migrations:migrate --no-interaction --quiet
+    bin/console doctrine:migrations:migrate --no-interaction
 }
 
 #######################################################################################################################

--- a/doc/dev/en/storage.md
+++ b/doc/dev/en/storage.md
@@ -12,11 +12,6 @@ from application.ini files:
         Iron.fso.localStoragePath  = "/opt/irontec/ivozprovider/storage"
         Iron.fso.localStorageChmod = "0777"
 
-You may have found some files with
-0777 as well, that's because the command below is executed after every package upgrade:
-
-    chmod 777 -R /opt/irontec/ivozprovider/storage
-
 ## Recordings
 
 Recording system is executed as root and it uses these three folders:


### PR DESCRIPTION

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

Two changes in postinstall scripts:

- Apply doctrine migrations without quietness.

- Do not execute recursive chmod on storage.
