### PR TITLE
Huntgroup external numbers

### DIFF
--- a/asterisk/agi/config/services.yml
+++ b/asterisk/agi/config/services.yml
@@ -75,6 +75,9 @@ services:
   Dialplan\HuntGroupStatus:
     arguments: ~
 
+  Dialplan\HuntGroupMember:
+    arguments: ~
+
   Dialplan\Queues:
     arguments: ~
 

--- a/asterisk/agi/src/Agi/Action/HuntGroupCallAction.php
+++ b/asterisk/agi/src/Agi/Action/HuntGroupCallAction.php
@@ -57,16 +57,11 @@ class HuntGroupCallAction
         $timeout = array_shift($huntGroupTimeouts);
 
         // Configure Dial options
-        $options = "i";
+        $options = "";
 
         // Cancelled calls may be marked as 'answered elsewhere'
         if ($huntGroup->getPreventMissedCalls()) {
             $options .= "c";
-        }
-
-        // For record asterisk builtin feature code
-        if ($huntGroup->getCompany()->getOnDemandRecord() == 2) {
-            $options .= "xX";
         }
 
         // Call the PSJIP endpoint

--- a/asterisk/agi/src/Agi/Action/HuntGroupStatusAction.php
+++ b/asterisk/agi/src/Agi/Action/HuntGroupStatusAction.php
@@ -71,7 +71,7 @@ class HuntGroupStatusAction
         $timeout = array_shift($huntGroupTimeouts);
 
         // Round Robin strategy infinite loop
