### PR TITLE
Improved API memory usage

### DIFF
--- a/asterisk/agi/composer.lock
+++ b/asterisk/agi/composer.lock
@@ -1424,11 +1424,11 @@
         },
         {
             "name": "irontec/ivoz-core",
-            "version": "2.3.5.0",
+            "version": "2.3.7.0",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/irontec/ivoz-core",
-                "reference": "db36f3808d2f70048001626ec2c687347834c2f0",
+                "reference": "ca596aeda4bee49666e418670b343a9abbf46057",
                 "shasum": null
             },
             "require": {

--- a/library/composer.json
+++ b/library/composer.json
@@ -65,7 +65,7 @@
         "doctrine/doctrine-migrations-bundle": "^1.2",
         "h4cc/wkhtmltopdf-amd64": "0.12.3",
         "irontec/ivoz-provider-bundle": "^2.3",
-        "irontec/ivoz-api-bundle": "^3.1",
+        "irontec/ivoz-api-bundle": "^3.2",
         "irontec/ivoz-dev-tools": "^3.0",
         "knplabs/knp-snappy": "0.4.3",
         "mmoreram/gearman-bundle": "^4.1",

--- a/library/composer.lock
+++ b/library/composer.lock
@@ -2837,16 +2837,16 @@
         },
         {
             "name": "phpxmlrpc/phpxmlrpc",
-            "version": "4.4.1",
+            "version": "4.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/gggeek/phpxmlrpc.git",
-                "reference": "3ba5608040e61564cf5e9a1ede98a9b0cf9d060e"
+                "reference": "9b400d2c102f2a55839af8f73279274ebe148526"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/gggeek/phpxmlrpc/zipball/3ba5608040e61564cf5e9a1ede98a9b0cf9d060e",
-                "reference": "3ba5608040e61564cf5e9a1ede98a9b0cf9d060e",
+                "url": "https://api.github.com/repos/gggeek/phpxmlrpc/zipball/9b400d2c102f2a55839af8f73279274ebe148526",
+                "reference": "9b400d2c102f2a55839af8f73279274ebe148526",
                 "shasum": ""
             },
             "require": {
@@ -2884,7 +2884,7 @@
                 "webservices",
                 "xmlrpc"
             ],
-            "time": "2019-07-29T14:20:48+00:00"
+            "time": "2020-03-04T10:26:33+00:00"
         },
         {
             "name": "psr/cache",
@@ -4875,16 +4875,16 @@
         },
         {
             "name": "behat/gherkin",
-            "version": "v4.6.0",
+            "version": "v4.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Behat/Gherkin.git",
-                "reference": "ab0a02ea14893860bca00f225f5621d351a3ad07"
+                "reference": "25bdcaf37898b4a939fa3031d5d753ced97e4759"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Behat/Gherkin/zipball/ab0a02ea14893860bca00f225f5621d351a3ad07",
-                "reference": "ab0a02ea14893860bca00f225f5621d351a3ad07",
+                "url": "https://api.github.com/repos/Behat/Gherkin/zipball/25bdcaf37898b4a939fa3031d5d753ced97e4759",
+                "reference": "25bdcaf37898b4a939fa3031d5d753ced97e4759",
                 "shasum": ""
             },
             "require": {
@@ -4930,39 +4930,42 @@
                 "gherkin",
                 "parser"
             ],
-            "time": "2019-01-16T14:22:17+00:00"
+            "time": "2020-02-27T11:29:57+00:00"
         },
         {
             "name": "behat/mink",
-            "version": "v1.7.1",
+            "version": "v1.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/minkphp/Mink.git",
-                "reference": "e6930b9c74693dff7f4e58577e1b1743399f3ff9"
+                "reference": "07c6a9fe3fa98c2de074b25d9ed26c22904e3887"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/minkphp/Mink/zipball/e6930b9c74693dff7f4e58577e1b1743399f3ff9",
-                "reference": "e6930b9c74693dff7f4e58577e1b1743399f3ff9",
+                "url": "https://api.github.com/repos/minkphp/Mink/zipball/07c6a9fe3fa98c2de074b25d9ed26c22904e3887",
+                "reference": "07c6a9fe3fa98c2de074b25d9ed26c22904e3887",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.1",
-                "symfony/css-selector": "~2.1|~3.0"
+                "symfony/css-selector": "^2.7|^3.0|^4.0|^5.0"
             },
             "require-dev": {
-                "symfony/phpunit-bridge": "~2.7|~3.0"
+                "phpunit/phpunit": "^4.8.36 || ^5.7.27 || ^6.5.14 || ^7.5.20",
+                "symfony/debug": "^2.7|^3.0|^4.0",
+                "symfony/phpunit-bridge": "^3.4.38 || ^5.0.5"
             },
             "suggest": {
                 "behat/mink-browserkit-driver": "extremely fast headless driver for Symfony\\Kernel-based apps (Sf2, Silex)",
                 "behat/mink-goutte-driver": "fast headless driver for any app without JS emulation",
                 "behat/mink-selenium2-driver": "slow, but JS-enabled driver for any app (requires Selenium2)",
-                "behat/mink-zombie-driver": "fast and JS-enabled headless driver for any app (requires node.js)"
+                "behat/mink-zombie-driver": "fast and JS-enabled headless driver for any app (requires node.js)",
+                "dmore/chrome-mink-driver": "fast and JS-enabled driver for any app (requires chromium or google chrome)"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.7.x-dev"
+                    "dev-master": "1.8.x-dev"
                 }
             },
             "autoload": {
@@ -4988,20 +4991,20 @@
                 "testing",
                 "web"
             ],
