### PR TITLE
Friends intervpbx need no regexp

### DIFF
--- a/doc/sphinx/administration_portal/client/vpbx/routing_endpoints/friends/index.rst
+++ b/doc/sphinx/administration_portal/client/vpbx/routing_endpoints/friends/index.rst
@@ -27,6 +27,18 @@ There are 2 main types of Friends:
 
 - **Internal friends**: connection between extensions of two vPBX client in the same brand.
 
+
+What kind of calls can be routed through an *internal friend*?
+--------------------------------------------------------------
+
+IvozProvider will route a call received by a :ref:`user <users>` or a :ref:`friend <friends>` following this logic:
+
+#. Destination matches an existing IvozProvider extension?
+#. If not: Destination matches any *friend* regular expression (for remote friends) or extensions (for internal ones)? Ordered by priority (lower has precedence).
+#. If not: This is an external call.
+
+
+
 Following sections explain both kind of friends:
 
 .. toctree::

--- a/doc/sphinx/administration_portal/client/vpbx/routing_endpoints/friends/internal_friends.rst
+++ b/doc/sphinx/administration_portal/client/vpbx/routing_endpoints/friends/internal_friends.rst
@@ -18,23 +18,7 @@ If calling to an extension in another vPBX causes an external call, it is allowe
 What kind of calls can be routed through an *internal friend*?
 --------------------------------------------------------------
 
-IvozProvider must know what calls must be routed to the different defined *friends* (both internal and remote friends).
-For that, **client administrator** will configure regular expressions that
-describe the numbers that *can be reached* through the **internal friend**.
-
-.. note:: Internal :ref:`extensions <extensions>` have priority over any expression
-          defined in the *friends*.
-
-To sum up, IvozProvider will route a call received by a :ref:`user <users>` or
-a :ref:`friend <friends>` following this logic:
-
-1. Destination matches an existing IvozProvider extension?
-
-2. If not: Destination matches any *friend* regular expression?
-
-3. If not: This is an external call.
-
-.. important:: Avoid PCRE regular expressions in friend configuration: use [0-9] instead of \\d.
+IvozProvider will route any call matching an Extension in vpbx client connected by the internal friend.
 
 Configuration of internal friends
 ---------------------------------

--- a/doc/sphinx/administration_portal/client/vpbx/routing_endpoints/friends/remote_friends.rst
+++ b/doc/sphinx/administration_portal/client/vpbx/routing_endpoints/friends/remote_friends.rst
@@ -29,21 +29,12 @@ SIP *trunk*, but also:
 What kind of calls can be routed through a *remote friend*?
 -----------------------------------------------------------
 
-IvozProvider must know what calls must be routed to the different defined *friends* (both internal and remote friends).
+IvozProvider must know what calls must be routed to the different defined *remote friends*.
 For that, **client administrator** will configure regular expressions that
 describe the numbers that *can be reached* through the **friend**.
 
 .. note:: Internal :ref:`extensions <extensions>` have priority over any expression
           defined in the *friends*.
-
-To sum up, IvozProvider will route a call received by a :ref:`user <users>` or
-a :ref:`friend <friends>` following this logic:
-
-1. Destination matches an existing IvozProvider extension?
-
-2. If not: Destination matches any *friend* regular expression?
-
-3. If not: This is an external call.
 
 .. important:: Avoid PCRE regular expressions in friend configuration: use [0-9] instead of \\d.
 

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -1416,21 +1416,40 @@ route[IS_INTERNAL] {
     }
 
     # Is a friend?