-        if ($huntGroup->getStrategy() == HuntGroupAction::RoundRobin) {
+        if ($huntGroup->getStrategy() == HuntGroupInterface::STRATEGY_ROUNDROBIN) {
             // Push again the called user to the end of the list
             if ($dialStatus == "NOANSWER") {
                 // Push again the interface to the back of the list

--- a/asterisk/agi/src/Dialplan/HuntGroupMember.php
+++ b/asterisk/agi/src/Dialplan/HuntGroupMember.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Dialplan;
+
+use Agi\Action\HuntGroupCallAction;
+use Agi\Action\RouterAction;
+use Agi\Wrapper;
+use Doctrine\ORM\EntityManagerInterface;
+use Ivoz\Provider\Domain\Model\HuntGroupsRelUser\HuntGroupsRelUser;
+use Ivoz\Provider\Domain\Model\HuntGroupsRelUser\HuntGroupsRelUserInterface;
+use Ivoz\Provider\Domain\Model\HuntGroupsRelUser\HuntGroupsRelUserRepository;
+use RouteHandlerAbstract;
+
+class HuntGroupMember extends RouteHandlerAbstract
+{
+    /**
+     * @var Wrapper
+     */
+    protected $agi;
+
+    /**
+     * @var EntityManagerInterface
+     */
+    protected $em;
+
+    /**
+     * @var RouterAction
+     */
+    protected $routerAction;
+
+    /**
+     * HuntGroups constructor.
+     *
+     * @param Wrapper $agi
+     * @param EntityManagerInterface $em
+     * @param RouterAction $routerAction
+     */
+    public function __construct(
+        Wrapper $agi,
+        EntityManagerInterface $em,
+        RouterAction $routerAction
+    ) {
+        $this->agi = $agi;
+        $this->em = $em;
+        $this->routerAction = $routerAction;
+    }
+
+    public function process()
+    {
+        /** @var HuntGroupsRelUserRepository $huntgroupsRelUserRepository */
+        $huntgroupsRelUserRepository = $this->em->getRepository(HuntGroupsRelUser::class);
+
+        // Get conference Id from extension
+        $huntgroupsRelUserId = $this->agi->getExtension();
+
+        /** @var HuntGroupsRelUserInterface $huntgroupsRelUser */
+        $huntgroupsRelUser = $huntgroupsRelUserRepository->find($huntgroupsRelUserId);
+
+        // Route to the extension destination
+        $this->routerAction
+            ->setRouteType($huntgroupsRelUser->getRouteType())
+            ->setRouteUser($huntgroupsRelUser->getUser())
+            ->setRouteExternal($huntgroupsRelUser->getNumberValueE164())
+            ->route();
+    }
+}

--- a/asterisk/agi/src/Dialplan/HuntGroups.php
+++ b/asterisk/agi/src/Dialplan/HuntGroups.php
@@ -6,6 +6,8 @@ use Agi\Action\HuntGroupCallAction;
 use Agi\Wrapper;
 use Doctrine\ORM\EntityManagerInterface;
 use Ivoz\Provider\Domain\Model\HuntGroup\HuntGroup;
+use Ivoz\Provider\Domain\Model\HuntGroup\HuntGroupInterface;
+use Ivoz\Provider\Domain\Model\HuntGroup\HuntGroupRepository;
 use RouteHandlerAbstract;
 
 class HuntGroups extends RouteHandlerAbstract
@@ -44,13 +46,13 @@ class HuntGroups extends RouteHandlerAbstract
 
     public function process()
     {
-        /** @var \Ivoz\Provider\Domain\Model\HuntGroup\HuntGroupRepository $huntgroupRepository */
+        /** @var HuntGroupRepository $huntgroupRepository */
         $huntgroupRepository = $this->em->getRepository(HuntGroup::class);
 
         // Get conference Id from extension
         $huntgroupId = $this->agi->getVariable("HG_ID");
 
-        /** @var \Ivoz\Provider\Domain\Model\HuntGroup\HuntGroupInterface $huntgroup */
+        /** @var HuntGroupInterface $huntgroup */
         $huntgroup = $huntgroupRepository->find($huntgroupId);
 
         // Configure next call

--- a/asterisk/agi/src/MicroKernel.php
+++ b/asterisk/agi/src/MicroKernel.php
@@ -69,6 +69,7 @@ class MicroKernel extends Kernel
         $routes->add('/dialplan/headers', 'kernel:handleRequestAction');
         $routes->add('/dialplan/huntgroups', 'kernel:handleRequestAction');
         $routes->add('/dialplan/huntgroupstatus', 'kernel:handleRequestAction');
+        $routes->add('/dialplan/huntgroupmember', 'kernel:handleRequestAction');
         $routes->add('/dialplan/queues', 'kernel:handleRequestAction');
         $routes->add('/dialplan/queuestatus', 'kernel:handleRequestAction');
         $routes->add('/dialplan/faxdial', 'kernel:handleRequestAction');

--- a/asterisk/config/dialplan/default.conf
+++ b/asterisk/config/dialplan/default.conf
@@ -68,12 +68,16 @@ exten => _[+*0-9]!,1,NoOp(Calling external number)
 exten => _[+*0-9]!,1,NoOp(Calling from IVR to ${DIAL_DST})
     same => n,Dial(${DIAL_DST},${DIAL_TIMEOUT},gb(add-headers^${EXTEN}^1))
 
-;; Context for Calling a user from a HuntGroup (and handle HuntGroup post-process or continues)
+;; Context for Calling HuntGroup members (and handle HuntGroup post-process or continues)
 [call-huntgroup]
 exten => _[+*0-9]!,1,NoOp(Calling huntgroup)
     same => n,AGI(agi://127.0.0.1:4573/fastagi-runner.php?command=dialplan/huntgroups)
-    same => n,Dial(${DIAL_DST},${DIAL_TIMEOUT},${DIAL_OPTS}gb(add-headers^${EXTEN}^1))
+    same => n,Dial(${DIAL_DST},${DIAL_TIMEOUT},${DIAL_OPTS})
     same => n,AGI(agi://127.0.0.1:4573/fastagi-runner.php?command=dialplan/huntgroupstatus)
+
+[call-huntgroup-member]
+exten => _[0-9]!,1,NoOp(Calling huntgroup member ${EXTEN})
+    same => n,AGI(agi://127.0.0.1:4573/fastagi-runner.php?command=dialplan/huntgroupmember)
 
 ;; Context for entering a Conference Room
 [call-conference]

--- a/doc/sphinx/administration_portal/client/vpbx/routing_endpoints/hunt_groups.rst
+++ b/doc/sphinx/administration_portal/client/vpbx/routing_endpoints/hunt_groups.rst
@@ -68,9 +68,9 @@ There are 4 strategies available:
 Adding members to hunt group
 ============================
 
-**List of users** subsection allows adding users to each group:
+**List of members** subsection allows adding users or external numbers to each group:
 
-- For *RingAll hunt groups*, users will be added without any additional parameters.
+- For *RingAll hunt groups*, members will be added without any additional parameters.
 
 - For remaining groups, priority and timeout will be specified for each member. Priority determines the order, timeout ring
   duration for each member.

--- a/library/DataFixtures/ORM/ProviderHuntGroupsRelUser.php
+++ b/library/DataFixtures/ORM/ProviderHuntGroupsRelUser.php
@@ -23,6 +23,7 @@ class ProviderHuntGroupsRelUser extends Fixture implements DependentFixtureInter
     
         $item1 = $this->createEntityInstance(HuntGroupsRelUser::class);
         (function () use ($fixture) {
+            $this->setRouteType("user");
             $this->setTimeoutTime(1);
             $this->setPriority(1);
             $this->setHuntGroup($fixture->getReference('_reference_ProviderHuntGroup1'));
@@ -33,6 +34,19 @@ class ProviderHuntGroupsRelUser extends Fixture implements DependentFixtureInter
         $this->sanitizeEntityValues($item1);
         $manager->persist($item1);
 
+        $item2 = $this->createEntityInstance(HuntGroupsRelUser::class);
+        (function () use ($fixture) {
+            $this->setRouteType("number");
+            $this->setTimeoutTime(1);
+            $this->setPriority(2);
+            $this->setHuntGroup($fixture->getReference('_reference_ProviderHuntGroup1'));
+            $this->setNumberValue("946002050");
+            $this->setNumberCountry($fixture->getReference('_reference_ProviderCountry70'));
+        })->call($item2);
+
+        $this->addReference('_reference_ProviderHuntGroupsRelUser2', $item2);
+        $this->sanitizeEntityValues($item2);
+        $manager->persist($item2);
         $manager->flush();
     }
 

--- a/library/Ivoz/Provider/Domain/Model/HuntGroupsRelUser/HuntGroupsRelUser.php
+++ b/library/Ivoz/Provider/Domain/Model/HuntGroupsRelUser/HuntGroupsRelUser.php
@@ -3,6 +3,7 @@ namespace Ivoz\Provider\Domain\Model\HuntGroupsRelUser;
 
 use Ivoz\Core\Domain\Assert\Assertion;
 use Ivoz\Provider\Domain\Model\HuntGroup\HuntGroupInterface;
+use Ivoz\Provider\Domain\Traits\RoutableTrait;
 
 /**
  * HuntGroupsRelUser
@@ -10,6 +11,7 @@ use Ivoz\Provider\Domain\Model\HuntGroup\HuntGroupInterface;
 class HuntGroupsRelUser extends HuntGroupsRelUserAbstract implements HuntGroupsRelUserInterface
 {
     use HuntGroupsRelUserTrait;
+    use RoutableTrait;
 
     protected function sanitizeValues()
     {
@@ -46,6 +48,14 @@ class HuntGroupsRelUser extends HuntGroupsRelUserAbstract implements HuntGroupsR
                 'timeoutTime value "%s" is not an integer or a number castable to integer.'
             );
         }
+
+        // Set Routable options to avoid naming collision
+        $this->routeTypes = [
+            'number',
+            'user',
+        ];
+
+        $this->sanitizeRouteValues();
     }
 
     /**
@@ -65,5 +75,21 @@ class HuntGroupsRelUser extends HuntGroupsRelUserAbstract implements HuntGroupsR
     public function getId()
     {
         return $this->id;
+    }
+
+    /**
+     * Get the numberValue in E.164 format when routing to 'number'
+     *
+     * @return string
+     */
+    public function getNumberValueE164()
+    {
+        if (!$this->getNumberCountry()) {
+            return "";
+        }
+
+        return
+            $this->getNumberCountry()->getCountryCode() .
+            $this->getNumberValue();
     }
 }

--- a/library/Ivoz/Provider/Domain/Model/HuntGroupsRelUser/HuntGroupsRelUserAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/HuntGroupsRelUser/HuntGroupsRelUserAbstract.php
@@ -24,14 +24,30 @@ abstract class HuntGroupsRelUserAbstract
     protected $priority;
 
     /**
+     * comment: enum:number|user
+     * @var string
+     */
+    protected $routeType;
+
+    /**
+     * @var string | null
+     */
+    protected $numberValue;
+
+    /**
      * @var \Ivoz\Provider\Domain\Model\HuntGroup\HuntGroupInterface | null
      */
     protected $huntGroup;
 
     /**
-     * @var \Ivoz\Provider\Domain\Model\User\UserInterface
+     * @var \Ivoz\Provider\Domain\Model\User\UserInterface | null
      */
     protected $user;
+
+    /**
+     * @var \Ivoz\Provider\Domain\Model\Country\CountryInterface | null
+     */
+    protected $numberCountry;
 
 
     use ChangelogTrait;
@@ -39,8 +55,9 @@ abstract class HuntGroupsRelUserAbstract
     /**
      * Constructor
      */
-    protected function __construct()
+    protected function __construct($routeType)
     {
+        $this->setRouteType($routeType);
     }
 
     abstract public function getId();
@@ -111,13 +128,17 @@ abstract class HuntGroupsRelUserAbstract
     ) {
         Assertion::isInstanceOf($dto, HuntGroupsRelUserDto::class);
 
-        $self = new static();
+        $self = new static(
+            $dto->getRouteType()
+        );
 
         $self
             ->setTimeoutTime($dto->getTimeoutTime())
             ->setPriority($dto->getPriority())
+            ->setNumberValue($dto->getNumberValue())
             ->setHuntGroup($fkTransformer->transform($dto->getHuntGroup()))
             ->setUser($fkTransformer->transform($dto->getUser()))
+            ->setNumberCountry($fkTransformer->transform($dto->getNumberCountry()))
         ;
 
         $self->initChangelog();
@@ -139,8 +160,11 @@ abstract class HuntGroupsRelUserAbstract
         $this
             ->setTimeoutTime($dto->getTimeoutTime())
             ->setPriority($dto->getPriority())
+            ->setRouteType($dto->getRouteType())
+            ->setNumberValue($dto->getNumberValue())
             ->setHuntGroup($fkTransformer->transform($dto->getHuntGroup()))
-            ->setUser($fkTransformer->transform($dto->getUser()));
+            ->setUser($fkTransformer->transform($dto->getUser()))
+            ->setNumberCountry($fkTransformer->transform($dto->getNumberCountry()));
 
 
 
@@ -157,8 +181,11 @@ abstract class HuntGroupsRelUserAbstract
         return self::createDto()
             ->setTimeoutTime(self::getTimeoutTime())
             ->setPriority(self::getPriority())
+            ->setRouteType(self::getRouteType())
+            ->setNumberValue(self::getNumberValue())
             ->setHuntGroup(\Ivoz\Provider\Domain\Model\HuntGroup\HuntGroup::entityToDto(self::getHuntGroup(), $depth))
-            ->setUser(\Ivoz\Provider\Domain\Model\User\User::entityToDto(self::getUser(), $depth));
+            ->setUser(\Ivoz\Provider\Domain\Model\User\User::entityToDto(self::getUser(), $depth))
+            ->setNumberCountry(\Ivoz\Provider\Domain\Model\Country\Country::entityToDto(self::getNumberCountry(), $depth));
     }
 
     /**
@@ -169,8 +196,11 @@ abstract class HuntGroupsRelUserAbstract
         return [
             'timeoutTime' => self::getTimeoutTime(),
             'priority' => self::getPriority(),
+            'routeType' => self::getRouteType(),
+            'numberValue' => self::getNumberValue(),
             'huntGroupId' => self::getHuntGroup() ? self::getHuntGroup()->getId() : null,
-            'userId' => self::getUser()->getId()
+            'userId' => self::getUser() ? self::getUser()->getId() : null,
+            'numberCountryId' => self::getNumberCountry() ? self::getNumberCountry()->getId() : null
         ];
     }
     // @codeCoverageIgnoreStart
@@ -234,6 +264,65 @@ abstract class HuntGroupsRelUserAbstract
     }
 
     /**
+     * Set routeType
+     *
+     * @param string $routeType
+     *
+     * @return static
+     */
+    protected function setRouteType($routeType)
+    {
+        Assertion::notNull($routeType, 'routeType value "%s" is null, but non null value was expected.');
+        Assertion::maxLength($routeType, 25, 'routeType value "%s" is too long, it should have no more than %d characters, but has %d characters.');
+        Assertion::choice($routeType, [
+            HuntGroupsRelUserInterface::ROUTETYPE_NUMBER,
+            HuntGroupsRelUserInterface::ROUTETYPE_USER
+        ], 'routeTypevalue "%s" is not an element of the valid values: %s');
+
+        $this->routeType = $routeType;
+
+        return $this;
+    }
+
+    /**
+     * Get routeType
+     *
+     * @return string
+     */
+    public function getRouteType()
+    {
+        return $this->routeType;
+    }
+
+    /**
+     * Set numberValue
+     *
+     * @param string $numberValue | null
+     *
+     * @return static
+     */
+    protected function setNumberValue($numberValue = null)
+    {
+        if (!is_null($numberValue)) {
+            Assertion::maxLength($numberValue, 25, 'numberValue value "%s" is too long, it should have no more than %d characters, but has %d characters.');
+        }
+
+        $this->numberValue = $numberValue;
+
+        return $this;
+    }
+
+    /**
+     * Get numberValue
+     *
+     * @return string | null
+     */
+    public function getNumberValue()
+    {
+        return $this->numberValue;
+    }
+
+    /**
      * Set huntGroup
      *
      * @param \Ivoz\Provider\Domain\Model\HuntGroup\HuntGroupInterface $huntGroup | null
@@ -260,11 +349,11 @@ abstract class HuntGroupsRelUserAbstract
     /**
      * Set user
      *
-     * @param \Ivoz\Provider\Domain\Model\User\UserInterface $user
+     * @param \Ivoz\Provider\Domain\Model\User\UserInterface $user | null
      *
      * @return static
      */
-    protected function setUser(\Ivoz\Provider\Domain\Model\User\UserInterface $user)
+    protected function setUser(\Ivoz\Provider\Domain\Model\User\UserInterface $user = null)
     {
         $this->user = $user;
 
@@ -274,11 +363,35 @@ abstract class HuntGroupsRelUserAbstract
     /**
      * Get user
      *
-     * @return \Ivoz\Provider\Domain\Model\User\UserInterface
+     * @return \Ivoz\Provider\Domain\Model\User\UserInterface | null
      */
     public function getUser()
     {
         return $this->user;
+    }
+
+    /**
+     * Set numberCountry
+     *
+     * @param \Ivoz\Provider\Domain\Model\Country\CountryInterface $numberCountry | null
+     *
+     * @return static
+     */
+    protected function setNumberCountry(\Ivoz\Provider\Domain\Model\Country\CountryInterface $numberCountry = null)
+    {
+        $this->numberCountry = $numberCountry;
+
+        return $this;
+    }
+
+    /**
+     * Get numberCountry
+     *
+     * @return \Ivoz\Provider\Domain\Model\Country\CountryInterface | null
+     */
+    public function getNumberCountry()
+    {
+        return $this->numberCountry;
     }
 
     // @codeCoverageIgnoreEnd

--- a/library/Ivoz/Provider/Domain/Model/HuntGroupsRelUser/HuntGroupsRelUserDto.php
+++ b/library/Ivoz/Provider/Domain/Model/HuntGroupsRelUser/HuntGroupsRelUserDto.php
@@ -16,7 +16,7 @@ class HuntGroupsRelUserDto extends HuntGroupsRelUserDtoAbstract
                 'priority' => 'priority',
                 'id' => 'id',
                 'huntGroupId' => 'huntGroup',
-                'userId' => 'user'
+                'routeType' => 'routeType'
             ];
         }
 

--- a/library/Ivoz/Provider/Domain/Model/HuntGroupsRelUser/HuntGroupsRelUserDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/HuntGroupsRelUser/HuntGroupsRelUserDtoAbstract.php
@@ -21,6 +21,16 @@ abstract class HuntGroupsRelUserDtoAbstract implements DataTransferObjectInterfa
     private $priority;
 
     /**
+     * @var string
+     */
+    private $routeType;
+
+    /**
+     * @var string
+     */
+    private $numberValue;
+
+    /**
      * @var integer
      */
     private $id;
@@ -34,6 +44,11 @@ abstract class HuntGroupsRelUserDtoAbstract implements DataTransferObjectInterfa
      * @var \Ivoz\Provider\Domain\Model\User\UserDto | null
      */
     private $user;
+
+    /**
+     * @var \Ivoz\Provider\Domain\Model\Country\CountryDto | null
+     */
+    private $numberCountry;
 
 
     use DtoNormalizer;
@@ -55,9 +70,12 @@ abstract class HuntGroupsRelUserDtoAbstract implements DataTransferObjectInterfa
         return [
             'timeoutTime' => 'timeoutTime',
             'priority' => 'priority',
+            'routeType' => 'routeType',
+            'numberValue' => 'numberValue',
             'id' => 'id',
             'huntGroupId' => 'huntGroup',
-            'userId' => 'user'
+            'userId' => 'user',
+            'numberCountryId' => 'numberCountry'
         ];
     }
 
@@ -69,9 +87,12 @@ abstract class HuntGroupsRelUserDtoAbstract implements DataTransferObjectInterfa
         return [
             'timeoutTime' => $this->getTimeoutTime(),
             'priority' => $this->getPriority(),
+            'routeType' => $this->getRouteType(),
+            'numberValue' => $this->getNumberValue(),
             'id' => $this->getId(),
             'huntGroup' => $this->getHuntGroup(),
-            'user' => $this->getUser()
+            'user' => $this->getUser(),
+            'numberCountry' => $this->getNumberCountry()
         ];
     }
 
@@ -113,6 +134,46 @@ abstract class HuntGroupsRelUserDtoAbstract implements DataTransferObjectInterfa
     public function getPriority()
     {
         return $this->priority;
+    }
+
+    /**
+     * @param string $routeType
+     *
+     * @return static
+     */
+    public function setRouteType($routeType = null)
+    {
+        $this->routeType = $routeType;
+
+        return $this;
+    }
+
+    /**
+     * @return string | null
+     */
+    public function getRouteType()
+    {
+        return $this->routeType;
+    }
+
+    /**
+     * @param string $numberValue
+     *
+     * @return static
+     */
+    public function setNumberValue($numberValue = null)
+    {
+        $this->numberValue = $numberValue;
+
+        return $this;
+    }
+
+    /**
+     * @return string | null
+     */
+    public function getNumberValue()
+    {
+        return $this->numberValue;
     }
 
     /**
@@ -221,6 +282,52 @@ abstract class HuntGroupsRelUserDtoAbstract implements DataTransferObjectInterfa
     public function getUserId()
     {
         if ($dto = $this->getUser()) {
+            return $dto->getId();
+        }
+
+        return null;
+    }
+
+    /**
+     * @param \Ivoz\Provider\Domain\Model\Country\CountryDto $numberCountry
+     *
+     * @return static
+     */
+    public function setNumberCountry(\Ivoz\Provider\Domain\Model\Country\CountryDto $numberCountry = null)
+    {
+        $this->numberCountry = $numberCountry;
+
+        return $this;
+    }
+
+    /**
+     * @return \Ivoz\Provider\Domain\Model\Country\CountryDto | null
+     */
+    public function getNumberCountry()
+    {
+        return $this->numberCountry;
+    }
+
+    /**
+     * @param mixed | null $id
+     *
+     * @return static
+     */
+    public function setNumberCountryId($id)
+    {
+        $value = !is_null($id)
+            ? new \Ivoz\Provider\Domain\Model\Country\CountryDto($id)
+            : null;
+
+        return $this->setNumberCountry($value);
+    }
+
+    /**
+     * @return mixed | null
+     */
+    public function getNumberCountryId()
+    {
+        if ($dto = $this->getNumberCountry()) {
             return $dto->getId();
         }
 

--- a/library/Ivoz/Provider/Domain/Model/HuntGroupsRelUser/HuntGroupsRelUserInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/HuntGroupsRelUser/HuntGroupsRelUserInterface.php
@@ -6,11 +6,22 @@ use Ivoz\Core\Domain\Model\LoggableEntityInterface;
 
 interface HuntGroupsRelUserInterface extends LoggableEntityInterface
 {
+    const ROUTETYPE_NUMBER = 'number';
+    const ROUTETYPE_USER = 'user';
+
+
     /**
      * @codeCoverageIgnore
      * @return array
      */
     public function getChangeSet();
+
+    /**
+     * Get the numberValue in E.164 format when routing to 'number'
+     *
+     * @return string
+     */
+    public function getNumberValueE164();
 
     /**
      * Get timeoutTime
@@ -25,6 +36,20 @@ interface HuntGroupsRelUserInterface extends LoggableEntityInterface
      * @return integer | null
      */
     public function getPriority();
+
+    /**
+     * Get routeType
+     *
+     * @return string
+     */
+    public function getRouteType();
+
+    /**
+     * Get numberValue
+     *
+     * @return string | null
+     */
+    public function getNumberValue();
 
     /**
      * Set huntGroup
@@ -45,7 +70,20 @@ interface HuntGroupsRelUserInterface extends LoggableEntityInterface
     /**
      * Get user
      *
-     * @return \Ivoz\Provider\Domain\Model\User\UserInterface
+     * @return \Ivoz\Provider\Domain\Model\User\UserInterface | null
      */
     public function getUser();
+
+    /**
+     * Get numberCountry
+     *
+     * @return \Ivoz\Provider\Domain\Model\Country\CountryInterface | null
+     */
+    public function getNumberCountry();
+
+    /**
+     * @param string $prefix
+     * @return null|string
+     */
+    public function getTarget(string $prefix = '');
 }

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/HuntGroupsRelUser.HuntGroupsRelUserAbstract.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/HuntGroupsRelUser.HuntGroupsRelUserAbstract.orm.yml
@@ -21,6 +21,21 @@ Ivoz\Provider\Domain\Model\HuntGroupsRelUser\HuntGroupsRelUserAbstract:
       nullable: true
       options:
         unsigned: false
+    routeType:
+      type: string
+      nullable: false
+      length: 25
+      options:
+        fixed: false
+        comment: '[enum:number|user]'
+      column: routeType
+    numberValue:
+      type: string
+      nullable: true
+      length: 25
+      options:
+        fixed: false
+      column: numberValue
   manyToOne:
     huntGroup:
       targetEntity: \Ivoz\Provider\Domain\Model\HuntGroup\HuntGroupInterface
@@ -43,6 +58,17 @@ Ivoz\Provider\Domain\Model\HuntGroupsRelUser\HuntGroupsRelUserAbstract:
       joinColumns:
         userId:
           referencedColumnName: id
-          nullable: false
+          nullable: true
           onDelete: cascade
+      orphanRemoval: false
+    numberCountry:
+      targetEntity: \Ivoz\Provider\Domain\Model\Country\CountryInterface
+      cascade: {  }
+      fetch: LAZY
+      mappedBy: null
+      inversedBy: null
+      joinColumns:
+        numberCountryId:
+          referencedColumnName: id
+          onDelete: set null
       orphanRemoval: false

--- a/library/spec/Ivoz/Provider/Domain/Model/HuntGroupsRelUser/HuntGroupsRelUserSpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Model/HuntGroupsRelUser/HuntGroupsRelUserSpec.php
@@ -41,6 +41,7 @@ class HuntGroupsRelUserSpec extends ObjectBehavior
             [
                 'huntGroup' => $huntGroup->reveal(),
                 'user' => $user->reveal(),
+                'routeType' => 'user',
             ]
         );
 

--- a/schema/DoctrineMigrations/Version20200220113025.php
+++ b/schema/DoctrineMigrations/Version20200220113025.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Application\Migrations;
+
+use Ivoz\Core\Infrastructure\Persistence\Doctrine\LoggableMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20200220113025 extends LoggableMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE HuntGroupsRelUsers ADD routeType VARCHAR(25) NOT NULL COMMENT \'[enum:number|user]\', ADD numberValue VARCHAR(25) DEFAULT NULL, ADD numberCountryId INT UNSIGNED DEFAULT NULL, CHANGE userId userId INT UNSIGNED DEFAULT NULL');
+        $this->addSql('ALTER TABLE HuntGroupsRelUsers ADD CONSTRAINT FK_79ED31ABD7819488 FOREIGN KEY (numberCountryId) REFERENCES Countries (id) ON DELETE SET NULL');
+        $this->addSql('CREATE INDEX IDX_79ED31ABD7819488 ON HuntGroupsRelUsers (numberCountryId)');
+        $this->addSql('UPDATE HuntGroupsRelUsers SET routeType="user"');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE HuntGroupsRelUsers DROP FOREIGN KEY FK_79ED31ABD7819488');
+        $this->addSql('DROP INDEX IDX_79ED31ABD7819488 ON HuntGroupsRelUsers');
+        $this->addSql('ALTER TABLE HuntGroupsRelUsers DROP routeType, DROP numberValue, DROP numberCountryId, CHANGE userId userId INT UNSIGNED NOT NULL');
+    }
+}