-            "time": "2016-03-05T08:26:18+00:00"
+            "time": "2020-03-11T15:45:53+00:00"
         },
         {
             "name": "behat/mink-browserkit-driver",
-            "version": "1.3.3",
+            "version": "v1.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/minkphp/MinkBrowserKitDriver.git",
-                "reference": "1b9a7ce903cfdaaec5fb32bfdbb26118343662eb"
+                "reference": "e3b90840022ebcd544c7b394a3c9597ae242cbee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/minkphp/MinkBrowserKitDriver/zipball/1b9a7ce903cfdaaec5fb32bfdbb26118343662eb",
-                "reference": "1b9a7ce903cfdaaec5fb32bfdbb26118343662eb",
+                "url": "https://api.github.com/repos/minkphp/MinkBrowserKitDriver/zipball/e3b90840022ebcd544c7b394a3c9597ae242cbee",
+                "reference": "e3b90840022ebcd544c7b394a3c9597ae242cbee",
                 "shasum": ""
             },
             "require": {
@@ -5012,6 +5015,7 @@
             },
             "require-dev": {
                 "mink/driver-testsuite": "dev-master",
+                "symfony/debug": "^2.7|^3.0|^4.0",
                 "symfony/http-kernel": "~2.3|~3.0|~4.0"
             },
             "type": "mink-driver",
@@ -5044,7 +5048,7 @@
                 "browser",
                 "testing"
             ],
-            "time": "2018-05-02T09:25:31+00:00"
+            "time": "2020-03-11T09:49:45+00:00"
         },
         {
             "name": "behat/mink-extension",
@@ -5332,16 +5336,16 @@
         },
         {
             "name": "composer/xdebug-handler",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "cbe23383749496fe0f373345208b79568e4bc248"
+                "reference": "1ab9842d69e64fb3a01be6b656501032d1b78cb7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/cbe23383749496fe0f373345208b79568e4bc248",
-                "reference": "cbe23383749496fe0f373345208b79568e4bc248",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/1ab9842d69e64fb3a01be6b656501032d1b78cb7",
+                "reference": "1ab9842d69e64fb3a01be6b656501032d1b78cb7",
                 "shasum": ""
             },
             "require": {
@@ -5372,7 +5376,7 @@
                 "Xdebug",
                 "performance"
             ],
-            "time": "2019-11-06T16:40:04+00:00"
+            "time": "2020-03-01T12:26:26+00:00"
         },
         {
             "name": "container-interop/container-interop",
@@ -5561,20 +5565,20 @@
         },
         {
             "name": "felixfbecker/advanced-json-rpc",
-            "version": "v3.1.0",
+            "version": "v3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/felixfbecker/php-advanced-json-rpc.git",
-                "reference": "a407a6cb0325cd489c6dff57afcba6baeccc0483"
+                "reference": "0ed363f8de17d284d479ec813c9ad3f6834b5c40"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/felixfbecker/php-advanced-json-rpc/zipball/a407a6cb0325cd489c6dff57afcba6baeccc0483",
-                "reference": "a407a6cb0325cd489c6dff57afcba6baeccc0483",
+                "url": "https://api.github.com/repos/felixfbecker/php-advanced-json-rpc/zipball/0ed363f8de17d284d479ec813c9ad3f6834b5c40",
+                "reference": "0ed363f8de17d284d479ec813c9ad3f6834b5c40",
                 "shasum": ""
             },
             "require": {
-                "netresearch/jsonmapper": "^1.0",
+                "netresearch/jsonmapper": "^1.0 || ^2.0",
                 "php": ">=7.0",
                 "phpdocumentor/reflection-docblock": "^4.0.0 || ^5.0.0"
             },
@@ -5598,7 +5602,7 @@
                 }
             ],
             "description": "A more advanced JSONRPC implementation",
