### PR TITLE
kamailio: save realtime information in Redis

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -28,6 +28,7 @@
 
 # - options
 #!define WITH_ANTIFLOOD
+#!define WITH_REALTIME
 
 #!define DBURL "mysql://kamailio:ironsecret@data/ivozprovider"
 
@@ -165,8 +166,18 @@ loadmodule    "jsonrpcs.so"
 loadmodule    "http_client.so"
 loadmodule    "ipops.so"
 
+#!ifdef WITH_REALTIME
+loadmodule    "ndb_redis.so"
+#!endif
+
 #!ifdef WITH_ANTIFLOOD
 loadmodule    "pike.so"
+#!endif
+
+#!ifdef WITH_REALTIME
+# REDIS
+modparam("ndb_redis", "server", "name=realtime;sentinel_group=mymaster;sentinel_master=1;sentinel=data.ivozprovider.local:26379")
+modparam("ndb_redis", "init_without_redis", 1)
 #!endif
 
 # JSONRPC-S
@@ -478,6 +489,11 @@ request_route {
             exit;
         }
     }
+
+    #!ifdef WITH_REALTIME
+    $var(rtEvent) = "Trying";
+    route(REALTIME);
+    #!endif
 
     route(RELAY);
 }
@@ -1608,6 +1624,64 @@ route[SAVE_CONTACT] {
     xinfo("[$dlg_var(cidhash)] SAVE-CONTACT: Save inside contact $dlg_var(contact)");
 }
 
