### PR TITLE
Dont allow updates on call csv reports

### DIFF
--- a/web/rest/brand/config/api/raw/provider.yml
+++ b/web/rest/brand/config/api/raw/provider.yml
@@ -192,14 +192,7 @@ Ivoz\Provider\Domain\Model\CallCsvReport\CallCsvReport:
           eq: "user.getBrand().getId()"
     write_access_control:
       ROLE_BRAND_ADMIN:
-      - and:
-        - brand:
-            eq: "user.getBrand().getId()"
-        - company:
-            isNull: ~
-      - or:
-        - inheritedOrNull:
-            callCsvScheduler: 'Ivoz\Provider\Domain\Model\CallCsvScheduler\CallCsvScheduler'
+        raw: 'FALSE'
     swagger_context:
       required:
       - brand

--- a/web/rest/brand/features/provider/callCsvReport/putCallCsvReport.feature
+++ b/web/rest/brand/features/provider/callCsvReport/putCallCsvReport.feature
@@ -8,7 +8,7 @@ Feature: Update call CSV reports
     Given I add Brand Authorization header
     When I add "Content-Type" header equal to "application/json"
     And I add "Accept" header equal to "application/json"
-    And I send a "POST" request to "/call_csv_reports/1" with body:
+    And I send a "PUT" request to "/call_csv_reports/1" with body:
     """
       {
           "inDate": "2019-06-01 02:00:00",

--- a/web/rest/brand/tests/DataAccessControl/Provider/CallCsvReportTest.php
+++ b/web/rest/brand/tests/DataAccessControl/Provider/CallCsvReportTest.php
@@ -56,36 +56,7 @@ class CallCsvReportTest extends KernelTestCase
 
         $this->assertEquals(
             $accessControl,
-            [
-                [
-                    'and' => [
-                        [
-                            'brand',
-                            'eq',
-                            'user.getBrand().getId()'
-                        ],
-                        [
-                            'company',
-                            'isNull',
-                            null
-                        ]
-                    ]
-                ],
-                [
-                    'or' => [
-                        [
-                            'callCsvScheduler',
-                            'in',
-                            'CallCsvSchedulerRepository([["brand","eq","user.getBrand().getId()"]])'
-                        ],
-                        [
-                            'callCsvScheduler',
-                            'isNull',
-                            null
-                        ]
-                    ]
-                ]
-            ]
+            ['FALSE']
         );
     }
 }

--- a/web/rest/client/config/api/raw/provider.yml
+++ b/web/rest/client/config/api/raw/provider.yml
@@ -157,7 +157,6 @@ Ivoz\Provider\Domain\Model\CallCsvScheduler\CallCsvScheduler:
 Ivoz\Provider\Domain\Model\CallCsvReport\CallCsvReport:
   itemOperations:
     get: ~
-    put: ~
   collectionOperations:
     get: ~
   attributes:
@@ -168,12 +167,7 @@ Ivoz\Provider\Domain\Model\CallCsvReport\CallCsvReport:
           eq: "user.getCompany().getId()"
     write_access_control:
       ROLE_COMPANY_ADMIN:
-      - and:
-        - company:
-            eq: "user.getCompany().getId()"
-      - or:
-        - inheritedOrNull:
-            callCsvScheduler: 'Ivoz\Provider\Domain\Model\CallCsvScheduler\CallCsvScheduler'
+        raw: 'FALSE'
     swagger_context:
       required:
       - company

--- a/web/rest/client/features/provider/callCsvReport/putCallCsvReport.feature
+++ b/web/rest/client/features/provider/callCsvReport/putCallCsvReport.feature
@@ -8,7 +8,7 @@ Feature: Update call CSV reports
     Given I add Company Authorization header
     When I add "Content-Type" header equal to "application/json"
     And I add "Accept" header equal to "application/json"
-    And I send a "POST" request to "/call_csv_reports/1" with body:
+    And I send a "PUT" request to "/call_csv_reports/1" with body:
     """
       {
           "inDate": "2019-06-01 02:00:00",

--- a/web/rest/client/tests/DataAccessControl/Provider/CallCsvReportTest.php
+++ b/web/rest/client/tests/DataAccessControl/Provider/CallCsvReportTest.php
@@ -56,31 +56,7 @@ class CallCsvReportTest extends KernelTestCase
 
         $this->assertEquals(
             $accessControl,
-            [
-                [
-                    'and' => [
-                        [
-                            'company',
-                            'eq',
-                            'user.getCompany().getId()'
-                        ],
-                    ]
-                ],
-                [
-                    'or' => [
-                        [
-                            'callCsvScheduler',
-                            'in',
-                            'CallCsvSchedulerRepository([["company","eq","user.getCompany().getId()"],["brand","eq",null]])'
-                        ],
-                        [
-                            'callCsvScheduler',
-                            'isNull',
-                            null
-                        ]
-                    ]
-                ]
-            ]
+            ['FALSE']
         );
     }
 }


### PR DESCRIPTION
Remove PUT operation on CallCsvReports from client API.

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