-    $xavp(rd) = $null;
-    sql_xquery("cb", "SELECT F.id, F.directConnectivity, F.interCompanyId FROM FriendsPatterns FP JOIN Friends F ON FP.friendId=F.id WHERE F.companyId='$dlg_var(companyId)' AND '$var(number)' REGEXP `regExp` ORDER BY F.priority ASC LIMIT 1", "rd");
-    if ($xavp(rd=>directConnectivity) != $null) {
-        if ($xavp(rd=>directConnectivity) == 'intervpbx') {
-            xinfo("[$dlg_var(cidhash)] IS-INTERNAL: $var(number) is an internal friend\n");
-        } else {
-            xinfo("[$dlg_var(cidhash)] IS-INTERNAL: $var(number) is a remote friend\n");
+    sql_query("cb", "SELECT id, name, directConnectivity, interCompanyId FROM Friends WHERE companyId = '$dlg_var(companyId)' ORDER BY PRIORITY ASC", "friends");
+    if ($dbr(friends=>rows) > 0) {
+        $var(i) = 0;
+        while($var(i) < $dbr(friends=>rows)) {
+            $var(currentFriendId) = $dbr(friends=>[$var(i),0]);
+            $var(currentFriendName) = $dbr(friends=>[$var(i),1]);
+            $var(directConnectivity) = $dbr(friends=>[$var(i),2]);
+            $var(interCompanyId) = $dbr(friends=>[$var(i),3]);
+            if ($var(directConnectivity) == "intervpbx") {
+                $xavp(ra) = $null;
+                sql_xquery("cb", "SELECT COUNT(*) > 0 AS isExtension FROM Extensions E WHERE number='$var(number)' AND companyId='$var(interCompanyId)'", "ra");
+                if ($xavp(ra=>isExtension) == '1') {
+                    $avp(is_internal) = '1';
+                    xinfo("[$dlg_var(cidhash)] IS-INTERNAL: $var(number) is an internal friend ([$var(currentFriendId)] $var(currentFriendName))\n");
+                    break;
+                }
+            } else {
+                $xavp(rd) = $null;
+                sql_xquery("cb", "SELECT F.id, F.directConnectivity, F.interCompanyId FROM FriendsPatterns FP JOIN Friends F ON FP.friendId=F.id WHERE F.id='$var(currentFriendId)' AND '$var(number)' REGEXP `regExp` ORDER BY F.priority ASC LIMIT 1", "rd");
+                if ($xavp(rd=>directConnectivity) != $null) {
+                    xinfo("[$dlg_var(cidhash)] IS-INTERNAL: $var(number) is a remote friend ([$var(currentFriendId)] $var(currentFriendName))\n");
+                    if ($(var(number){s.substr,0,1}) == '+') {
+                        xwarn("[$dlg_var(cidhash)] IS-INTERNAL: $var(number) not considered as internal as starts with +\n");
+                    } else {
+                        $avp(is_internal) = '1';
+                    }
+                    break;
+                }
+            }
+            $var(i) = $var(i) + 1;
         }
-        if ($(var(number){s.substr,0,1}) == '+') {
-            xinfo("[$dlg_var(cidhash)] IS-INTERNAL: $var(number) not considered as internal as starts with +\n");
-        } else {
-            $avp(is_internal) = '1';
-        }
-        return;
     }
+    sql_result_free("friends");
+    if ($avp(is_internal) == '1') return;
 
     xinfo("[$dlg_var(cidhash)] IS-INTERNAL: $var(number) is an external number\n");
 

--- a/library/Ivoz/Provider/Domain/Model/Friend/Friend.php
+++ b/library/Ivoz/Provider/Domain/Model/Friend/Friend.php
@@ -181,6 +181,15 @@ class Friend extends FriendAbstract implements FriendInterface
      */
     public function checkExtension($exten)
     {
+        if ($this->isInterPbxConnectivity()) {
+            // Inter-vPBX can call to any Extension pointing to user
+            $extension = $this->getInterCompany()->getExtension($exten);
+            if (is_null($extension)) {
+                return false;
+            }
+            return true;
+        }
+
         $patterns = $this->getPatterns();
         /**
          * @var FriendsPattern $pattern

--- a/schema/DoctrineMigrations/Version20200220142749.php
+++ b/schema/DoctrineMigrations/Version20200220142749.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Application\Migrations;
+
+use Ivoz\Core\Infrastructure\Persistence\Doctrine\LoggableMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20200220142749 extends LoggableMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql("DELETE FP FROM FriendsPatterns FP JOIN Friends F ON F.id=FP.friendId WHERE F.directConnectivity='intervpbx'");
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+
+    }
+}

--- a/web/admin/application/configs/klear/FriendsList.yaml
+++ b/web/admin/application/configs/klear/FriendsList.yaml
@@ -193,6 +193,7 @@ production:
       <<: *friendsPatternsList_screenLink
       filterField: Friend
       parentOptionCustomizer:
+        - IvozProvider_Klear_Options_OptionsCustomizer
         - recordCount
     friendsPatternsNew_screen:
       <<: *friendsPatternsNew_screenLink

--- a/web/admin/application/library/IvozProvider/Klear/Options/OptionsCustomizer.php
+++ b/web/admin/application/library/IvozProvider/Klear/Options/OptionsCustomizer.php
@@ -1,6 +1,7 @@
 <?php
 
 use Ivoz\Provider\Domain\Model\BillableCall\BillableCallInterface;
+use \Ivoz\Provider\Domain\Model\Friend\FriendInterface;
 
 class IvozProvider_Klear_Options_OptionsCustomizer implements \KlearMatrix_Model_Interfaces_ParentOptionCustomizer
 {
@@ -135,6 +136,11 @@ class IvozProvider_Klear_Options_OptionsCustomizer implements \KlearMatrix_Model
                 break;
             case "specialNumbersView_screen":
                 $show = !$this->_isBrandData();
+                break;
+            case "friendsPatternsList_screen":
+                $directConnectivity = $this->_parentModel->getDirectConnectivity();
+                $isNotInterPbx = $directConnectivity != FriendInterface::DIRECTCONNECTIVITY_INTERVPBX;
+                $show = $isNotInterPbx;
                 break;
             default:
                 throw new Klear_Exception_Default("Unsupported dialog " . $this->_option->getName());


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

Regexps linked to Friends let IvozProvider know who is in the other side. This is not necessary for intervpbx friends, as that other side is another IvozProvider client.

This PR adds the logic to make intervpbx regexps not necessary.
