### PR TITLE
kamusers: adapt presentity uri for Event: presence SUBSCRIBEs

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -2188,6 +2188,7 @@ route[PRESENCE] {
         t_release();
     } else if(is_method("SUBSCRIBE")) {
         record_route();
+        route(EVENT_PRESENCE);
         handle_subscribe();
         t_release();
     } else if(is_method("NOTIFY")) {
@@ -2203,6 +2204,16 @@ route[PRESENCE] {
         route(RELAY);
     }
     exit;
+}
+
+route[EVENT_PRESENCE] {
+    if ($hdr(Event) != "presence") return;
+
+    sql_xquery("cb", "select name from kam_users WHERE extension='$rU' and domain='$rd'", "rp");
+    if ($xavp(rp=>name) == $null) return; # No change for non-users SUBSCRIBEs
+
+    $rU = $xavp(rp=>name);
+    xinfo("[$dlg_var(cidhash)] EVENT-PRESENCE: change presentity-uri to '$ru'\n");
 }
 
 event_route[xhttp:request] {


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

'Event: presence' subscriptions needs adapting presentity uri (from extension
to terminal name).

This way UAC can subscribe to events of 101 and listen to changes in state
published by UAC of user with extension 101.