-            "time": "2020-02-11T20:48:40+00:00"
+            "time": "2020-03-11T15:21:41+00:00"
         },
         {
             "name": "felixfbecker/language-server-protocol",
@@ -6714,16 +6718,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.10.2",
+            "version": "v1.10.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "b4400efc9d206e83138e2bb97ed7f5b14b831cd9"
+                "reference": "451c3cd1418cf640de218914901e51b064abb093"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/b4400efc9d206e83138e2bb97ed7f5b14b831cd9",
-                "reference": "b4400efc9d206e83138e2bb97ed7f5b14b831cd9",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/451c3cd1418cf640de218914901e51b064abb093",
+                "reference": "451c3cd1418cf640de218914901e51b064abb093",
                 "shasum": ""
             },
             "require": {
@@ -6773,7 +6777,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2020-01-20T15:57:02+00:00"
+            "time": "2020-03-05T15:02:03+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/library/composer.lock
+++ b/library/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "48d707ca77ffd4aba32f61b212127149",
+    "content-hash": "cca57bc3f19535046fe41cc1aa1bcc91",
     "packages": [
         {
             "name": "api-platform/core",
@@ -1748,16 +1748,16 @@
         },
         {
             "name": "irontec/ivoz-api",
-            "version": "2.3.1",
+            "version": "2.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/irontec/ivoz-api.git",
-                "reference": "e7efd8ad01e9c52b26ff85095bb77f3a943b0720"
+                "reference": "13ba0ab5887a087a17521e6ed26c00a66fedc781"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/irontec/ivoz-api/zipball/e7efd8ad01e9c52b26ff85095bb77f3a943b0720",
-                "reference": "e7efd8ad01e9c52b26ff85095bb77f3a943b0720",
+                "url": "https://api.github.com/repos/irontec/ivoz-api/zipball/13ba0ab5887a087a17521e6ed26c00a66fedc781",
+                "reference": "13ba0ab5887a087a17521e6ed26c00a66fedc781",
                 "shasum": ""
             },
             "require": {
@@ -1798,26 +1798,26 @@
                 }
             ],
             "description": "Api library built on api-platform for ivozprovider",
-            "time": "2020-02-25T16:48:48+00:00"
+            "time": "2020-03-13T11:40:14+00:00"
         },
         {
             "name": "irontec/ivoz-api-bundle",
-            "version": "3.1",
+            "version": "3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/irontec/ivoz-api-bundle.git",
-                "reference": "975fd589cbc11237f608fb38a2105594ff35fe19"
+                "reference": "2bfbada4520d7429debe101f926279006922b667"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/irontec/ivoz-api-bundle/zipball/975fd589cbc11237f608fb38a2105594ff35fe19",
-                "reference": "975fd589cbc11237f608fb38a2105594ff35fe19",
+                "url": "https://api.github.com/repos/irontec/ivoz-api-bundle/zipball/2bfbada4520d7429debe101f926279006922b667",
+                "reference": "2bfbada4520d7429debe101f926279006922b667",
                 "shasum": ""
             },
             "require": {
                 "api-platform/core": "2.2.*",
                 "gesdinet/jwt-refresh-token-bundle": "^0.6.2",
-                "irontec/ivoz-api": "^2.3",
+                "irontec/ivoz-api": "^2.4",
                 "irontec/ivoz-core-bundle": "^2.3",
                 "lexik/jwt-authentication-bundle": "^2.5",
                 "nelmio/cors-bundle": "^1.5",
@@ -1849,20 +1849,20 @@
                 }
             ],
             "description": "Symfony bridge for ivoz-api",
-            "time": "2020-02-25T16:29:58+00:00"
+            "time": "2020-03-13T11:41:18+00:00"
         },
         {
             "name": "irontec/ivoz-core",
-            "version": "2.3.5",
+            "version": "2.3.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/irontec/ivoz-core.git",
-                "reference": "db36f3808d2f70048001626ec2c687347834c2f0"
+                "reference": "ca596aeda4bee49666e418670b343a9abbf46057"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/irontec/ivoz-core/zipball/db36f3808d2f70048001626ec2c687347834c2f0",
-                "reference": "db36f3808d2f70048001626ec2c687347834c2f0",
+                "url": "https://api.github.com/repos/irontec/ivoz-core/zipball/ca596aeda4bee49666e418670b343a9abbf46057",
+                "reference": "ca596aeda4bee49666e418670b343a9abbf46057",
                 "shasum": ""
             },
             "require": {
@@ -1903,7 +1903,7 @@
                 }
             ],
             "description": "Core library for ivozprovider",
