### PR TITLE
Propagate client side endpoint to trunks cdrs for outbound calls

### DIFF
--- a/asterisk/agi/src/Agi/Action/ExternalFaxCallAction.php
+++ b/asterisk/agi/src/Agi/Action/ExternalFaxCallAction.php
@@ -103,6 +103,9 @@ class ExternalFaxCallAction
             return;
         }
 
+        // Set fax
+        $this->agi->setVariable("__FAXID", $faxOut->getFax()->getId());
+
         // Set presentation
         $this->agi->setCallerIdNum($ddi->getDdie164());
 

--- a/asterisk/agi/src/Dialplan/Friends.php
+++ b/asterisk/agi/src/Dialplan/Friends.php
@@ -82,6 +82,7 @@ class Friends extends RouteHandlerAbstract
 
         // Get friend from the endpoint.
         $friend = $this->endpointResolver->getFriendFromEndpoint($endpointName);
+        $this->agi->setVariable("__FRIENDID", $friend->getId());
 
         // Set Company/Brand/Generic Music class
         $company = $friend->getCompany();

--- a/asterisk/agi/src/Dialplan/Headers.php
+++ b/asterisk/agi/src/Dialplan/Headers.php
@@ -92,6 +92,24 @@ class Headers extends RouteHandlerAbstract
             if (!empty($retailAccountId)) {
                 $this->agi->setSIPHeader("X-Info-RetailAccount", $retailAccountId);
             }
+
+            // Get user from channel variables
+            $userId = $this->agi->getVariable("USERID");
+            if (!empty($userId)) {
+                $this->agi->setSIPHeader("X-Info-UserId", $userId);
+            }
+
+            // Get friend from channel variables
+            $friendId = $this->agi->getVariable("FRIENDID");
+            if (!empty($friendId)) {
+                $this->agi->setSIPHeader("X-Info-FriendId", $friendId);
+            }
+
+            // Get fax from channel variables
+            $faxId = $this->agi->getVariable("FAXID");
+            if (!empty($faxId)) {
+                $this->agi->setSIPHeader("X-Info-FaxId", $faxId);
+            }
         }
 
         // Set recording header

--- a/asterisk/agi/src/Dialplan/Users.php
+++ b/asterisk/agi/src/Dialplan/Users.php
@@ -124,6 +124,7 @@ class Users extends RouteHandlerAbstract
 
         // Get caller user from endpoint name
         $user = $this->endpointResolver->getUserFromEndpoint($endpointName);
+        $this->agi->setVariable("__USERID", $user->getId());
 
         // Create a new agent for caller user
         $caller = new UserAgent($this->agi, $user);

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -243,7 +243,7 @@ modparam("acc", "cdr_on_failed", 0)
 modparam("acc", "cdr_expired_dlg_enable", 1)
 modparam("acc", "cdr_start_on_confirmed", 1)
 modparam("acc", "cdr_facility", "LOG_LOCAL3")
-modparam("acc", "cdr_extra", "brandId=$dlg_var(brandId);companyId=$dlg_var(companyId);caller=$dlg_var(caller);callee=$dlg_var(callee);callid=$dlg_var(callid);callidHash=$dlg_var(cidhash);xcallid=$dlg_var(xcallid);diversion=$dlg_var(diversion);carrierId=$dlg_var(carrierId);direction=$dlg_var(direction);bounced=$dlg_var(bounced);cgrid=$dlg_var(cgrid);retailAccountId=$dlg_var(retailAccountId);residentialDeviceId=$dlg_var(residentialDeviceId);parsed=$dlg_var(parsed)")
+modparam("acc", "cdr_extra", "brandId=$dlg_var(brandId);companyId=$dlg_var(companyId);caller=$dlg_var(caller);callee=$dlg_var(callee);callid=$dlg_var(callid);callidHash=$dlg_var(cidhash);xcallid=$dlg_var(xcallid);diversion=$dlg_var(diversion);carrierId=$dlg_var(carrierId);direction=$dlg_var(direction);bounced=$dlg_var(bounced);cgrid=$dlg_var(cgrid);retailAccountId=$dlg_var(retailAccountId);residentialDeviceId=$dlg_var(residentialDeviceId);parsed=$dlg_var(parsed);userId=$dlg_var(userId);friendId=$dlg_var(friendId);faxId=$dlg_var(faxId)")
 modparam("acc", "cdr_extra_nullable", 1)
 
 # DIALOG
