### PR TITLE
Brand API: forbidden global record updates

### DIFF
--- a/library/DataFixtures/FixtureHelperTrait.php
+++ b/library/DataFixtures/FixtureHelperTrait.php
@@ -22,6 +22,7 @@ trait FixtureHelperTrait
     protected function sanitizeEntityValues(EntityInterface $entity)
     {
         $sanitizer = function () {
+            $this->initChangelog();
             $this->sanitizeValues();
         };
 

--- a/library/DataFixtures/ORM/ProviderCallCsvReport.php
+++ b/library/DataFixtures/ORM/ProviderCallCsvReport.php
@@ -7,6 +7,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Ivoz\Provider\Domain\Model\CallCsvReport\CallCsvReport;
+use Ivoz\Provider\Domain\Model\CallCsvReport\Csv;
 
 class ProviderCallCsvReport extends Fixture implements DependentFixtureInterface
 {
@@ -36,6 +37,9 @@ class ProviderCallCsvReport extends Fixture implements DependentFixtureInterface
             $this->setCallCsvScheduler(
                 $fixture->getReference('_reference_ProviderCallCsvScheduler1')
             );
+            $this->setCsv(
+                new Csv(null, null, null)
+            );
         })->call($item1);
 
         $this->addReference('_reference_ProviderCallCsvReport1', $item1);
@@ -54,6 +58,9 @@ class ProviderCallCsvReport extends Fixture implements DependentFixtureInterface
             );
             $this->setCallCsvScheduler(
                 $fixture->getReference('_reference_ProviderCallCsvScheduler2')
+            );
+            $this->setCsv(
+                new Csv(null, null, null)
             );
         })->call($item2);
 

--- a/library/DataFixtures/ORM/ProviderDestinationRateGroup.php
+++ b/library/DataFixtures/ORM/ProviderDestinationRateGroup.php
@@ -10,6 +10,7 @@ use Ivoz\Provider\Domain\Model\DestinationRateGroup\DestinationRateGroup;
 use Ivoz\Provider\Domain\Model\DestinationRateGroup\Name;
 use Ivoz\Provider\Domain\Model\DestinationRateGroup\Description;
 use Ivoz\Provider\Domain\Model\DestinationRateGroup\DestinationRateGroupInterface;
+use Ivoz\Provider\Domain\Model\DestinationRateGroup\File;
 
 class ProviderDestinationRateGroup extends Fixture implements DependentFixtureInterface
 {
@@ -31,6 +32,7 @@ class ProviderDestinationRateGroup extends Fixture implements DependentFixtureIn
             $this->setName(new Name('Standard', 'Standard', 'Standard', 'Standard'));
             $this->setDescription(new Description('', '', '', ''));
             $this->setBrand($fixture->getReference('_reference_ProviderBrand1'));
+            $this->setFile(new File(null, null, null, null));
         })->call($item1);
 
         $this->addReference('_reference_ProviderDestinationRateGroup1', $item1);
@@ -45,6 +47,7 @@ class ProviderDestinationRateGroup extends Fixture implements DependentFixtureIn
             $this->setName(new Name('Fallback', 'Fallback', 'Fallback', 'Fallback'));
             $this->setDescription(new Description('', '', '', ''));
             $this->setBrand($fixture->getReference('_reference_ProviderBrand1'));
+            $this->setFile(new File(null, null, null, null));
         })->call($item2);
 
         $this->addReference('_reference_ProviderDestinationRateGroup2', $item2);

--- a/library/DataFixtures/ORM/ProviderFaxesInOut.php
+++ b/library/DataFixtures/ORM/ProviderFaxesInOut.php
@@ -7,6 +7,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Ivoz\Provider\Domain\Model\FaxesInOut\FaxesInOut;
+use Ivoz\Provider\Domain\Model\FaxesInOut\File;
 
 class ProviderFaxesInOut extends Fixture implements DependentFixtureInterface
 {
@@ -31,6 +32,9 @@ class ProviderFaxesInOut extends Fixture implements DependentFixtureInterface
             $this->setStatus('error');
             $this->setFax(
                 $fixture->getReference('_reference_ProviderFax1')
+            );
+            $this->setFile(
+                new File(null, null, null)
             );
         })->call($item1);
 

--- a/library/Ivoz/Provider/Domain/Model/InvoiceTemplate/InvoiceTemplate.php
+++ b/library/Ivoz/Provider/Domain/Model/InvoiceTemplate/InvoiceTemplate.php
@@ -27,6 +27,20 @@ class InvoiceTemplate extends InvoiceTemplateAbstract implements InvoiceTemplate
         return $this->id;
     }
 