-            "time": "2020-02-13T17:25:53+00:00"
+            "time": "2020-03-13T08:35:19+00:00"
         },
         {
             "name": "irontec/ivoz-core-bundle",

--- a/microservices/balances/composer.lock
+++ b/microservices/balances/composer.lock
@@ -1424,11 +1424,11 @@
         },
         {
             "name": "irontec/ivoz-core",
-            "version": "2.3.5.0",
+            "version": "2.3.7.0",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/irontec/ivoz-core",
-                "reference": "db36f3808d2f70048001626ec2c687347834c2f0",
+                "reference": "ca596aeda4bee49666e418670b343a9abbf46057",
                 "shasum": null
             },
             "require": {

--- a/microservices/recordings/composer.lock
+++ b/microservices/recordings/composer.lock
@@ -1453,11 +1453,11 @@
         },
         {
             "name": "irontec/ivoz-core",
-            "version": "2.3.5.0",
+            "version": "2.3.7.0",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/irontec/ivoz-core",
-                "reference": "db36f3808d2f70048001626ec2c687347834c2f0",
+                "reference": "ca596aeda4bee49666e418670b343a9abbf46057",
                 "shasum": null
             },
             "require": {

--- a/microservices/scheduler/composer.lock
+++ b/microservices/scheduler/composer.lock
@@ -1424,11 +1424,11 @@
         },
         {
             "name": "irontec/ivoz-core",
-            "version": "2.3.5.0",
+            "version": "2.3.7.0",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/irontec/ivoz-core",
-                "reference": "db36f3808d2f70048001626ec2c687347834c2f0",
+                "reference": "ca596aeda4bee49666e418670b343a9abbf46057",
                 "shasum": null
             },
             "require": {

--- a/microservices/workers/composer.lock
+++ b/microservices/workers/composer.lock
@@ -1460,11 +1460,11 @@
         },
         {
             "name": "irontec/ivoz-core",
-            "version": "2.3.5.0",
+            "version": "2.3.7.0",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/irontec/ivoz-core",
-                "reference": "db36f3808d2f70048001626ec2c687347834c2f0",
+                "reference": "ca596aeda4bee49666e418670b343a9abbf46057",
                 "shasum": null
             },
             "require": {

--- a/schema/composer.lock
+++ b/schema/composer.lock
@@ -1610,11 +1610,11 @@
         },
         {
             "name": "irontec/ivoz-core",
-            "version": "2.3.5.0",
+            "version": "2.3.7.0",
             "dist": {
                 "type": "path",
                 "url": "../library/vendor/irontec/ivoz-core",
-                "reference": "db36f3808d2f70048001626ec2c687347834c2f0",
+                "reference": "ca596aeda4bee49666e418670b343a9abbf46057",
                 "shasum": null
             },
             "require": {

--- a/web/rest/brand/composer.lock
+++ b/web/rest/brand/composer.lock
@@ -1597,11 +1597,11 @@
         },
         {
             "name": "irontec/ivoz-api",
-            "version": "2.3.1.0",
+            "version": "2.4.2.0",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/irontec/ivoz-api",
-                "reference": "e7efd8ad01e9c52b26ff85095bb77f3a943b0720",
+                "reference": "13ba0ab5887a087a17521e6ed26c00a66fedc781",
                 "shasum": null
             },
             "require": {
@@ -1647,17 +1647,17 @@
         },
         {
             "name": "irontec/ivoz-api-bundle",
-            "version": "3.1.0.0",
+            "version": "3.2.1.0",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/irontec/ivoz-api-bundle",
-                "reference": "975fd589cbc11237f608fb38a2105594ff35fe19",
+                "reference": "2bfbada4520d7429debe101f926279006922b667",
                 "shasum": null
             },
             "require": {
                 "api-platform/core": "2.2.*",
                 "gesdinet/jwt-refresh-token-bundle": "^0.6.2",
-                "irontec/ivoz-api": "^2.3",
+                "irontec/ivoz-api": "^2.4",
                 "irontec/ivoz-core-bundle": "^2.3",
                 "lexik/jwt-authentication-bundle": "^2.5",
                 "nelmio/cors-bundle": "^1.5",
@@ -1694,11 +1694,11 @@
         },
         {
             "name": "irontec/ivoz-core",
-            "version": "2.3.5.0",
+            "version": "2.3.7.0",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/irontec/ivoz-core",
-                "reference": "db36f3808d2f70048001626ec2c687347834c2f0",
+                "reference": "ca596aeda4bee49666e418670b343a9abbf46057",
                 "shasum": null
             },
             "require": {
@@ -4261,11 +4261,11 @@
         },
         {
             "name": "behat/gherkin",
-            "version": "4.6.0.0",
+            "version": "4.6.1.0",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/behat/gherkin",
-                "reference": "ab0a02ea14893860bca00f225f5621d351a3ad07",
+                "reference": "25bdcaf37898b4a939fa3031d5d753ced97e4759",
                 "shasum": null
             },
             "require": {
@@ -4321,30 +4321,33 @@
         },
         {
             "name": "behat/mink",
-            "version": "1.7.1.0",
+            "version": "1.8.1.0",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/behat/mink",
-                "reference": "e6930b9c74693dff7f4e58577e1b1743399f3ff9",
+                "reference": "07c6a9fe3fa98c2de074b25d9ed26c22904e3887",
                 "shasum": null
             },
             "require": {
                 "php": ">=5.3.1",
-                "symfony/css-selector": "~2.1|~3.0"
+                "symfony/css-selector": "^2.7|^3.0|^4.0|^5.0"
             },
             "require-dev": {
-                "symfony/phpunit-bridge": "~2.7|~3.0"
+                "phpunit/phpunit": "^4.8.36 || ^5.7.27 || ^6.5.14 || ^7.5.20",
+                "symfony/debug": "^2.7|^3.0|^4.0",
+                "symfony/phpunit-bridge": "^3.4.38 || ^5.0.5"
             },
             "suggest": {
                 "behat/mink-browserkit-driver": "extremely fast headless driver for Symfony\\Kernel-based apps (Sf2, Silex)",
                 "behat/mink-goutte-driver": "fast headless driver for any app without JS emulation",
                 "behat/mink-selenium2-driver": "slow, but JS-enabled driver for any app (requires Selenium2)",
-                "behat/mink-zombie-driver": "fast and JS-enabled headless driver for any app (requires node.js)"
+                "behat/mink-zombie-driver": "fast and JS-enabled headless driver for any app (requires node.js)",
+                "dmore/chrome-mink-driver": "fast and JS-enabled driver for any app (requires chromium or google chrome)"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.7.x-dev"
+                    "dev-master": "1.8.x-dev"
                 }
             },
             "autoload": {
@@ -4380,11 +4383,11 @@
         },
         {
             "name": "behat/mink-browserkit-driver",
-            "version": "1.3.3.0",
+            "version": "1.3.4.0",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/behat/mink-browserkit-driver",
-                "reference": "1b9a7ce903cfdaaec5fb32bfdbb26118343662eb",
+                "reference": "e3b90840022ebcd544c7b394a3c9597ae242cbee",
                 "shasum": null
             },
             "require": {
@@ -4395,6 +4398,7 @@
             },
             "require-dev": {
                 "mink/driver-testsuite": "dev-master",
+                "symfony/debug": "^2.7|^3.0|^4.0",
                 "symfony/http-kernel": "~2.3|~3.0|~4.0"
             },
             "type": "mink-driver",

