### PR TITLE
web/admin: show red if runtime MaxDailyUsage is not equal to database value

### DIFF
--- a/doc/sphinx/administration_portal/brand/billing/current_day_usages.rst
+++ b/doc/sphinx/administration_portal/brand/billing/current_day_usages.rst
@@ -30,3 +30,6 @@ This section lists current day usage for each client in the brand:
 
 .. error:: This is one of main :ref:`security` mechanisms available in IvozProvider. Use it to avoid toll fraud calls
            (see :ref:`Current day max usage`).
+
+This section shows runtime value obtained asking to CGRateS (value actually applying) that should be equal to the one
+set editing the client itself. If data is shown in red, these values differ.

--- a/web/admin/application/configs/klear/model/Companies.yaml
+++ b/web/admin/application/configs/klear/model/Companies.yaml
@@ -477,6 +477,7 @@ production:
       title: _('Max daily usage')
       type: ghost
       readonly: true
+      dirty: true
       source:
         class: IvozProvider_Klear_Ghost_Companies
         method: getCurrentDayMaxUsage


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

MaxDailyUsage has a runtime value (obtained asking to CGRateS) and a database value (Companies.maxDailyUsage) that should be equal.

_Current Day Usage_ shows runtime value. This PR shows this value in red if database value is different.