@@ -974,6 +974,30 @@ route[PARSE_X_HEADERS] {
     if ($var(header-value) != '') {
         xinfo("[$dlg_var(cidhash)] X-HEADERS-OTHER: '$var(header)' header found: $var(header-value)\n");
         $dlg_var(residentialDeviceId) = $var(header-value);
+    }
+
+    # Extract UserId for cdr entry
+    $var(header) = 'X-Info-UserId';
+    route(PARSE_OPTIONAL_X_HEADER);
+    if ($var(header-value) != '') {
+        xinfo("[$dlg_var(cidhash)] X-HEADERS-OTHER: '$var(header)' header found: $var(header-value)\n");
+        $dlg_var(userId) = $var(header-value);
+    }
+
+    # Extract FriendId for cdr entry
+    $var(header) = 'X-Info-FriendId';
+    route(PARSE_OPTIONAL_X_HEADER);
+    if ($var(header-value) != '') {
+        xinfo("[$dlg_var(cidhash)] X-HEADERS-OTHER: '$var(header)' header found: $var(header-value)\n");
+        $dlg_var(friendId) = $var(header-value);
+    }
+
+    # Extract FaxId for cdr entry
+    $var(header) = 'X-Info-FaxId';
+    route(PARSE_OPTIONAL_X_HEADER);
+    if ($var(header-value) != '') {
+        xinfo("[$dlg_var(cidhash)] X-HEADERS-OTHER: '$var(header)' header found: $var(header-value)\n");
+        $dlg_var(faxId) = $var(header-value);
     }
 
     # Extract xcallid

--- a/library/Ivoz/Kam/Domain/Model/TrunksCdr/TrunksCdrAbstract.php
+++ b/library/Ivoz/Kam/Domain/Model/TrunksCdr/TrunksCdrAbstract.php
@@ -110,6 +110,21 @@ abstract class TrunksCdrAbstract
      */
     protected $residentialDevice;
 
+    /**
+     * @var \Ivoz\Provider\Domain\Model\User\UserInterface | null
+     */
+    protected $user;
+
+    /**
+     * @var \Ivoz\Provider\Domain\Model\Friend\FriendInterface | null
+     */
+    protected $friend;
+
+    /**
+     * @var \Ivoz\Provider\Domain\Model\Fax\FaxInterface | null
+     */
+    protected $fax;
+
 
     use ChangelogTrait;
 
@@ -219,6 +234,9 @@ abstract class TrunksCdrAbstract
             ->setCarrier($fkTransformer->transform($dto->getCarrier()))
             ->setRetailAccount($fkTransformer->transform($dto->getRetailAccount()))
             ->setResidentialDevice($fkTransformer->transform($dto->getResidentialDevice()))
+            ->setUser($fkTransformer->transform($dto->getUser()))
+            ->setFriend($fkTransformer->transform($dto->getFriend()))
+            ->setFax($fkTransformer->transform($dto->getFax()))
         ;
 
         $self->initChangelog();
@@ -256,7 +274,10 @@ abstract class TrunksCdrAbstract
             ->setCompany($fkTransformer->transform($dto->getCompany()))
             ->setCarrier($fkTransformer->transform($dto->getCarrier()))
             ->setRetailAccount($fkTransformer->transform($dto->getRetailAccount()))
-            ->setResidentialDevice($fkTransformer->transform($dto->getResidentialDevice()));
+            ->setResidentialDevice($fkTransformer->transform($dto->getResidentialDevice()))
+            ->setUser($fkTransformer->transform($dto->getUser()))
+            ->setFriend($fkTransformer->transform($dto->getFriend()))
+            ->setFax($fkTransformer->transform($dto->getFax()));
 
 
 
@@ -289,7 +310,10 @@ abstract class TrunksCdrAbstract
             ->setCompany(\Ivoz\Provider\Domain\Model\Company\Company::entityToDto(self::getCompany(), $depth))
             ->setCarrier(\Ivoz\Provider\Domain\Model\Carrier\Carrier::entityToDto(self::getCarrier(), $depth))
             ->setRetailAccount(\Ivoz\Provider\Domain\Model\RetailAccount\RetailAccount::entityToDto(self::getRetailAccount(), $depth))
-            ->setResidentialDevice(\Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDevice::entityToDto(self::getResidentialDevice(), $depth));
+            ->setResidentialDevice(\Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDevice::entityToDto(self::getResidentialDevice(), $depth))
+            ->setUser(\Ivoz\Provider\Domain\Model\User\User::entityToDto(self::getUser(), $depth))
+            ->setFriend(\Ivoz\Provider\Domain\Model\Friend\Friend::entityToDto(self::getFriend(), $depth))
+            ->setFax(\Ivoz\Provider\Domain\Model\Fax\Fax::entityToDto(self::getFax(), $depth));
     }
 
     /**
@@ -316,7 +340,10 @@ abstract class TrunksCdrAbstract
             'companyId' => self::getCompany() ? self::getCompany()->getId() : null,
             'carrierId' => self::getCarrier() ? self::getCarrier()->getId() : null,
             'retailAccountId' => self::getRetailAccount() ? self::getRetailAccount()->getId() : null,
-            'residentialDeviceId' => self::getResidentialDevice() ? self::getResidentialDevice()->getId() : null
+            'residentialDeviceId' => self::getResidentialDevice() ? self::getResidentialDevice()->getId() : null,
+            'userId' => self::getUser() ? self::getUser()->getId() : null,
+            'friendId' => self::getFriend() ? self::getFriend()->getId() : null,
+            'faxId' => self::getFax() ? self::getFax()->getId() : null
         ];
     }
     // @codeCoverageIgnoreStart
@@ -846,6 +873,78 @@ abstract class TrunksCdrAbstract
     public function getResidentialDevice()
     {
         return $this->residentialDevice;
+    }
+
+    /**
+     * Set user
+     *
+     * @param \Ivoz\Provider\Domain\Model\User\UserInterface $user | null
+     *
+     * @return static
+     */
+    protected function setUser(\Ivoz\Provider\Domain\Model\User\UserInterface $user = null)
+    {
+        $this->user = $user;
+
+        return $this;
+    }
+
+    /**
+     * Get user
+     *
+     * @return \Ivoz\Provider\Domain\Model\User\UserInterface | null
+     */
+    public function getUser()
+    {
+        return $this->user;
+    }
+
+    /**
+     * Set friend
+     *
+     * @param \Ivoz\Provider\Domain\Model\Friend\FriendInterface $friend | null
+     *
+     * @return static
+     */
+    protected function setFriend(\Ivoz\Provider\Domain\Model\Friend\FriendInterface $friend = null)
+    {
+        $this->friend = $friend;
+
+        return $this;
+    }
+
+    /**
+     * Get friend
+     *
+     * @return \Ivoz\Provider\Domain\Model\Friend\FriendInterface | null
+     */
+    public function getFriend()
+    {
+        return $this->friend;
+    }
+
+    /**
+     * Set fax
+     *
+     * @param \Ivoz\Provider\Domain\Model\Fax\FaxInterface $fax | null
+     *
+     * @return static
+     */
+    protected function setFax(\Ivoz\Provider\Domain\Model\Fax\FaxInterface $fax = null)
+    {
+        $this->fax = $fax;
+
+        return $this;
+    }
+
+    /**
+     * Get fax
+     *
+     * @return \Ivoz\Provider\Domain\Model\Fax\FaxInterface | null
+     */
+    public function getFax()
+    {
+        return $this->fax;
     }
 
     // @codeCoverageIgnoreEnd