--- a/web/rest/brand/config/api_platform.yml
+++ b/web/rest/brand/config/api_platform.yml
@@ -3,3 +3,8 @@ imports:
 
 api_platform:
     description: 'Brand REST API'
+    version: 2.15
+    collection:
+        pagination:
+            # The maximum number of items per page.
+            maximum_items_per_page: 10000

--- a/web/rest/brand/features/provider/country/getCountry.feature
+++ b/web/rest/brand/features/provider/country/getCountry.feature
@@ -380,7 +380,7 @@ Feature: Retrieve countries
     When I add "Accept" header equal to "application/json"
     And I send a "GET" request to "countries?_pagination=false"
     Then the response status code should be 200
-    And the response should be in JSON
+    And the streamed response should be in JSON
     And the header "Content-Type" should be equal to "application/json; charset=utf-8"
-    And the JSON node "root" should have 249 elements
-    And the JSON node "root[0].code" should be equal to "AD"
+    And the streamed JSON node "root" should have 249 elements
+    And the streamed JSON node "root[0].code" should be equal to "AD"

--- a/web/rest/brand/features/provider/timezone/getTimezone.feature
+++ b/web/rest/brand/features/provider/timezone/getTimezone.feature
@@ -165,7 +165,7 @@ Feature: Retrieve timezones
     When I add "Accept" header equal to "application/json"
     And I send a "GET" request to "timezones?_pagination=false"
     Then the response status code should be 200
-    And the response should be in JSON
+    And the streamed response should be in JSON
     And the header "Content-Type" should be equal to "application/json; charset=utf-8"
-    And the JSON node "root" should have 416 elements
-    And the JSON node "root[0].tz" should be equal to "Europe/Andorra"
+    And the streamed JSON node "root" should have 416 elements
+    And the streamed JSON node "root[0].tz" should be equal to "Europe/Andorra"

--- a/web/rest/client/composer.lock
+++ b/web/rest/client/composer.lock
@@ -1597,11 +1597,11 @@
         },
         {
             "name": "irontec/ivoz-api",
-            "version": "2.3.1.0",
+            "version": "2.4.2.0",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/irontec/ivoz-api",
-                "reference": "e7efd8ad01e9c52b26ff85095bb77f3a943b0720",
+                "reference": "13ba0ab5887a087a17521e6ed26c00a66fedc781",
                 "shasum": null
             },
             "require": {
@@ -1647,17 +1647,17 @@
         },
         {
             "name": "irontec/ivoz-api-bundle",
-            "version": "3.1.0.0",
+            "version": "3.2.1.0",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/irontec/ivoz-api-bundle",
-                "reference": "975fd589cbc11237f608fb38a2105594ff35fe19",
+                "reference": "2bfbada4520d7429debe101f926279006922b667",
                 "shasum": null
             },
             "require": {
                 "api-platform/core": "2.2.*",
                 "gesdinet/jwt-refresh-token-bundle": "^0.6.2",
-                "irontec/ivoz-api": "^2.3",
+                "irontec/ivoz-api": "^2.4",
                 "irontec/ivoz-core-bundle": "^2.3",
                 "lexik/jwt-authentication-bundle": "^2.5",
                 "nelmio/cors-bundle": "^1.5",
@@ -1694,11 +1694,11 @@
         },
         {
             "name": "irontec/ivoz-core",
-            "version": "2.3.5.0",
+            "version": "2.3.7.0",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/irontec/ivoz-core",
-                "reference": "db36f3808d2f70048001626ec2c687347834c2f0",
+                "reference": "ca596aeda4bee49666e418670b343a9abbf46057",
                 "shasum": null
             },
             "require": {
@@ -4261,11 +4261,11 @@
         },
         {
             "name": "behat/gherkin",
-            "version": "4.6.0.0",
+            "version": "4.6.1.0",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/behat/gherkin",
-                "reference": "ab0a02ea14893860bca00f225f5621d351a3ad07",
+                "reference": "25bdcaf37898b4a939fa3031d5d753ced97e4759",
                 "shasum": null
             },
             "require": {
@@ -4321,30 +4321,33 @@
         },
         {
             "name": "behat/mink",
-            "version": "1.7.1.0",
+            "version": "1.8.1.0",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/behat/mink",
-                "reference": "e6930b9c74693dff7f4e58577e1b1743399f3ff9",
+                "reference": "07c6a9fe3fa98c2de074b25d9ed26c22904e3887",
                 "shasum": null
             },
             "require": {
                 "php": ">=5.3.1",
-                "symfony/css-selector": "~2.1|~3.0"
+                "symfony/css-selector": "^2.7|^3.0|^4.0|^5.0"
             },
             "require-dev": {
-                "symfony/phpunit-bridge": "~2.7|~3.0"
+                "phpunit/phpunit": "^4.8.36 || ^5.7.27 || ^6.5.14 || ^7.5.20",
+                "symfony/debug": "^2.7|^3.0|^4.0",
+                "symfony/phpunit-bridge": "^3.4.38 || ^5.0.5"
             },
             "suggest": {
                 "behat/mink-browserkit-driver": "extremely fast headless driver for Symfony\\Kernel-based apps (Sf2, Silex)",
                 "behat/mink-goutte-driver": "fast headless driver for any app without JS emulation",
                 "behat/mink-selenium2-driver": "slow, but JS-enabled driver for any app (requires Selenium2)",
-                "behat/mink-zombie-driver": "fast and JS-enabled headless driver for any app (requires node.js)"
+                "behat/mink-zombie-driver": "fast and JS-enabled headless driver for any app (requires node.js)",
+                "dmore/chrome-mink-driver": "fast and JS-enabled driver for any app (requires chromium or google chrome)"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.7.x-dev"
+                    "dev-master": "1.8.x-dev"
                 }
             },
             "autoload": {
@@ -4380,11 +4383,11 @@
         },
         {
             "name": "behat/mink-browserkit-driver",
-            "version": "1.3.3.0",
+            "version": "1.3.4.0",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/behat/mink-browserkit-driver",
-                "reference": "1b9a7ce903cfdaaec5fb32bfdbb26118343662eb",
+                "reference": "e3b90840022ebcd544c7b394a3c9597ae242cbee",
                 "shasum": null
             },
             "require": {
@@ -4395,6 +4398,7 @@
             },
             "require-dev": {
                 "mink/driver-testsuite": "dev-master",
+                "symfony/debug": "^2.7|^3.0|^4.0",
                 "symfony/http-kernel": "~2.3|~3.0|~4.0"
             },
             "type": "mink-driver",