+    protected function sanitizeValues()
+    {
+        $notNew = !$this->isNew();
+        $brandHasChanged = $this->hasChanged('brandId');
+
+        if ($notNew && $brandHasChanged) {
+            $errorMsg = $this->getBrand()
+                ? 'Unable to convert a global invoice template into a brand invoice template'
+                : 'Unable to convert a brand invoice template into a global invoice template';
+
+            throw new \DomainException($errorMsg);
+        }
+    }
+
     /**
      * @inheritdoc
      */

--- a/library/Ivoz/Provider/Domain/Model/InvoiceTemplate/InvoiceTemplateDto.php
+++ b/library/Ivoz/Provider/Domain/Model/InvoiceTemplate/InvoiceTemplateDto.php
@@ -2,8 +2,19 @@
 
 namespace Ivoz\Provider\Domain\Model\InvoiceTemplate;
 
+use Ivoz\Api\Core\Annotation\AttributeDefinition;
+
 class InvoiceTemplateDto extends InvoiceTemplateDtoAbstract
 {
+    /**
+     * @var string
+     * @AttributeDefinition(
+     *     type="bool",
+     *     writable=false,
+     *     description="Global Special Number"
+     * )
+     */
+    protected $global;
 
     /**
      * @inheritdoc
@@ -22,6 +33,22 @@ class InvoiceTemplateDto extends InvoiceTemplateDtoAbstract
 
         if ($role === 'ROLE_BRAND_ADMIN') {
             unset($response['brandId']);
+            $response['global'] = 'global';
+        }
+
+        return $response;
+    }
+
+    public function normalize(string $context, string $role = '')
+    {
+        $response = parent::normalize(...func_get_args());
+
+        $isBrandAdmin = $role === 'ROLE_BRAND_ADMIN';
+
+        if ($isBrandAdmin) {
+            $response['global'] = $this->getBrandId()
+                ? false
+                : true;
         }
 
         return $response;

--- a/library/Ivoz/Provider/Domain/Model/NotificationTemplate/NotificationTemplate.php
+++ b/library/Ivoz/Provider/Domain/Model/NotificationTemplate/NotificationTemplate.php
@@ -20,6 +20,20 @@ class NotificationTemplate extends NotificationTemplateAbstract implements Notif
         return parent::getChangeSet();
     }
 
+    protected function sanitizeValues()
+    {
+        $notNew = !$this->isNew();
+        $brandHasChanged = $this->hasChanged('brandId');
+
+        if ($notNew && $brandHasChanged) {
+            $errorMsg = $this->getBrand()
+                ? 'Unable to convert a global notification template into a brand notification template'
+                : 'Unable to convert a brand notification template into a global notification template';
+
+            throw new \DomainException($errorMsg);
+        }
+    }
+
     /**
      * Get id
      * @codeCoverageIgnore

--- a/library/Ivoz/Provider/Domain/Model/SpecialNumber/SpecialNumber.php
+++ b/library/Ivoz/Provider/Domain/Model/SpecialNumber/SpecialNumber.php
@@ -20,6 +20,17 @@ class SpecialNumber extends SpecialNumberAbstract implements SpecialNumberInterf
 
     protected function sanitizeValues()
     {
+        $notNew = !$this->isNew();
+        $brandHasChanged = $this->hasChanged('brandId');
+
+        if ($notNew && $brandHasChanged) {
+            $errorMsg = $this->getBrand()
+                ? 'Unable to convert a global special number into a brand special number'
+                : 'Unable to convert a brand special number into a global special number';
+
+            throw new \DomainException($errorMsg);
+        }
+
         $country = $this->getCountry();
 
         $this->setNumberE164(

--- a/library/Ivoz/Provider/Domain/Model/SpecialNumber/SpecialNumberDto.php
+++ b/library/Ivoz/Provider/Domain/Model/SpecialNumber/SpecialNumberDto.php
@@ -2,8 +2,20 @@
 
 namespace Ivoz\Provider\Domain\Model\SpecialNumber;
 
+use Ivoz\Api\Core\Annotation\AttributeDefinition;
+
 class SpecialNumberDto extends SpecialNumberDtoAbstract
 {
+    /**
+     * @var string
+     * @AttributeDefinition(
+     *     type="bool",
+     *     writable=false,
+     *     description="Global Special Number"
+     * )
+     */
+    protected $global;
+
     public static function getPropertyMap(string $context = '', string $role = null)
     {
         if ($context === self::CONTEXT_COLLECTION) {
@@ -17,8 +29,27 @@ class SpecialNumberDto extends SpecialNumberDtoAbstract
             $response = parent::getPropertyMap($context, $role);
         }
 
+        if ($role === 'ROLE_BRAND_ADMIN') {
+            $response['global'] = 'global';
+        }
+
         unset($response['brandId']);
         unset($response['numberE164']);
+
+        return $response;
+    }
+
+    public function normalize(string $context, string $role = '')
+    {
+        $response = parent::normalize(...func_get_args());
+
+        $isBrandAdmin = $role === 'ROLE_BRAND_ADMIN';
+
+        if ($isBrandAdmin) {
+            $response['global'] = $this->getBrandId()
+                ? false
+                : true;
+        }
 
         return $response;
     }

--- a/web/rest/brand/features/provider/invoiceTemplate/getInvoiceTemplate.feature
+++ b/web/rest/brand/features/provider/invoiceTemplate/getInvoiceTemplate.feature
@@ -16,11 +16,13 @@ Feature: Retrieve invoice templates
       [
           {
               "name": "Default",
-              "id": 1
+              "id": 1,
+              "global": false
           },
           {
               "name": "Generic",
-              "id": 2
+              "id": 2,
+              "global": true
           }
       ]
     """
@@ -40,6 +42,7 @@ Feature: Retrieve invoice templates
           "template": "Template",
           "templateHeader": "Template header",
           "templateFooter": "Template footer",
-          "id": 1
+          "id": 1,
+          "global": false
       }
     """

--- a/web/rest/brand/features/provider/invoiceTemplate/postInvoiceTemplate.feature
+++ b/web/rest/brand/features/provider/invoiceTemplate/postInvoiceTemplate.feature
@@ -29,7 +29,8 @@ Feature: Create invoice templates
           "template": "body",
           "templateHeader": "header",
           "templateFooter": "footer",
-          "id": 3
+          "id": 3,
+          "global": false
       }
     """
 
@@ -48,6 +49,7 @@ Feature: Create invoice templates
           "template": "body",
           "templateHeader": "header",
           "templateFooter": "footer",
-          "id": 3
+          "id": 3,
+          "global": false
       }
     """