--- a/library/Ivoz/Kam/Domain/Model/TrunksCdr/TrunksCdrDtoAbstract.php
+++ b/library/Ivoz/Kam/Domain/Model/TrunksCdr/TrunksCdrDtoAbstract.php
@@ -110,6 +110,21 @@ abstract class TrunksCdrDtoAbstract implements DataTransferObjectInterface
      */
     private $residentialDevice;
 
+    /**
+     * @var \Ivoz\Provider\Domain\Model\User\UserDto | null
+     */
+    private $user;
+
+    /**
+     * @var \Ivoz\Provider\Domain\Model\Friend\FriendDto | null
+     */
+    private $friend;
+
+    /**
+     * @var \Ivoz\Provider\Domain\Model\Fax\FaxDto | null
+     */
+    private $fax;
+
 
     use DtoNormalizer;
 
@@ -147,7 +162,10 @@ abstract class TrunksCdrDtoAbstract implements DataTransferObjectInterface
             'companyId' => 'company',
             'carrierId' => 'carrier',
             'retailAccountId' => 'retailAccount',
-            'residentialDeviceId' => 'residentialDevice'
+            'residentialDeviceId' => 'residentialDevice',
+            'userId' => 'user',
+            'friendId' => 'friend',
+            'faxId' => 'fax'
         ];
     }
 