--- a/web/rest/client/config/api_platform.yml
+++ b/web/rest/client/config/api_platform.yml
@@ -3,3 +3,4 @@ imports:
 
 api_platform:
     description: 'Client REST API'
+    version: 2.15

--- a/web/rest/client/features/provider/country/getCountry.feature
+++ b/web/rest/client/features/provider/country/getCountry.feature
@@ -380,7 +380,7 @@ Feature: Retrieve countries
     When I add "Accept" header equal to "application/json"
     And I send a "GET" request to "countries?_pagination=false"
     Then the response status code should be 200
-    And the response should be in JSON
+    And the streamed response should be in JSON
     And the header "Content-Type" should be equal to "application/json; charset=utf-8"
-    And the JSON node "root" should have 249 elements
-    And the JSON node "root[0].code" should be equal to "AD"
+    And the streamed JSON node "root" should have 249 elements
+    And the streamed JSON node "root[0].code" should be equal to "AD"

--- a/web/rest/client/features/provider/ratingPlanGroup/getPrices.feature
+++ b/web/rest/client/features/provider/ratingPlanGroup/getPrices.feature
@@ -7,9 +7,8 @@ Feature: Retrieve my rating plan information by group id
       And I send a "GET" request to "rating_plan_groups/1/prices"
      Then the response status code should be 200
       And the header "Content-Type" should be equal to "text/csv; charset=utf-8"
-      And the streamed response should be equal to
+      And the streamed response should be equal to:
       """
 "rating plan", name, prefix, "connection fee", cost, "rate increment", "group interval start", "time in", days
 Something,Bilbao,+94600,0.01,3.3,1s,0s,00:00:00,1111111
-
       """

--- a/web/rest/client/features/provider/timezone/getTimezone.feature
+++ b/web/rest/client/features/provider/timezone/getTimezone.feature
@@ -165,7 +165,7 @@ Feature: Retrieve timezones
     When I add "Accept" header equal to "application/json"
     And I send a "GET" request to "timezones?_pagination=false"
     Then the response status code should be 200
-    And the response should be in JSON
+    And the streamed response should be in JSON
     And the header "Content-Type" should be equal to "application/json; charset=utf-8"
-    And the JSON node "root" should have 416 elements
-    And the JSON node "root[0].tz" should be equal to "Europe/Andorra"
+    And the streamed JSON node "root" should have 416 elements
+    And the streamed JSON node "root[0].tz" should be equal to "Europe/Andorra"