--- a/web/admin/application/configs/klear/HuntGroupsList.yaml
+++ b/web/admin/application/configs/klear/HuntGroupsList.yaml
@@ -98,33 +98,41 @@ production:
     <<: *huntGroupsRelUsers_screensLink
     huntGroupsRelUsersList_screen:
       <<: *huntGroupsRelUsersList_screenLink
-      title: _("List of %s %2s", ngettext('User', 'Users', 0), "[format| (%parent%)]")
-      class: ui-silk-user
+      title: _("List of %s %2s", ngettext('Member', 'Members', 0), "[format| (%parent%)]")
+      class: ui-silk-group-go
       filterField: HuntGroup
       parentOptionCustomizer:
         - IvozProvider_Klear_Options_OptionsCustomizerFilterForHuntGroup
         - recordCount
+
     huntGroupsRelUsersEdit_screen:
       <<: *huntGroupsRelUsersEdit_screenLink
-      title: _("Edit %s", ngettext('User', 'User', 1))
+      title: _("Edit %s", ngettext('Member', 'Members', 1))
       filterField: HuntGroup
+
     huntGroupsRelUsersNew_screen:
       <<: *huntGroupsRelUsersNew_screenLink
-      title: _("Add %s %2s", ngettext("User", "users", 1), "[format| (%parent%)]")
+      title: _("Add %s %2s", ngettext('Member', 'Members', 1), "[format| (%parent%)]")
       filterField: HuntGroup
 
     # HuntGroupRelUsers filter by "ringAll"
     huntGroupsRelUsersFilterRingAllList_screen:
       <<: *huntGroupsRelUsersList_screenLink