--- a/web/rest/brand/features/provider/invoiceTemplate/putInvoiceTemplate.feature
+++ b/web/rest/brand/features/provider/invoiceTemplate/putInvoiceTemplate.feature
@@ -30,6 +30,7 @@ Feature: Update invoice templates
           "template": "body v2",
           "templateHeader": "header v2",
           "templateFooter": "footer v2",
-          "id": 1
+          "id": 1,
+          "global": false
       }
     """

--- a/web/rest/brand/features/provider/specialNumber/getSpecialNumber.feature
+++ b/web/rest/brand/features/provider/specialNumber/getSpecialNumber.feature
@@ -18,13 +18,15 @@ Feature: Retrieve special numbers
               "number": "016",
               "disableCDR": 1,
               "id": 1,
-              "country": 68
+              "country": 68,
+              "global": true
           },
           {
               "number": "091",
               "disableCDR": 1,
               "id": 2,
-              "country": 68
+              "country": 68,
+              "global": false
           }
       ]
     """
@@ -58,6 +60,7 @@ Feature: Retrieve special numbers
                   "ca": "Europa",
                   "it": "Europe"
               }
-          }
+          },
+          "global": false
       }
     """

--- a/web/rest/brand/features/provider/specialNumber/postSpecialNumber.feature
+++ b/web/rest/brand/features/provider/specialNumber/postSpecialNumber.feature
@@ -25,7 +25,8 @@ Feature: Create special numbers
           "number": "118",
           "disableCDR": 1,
           "id": 3,
-          "country": 68
+          "country": 68,
+          "global": false 
       }
     """
 
@@ -59,6 +60,7 @@ Feature: Create special numbers
                   "ca": "Europa",
                   "it": "Europe"
               }
-          }
+          },
+          "global": false
       }
     """

--- a/web/rest/brand/features/provider/specialNumber/putSpecialNumber.feature
+++ b/web/rest/brand/features/provider/specialNumber/putSpecialNumber.feature
@@ -41,7 +41,8 @@ Feature: Update special numbers
                   "ca": "Europa",
                   "it": "Europe"
               }
-          }
+          },
+          "global": false
       }
     """
 


### PR DESCRIPTION
Fixed security checks so that a global record is not turned into a brand one on:

- SpecialNumber
- NotificationTemplate
- InvoiceTemplate

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