--- a/web/rest/platform/composer.lock
+++ b/web/rest/platform/composer.lock
@@ -1597,11 +1597,11 @@
         },
         {
             "name": "irontec/ivoz-api",
-            "version": "2.3.1.0",
+            "version": "2.4.2.0",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/irontec/ivoz-api",
-                "reference": "e7efd8ad01e9c52b26ff85095bb77f3a943b0720",
+                "reference": "13ba0ab5887a087a17521e6ed26c00a66fedc781",
                 "shasum": null
             },
             "require": {
@@ -1647,17 +1647,17 @@
         },
         {
             "name": "irontec/ivoz-api-bundle",
-            "version": "3.1.0.0",
+            "version": "3.2.1.0",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/irontec/ivoz-api-bundle",
-                "reference": "975fd589cbc11237f608fb38a2105594ff35fe19",
+                "reference": "2bfbada4520d7429debe101f926279006922b667",
                 "shasum": null
             },
             "require": {
                 "api-platform/core": "2.2.*",
                 "gesdinet/jwt-refresh-token-bundle": "^0.6.2",
-                "irontec/ivoz-api": "^2.3",
+                "irontec/ivoz-api": "^2.4",
                 "irontec/ivoz-core-bundle": "^2.3",
                 "lexik/jwt-authentication-bundle": "^2.5",
                 "nelmio/cors-bundle": "^1.5",
@@ -1694,11 +1694,11 @@
         },
         {
             "name": "irontec/ivoz-core",
-            "version": "2.3.5.0",
+            "version": "2.3.7.0",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/irontec/ivoz-core",
-                "reference": "db36f3808d2f70048001626ec2c687347834c2f0",
+                "reference": "ca596aeda4bee49666e418670b343a9abbf46057",
                 "shasum": null
             },
             "require": {
@@ -4261,11 +4261,11 @@
         },
         {
             "name": "behat/gherkin",
-            "version": "4.6.0.0",
+            "version": "4.6.1.0",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/behat/gherkin",
-                "reference": "ab0a02ea14893860bca00f225f5621d351a3ad07",
+                "reference": "25bdcaf37898b4a939fa3031d5d753ced97e4759",
                 "shasum": null
             },
             "require": {
@@ -4321,30 +4321,33 @@
         },
         {
             "name": "behat/mink",
-            "version": "1.7.1.0",
+            "version": "1.8.1.0",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/behat/mink",
-                "reference": "e6930b9c74693dff7f4e58577e1b1743399f3ff9",
+                "reference": "07c6a9fe3fa98c2de074b25d9ed26c22904e3887",
                 "shasum": null
             },
             "require": {
                 "php": ">=5.3.1",
-                "symfony/css-selector": "~2.1|~3.0"
+                "symfony/css-selector": "^2.7|^3.0|^4.0|^5.0"
             },
             "require-dev": {
-                "symfony/phpunit-bridge": "~2.7|~3.0"
+                "phpunit/phpunit": "^4.8.36 || ^5.7.27 || ^6.5.14 || ^7.5.20",
+                "symfony/debug": "^2.7|^3.0|^4.0",
+                "symfony/phpunit-bridge": "^3.4.38 || ^5.0.5"
             },
             "suggest": {
                 "behat/mink-browserkit-driver": "extremely fast headless driver for Symfony\\Kernel-based apps (Sf2, Silex)",
                 "behat/mink-goutte-driver": "fast headless driver for any app without JS emulation",
                 "behat/mink-selenium2-driver": "slow, but JS-enabled driver for any app (requires Selenium2)",
-                "behat/mink-zombie-driver": "fast and JS-enabled headless driver for any app (requires node.js)"
+                "behat/mink-zombie-driver": "fast and JS-enabled headless driver for any app (requires node.js)",
+                "dmore/chrome-mink-driver": "fast and JS-enabled driver for any app (requires chromium or google chrome)"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.7.x-dev"
+                    "dev-master": "1.8.x-dev"
                 }
             },
             "autoload": {
@@ -4380,11 +4383,11 @@
         },
         {
             "name": "behat/mink-browserkit-driver",
-            "version": "1.3.3.0",
+            "version": "1.3.4.0",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/behat/mink-browserkit-driver",
-                "reference": "1b9a7ce903cfdaaec5fb32bfdbb26118343662eb",
+                "reference": "e3b90840022ebcd544c7b394a3c9597ae242cbee",
                 "shasum": null
             },
             "require": {
@@ -4395,6 +4398,7 @@
             },
             "require-dev": {
                 "mink/driver-testsuite": "dev-master",
+                "symfony/debug": "^2.7|^3.0|^4.0",
                 "symfony/http-kernel": "~2.3|~3.0|~4.0"
             },
             "type": "mink-driver",

--- a/web/rest/platform/config/api_platform.yml
+++ b/web/rest/platform/config/api_platform.yml
@@ -3,3 +3,8 @@ imports:
 
 api_platform:
     description: 'Platform REST API'
+    version: 2.15
+    collection:
+        pagination:
+            # The maximum number of items per page.
+            maximum_items_per_page: 10000

--- a/web/rest/platform/features/pagination.feature
+++ b/web/rest/platform/features/pagination.feature
@@ -32,6 +32,6 @@ Feature: Authorization checking
      When I add "Accept" header equal to "application/json"
       And I send a "GET" request to "billable_calls?_pagination=false"
      Then the response status code should be 200
-      And the response should be in JSON
+      And the streamed response should be in JSON
       And the header "Content-Type" should be equal to "application/json; charset=utf-8"
-      And the JSON node "root" should have 100 elements
+      And the streamed JSON node "root" should have 100 elements

