### PR TITLE
On-demand record DTMFs supports both SIP INFO and DTMFs

### DIFF
--- a/web/admin/application/configs/klear/model/Companies.yaml
+++ b/web/admin/application/configs/klear/model/Companies.yaml
@@ -293,12 +293,12 @@ production:
               show: []
               hide: ["onDemandRecordCode"]
           '1':
-            title: _("Using INFO")
+            title: _("Enabled (SIP INFO)")
             visualFilter:
               show: []
               hide: ["onDemandRecordCode"]
           '2':
-            title: _("Using DTMFs")
+            title: _("Enabled (SIP INFO + DTMFs)")
             visualFilter:
               show: ["onDemandRecordCode"]
               hide: []

--- a/web/admin/application/configs/klear/model/ResidentialClients.yaml
+++ b/web/admin/application/configs/klear/model/ResidentialClients.yaml
@@ -272,12 +272,12 @@ production:
               show: []
               hide: ["onDemandRecordCode"]
           '1':
-            title: _("Using INFO")
+            title: _("Enabled (SIP INFO)")
             visualFilter:
               show: []
               hide: ["onDemandRecordCode"]
           '2':
-            title: _("Using DTMFs")
+            title: _("Enabled (SIP INFO + DTMFs)")
             visualFilter:
               show: ["onDemandRecordCode"]
               hide: []

--- a/web/admin/application/languages/ca_ES/ca_ES.po
+++ b/web/admin/application/languages/ca_ES/ca_ES.po
@@ -823,6 +823,12 @@ msgstr ""
 msgid "Enabled"
 msgstr "Habilitat"
 
+msgid "Enabled (SIP INFO + DTMFs)"
+msgstr "Habilitat (SIP INFO + DTMFs)"
+
+msgid "Enabled (SIP INFO)"
+msgstr "Habilitat (SIP INFO)"
+
 msgid "End date"
 msgstr "Data fi"
 
@@ -2757,12 +2763,6 @@ msgstr "Configuració d'usuari"
 
 msgid "Username"
 msgstr "Nom d'usuari"
-
-msgid "Using DTMFs"
-msgstr "Utilitzant DTMFs"
-
-msgid "Using INFO"
-msgstr "Utilitzant INFO"
 
 #, python-format
 msgid "View %s %2s"

--- a/web/admin/application/languages/en_US/en_US.po
+++ b/web/admin/application/languages/en_US/en_US.po
@@ -813,6 +813,12 @@ msgstr ""
 msgid "Enabled"
 msgstr "Enabled"
 
+msgid "Enabled (SIP INFO + DTMFs)"
+msgstr "Enabled (SIP INFO + DTMFs)"
+
+msgid "Enabled (SIP INFO)"
+msgstr "Enabled (SIP INFO)"
+
 msgid "End date"
 msgstr "End date"
 
@@ -2733,12 +2739,6 @@ msgstr "User configuration"
 
 msgid "Username"
 msgstr "Username"
-
-msgid "Using DTMFs"
-msgstr "Using DTMFs"
-
-msgid "Using INFO"
-msgstr "Using INFO"
 
 #, python-format
 msgid "View %s %2s"

--- a/web/admin/application/languages/es_ES/es_ES.po
+++ b/web/admin/application/languages/es_ES/es_ES.po
@@ -826,6 +826,12 @@ msgstr ""
 msgid "Enabled"
 msgstr "Activado"
 
+msgid "Enabled (SIP INFO + DTMFs)"
+msgstr "Activado (SIP INFO + DTMFs)"
+
+msgid "Enabled (SIP INFO)"
+msgstr "Activado (SIP INFO)"
+
 msgid "End date"
 msgstr "Fecha fin"
 
@@ -2769,12 +2775,6 @@ msgstr "Configuración de usuario"
 
 msgid "Username"
 msgstr "Nombre de usuario"
-
-msgid "Using DTMFs"
-msgstr "Empleando DTMFs"
-
-msgid "Using INFO"
-msgstr "Empleando INFO"
 
 #, python-format
 msgid "View %s %2s"

--- a/web/admin/application/languages/it_IT/it_IT.po
+++ b/web/admin/application/languages/it_IT/it_IT.po
@@ -827,6 +827,12 @@ msgstr ""
 msgid "Enabled"
 msgstr "Abilitato"
 
+msgid "Enabled (SIP INFO + DTMFs)"
+msgstr "Abilitato (SIP INFO + DTMFs)"
+
+msgid "Enabled (SIP INFO)"
+msgstr "Abilitato (SIP INFO)"
+
 msgid "End date"
 msgstr "End date"
 
@@ -2772,12 +2778,6 @@ msgstr "User configuration"
 
 msgid "Username"
 msgstr "Nome utente"
-
-msgid "Using DTMFs"
-msgstr "Using DTMFs"
-
-msgid "Using INFO"
-msgstr "Using INFO"
 
 #, python-format
 msgid "View %s %2s"


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

Fix labels so that "DTMFs" turns into "Both SIP INFO + DTMFs"