-      title: _("List of %s %2s", ngettext('User', 'Users', 0), "[format| (%parent%)]")
-      class: ui-silk-user
+      title: _("List of %s %2s", ngettext('Member', 'Members', 0), "[format| (%parent%)]")
+      class: ui-silk-group-go
       filterField: HuntGroup
       parentOptionCustomizer:
         - IvozProvider_Klear_Options_OptionsCustomizerFilterForHuntGroup
         - recordCount
       fields:
+        order:
+          routeType: true
+          target: true
         blacklist:
           timeoutTime: true
+          numberCountry: true
+          numberValue: true
+          user: true
           priority: true
         options:
           title: _("Options")
@@ -141,32 +149,46 @@ production:
           huntGroupsRelUsersDel_dialog: ${auth.acls.HuntGroupsRelUsers.delete}
     huntGroupsRelUsersFilterRingAllEdit_screen:
       <<: *huntGroupsRelUsersEdit_screenLink
-      title: _("Edit %s", ngettext('User', 'User', 1))
+      title: _("Edit %s", ngettext('Member', 'Members', 1))
       filterField: HuntGroup
       fields:
         blacklist:
           timeoutTime: true
           priority: true
+          user: true
+          numberValue: true
+          numberCountry: true
+        readOnly:
+          target: true
+          routeType: true
+
     huntGroupsRelUsersFilterRingAllNew_screen:
       <<: *huntGroupsRelUsersNew_screenLink