--- a/web/rest/platform/features/provider/billableCalls/getBillableCalls.feature
+++ b/web/rest/platform/features/provider/billableCalls/getBillableCalls.feature
@@ -194,3 +194,88 @@ callid,startTime,duration,caller,callee,cost,price,endpointType,endpointId,direc
 017cc7c8-eb38-4bbd-9318-524a274f7098,"2019-01-01 09:01:38",0,+34633646464,+34633656565,,1,,,outbound,99,1,1,1,,1
 017cc7c8-eb38-4bbd-9318-524a274f7099,"2019-01-01 09:01:39",0,+34633646464,+34633656565,,1,,,outbound,100,1,1,1,,1
 """
+
+
+  Scenario: Retrieve unpaginated billable call json list
+    Given I add Authorization header
+    When I add "Accept" header equal to "application/json"
+    And I send a "GET" request to "billable_calls?startTime%5Bbefore%5D=2019-01-01%2009%3A00%3A03&_pagination=false"
+    Then the response status code should be 200
+    And the header "Content-Type" should be equal to "application/json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+    [
+       {
+          "callid":"017cc7c8-eb38-4bbd-9318-524a274f7000",
+          "startTime":"2019-01-01 09:00:00",
+          "duration":0,
+          "caller":"+34633646464",
+          "callee":"+34633656565",
+          "cost":null,
+          "price":1,
+          "endpointType":null,
+          "endpointId":null,
+          "direction":"outbound",
+          "id":1,
+          "brand":1,
+          "company":1,
+          "carrier":2,
+          "invoice":1,
+          "ddi":1
+       },
+       {
+          "callid":"017cc7c8-eb38-4bbd-9318-524a274f7001",
+          "startTime":"2019-01-01 09:00:01",
+          "duration":0,
+          "caller":"+34633646464",
+          "callee":"+34633656565",
+          "cost":null,
+          "price":1,
+          "endpointType":null,
+          "endpointId":null,
+          "direction":"outbound",
+          "id":2,
+          "brand":1,
+          "company":1,
+          "carrier":1,
+          "invoice":null,
+          "ddi":1
+       },
+       {
+          "callid":"017cc7c8-eb38-4bbd-9318-524a274f7002",
+          "startTime":"2019-01-01 09:00:02",
+          "duration":0,
+          "caller":"+34633646464",
+          "callee":"+34633656565",
+          "cost":null,
+          "price":1,
+          "endpointType":null,
+          "endpointId":null,
+          "direction":"outbound",
+          "id":3,
+          "brand":1,
+          "company":1,
+          "carrier":1,
+          "invoice":null,
+          "ddi":1
+       },
+       {
+          "callid":"017cc7c8-eb38-4bbd-9318-524a274f7003",
+          "startTime":"2019-01-01 09:00:03",
+          "duration":0,
+          "caller":"+34633646464",
+          "callee":"+34633656565",
+          "cost":null,
+          "price":1,
+          "endpointType":null,
+          "endpointId":null,
+          "direction":"outbound",
+          "id":4,
+          "brand":1,
+          "company":1,
+          "carrier":1,
+          "invoice":null,
+          "ddi":1
+       }
+    ]
+    """

--- a/web/rest/platform/features/provider/billableCalls/getBillableCalls.feature
+++ b/web/rest/platform/features/provider/billableCalls/getBillableCalls.feature
@@ -90,7 +90,7 @@ Feature: Retrieve billable calls
     And I send a "GET" request to "billable_calls?_pagination=false"
     Then the response status code should be 200
     And the header "Content-Type" should be equal to "text/csv; charset=utf-8"
-    And the response should be equal to
+    And the streamed response should be equal to:
     """
 callid,startTime,duration,caller,callee,cost,price,endpointType,endpointId,direction,id,brand,company,carrier,invoice,ddi
 017cc7c8-eb38-4bbd-9318-524a274f7000,"2019-01-01 09:00:00",0,+34633646464,+34633656565,,1,,,outbound,1,1,1,2,1,1
@@ -202,7 +202,7 @@ callid,startTime,duration,caller,callee,cost,price,endpointType,endpointId,direc
     And I send a "GET" request to "billable_calls?startTime%5Bbefore%5D=2019-01-01%2009%3A00%3A03&_pagination=false"
     Then the response status code should be 200
     And the header "Content-Type" should be equal to "application/json; charset=utf-8"
-    And the JSON should be equal to:
+    And the streamed JSON should be equal to:
     """
     [
        {

--- a/web/rest/platform/features/provider/country/getCountry.feature
+++ b/web/rest/platform/features/provider/country/getCountry.feature
@@ -381,7 +381,7 @@ Feature: Retrieve countries
     When I add "Accept" header equal to "application/json"
     And I send a "GET" request to "countries?_pagination=false"
     Then the response status code should be 200
-    And the response should be in JSON
+    And the streamed response should be in JSON
     And the header "Content-Type" should be equal to "application/json; charset=utf-8"
-    And the JSON node "root" should have 249 elements
-    And the JSON node "root[0].code" should be equal to "AD"
+    And the streamed JSON node "root" should have 249 elements
+    And the streamed JSON node "root[0].code" should be equal to "AD"

--- a/web/rest/platform/features/provider/timezone/getTimezone.feature
+++ b/web/rest/platform/features/provider/timezone/getTimezone.feature
@@ -181,7 +181,7 @@ Feature: Retrieve timezones
     When I add "Accept" header equal to "application/json"
     And I send a "GET" request to "timezones?_pagination=false"
     Then the response status code should be 200
-    And the response should be in JSON
+    And the streamed response should be in JSON
     And the header "Content-Type" should be equal to "application/json; charset=utf-8"
-    And the JSON node "root" should have 416 elements
-    And the JSON node "root[0].tz" should be equal to "Europe/Andorra"
+    And the streamed JSON node "root" should have 416 elements
+    And the streamed JSON node "root[0].tz" should be equal to "Europe/Andorra"


### PR DESCRIPTION
Optimized memory usage on unpaginated API requests. Current memory usage on BillableCalls:
- CSV
  - 500 result => 11.84 mb
  - 5k => 43.42 mb
  - 10k => 77.93 mb
  - Unpaginated (60k) => 30.66 mb (35.15 mb before this PR)
- JSON
  - 500 result => 12.16 mb
  - 5k => 40.04 mb
  - 10k => 71.09 mb
  - Unpaginated (60k) => 27.96 mb (75.57 mb before this PR)

#### Additional information
Maximun items per page have been increased from 500 to 5k on client API and from 500 to 10k on brand and platform APIs.

updated ivoz dependencies:
- https://github.com/irontec/ivoz-api/commits/2.4.2
- https://github.com/irontec/ivoz-api-bundle/commits/3.2.1
- https://github.com/irontec/ivoz-core/commits/2.3.7

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
