### PR TITLE
core: removed duplicated settings

### DIFF
--- a/asterisk/agi/composer.lock
+++ b/asterisk/agi/composer.lock
@@ -1311,11 +1311,11 @@
         },
         {
             "name": "irontec/ivoz-core-bundle",
-            "version": "2.3.0.0-RC",
+            "version": "2.3.1.0",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/irontec/ivoz-core-bundle",
-                "reference": "1aed75a07514075390cc1f6e201e7177b5e7dc1a",
+                "reference": "18cc348118422d3cfb27e5b1671261f698cdc6f7",
                 "shasum": null
             },
             "require": {

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/BillableCall.BillableCallAbstract.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/BillableCall.BillableCallAbstract.orm.yml
@@ -84,8 +84,6 @@ Ivoz\Provider\Domain\Model\BillableCall\BillableCallAbstract:
       nullable: true
       options:
         unsigned: true
-      type: integer
-      options:
         fixed: false
       column: endpointId
     direction:

--- a/library/composer-packages/irontec/ivoz-provider-bundle/ProviderBundle.php
+++ b/library/composer-packages/irontec/ivoz-provider-bundle/ProviderBundle.php
@@ -6,8 +6,4 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class ProviderBundle extends Bundle
 {
-    public function getParent()
-    {
-        return 'CoreBundle';
-    }
 }

--- a/library/composer.json
+++ b/library/composer.json
@@ -66,7 +66,7 @@
         "h4cc/wkhtmltopdf-amd64": "0.12.3",
         "incenteev/composer-parameter-handler": "^2.0",
         "irontec/ivoz-api-bundle": "^2.0",
-        "irontec/ivoz-core-bundle": "^2.3",
+        "irontec/ivoz-core-bundle": "^2.3.1",
         "irontec/ivoz-dev-tools": "^2.0",
         "irontec/ivoz-provider-bundle": "^2.0",
         "knplabs/knp-snappy": "0.4.3",

--- a/library/composer.json
+++ b/library/composer.json
@@ -38,6 +38,10 @@
             "options": {
                 "symlink": false
             }
+        },
+        {
+            "url": "https://github.com/mmadariaga/TestDoubleBundle.git",
+            "type": "git"
         }
     ],
     "autoload-dev": {

--- a/library/composer.lock
+++ b/library/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "78b2f723382c6a804604485973b6880d",
+    "content-hash": "e3fd7820bd7b5d1f8482188cfbdabcd0",
     "packages": [
         {
             "name": "api-platform/core",
@@ -1853,16 +1853,16 @@
         },
         {
             "name": "irontec/ivoz-core-bundle",
-            "version": "2.3",
+            "version": "2.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/irontec/ivoz-core-bundle.git",
-                "reference": "1aed75a07514075390cc1f6e201e7177b5e7dc1a"
+                "reference": "18cc348118422d3cfb27e5b1671261f698cdc6f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/irontec/ivoz-core-bundle/zipball/1aed75a07514075390cc1f6e201e7177b5e7dc1a",
-                "reference": "1aed75a07514075390cc1f6e201e7177b5e7dc1a",
+                "url": "https://api.github.com/repos/irontec/ivoz-core-bundle/zipball/18cc348118422d3cfb27e5b1671261f698cdc6f7",
+                "reference": "18cc348118422d3cfb27e5b1671261f698cdc6f7",
                 "shasum": ""
             },
             "require": {
@@ -1900,7 +1900,7 @@
                 }
             ],
             "description": "Symfony bridge for ivoz-core",
-            "time": "2020-01-17T13:32:06+00:00"
+            "time": "2020-02-13T14:20:46+00:00"
         },
         {
             "name": "irontec/ivoz-dev-tools",

--- a/library/composer.lock
+++ b/library/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "5faf3b361f6a3f58fe04bf0df559c8d8",
+    "content-hash": "78b2f723382c6a804604485973b6880d",
     "packages": [
         {
             "name": "api-platform/core",
@@ -5337,23 +5337,17 @@
         },
         {
             "name": "docteurklein/test-double-bundle",
-            "version": "1.0.0",
+            "version": "1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/docteurklein/TestDoubleBundle.git",
-                "reference": "01fe312bdf2069b095f70ed3d92f4578a7b6e549"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/docteurklein/TestDoubleBundle/zipball/01fe312bdf2069b095f70ed3d92f4578a7b6e549",
-                "reference": "01fe312bdf2069b095f70ed3d92f4578a7b6e549",
-                "shasum": ""
+                "url": "https://github.com/mmadariaga/TestDoubleBundle.git",
+                "reference": "8927771953f53317b54e6fd8fc05058f62570be6"
             },
             "require": {
                 "php": ">=5.4",
-                "phpspec/prophecy": "^1.6",
-                "symfony/dependency-injection": "^2.0|^3.0",
-                "symfony/http-kernel": "^2.0|^3.0"
+                "phpspec/prophecy": "^1.8",
+                "symfony/dependency-injection": "^2.0|^3.0|^4.0",
+                "symfony/http-kernel": "^2.0|^3.0|^4.0"
             },
             "type": "symfony-bundle",
             "autoload": {
@@ -5361,7 +5355,6 @@
                     "DocteurKlein\\": ""
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -5372,7 +5365,7 @@
                 }
             ],
             "description": "Easily create test doubles using symfony DIC",
-            "time": "2016-02-27T13:58:30+00:00"
+            "time": "2019-07-10T20:36:52+00:00"
         },
         {
             "name": "doctrine/data-fixtures",

--- a/microservices/balances/composer.lock
+++ b/microservices/balances/composer.lock
@@ -1311,11 +1311,11 @@
         },
         {
             "name": "irontec/ivoz-core-bundle",
-            "version": "2.3.0.0-RC",
+            "version": "2.3.1.0",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/irontec/ivoz-core-bundle",
-                "reference": "1aed75a07514075390cc1f6e201e7177b5e7dc1a",
+                "reference": "18cc348118422d3cfb27e5b1671261f698cdc6f7",
                 "shasum": null
             },
             "require": {

--- a/microservices/recordings/composer.lock
+++ b/microservices/recordings/composer.lock
@@ -1340,11 +1340,11 @@
         },
         {
             "name": "irontec/ivoz-core-bundle",
-            "version": "2.3.0.0-RC",
+            "version": "2.3.1.0",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/irontec/ivoz-core-bundle",
-                "reference": "1aed75a07514075390cc1f6e201e7177b5e7dc1a",
+                "reference": "18cc348118422d3cfb27e5b1671261f698cdc6f7",
                 "shasum": null
             },
             "require": {

--- a/microservices/scheduler/composer.lock
+++ b/microservices/scheduler/composer.lock
@@ -1311,11 +1311,11 @@
         },
         {
             "name": "irontec/ivoz-core-bundle",
-            "version": "2.3.0.0-RC",
+            "version": "2.3.1.0",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/irontec/ivoz-core-bundle",
-                "reference": "1aed75a07514075390cc1f6e201e7177b5e7dc1a",
+                "reference": "18cc348118422d3cfb27e5b1671261f698cdc6f7",
                 "shasum": null
             },
             "require": {

--- a/microservices/workers/composer.lock
+++ b/microservices/workers/composer.lock
@@ -1347,11 +1347,11 @@
         },
         {
             "name": "irontec/ivoz-core-bundle",
-            "version": "2.3.0.0-RC",
+            "version": "2.3.1.0",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/irontec/ivoz-core-bundle",
-                "reference": "1aed75a07514075390cc1f6e201e7177b5e7dc1a",
+                "reference": "18cc348118422d3cfb27e5b1671261f698cdc6f7",
                 "shasum": null
             },
             "require": {

--- a/schema/app/config/config.yml
+++ b/schema/app/config/config.yml
@@ -13,9 +13,6 @@ doctrine:
         is_bundle: false
         dir: '%kernel.root_dir%/../src/Entity'
         prefix: 'Gesdinet\JWTRefreshTokenBundle\Entity'
-imports:
-  - { resource: "orm_target_entities.yml" }
-
 
 doctrine_migrations:
   dir_name: "%kernel.root_dir%/DoctrineMigrations"

--- a/schema/composer.lock
+++ b/schema/composer.lock
@@ -1760,11 +1760,11 @@
         },
         {
             "name": "irontec/ivoz-core-bundle",
-            "version": "2.3.0.0-RC",
+            "version": "2.3.1.0",
             "dist": {
                 "type": "path",
                 "url": "../library/vendor/irontec/ivoz-core-bundle",
-                "reference": "1aed75a07514075390cc1f6e201e7177b5e7dc1a",
+                "reference": "18cc348118422d3cfb27e5b1671261f698cdc6f7",
                 "shasum": null
             },
             "require": {

--- a/schema/composer.lock
+++ b/schema/composer.lock
@@ -4035,18 +4035,18 @@
     "packages-dev": [
         {
             "name": "docteurklein/test-double-bundle",
-            "version": "1.0.0.0",
+            "version": "1.1.0.0",
             "dist": {
                 "type": "path",
                 "url": "../library/vendor/docteurklein/test-double-bundle",
-                "reference": "01fe312bdf2069b095f70ed3d92f4578a7b6e549",
+                "reference": "8927771953f53317b54e6fd8fc05058f62570be6",
                 "shasum": null
             },
             "require": {
                 "php": ">=5.4",
-                "phpspec/prophecy": "^1.6",
-                "symfony/dependency-injection": "^2.0|^3.0",
-                "symfony/http-kernel": "^2.0|^3.0"
+                "phpspec/prophecy": "^1.8",
+                "symfony/dependency-injection": "^2.0|^3.0|^4.0",
+                "symfony/http-kernel": "^2.0|^3.0|^4.0"
             },
             "type": "symfony-bundle",
             "autoload": {

--- a/web/rest/brand/app/config/security.yml
+++ b/web/rest/brand/app/config/security.yml
@@ -27,7 +27,6 @@ security:
       provider: admin_orm
       form_login:
           check_path: /admin_login
-          require_previous_session: false
           username_parameter: username
           password_parameter: password
           success_handler: lexik_jwt_authentication.handler.authentication_success

--- a/web/rest/brand/composer.lock
+++ b/web/rest/brand/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "ba1beed9eb8b3dba480908fddd83422d",
+    "content-hash": "58d46e1a131b60805a5f5cb4b65938bb",
     "packages": [
         {
             "name": "api-platform/core",
@@ -4598,18 +4598,18 @@
         },
         {
             "name": "docteurklein/test-double-bundle",
-            "version": "1.0.0.0",
+            "version": "1.1.0.0",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/docteurklein/test-double-bundle",
-                "reference": "01fe312bdf2069b095f70ed3d92f4578a7b6e549",
+                "reference": "8927771953f53317b54e6fd8fc05058f62570be6",
                 "shasum": null
             },
             "require": {
                 "php": ">=5.4",
-                "phpspec/prophecy": "^1.6",
-                "symfony/dependency-injection": "^2.0|^3.0",
-                "symfony/http-kernel": "^2.0|^3.0"
+                "phpspec/prophecy": "^1.8",
+                "symfony/dependency-injection": "^2.0|^3.0|^4.0",
+                "symfony/http-kernel": "^2.0|^3.0|^4.0"
             },
             "type": "symfony-bundle",
             "autoload": {

--- a/web/rest/brand/composer.lock
+++ b/web/rest/brand/composer.lock
@@ -1689,11 +1689,11 @@
         },
         {
             "name": "irontec/ivoz-core-bundle",
-            "version": "2.3.0.0-RC",
+            "version": "2.3.1.0",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/irontec/ivoz-core-bundle",
-                "reference": "1aed75a07514075390cc1f6e201e7177b5e7dc1a",
+                "reference": "18cc348118422d3cfb27e5b1671261f698cdc6f7",
                 "shasum": null
             },
             "require": {

--- a/web/rest/client/app/config/api/raw/kam.yml
+++ b/web/rest/client/app/config/api/raw/kam.yml
@@ -23,7 +23,6 @@ Ivoz\Kam\Domain\Model\UsersCdr\UsersCdr:
           eq: "user.getCompany().getId()"
         hidden:
           eq: 0
-
   itemOperations:
     get: ~
   collectionOperations:
@@ -44,5 +43,3 @@ Ivoz\Kam\Domain\Model\UsersCdr\UsersCdr:
         - 'text/csv'
         tags:
         - My
-  attributes:
-    pagination_client_enabled: true

--- a/web/rest/client/app/config/security.yml
+++ b/web/rest/client/app/config/security.yml
@@ -29,7 +29,6 @@ security:
       provider: admin_orm
       form_login:
           check_path: /admin_login
-          require_previous_session: false
           username_parameter: username
           password_parameter: password
           success_handler: lexik_jwt_authentication.handler.authentication_success
@@ -43,7 +42,6 @@ security:
       provider: user_orm
       form_login:
           check_path: /user_login
-          require_previous_session: false
           username_parameter: email
           password_parameter: password
           success_handler: Ivoz\Provider\Infrastructure\Api\Jwt\UserAuthenticationSuccessHandler

--- a/web/rest/client/composer.lock
+++ b/web/rest/client/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "ba1beed9eb8b3dba480908fddd83422d",
+    "content-hash": "58d46e1a131b60805a5f5cb4b65938bb",
     "packages": [
         {
             "name": "api-platform/core",
@@ -4598,18 +4598,18 @@
         },
         {
             "name": "docteurklein/test-double-bundle",
-            "version": "1.0.0.0",
+            "version": "1.1.0.0",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/docteurklein/test-double-bundle",
-                "reference": "01fe312bdf2069b095f70ed3d92f4578a7b6e549",
+                "reference": "8927771953f53317b54e6fd8fc05058f62570be6",
                 "shasum": null
             },
             "require": {
                 "php": ">=5.4",
-                "phpspec/prophecy": "^1.6",
-                "symfony/dependency-injection": "^2.0|^3.0",
-                "symfony/http-kernel": "^2.0|^3.0"
+                "phpspec/prophecy": "^1.8",
+                "symfony/dependency-injection": "^2.0|^3.0|^4.0",
+                "symfony/http-kernel": "^2.0|^3.0|^4.0"
             },
             "type": "symfony-bundle",
             "autoload": {

--- a/web/rest/client/composer.lock
+++ b/web/rest/client/composer.lock
@@ -1689,11 +1689,11 @@
         },
         {
             "name": "irontec/ivoz-core-bundle",
-            "version": "2.3.0.0-RC",
+            "version": "2.3.1.0",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/irontec/ivoz-core-bundle",
-                "reference": "1aed75a07514075390cc1f6e201e7177b5e7dc1a",
+                "reference": "18cc348118422d3cfb27e5b1671261f698cdc6f7",
                 "shasum": null
             },
             "require": {

--- a/web/rest/platform/app/config/security.yml
+++ b/web/rest/platform/app/config/security.yml
@@ -27,7 +27,6 @@ security:
       provider: admin_orm
       form_login:
           check_path: /admin_login
-          require_previous_session: false
           username_parameter: username
           password_parameter: password
           success_handler: lexik_jwt_authentication.handler.authentication_success

--- a/web/rest/platform/composer.lock
+++ b/web/rest/platform/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "ba1beed9eb8b3dba480908fddd83422d",
+    "content-hash": "58d46e1a131b60805a5f5cb4b65938bb",
     "packages": [
         {
             "name": "api-platform/core",
@@ -4598,18 +4598,18 @@
         },
         {
             "name": "docteurklein/test-double-bundle",
-            "version": "1.0.0.0",
+            "version": "1.1.0.0",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/docteurklein/test-double-bundle",
-                "reference": "01fe312bdf2069b095f70ed3d92f4578a7b6e549",
+                "reference": "8927771953f53317b54e6fd8fc05058f62570be6",
                 "shasum": null
             },
             "require": {
                 "php": ">=5.4",
-                "phpspec/prophecy": "^1.6",
-                "symfony/dependency-injection": "^2.0|^3.0",
-                "symfony/http-kernel": "^2.0|^3.0"
+                "phpspec/prophecy": "^1.8",
+                "symfony/dependency-injection": "^2.0|^3.0|^4.0",
+                "symfony/http-kernel": "^2.0|^3.0|^4.0"
             },
             "type": "symfony-bundle",
             "autoload": {

--- a/web/rest/platform/composer.lock
+++ b/web/rest/platform/composer.lock
@@ -1689,11 +1689,11 @@
         },
         {
             "name": "irontec/ivoz-core-bundle",
-            "version": "2.3.0.0-RC",
+            "version": "2.3.1.0",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/irontec/ivoz-core-bundle",
-                "reference": "1aed75a07514075390cc1f6e201e7177b5e7dc1a",
+                "reference": "18cc348118422d3cfb27e5b1671261f698cdc6f7",
                 "shasum": null
             },
             "require": {


### PR DESCRIPTION
Removed symfony deprecation warnings below: 
- Silent handling of duplicate mapping keys in YAML is deprecated since Symfony 3.2 and will throw \Symfony\Component\Yaml\Exception\ParseException in 4.0
- Bundle inheritance is deprecated since Symfony 3.4 and will be removed in 4.0
- The stub.prophet service is private
- User Deprecated: Auto-registration of the command



#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