-      title: _("Add %s %2s", ngettext("User", "users", 1), "[format| (%parent%)]")
+      title: _("Add %s %2s", ngettext('Member', 'Members', 1), "[format| (%parent%)]")
       filterField: HuntGroup
       fields:
         blacklist:
           timeoutTime: true
           priority: true
+          target: true
 
     # HuntGroupRelUsers filter by "random"
     huntGroupsRelUsersFilterRandomList_screen:
       <<: *huntGroupsRelUsersList_screenLink
-      title: _("List of %s %2s", ngettext('User', 'Users', 0), "[format| (%parent%)]")
-      class: ui-silk-user
+      title: _("List of %s %2s", ngettext('Member', 'Members', 0), "[format| (%parent%)]")
+      class: ui-silk-group-go
       filterField: HuntGroup
       parentOptionCustomizer:
         - IvozProvider_Klear_Options_OptionsCustomizerFilterForHuntGroup
         - recordCount
       fields:
+        order:
+          routeType: true
+          target: true
         blacklist:
+          numberCountry: true
+          numberValue: true
+          user: true
           priority: true
         options:
           title: _("Options")
@@ -183,18 +205,29 @@ production:
           huntGroupsRelUsersDel_dialog: ${auth.acls.HuntGroupsRelUsers.delete}
     huntGroupsRelUsersFilterRandomEdit_screen:
       <<: *huntGroupsRelUsersEdit_screenLink
