### PR TITLE
kamtrunks: do not inactivate stopper route carriers

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -817,6 +817,12 @@ route[ADD_LCR_CARRIERSERVER]{
 }
 
 route[SELECT_NEXT_GW] {
+    # Save route stopper condition to avoid gateway inactivation
+    if ($(avp(gw_uri_avp)[0]) != $null) {
+        $var(rule_id) = $(avp(gw_uri_avp)[0]{s.select,-1,|});
+        sql_xquery("cb", "SELECT O.stopper FROM kam_trunks_lcr_rules K JOIN OutgoingRouting O ON O.id=K.outgoingRoutingId WHERE K.id=$var(rule_id)", "OutgoingRouting");
+    }
+
     # Evaluate gateway rules
     if (!next_gw()) {
         xerr("[$dlg_var(cidhash)] SELECT-NEXT-GW: NO next GW, send 503 No gateways");
@@ -1624,7 +1630,7 @@ failure_route[MANAGE_FAILURE_GW] {
     } else if (t_check_status("422")) {
         xwarn("[$dlg_var(cidhash)] MANAGE-FAILURE-GW: Session Interval Too Small, forward to AS (reply code: $T_reply_code)\n");
         exit;
-    } else if (t_check_status("408") && t_branch_timeout()) {
+    } else if (t_check_status("408") && t_branch_timeout() && !$xavp(OutgoingRouting=>stopper)) {
         xwarn("[$dlg_var(cidhash)] MANAGE-FAILURE-GW: $T_reply_code: Inactivate carrier '$dlg_var(carrierId)' (no reply received)\n");
         inactivate_gw(); # Inactivate GW temporally (until it answers OPTIONS)
     } else if (t_check_status("3[0-9]{2}")) {


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

Gateways selected by stopper routes should not be inactivated to avoid this route from being skipped in next calls.