+#!ifdef WITH_REALTIME
+route[REALTIME] {
+    # Reset JSON value
+    $var(rtValue) = 0;
+
+    # Common fields
+    jansson_set("string", "Event", "$var(rtEvent)", "$var(rtValue)");
+    jansson_set("integer", "time", "$TS", "$var(rtValue)");
+    jansson_set("string", "callid", "$ci", "$var(rtValue)");
+
+    if ($var(rtEvent) == $dlg_var(lastCallState)) return; # No state change, leave
+
+    if ($var(rtEvent) == 'Trying') {
+        route(RT_NEWCALL);
+    }
+
+    # Save to avoid repeated events
+    $dlg_var(lastCallState) = $var(rtEvent);
+
+    # Publish to redis
+    xinfo("[$dlg_var(cidhash)] REALTIME: $dlg_var(rtChannel) -> $var(rtValue)");
+    redis_cmd("realtime", "PUBLISH %s %s", "$dlg_var(rtChannel)", "$var(rtValue)", "r");
+}
+
+route[RT_NEWCALL] {
+    # Set rtChannel
+    if ($dlg_var(carrierId) != $null && $dlg_var(ddiProviderId) == $null) {
+        sql_xquery("cb", "SELECT CS.name AS carrierName, B.name AS brandName, C.name AS companyName FROM Carriers CS JOIN Brands B ON B.id=CS.brandId JOIN Companies C ON C.brandId=B.id WHERE CS.id=$dlg_var(carrierId) AND C.id=$dlg_var(companyId)", "names");
+        $dlg_var(rtChannel) = 'trunks' + ':b' + $dlg_var(brandId) + ':c' + $dlg_var(companyId) + ':cr' + $dlg_var(carrierId) + ':' + $ci;
+    } else if ($dlg_var(ddiProviderId) != $null && $dlg_var(carrierId) == $null) {
+        sql_xquery("cb", "SELECT DP.name AS ddiProviderName, B.name AS brandName, C.name AS companyName FROM DDIProviders DP JOIN Brands B ON B.id=DP.brandId JOIN Companies C ON C.brandId=B.id WHERE DP.id=$dlg_var(ddiProviderId) AND C.id=$dlg_var(companyId)", "names");
+        $dlg_var(rtChannel) = 'trunks' + ':b' + $dlg_var(brandId) + ':c' + $dlg_var(companyId) + ':dp' + $dlg_var(ddiProviderId) + ':' + $ci;
+    } else {
+        xerr("[$dlg_var(cidhash)] REALTIME: carrierId $dlg_var(carrierId) and ddiProviderId $dlg_var(ddiProviderId)");
+        return;
+    }
+
+    # Set brand, company, diraction, caller and callee
+    jansson_set("integer", "brand", "$dlg_var(brandId)", "$var(rtValue)");
+    jansson_set("string", "brandName", "$xavp(names=>brandName)", "$var(rtValue)");
+    jansson_set("integer", "company", "$dlg_var(companyId)", "$var(rtValue)");
+    jansson_set("string", "companyName", "$xavp(names=>companyName)", "$var(rtValue)");
+    jansson_set("string", "direction", "$dlg_var(direction)", "$var(rtValue)");
+    jansson_set("string", "caller", "$dlg_var(caller)", "$var(rtValue)");
+    jansson_set("string", "callee", "$dlg_var(callee)", "$var(rtValue)");
+
+    # Set carrier / ddiProvider
+    if ($dlg_var(carrierId) != $null) {
+        jansson_set("integer", "carrier", "$dlg_var(carrierId)", "$var(rtValue)");
+        jansson_set("string", "carrierName", "$xavp(names=>carrierName)", "$var(rtValue)");
+    }
+    if ($dlg_var(ddiProviderId) != $null) {
+        jansson_set("integer", "ddiProvider", "$dlg_var(ddiProviderId)", "$var(rtValue)");
+        jansson_set("string", "ddiProviderName", "$xavp(names=>ddiProviderName)", "$var(rtValue)");
+    }
+}
+#!endif
+
 # Reply generic route (all replies goes through this route)
 onreply_route {
     xnotice("[$dlg_var(cidhash)] Response: '$rs $rr' to '$cs $rm' from '$fu' ($si:$sp) [$proto]\n");
@@ -1624,6 +1698,17 @@ onreply_route[MANAGE_REPLY] {
     if (t_check_status("2[0-9]{2}") && ($var(is_from_inside) == 1)) {
         route(SAVE_CONTACT);
     }
+
+    #!ifdef WITH_REALTIME
+    if (is_method("INVITE") && t_check_status("1[0-9]{2}")) {
+        if (has_totag()) {
+            $var(rtEvent) = "Early";
+        } else {
+            $var(rtEvent) = "Proceeding";
+        }
+        route(REALTIME);
+    }
+    #!endif
 }
 
 # Manage failure replies (only for failure response codes, executed after previous 2 routes)
@@ -1732,6 +1817,11 @@ branch_route[MANAGE_BRANCH_GW] {
 event_route[dialog:start] {
     xnotice("[$dlg_var(cidhash)] $dlg_var(direction) call confirmed for company '$dlg_var(companyId)' [$ci]\n");
 
+    #!ifdef WITH_REALTIME
+    $var(rtEvent) = 'Confirmed';
+    route(REALTIME);
+    #!endif
+
     if ($dlg_var(direction) == 'outbound') {
         if ($dlg_var(cgrid) == $null) {
             xinfo("[$dlg_var(cidhash)] No cgrid, skip rating logic");
@@ -1745,6 +1835,12 @@ event_route[dialog:start] {
 event_route[dialog:end] {
     # Dialog end, print stats
     xinfo("[$dlg_var(cidhash)] $dlg_var(direction) call ended for company '$dlg_var(companyId)' [$ci]\n");
+
+    #!ifdef WITH_REALTIME
+    $var(rtEvent) = 'Terminated';
+    route(REALTIME);
+    #!endif
+
     if ($dlg_var(cgrid) == $null) {
         xinfo("[$dlg_var(cidhash)] No cgrid, skip rating logic");
         return;
@@ -1755,6 +1851,11 @@ event_route[dialog:end] {
 # Executed when dialog is not established
 event_route[dialog:failed] {
     xwarn("[$dlg_var(cidhash)] $dlg_var(direction) call failed for company '$dlg_var(companyId)' [$ci]\n");
+
+    #!ifdef WITH_REALTIME
+    $var(rtEvent) = 'Terminated';
+    route(REALTIME);
+    #!endif
 }
 
 # Executed for request generated by Kamailio

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -53,6 +53,7 @@
 
 # - options
 #!define WITH_ANTIFLOOD
+#!define WITH_REALTIME
 
 #!define DBURL "mysql://kamailio:ironsecret@data/ivozprovider"
 
@@ -174,6 +175,7 @@ loadmodule    "websocket.so"
 loadmodule    "xhttp.so"
 loadmodule    "jsonrpcs.so"
 loadmodule    "json.so"
+loadmodule    "jansson.so"
 loadmodule    "pua.so"
 loadmodule    "pua_dialoginfo.so"
 loadmodule    "presence.so"
@@ -187,6 +189,10 @@ loadmodule    "uac.so"
 
 #!ifdef WITH_ANTIFLOOD
 loadmodule    "pike.so"
+#!endif
+
+#!ifdef WITH_REALTIME
+loadmodule    "ndb_redis.so"
 #!endif
 
 # RTPENGINE
@@ -390,6 +396,12 @@ modparam("dialplan", "attrs_pvar", "$avp(s:appliedrule)")
 modparam("uac", "restore_mode","auto")
 modparam("uac", "restore_dlg", 1)
 
+#!ifdef WITH_REALTIME
+# REDIS
+modparam("ndb_redis", "server", "name=realtime;sentinel_group=mymaster;sentinel_master=1;sentinel=data.ivozprovider.local:26379")
+modparam("ndb_redis", "init_without_redis", 1)
+#!endif
+
 ####### Routing Logic ########
 
 request_route {
@@ -507,6 +519,10 @@ request_route {
 
     if(!t_is_set("failure_route")) t_on_failure("MANAGE_FAILURE");
     route(ACCOUNTING);
+    #!ifdef WITH_REALTIME
+    $var(rtEvent) = "Trying";
+    route(REALTIME);
+    #!endif
     route(RELAY);
 }
 
@@ -1522,6 +1538,14 @@ route[WITHINDLG] {
     if (!$dlg_var(confirmed) && is_method("UPDATE|INVITE")) drop;
 
     route(ADAPT_CALLER);
+
+    #!ifdef WITH_REALTIME
+    if (is_method("UPDATE|INVITE") && $var(is_from_inside)) {
+        $var(rtEvent) = 'UpdateCLID';
+        route(REALTIME);
+    }
+    #!endif
+
     route(ADAPT_REFERTO);
 
     # sequential request withing a dialog should
@@ -1962,6 +1986,89 @@ route[CHECK_SPECIAL] {
     }
 }
 
+#!ifdef WITH_REALTIME
+route[REALTIME] {
+    # Reset JSON value
+    $var(rtValue) = 0;
+
+    # Common fields
+    jansson_set("string", "Event", "$var(rtEvent)", "$var(rtValue)");
+    jansson_set("integer", "time", "$TS", "$var(rtValue)");
+    jansson_set("string", "callid", "$ci", "$var(rtValue)");
+
+    if ($var(rtEvent) == 'UpdateCLID') {
+        route(GET_CALLER);
+        if ($var(number) == $dlg_var(party)) return; # No CLID change, leave
+
+        jansson_set("string", "party", "$var(number)", "$var(rtValue)");
+
+        # Save to avoid events for same CLID
+        $dlg_var(party) = $var(number);
+    } else {
+        if ($var(rtEvent) == $dlg_var(lastCallState)) return; # No state change, leave
+
+        if ($var(rtEvent) == 'Trying') {
+            route(RT_NEWCALL);
+        }
+
+        # Save to avoid repeated events
+        $dlg_var(lastCallState) = $var(rtEvent);
+    }
+
+    # Publish to redis
+    xinfo("[$dlg_var(cidhash)] REALTIME: $dlg_var(rtChannel) -> $var(rtValue)");
+    redis_cmd("realtime", "PUBLISH %s %s", "$dlg_var(rtChannel)", "$var(rtValue)", "r");
+}
+
+route[RT_NEWCALL] {
+    # Set brand, company and direction
+    jansson_set("integer", "brand", "$dlg_var(brandId)", "$var(rtValue)");
+    jansson_set("string", "brandName", "$xavp(names=>brandName)", "$var(rtValue)");
+    jansson_set("integer", "company", "$dlg_var(companyId)", "$var(rtValue)");
+    jansson_set("string", "companyName", "$xavp(names=>companyName)", "$var(rtValue)");
+    jansson_set("string", "direction", "$dlg_var(direction)", "$var(rtValue)");
+
+    # Set rtChannel, owner and ownerName
+    if ($dlg_var(residentialDeviceId) != $null) {
+        sql_xquery("cb", "SELECT RD.name AS residentialDeviceName, C.name AS companyName, B.name AS brandName FROM ResidentialDevices RD JOIN Companies C ON C.id=RD.companyId JOIN Brands B ON B.id=C.brandId WHERE RD.id=$dlg_var(residentialDeviceId)", "names");
+        $dlg_var(rtChannel) = 'users' + ':b' + $dlg_var(brandId) + ':c' + $dlg_var(companyId) + ':r' + $dlg_var(residentialDeviceId) + ':' + $ci;
+        jansson_set("string", "owner", "rt$dlg_var(residentialDeviceId)", "$var(rtValue)");
+        jansson_set("string", "ownerName", "$xavp(names=>residentialDeviceName)", "$var(rtValue)");
+    } else if ($dlg_var(retailAccountId) != $null) {
+        sql_xquery("cb", "SELECT RA.name AS retailAccountName, C.name AS companyName, B.name AS brandName FROM RetailAccounts RA JOIN Companies C ON C.id=RA.companyId JOIN Brands B ON B.id=C.brandId WHERE RA.id=$dlg_var(retailAccountId)", "names");
+        $dlg_var(rtChannel) = 'users' + ':b' + $dlg_var(brandId) + ':c' + $dlg_var(companyId) + ':rt' + $dlg_var(retailAccountId) + ':' + $ci;
+        jansson_set("string", "owner", "rs$dlg_var(retailAccountId)", "$var(rtValue)");
+        jansson_set("string", "ownerName", "$xavp(names=>retailAccountName)", "$var(rtValue)");
+    } else if ($dlg_var(userId) != $null) {
+        sql_xquery("cb", "SELECT CONCAT(U.name, ' ', U.lastname) AS userName, C.name AS companyName, B.name AS brandName FROM Users U JOIN Companies C ON C.id=U.companyId JOIN Brands B ON B.id=C.brandId WHERE U.id=$dlg_var(userId)", "names");
+        $dlg_var(rtChannel) = 'users' + ':b' + $dlg_var(brandId) + ':c' + $dlg_var(companyId) + ':u' + $dlg_var(userId) + ':' + $ci;
+        jansson_set("string", "owner", "u$dlg_var(userId)", "$var(rtValue)");
+        jansson_set("string", "ownerName", "$xavp(names=>userName)", "$var(rtValue)");
+    } else if ($dlg_var(friendId) != $null) {
+        sql_xquery("cb", "SELECT F.name AS friendName, C.name AS companyName, B.name AS brandName FROM Friends F JOIN Companies C ON C.id=F.companyId JOIN Brands B ON B.id=C.brandId WHERE F.id=$dlg_var(friendId)", "names");
+        $dlg_var(rtChannel) = 'users' + ':b' + $dlg_var(brandId) + ':c' + $dlg_var(companyId) + ':f' + $dlg_var(friendId) + ':' + $ci;
+        jansson_set("string", "owner", "f$dlg_var(friendId)", "$var(rtValue)");
+        jansson_set("string", "ownerName", "$xavp(names=>friendName)", "$var(rtValue)");
+    } else {
+        # wholesale
+        $dlg_var(rtChannel) = 'users' + ':b' + $dlg_var(brandId) + ':c' + $dlg_var(companyId) + ':w' + ':' + $ci;
+        if ($dlg_var(direction) == 'inbound') {
+            jansson_set("string", "owner", "w$dlg_var(callee)", "$var(rtValue)");
+        } else {
+            jansson_set("string", "owner", "w$dlg_var(caller)", "$var(rtValue)");
+        }
+    }
+
+    # Set party
+    if ($dlg_var(direction) == 'inbound') {
+        $dlg_var(party) = $dlg_var(caller);
+    } else {
+        $dlg_var(party) = $dlg_var(callee);
+    }
+    jansson_set("string", "party", "$dlg_var(party)", "$var(rtValue)");
+}
+#!endif
+
 # Reply generic route (all replies goes through this route)
 onreply_route {
     # Silent NAT-handling OPTIONS replies
@@ -1997,6 +2104,17 @@ onreply_route[MANAGE_REPLY] {
     if (t_check_status("[12][0-9]{2}")) {
         route(NATMANAGE);
     }
+
+    #!ifdef WITH_REALTIME
+    if (is_method("INVITE") && t_check_status("1[0-9]{2}")) {
+        if (has_totag()) {
+            $var(rtEvent) = "Early";
+        } else {
+            $var(rtEvent) = "Proceeding";
+        }
+        route(REALTIME);
+    }
+    #!endif
 
     # Manage WS
     if (nat_uac_test(64)) { # 64 - Test if the source connection of signaling is WS
@@ -2106,12 +2224,36 @@ event_route[dialog:start] {
         xwarn("[$dlg_var(cidhash)] Answered dialog involves websockets\n");
         $dlg_var(ws) = 'yes';
     }
+
+    #!ifdef WITH_REALTIME
+    $var(rtEvent) = "Confirmed";
+    route(REALTIME);
+    if ($dlg_var(direction) == 'outbound') {
+        $var(rtEvent) = "UpdateCLID";
+        route(REALTIME);
+    }
+    #!endif
 }
 
 # Executed when dialog is ended with BYE or timeout
 event_route[dialog:end] {
     xnotice("[$dlg_var(cidhash)] Dialog ended, delete keys from dialogs htable starting with $ci\n");
     sht_rm_name_re("dialogs=>$ci::.*");
+
+    #!ifdef WITH_REALTIME
+    $var(rtEvent) = "Terminated";
+    route(REALTIME);
+    #!endif
+}
+
+# Executed when dialog is not established
+event_route[dialog:failed] {
+    xwarn("[$dlg_var(cidhash)] $dlg_var(direction) call failed for company '$dlg_var(companyId)' [$ci]\n");
+
+    #!ifdef WITH_REALTIME
+    $var(rtEvent) = 'Terminated';
+    route(REALTIME);
+    #!endif
 }
 
 onsend_route {


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #738) <!-- Replace XXXX with issue id -->

#### Description

This PR saves into Redis dialog status realtime information.

#### Additional information

Both proxies generate events related to dialog state machine explained [in RFC 4235](https://tools.ietf.org/html/rfc4235#section-3.7.1)

KamUsers has a special event to handle caller updates via 200 (in call diversions) or within dialog UPDATE/INVITE request (for call transfers).