-      title: _("Edit %s", ngettext('User', 'User', 1))
+      title: _("Edit %s", ngettext('Member', 'Members', 1))
       filterField: HuntGroup
       fields:
+        order:
+          routeType: true
+          target: true
         blacklist:
+          numberCountry: true
+          numberValue: true
+          user: true
           priority: true
+        readOnly:
+          target: true
+          routeType: true
+
     huntGroupsRelUsersFilterRandomNew_screen:
       <<: *huntGroupsRelUsersNew_screenLink
-      title: _("Add %s %2s", ngettext("User", "users", 1), "[format| (%parent%)]")
+      title: _("Add %s %2s", ngettext('Member', 'Members', 1), "[format| (%parent%)]")
       filterField: HuntGroup
       fields:
         blacklist:
           priority: true
+          target: true
 
   dialogs: &huntGroups_dialogsLink
     huntGroupsDel_dialog: &huntGroupsDel_dialogLink
@@ -211,7 +244,7 @@ production:
     <<: *huntGroupsRelUsers_dialogsLink
     huntGroupsRelUsersDel_dialog:
       <<: *huntGroupsRelUsersDel_dialogLink
-      title: _("Delete %s", ngettext('User', 'Users', 1))
+      title: _("Delete %s", ngettext('Member', 'Members', 1))
 
 staging:
   _extends: production

