### PR TITLE
web/admin: fix vpbx service selector filter

### DIFF
--- a/web/admin/application/library/IvozProvider/Klear/Filter/CompanyServices.php
+++ b/web/admin/application/library/IvozProvider/Klear/Filter/CompanyServices.php
@@ -5,6 +5,7 @@ use Ivoz\Provider\Domain\Model\BrandService\BrandServiceDto;
 use Ivoz\Provider\Domain\Model\CompanyService\CompanyService;
 use Ivoz\Provider\Domain\Model\CompanyService\CompanyServiceDto;
 use Ivoz\Provider\Domain\Model\Service\Service;
+use Ivoz\Provider\Domain\Model\Service\ServiceDto;
 
 /**
  * Class IvozProvider_Klear_Filter_CompanyServices
@@ -50,7 +51,14 @@ class IvozProvider_Klear_Filter_CompanyServices implements KlearMatrix_Model_Fie
 
         $brandServicesIds = array();
         foreach ($brandServices as $brandService) {
-            $serviceIden = $brandService->getService()->getIden();
+
+            /** @var ServiceDto $service */
+            $service = $dataGateway->findOneBy(
+                Service::class,
+                ["Service.id = " . $brandService->getService()->getId()]
+            );
+            $serviceIden = $service->getIden();
+
             if (in_array($serviceIden, Service::VPBX_AVAILABLE_SERVICES, true)) {
                 array_push($brandServicesIds, $brandService->getServiceId());
             }


### PR DESCRIPTION


#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
d877740 introduced a logic to hide non-vpbx services to vpbx clients. This logic was broken.

This PR aims to fix it.