@@ -176,7 +194,10 @@ abstract class TrunksCdrDtoAbstract implements DataTransferObjectInterface
             'company' => $this->getCompany(),
             'carrier' => $this->getCarrier(),
             'retailAccount' => $this->getRetailAccount(),
-            'residentialDevice' => $this->getResidentialDevice()
+            'residentialDevice' => $this->getResidentialDevice(),
+            'user' => $this->getUser(),
+            'friend' => $this->getFriend(),
+            'fax' => $this->getFax()
         ];
     }
 
@@ -704,6 +725,144 @@ abstract class TrunksCdrDtoAbstract implements DataTransferObjectInterface
     public function getResidentialDeviceId()
     {
         if ($dto = $this->getResidentialDevice()) {
+            return $dto->getId();
+        }
+
+        return null;
+    }
+
+    /**
+     * @param \Ivoz\Provider\Domain\Model\User\UserDto $user
+     *
+     * @return static
+     */
+    public function setUser(\Ivoz\Provider\Domain\Model\User\UserDto $user = null)
+    {
+        $this->user = $user;
+
+        return $this;
+    }
+
+    /**
+     * @return \Ivoz\Provider\Domain\Model\User\UserDto | null
+     */
+    public function getUser()
+    {
+        return $this->user;
+    }
+
+    /**
+     * @param mixed | null $id
+     *
+     * @return static
+     */
+    public function setUserId($id)
+    {
+        $value = !is_null($id)
+            ? new \Ivoz\Provider\Domain\Model\User\UserDto($id)
+            : null;
+
+        return $this->setUser($value);
+    }
+
+    /**
+     * @return mixed | null
+     */
+    public function getUserId()
+    {
+        if ($dto = $this->getUser()) {
+            return $dto->getId();
+        }
+
+        return null;
+    }
+
+    /**
+     * @param \Ivoz\Provider\Domain\Model\Friend\FriendDto $friend
+     *
+     * @return static
+     */
+    public function setFriend(\Ivoz\Provider\Domain\Model\Friend\FriendDto $friend = null)
+    {
+        $this->friend = $friend;
+
+        return $this;
+    }
+
+    /**
+     * @return \Ivoz\Provider\Domain\Model\Friend\FriendDto | null
+     */
+    public function getFriend()
+    {
+        return $this->friend;
+    }
+
+    /**
+     * @param mixed | null $id
+     *
+     * @return static
+     */
+    public function setFriendId($id)
+    {
+        $value = !is_null($id)
+            ? new \Ivoz\Provider\Domain\Model\Friend\FriendDto($id)
+            : null;
+
+        return $this->setFriend($value);
+    }
+
+    /**
+     * @return mixed | null
+     */
+    public function getFriendId()
+    {
+        if ($dto = $this->getFriend()) {
+            return $dto->getId();
+        }
+
+        return null;
+    }
+
+    /**
+     * @param \Ivoz\Provider\Domain\Model\Fax\FaxDto $fax
+     *
+     * @return static
+     */
+    public function setFax(\Ivoz\Provider\Domain\Model\Fax\FaxDto $fax = null)
+    {
+        $this->fax = $fax;
+
+        return $this;
+    }
+
+    /**
+     * @return \Ivoz\Provider\Domain\Model\Fax\FaxDto | null
+     */
+    public function getFax()
+    {
+        return $this->fax;
+    }
+
+    /**
+     * @param mixed | null $id
+     *
+     * @return static
+     */
+    public function setFaxId($id)
+    {
+        $value = !is_null($id)
+            ? new \Ivoz\Provider\Domain\Model\Fax\FaxDto($id)
+            : null;
+
+        return $this->setFax($value);
+    }
+
+    /**
+     * @return mixed | null
+     */
+    public function getFaxId()
+    {
+        if ($dto = $this->getFax()) {
             return $dto->getId();
         }
 

--- a/library/Ivoz/Kam/Domain/Model/TrunksCdr/TrunksCdrInterface.php
+++ b/library/Ivoz/Kam/Domain/Model/TrunksCdr/TrunksCdrInterface.php
@@ -140,4 +140,25 @@ interface TrunksCdrInterface extends EntityInterface
      * @return \Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDeviceInterface | null
      */
     public function getResidentialDevice();
+
+    /**
+     * Get user
+     *
+     * @return \Ivoz\Provider\Domain\Model\User\UserInterface | null
+     */
+    public function getUser();
+
+    /**
+     * Get friend
+     *
+     * @return \Ivoz\Provider\Domain\Model\Friend\FriendInterface | null
+     */
+    public function getFriend();
+
+    /**
+     * Get fax
+     *
+     * @return \Ivoz\Provider\Domain\Model\Fax\FaxInterface | null
+     */
+    public function getFax();
 }