--- a/web/admin/application/configs/klear/HuntGroupsRelUsersList.yaml
+++ b/web/admin/application/configs/klear/HuntGroupsRelUsersList.yaml
@@ -14,7 +14,14 @@ production:
         items: 25
       <<: *HuntGroupsRelUsers
       title: _("List of %s %2s", ngettext('Hunt Group', 'Hunt Groups', 0), "[format| (%parent%)]")
-      fields:
+      fields: &huntGroupsRelUsersList_fields
+        order:
+          routeType: true
+          target: true
+        blacklist:
+          numberCountry: true
+          numberValue: true
+          user: true
         options:
           title: _("Options")
           screens:
@@ -35,10 +42,29 @@ production:
       label: true
       multiInstance: true
       title: _("Add %s", ngettext('Hunt Group', 'Hunt Groups', 1))
+      defaultValues:
+        numberCountry: ${auth.companyCountryId}
+      fields:
+        blacklist:
+          target: true
       shortcutOption: N
-#      fields:
-#        blacklist:
-#          huntGroup: true
+      fixedPositions: &huntGroupsRelUsersFixedPositions_link
+        group1:
+          label: _("Routing configuration")
+          colsPerRow: 12
+          fields:
+            routeType: 4
+            numberCountry: 4
+            numberValue: 4
+            user: 4
+            target: 4
+        group0:
+          label: _("Entry information")
+          colsPerRow: 8
+          fields:
+            timeoutTime: 4
+            priority: 4
+
     huntGroupsRelUsersEdit_screen: &huntGroupsRelUsersEdit_screenLink
       <<: *HuntGroupsRelUsers
       controller: edit
@@ -47,19 +73,14 @@ production:
       title: _("Edit %s %2s", ngettext('Hunt Group', 'Hunt Groups', 1), "[format| (%parent%)]")
       fields:
         blacklist:
-          huntGroup: false
-        readOnly:
-          huntGroup: true
           user: true
-
-    #HuntGroups
-#    <<: *huntGroups_screensLink
-#    huntGroupsEdit_screen:
-#      <<: *huntGroupsEdit_screenLink
-#      class: ui-silk-group-go
-#      calculatedPk:
-#        class: IvozProvider_Klear_Calculated_Primarykeys
-#        method: huntGroupPk
+          numberValue: true
+          numberCountry: true
+        readOnly:
+          routeType: true
+          target: true
+      fixedPositions:
+        <<: *huntGroupsRelUsersFixedPositions_link
 
   dialogs: &huntGroupsRelUsers_dialogsLink
     huntGroupsRelUsersDel_dialog: &huntGroupsRelUsersDel_dialogLink

--- a/web/admin/application/configs/klear/model/HuntGroupsRelUsers.yaml
+++ b/web/admin/application/configs/klear/model/HuntGroupsRelUsers.yaml
@@ -17,6 +17,43 @@ production:
           order:
             HuntGroup.name: asc
       default: true
+    routeType:
+      title: _('Target type')
+      type: select
+      required: true
+      source:
+        data: inline
+        values:
+          'user':
+            title: ngettext('User', 'Users', 1)
+            visualFilter:
+              show: [ user ]
+              hide: [ numberCountry, numberValue]
+          'number':
+            title: _('Number')
+            visualFilter:
+              show: [ numberCountry, numberValue]
+              hide: [ user]
+    numberCountry:
+      title: _('Country')
+      type: select
+      required: true
+      source:
+        data: mapper
+        config:
+          entity: \Ivoz\Provider\Domain\Model\Country\Country
+          fieldName:
+            fields:
+              - name${lang}
+              - countryCode
+            template: '%name${lang}% (%countryCode%)'
+          order:
+            Country.name.${lang}: asc
+    numberValue:
+      title: _('Number')
+      type: text
+      trim: both
+      required: true
     user:
       title: ngettext('User', 'Users', 1)
       type: select
@@ -43,6 +80,12 @@ production:
       type: number
       source:
         control: Spinner
+    target:
+      title: _('Target')
+      type: ghost
+      source:
+        class: IvozProvider_Klear_Ghost_RouteTarget
+        method: getTarget
 staging:
   _extends: production
 testing:

--- a/web/admin/application/languages/ca_ES/ca_ES.po
+++ b/web/admin/application/languages/ca_ES/ca_ES.po
@@ -1666,6 +1666,11 @@ msgid_plural "Media relay sets"
 msgstr[0] "Conjunt de retransmissors de mijtans"
 msgstr[1] "Conjunts de retransmissors de mitjans"
 
+msgid "Member"
+msgid_plural "Members"
+msgstr[0] "Membre"
+msgstr[1] "Membres"
+
 msgid "Member call seconds"
 msgstr "Segons de trucada a membre"
 

--- a/web/admin/application/languages/en_US/en_US.po
+++ b/web/admin/application/languages/en_US/en_US.po
@@ -1650,6 +1650,11 @@ msgid_plural "Media relay sets"
 msgstr[0] "Media relay set"
 msgstr[1] "Media relay sets"
 
+msgid "Member"
+msgid_plural "Members"
+msgstr[0] "Member"
+msgstr[1] "Members"
+
 msgid "Member call seconds"
 msgstr "Member call seconds"
 

--- a/web/admin/application/languages/es_ES/es_ES.po
+++ b/web/admin/application/languages/es_ES/es_ES.po
@@ -1676,6 +1676,11 @@ msgid_plural "Media relay sets"
 msgstr[0] "Servidor de Media"
 msgstr[1] "Servidores de Media"
 
+msgid "Member"
+msgid_plural "Members"
+msgstr[0] "Miembro"
+msgstr[1] "Miembros"
+
 msgid "Member call seconds"
 msgstr "Duración llamada a miembro"
 

