### PR TITLE
kamusers: increase TCP max conns

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -115,6 +115,7 @@ tcp_accept_aliases=no
 tcp_async=yes
 tcp_keepalive=yes
 tcp_keepidle=5
+tcp_max_connections=8192
 
 enable_tls=yes
 


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

Increase KamUsers TCP max connections from 2048 (default value) to 8192.