--- a/library/Ivoz/Kam/Infrastructure/Persistence/Doctrine/Mapping/TrunksCdr.TrunksCdrAbstract.orm.yml
+++ b/library/Ivoz/Kam/Infrastructure/Persistence/Doctrine/Mapping/TrunksCdr.TrunksCdrAbstract.orm.yml
@@ -152,3 +152,36 @@ Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdrAbstract:
           referencedColumnName: id
           onDelete: set null
       orphanRemoval: false
+    user:
+      targetEntity: \Ivoz\Provider\Domain\Model\User\UserInterface
+      cascade: {  }
+      fetch: LAZY
+      mappedBy: null
+      inversedBy: null
+      joinColumns:
+        userId:
+          referencedColumnName: id
+          onDelete: set null
+      orphanRemoval: false
+    friend:
+      targetEntity: \Ivoz\Provider\Domain\Model\Friend\FriendInterface
+      cascade: {  }
+      fetch: LAZY
+      mappedBy: null
+      inversedBy: null
+      joinColumns:
+        friendId:
+          referencedColumnName: id
+          onDelete: set null
+      orphanRemoval: false
+    fax:
+      targetEntity: \Ivoz\Provider\Domain\Model\Fax\FaxInterface
+      cascade: {  }
+      fetch: LAZY
+      mappedBy: null
+      inversedBy: null
+      joinColumns:
+        faxId:
+          referencedColumnName: id
+          onDelete: set null
+      orphanRemoval: false