--- a/web/admin/application/languages/it_IT/it_IT.po
+++ b/web/admin/application/languages/it_IT/it_IT.po
@@ -1674,6 +1674,11 @@ msgid_plural "Media relay sets"
 msgstr[0] "Media relay set"
 msgstr[1] "Media relay sets"
 
+msgid "Member"
+msgid_plural "Members"
+msgstr[0] "Membro"
+msgstr[1] "Membros"
+
 msgid "Member call seconds"
 msgstr "Secondi chiamate dei membri"
 

--- a/web/admin/application/library/IvozProvider/Klear/Filter/HuntGroupsRelUsers.php
+++ b/web/admin/application/library/IvozProvider/Klear/Filter/HuntGroupsRelUsers.php
@@ -65,7 +65,9 @@ class IvozProvider_Klear_Filter_HuntGroupsRelUsers extends IvozProvider_Klear_Fi
 
         $userIdsInUse = [];
         foreach ($existingRelationships as $existingRelationship) {
-            $userIdsInUse[] = $existingRelationship->getUserId();
+            if ($existingRelationship->getRouteType() == HuntGroupsRelUser::ROUTETYPE_USER) {
+                $userIdsInUse[] = $existingRelationship->getUserId();
+            }
         }
 
         $this->_condition[] = "self::id NOT IN (" . implode(',', $userIdsInUse) . ")";

--- a/web/rest/client/features/provider/huntGroupsRelUser/getHuntGroupsRelUser.feature
+++ b/web/rest/client/features/provider/huntGroupsRelUser/getHuntGroupsRelUser.feature
@@ -32,7 +32,7 @@ Feature: Retrieve hunt groups rel users
                   "noAnswerVoiceMailUser": null,
                   "noAnswerNumberCountry": null
               },
-              "user": "~"
+              "routeType": "user"
           }
       ]
     """
@@ -49,6 +49,8 @@ Feature: Retrieve hunt groups rel users
       {
           "timeoutTime": 1,
           "priority": 1,
+          "routeType": "user",
+          "numberValue": null,
           "id": 1,
           "huntGroup": {
               "name": "testHuntGroup",
@@ -64,6 +66,7 @@ Feature: Retrieve hunt groups rel users
               "noAnswerVoiceMailUser": null,
               "noAnswerNumberCountry": null
           },
-          "user": "~"
+          "user": "~",
+          "numberCountry": null
       }
     """

--- a/web/rest/client/features/provider/huntGroupsRelUser/postHuntGroupsRelUser.feature
+++ b/web/rest/client/features/provider/huntGroupsRelUser/postHuntGroupsRelUser.feature
@@ -12,9 +12,10 @@ Feature: Create hunt groups rel users
     """
       {
           "timeoutTime": 1,
-          "priority": 2,
+          "priority": 3,
           "id": 1,
           "huntGroup": 1,
+          "routeType" : "user",
           "user": 2
       }
     """
@@ -25,8 +26,10 @@ Feature: Create hunt groups rel users
     """
       {
           "timeoutTime": 1,
-          "priority": 2,
-          "id": 2,
+          "priority": 3,
+          "routeType": "user",
+          "id": 3,
+          "numberValue": null,
           "huntGroup": {
               "name": "testHuntGroup",
               "description": "desc",
@@ -41,14 +44,15 @@ Feature: Create hunt groups rel users
               "noAnswerVoiceMailUser": null,
               "noAnswerNumberCountry": null
           },
-          "user": "~"
+          "user": "~",
+          "numberCountry": null
       }
     """
 
   Scenario: Retrieve created hunt group rel user
     Given I add Company Authorization header
      When I add "Accept" header equal to "application/json"
-      And I send a "GET" request to "hunt_groups_rel_users/2"
+      And I send a "GET" request to "hunt_groups_rel_users/3"
      Then the response status code should be 200
       And the response should be in JSON
       And the header "Content-Type" should be equal to "application/json; charset=utf-8"
@@ -56,8 +60,9 @@ Feature: Create hunt groups rel users
     """
       {
           "timeoutTime": 1,
-          "priority": 2,
-          "id": 2,
+          "priority": 3,
+          "id": 3,
+          "numberValue": null,
           "huntGroup": {
               "name": "testHuntGroup",
               "description": "desc",
@@ -72,6 +77,7 @@ Feature: Create hunt groups rel users
               "noAnswerVoiceMailUser": null,
               "noAnswerNumberCountry": null
           },
-          "user": "~"
+          "user": "~",
+          "numberCountry": null
       }
     """

--- a/web/rest/client/features/provider/huntGroupsRelUser/putHuntGroupsRelUser.feature
+++ b/web/rest/client/features/provider/huntGroupsRelUser/putHuntGroupsRelUser.feature
@@ -12,7 +12,8 @@ Feature: Update hunt groups rel users
     """
       {
           "timeoutTime": 2,
-          "priority": 2,
+          "priority": 10,
+          "routeType": "user",
           "id": 1,
           "huntGroup": 1,
           "user": 1
@@ -25,7 +26,9 @@ Feature: Update hunt groups rel users
     """
      {
           "timeoutTime": 2,
-          "priority": 2,
+          "priority": 10,
+          "routeType": "user",
+          "numberValue": null,
           "id": 1,
           "huntGroup": {
               "name": "testHuntGroup",
@@ -67,6 +70,7 @@ Feature: Update hunt groups rel users
               "outgoingDdi": null,
               "outgoingDdiRule": null,
               "voicemailLocution": null
-          }
+          },
+          "numberCountry": null
       }
     """


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [X] Fixes an existing issue (Fixes #721) <!-- Replace XXXX with issue id -->

#### Description
This PR adds support for external numbers in all HuntGroups types.

Instead of dialing huntgroup endpoints, a new dialplan context has been created to handle each huntgroup entry individually, now routed like the other entities based on its route type field.

This implies that calls from Huntgroups to Users are now handled in the same way Extension to Users calls are handled. Same applies for external numbers.


#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