--- a/library/Ivoz/Provider/Domain/Model/BillableCall/BillableCallAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/BillableCall/BillableCallAbstract.php
@@ -69,6 +69,7 @@ abstract class BillableCallAbstract
     protected $ratingPlanName;
 
     /**
+     * comment: enum:RetailAccount|ResidentialDevice|User|Friend|Fax
      * @var string | null
      */
     protected $endpointType;
@@ -654,6 +655,13 @@ abstract class BillableCallAbstract
     {
         if (!is_null($endpointType)) {
             Assertion::maxLength($endpointType, 55, 'endpointType value "%s" is too long, it should have no more than %d characters, but has %d characters.');
+            Assertion::choice($endpointType, [
+                BillableCallInterface::ENDPOINTTYPE_RETAILACCOUNT,
+                BillableCallInterface::ENDPOINTTYPE_RESIDENTIALDEVICE,
+                BillableCallInterface::ENDPOINTTYPE_USER,
+                BillableCallInterface::ENDPOINTTYPE_FRIEND,
+                BillableCallInterface::ENDPOINTTYPE_FAX
+            ], 'endpointTypevalue "%s" is not an element of the valid values: %s');
         }
 
         $this->endpointType = $endpointType;

--- a/library/Ivoz/Provider/Domain/Model/BillableCall/BillableCallInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/BillableCall/BillableCallInterface.php
@@ -6,6 +6,13 @@ use Ivoz\Core\Domain\Model\LoggableEntityInterface;
 
 interface BillableCallInterface extends LoggableEntityInterface
 {
+    const ENDPOINTTYPE_RETAILACCOUNT = 'RetailAccount';
+    const ENDPOINTTYPE_RESIDENTIALDEVICE = 'ResidentialDevice';
+    const ENDPOINTTYPE_USER = 'User';
+    const ENDPOINTTYPE_FRIEND = 'Friend';
+    const ENDPOINTTYPE_FAX = 'Fax';
+
+
     const DIRECTION_INBOUND = 'inbound';
     const DIRECTION_OUTBOUND = 'outbound';
 

--- a/library/Ivoz/Provider/Domain/Service/BillableCall/CreateOrUpdateByTrunksCdr.php
+++ b/library/Ivoz/Provider/Domain/Service/BillableCall/CreateOrUpdateByTrunksCdr.php
@@ -93,14 +93,32 @@ class CreateOrUpdateByTrunksCdr
 
         if ($trunksCdrDto->getRetailAccountId()) {
             $billableCallDto
-                ->setEndpointType('RetailAccount')
+                ->setEndpointType(BillableCallInterface::ENDPOINTTYPE_RETAILACCOUNT)
                 ->setEndpointId($trunksCdrDto->getRetailAccountId());
         }
 
         if ($trunksCdrDto->getResidentialDeviceId()) {
             $billableCallDto
-                ->setEndpointType('ResidentialDevice')
+                ->setEndpointType(BillableCallInterface::ENDPOINTTYPE_RESIDENTIALDEVICE)
                 ->setEndpointId($trunksCdrDto->getResidentialDeviceId());
+        }
+
+        if ($trunksCdrDto->getUserId()) {
+            $billableCallDto
+                ->setEndpointType(BillableCallInterface::ENDPOINTTYPE_USER)
+                ->setEndpointId($trunksCdrDto->getUserId());
+        }
+
+        if ($trunksCdrDto->getFriendId()) {
+            $billableCallDto
+                ->setEndpointType(BillableCallInterface::ENDPOINTTYPE_FRIEND)
+                ->setEndpointId($trunksCdrDto->getFriendId());
+        }
+
+        if ($trunksCdrDto->getFaxId()) {
+            $billableCallDto
+                ->setEndpointType(BillableCallInterface::ENDPOINTTYPE_FAX)
+                ->setEndpointId($trunksCdrDto->getFaxId());
         }
 
         /** @var BillableCallInterface $billableCall */

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/BillableCall.BillableCallAbstract.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/BillableCall.BillableCallAbstract.orm.yml
@@ -78,6 +78,7 @@ Ivoz\Provider\Domain\Model\BillableCall\BillableCallAbstract:
       length: 55
       options:
         fixed: false
+        comment: '[enum:RetailAccount|ResidentialDevice|User|Friend|Fax]'
       column: endpointType
     endpointId:
       type: integer

--- a/schema/DoctrineMigrations/Version20200221112255.php
+++ b/schema/DoctrineMigrations/Version20200221112255.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Application\Migrations;
+
+use Ivoz\Core\Infrastructure\Persistence\Doctrine\LoggableMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20200221112255 extends LoggableMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE kam_trunks_cdrs ADD userId INT UNSIGNED DEFAULT NULL, ADD friendId INT UNSIGNED DEFAULT NULL, ADD faxId INT UNSIGNED DEFAULT NULL');
+
+        $this->addSql('SET FOREIGN_KEY_CHECKS = 0');
+        $this->addSql('ALTER TABLE kam_trunks_cdrs ADD CONSTRAINT FK_92E58EB664B64DCC FOREIGN KEY (userId) REFERENCES Users (id) ON DELETE SET NULL');
+        $this->addSql('ALTER TABLE kam_trunks_cdrs ADD CONSTRAINT FK_92E58EB6893BA339 FOREIGN KEY (friendId) REFERENCES Friends (id) ON DELETE SET NULL');
+        $this->addSql('ALTER TABLE kam_trunks_cdrs ADD CONSTRAINT FK_92E58EB6624C8D73 FOREIGN KEY (faxId) REFERENCES Faxes (id) ON DELETE SET NULL');
+        $this->addSql('SET FOREIGN_KEY_CHECKS = 1');
+
+        $this->addSql('CREATE INDEX IDX_92E58EB664B64DCC ON kam_trunks_cdrs (userId)');
+        $this->addSql('CREATE INDEX IDX_92E58EB6893BA339 ON kam_trunks_cdrs (friendId)');
+        $this->addSql('CREATE INDEX IDX_92E58EB6624C8D73 ON kam_trunks_cdrs (faxId)');
+
+        $this->addSql('ALTER TABLE BillableCalls CHANGE endpointType endpointType VARCHAR(55) DEFAULT NULL COMMENT \'[enum:RetailAccount|ResidentialDevice|User|Friend|Fax]\'');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE BillableCalls CHANGE endpointType endpointType VARCHAR(55) DEFAULT NULL COLLATE utf8_unicode_ci');
+
+        $this->addSql('ALTER TABLE kam_trunks_cdrs DROP FOREIGN KEY FK_92E58EB664B64DCC');
+        $this->addSql('ALTER TABLE kam_trunks_cdrs DROP FOREIGN KEY FK_92E58EB6893BA339');
+        $this->addSql('ALTER TABLE kam_trunks_cdrs DROP FOREIGN KEY FK_92E58EB6624C8D73');
+        $this->addSql('DROP INDEX IDX_92E58EB664B64DCC ON kam_trunks_cdrs');
+        $this->addSql('DROP INDEX IDX_92E58EB6893BA339 ON kam_trunks_cdrs');
+        $this->addSql('DROP INDEX IDX_92E58EB6624C8D73 ON kam_trunks_cdrs');
+        $this->addSql('ALTER TABLE kam_trunks_cdrs DROP userId, DROP friendId, DROP faxId');
+    }
+}


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

Propagate to _kam_trunks_cdrs_:

- userId
- friendId
- faxId

**Just for outgoing calls**.

Propagate this new fields for new external outgoing call to:

- BillableCalls.endpointType:
  - User
  - Friend
  - Fax

- BillableCalls.endpointId

**IMPORTANT NOTE**: Just for **outgoing** external calls. In inbound calls KamTrunks does not know who is going to answer the call.
