### PR TITLE
kam: fix empty Party in client realtime

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -1665,35 +1665,38 @@ route[REALTIME] {
 }
 
 route[RT_NEWCALL] {
+    # Set brand, company and direction
+    sql_xquery("cb", "SELECT C.name AS companyName, B.name AS brandName FROM Companies C JOIN Brands B ON B.id=C.brandId WHERE C.id='$dlg_var(companyId)'", "names");
+    jansson_set("integer", "Brand", "$dlg_var(brandId)", "$var(rtValue)");
+    jansson_set("string", "BrandName", "$xavp(names=>brandName)", "$var(rtValue)");
+    jansson_set("integer", "Company", "$dlg_var(companyId)", "$var(rtValue)");
+    jansson_set("string", "CompanyName", "$xavp(names=>companyName)", "$var(rtValue)");
+    jansson_set("string", "Direction", "$dlg_var(direction)", "$var(rtValue)");
+
     # Set rtChannel
     if ($dlg_var(carrierId) != $null && $dlg_var(ddiProviderId) == $null) {
-        sql_xquery("cb", "SELECT CS.name AS carrierName, B.name AS brandName, C.name AS companyName FROM Carriers CS JOIN Brands B ON B.id=CS.brandId JOIN Companies C ON C.brandId=B.id WHERE CS.id=$dlg_var(carrierId) AND C.id=$dlg_var(companyId)", "names");
+        sql_xquery("cb", "SELECT name FROM Carriers WHERE id=$dlg_var(carrierId)", "cs");
         $dlg_var(rtChannel) = 'trunks' + ':b' + $dlg_var(brandId) + ':c' + $dlg_var(companyId) + ':cr' + $dlg_var(carrierId) + ':' + $ci;
     } else if ($dlg_var(ddiProviderId) != $null && $dlg_var(carrierId) == $null) {
-        sql_xquery("cb", "SELECT DP.name AS ddiProviderName, B.name AS brandName, C.name AS companyName FROM DDIProviders DP JOIN Brands B ON B.id=DP.brandId JOIN Companies C ON C.brandId=B.id WHERE DP.id=$dlg_var(ddiProviderId) AND C.id=$dlg_var(companyId)", "names");
+        sql_xquery("cb", "SELECT name FROM DDIProviders WHERE id=$dlg_var(ddiProviderId)", "dp");
         $dlg_var(rtChannel) = 'trunks' + ':b' + $dlg_var(brandId) + ':c' + $dlg_var(companyId) + ':dp' + $dlg_var(ddiProviderId) + ':' + $ci;
     } else {
         xerr("[$dlg_var(cidhash)] REALTIME: carrierId $dlg_var(carrierId) and ddiProviderId $dlg_var(ddiProviderId)");
         return;
     }
 
-    # Set brand, company, diraction, caller and callee
-    jansson_set("integer", "Brand", "$dlg_var(brandId)", "$var(rtValue)");
-    jansson_set("string", "BrandName", "$xavp(names=>brandName)", "$var(rtValue)");
-    jansson_set("integer", "Company", "$dlg_var(companyId)", "$var(rtValue)");
-    jansson_set("string", "CompanyName", "$xavp(names=>companyName)", "$var(rtValue)");
-    jansson_set("string", "Direction", "$dlg_var(direction)", "$var(rtValue)");
+    # Set caller and callee
     jansson_set("string", "Caller", "$dlg_var(caller)", "$var(rtValue)");
     jansson_set("string", "Callee", "$dlg_var(callee)", "$var(rtValue)");
 
     # Set carrier / ddiProvider
     if ($dlg_var(carrierId) != $null) {
         jansson_set("integer", "Carrier", "$dlg_var(carrierId)", "$var(rtValue)");
-        jansson_set("string", "CarrierName", "$xavp(names=>carrierName)", "$var(rtValue)");
+        jansson_set("string", "CarrierName", "$xavp(cs=>name)", "$var(rtValue)");
     }
     if ($dlg_var(ddiProviderId) != $null) {
         jansson_set("integer", "DdiProvider", "$dlg_var(ddiProviderId)", "$var(rtValue)");
-        jansson_set("string", "DdiProviderName", "$xavp(names=>ddiProviderName)", "$var(rtValue)");
+        jansson_set("string", "DdiProviderName", "$xavp(dp=>name)", "$var(rtValue)");
     }
 }
 #!endif

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -2022,6 +2022,7 @@ route[REALTIME] {
 
 route[RT_NEWCALL] {
     # Set brand, company and direction
+    sql_xquery("cb", "SELECT C.name AS companyName, B.name AS brandName FROM Companies C JOIN Brands B ON B.id=C.brandId WHERE C.id='$dlg_var(companyId)'", "names");
     jansson_set("integer", "Brand", "$dlg_var(brandId)", "$var(rtValue)");
     jansson_set("string", "BrandName", "$xavp(names=>brandName)", "$var(rtValue)");
     jansson_set("integer", "Company", "$dlg_var(companyId)", "$var(rtValue)");
@@ -2030,38 +2031,41 @@ route[RT_NEWCALL] {
 
     # Set rtChannel, owner and ownerName
     if ($dlg_var(residentialDeviceId) != $null) {
-        sql_xquery("cb", "SELECT RD.name AS residentialDeviceName, C.name AS companyName, B.name AS brandName FROM ResidentialDevices RD JOIN Companies C ON C.id=RD.companyId JOIN Brands B ON B.id=C.brandId WHERE RD.id=$dlg_var(residentialDeviceId)", "names");
+        sql_xquery("cb", "SELECT name FROM ResidentialDevices WHERE id=$dlg_var(residentialDeviceId)", "rd");
         $dlg_var(rtChannel) = 'users' + ':b' + $dlg_var(brandId) + ':c' + $dlg_var(companyId) + ':r' + $dlg_var(residentialDeviceId) + ':' + $ci;
         jansson_set("string", "Owner", "rt$dlg_var(residentialDeviceId)", "$var(rtValue)");
-        jansson_set("string", "OwnerName", "$xavp(names=>residentialDeviceName)", "$var(rtValue)");
+        jansson_set("string", "OwnerName", "$xavp(rd=>name)", "$var(rtValue)");
     } else if ($dlg_var(retailAccountId) != $null) {
-        sql_xquery("cb", "SELECT RA.name AS retailAccountName, C.name AS companyName, B.name AS brandName FROM RetailAccounts RA JOIN Companies C ON C.id=RA.companyId JOIN Brands B ON B.id=C.brandId WHERE RA.id=$dlg_var(retailAccountId)", "names");
+        sql_xquery("cb", "SELECT name FROM RetailAccounts WHERE id=$dlg_var(retailAccountId)", "ra");
         $dlg_var(rtChannel) = 'users' + ':b' + $dlg_var(brandId) + ':c' + $dlg_var(companyId) + ':rt' + $dlg_var(retailAccountId) + ':' + $ci;
         jansson_set("string", "Owner", "rs$dlg_var(retailAccountId)", "$var(rtValue)");
-        jansson_set("string", "OwnerName", "$xavp(names=>retailAccountName)", "$var(rtValue)");
+        jansson_set("string", "OwnerName", "$xavp(ra=>name)", "$var(rtValue)");
     } else if ($dlg_var(userId) != $null) {
-        sql_xquery("cb", "SELECT CONCAT(U.name, ' ', U.lastname) AS userName, C.name AS companyName, B.name AS brandName FROM Users U JOIN Companies C ON C.id=U.companyId JOIN Brands B ON B.id=C.brandId WHERE U.id=$dlg_var(userId)", "names");
+        sql_xquery("cb", "SELECT CONCAT(E.number, ' - ', U.name, ' ', U.lastname) AS userName FROM Users U JOIN Extensions E ON E.id=U.extensionId WHERE U.id=$dlg_var(userId)", "u");
         $dlg_var(rtChannel) = 'users' + ':b' + $dlg_var(brandId) + ':c' + $dlg_var(companyId) + ':u' + $dlg_var(userId) + ':' + $ci;
         jansson_set("string", "Owner", "u$dlg_var(userId)", "$var(rtValue)");
-        jansson_set("string", "OwnerName", "$xavp(names=>userName)", "$var(rtValue)");
+        jansson_set("string", "OwnerName", "$xavp(u=>userName)", "$var(rtValue)");
     } else if ($dlg_var(friendId) != $null) {
-        sql_xquery("cb", "SELECT F.name AS friendName, C.name AS companyName, B.name AS brandName FROM Friends F JOIN Companies C ON C.id=F.companyId JOIN Brands B ON B.id=C.brandId WHERE F.id=$dlg_var(friendId)", "names");
+        sql_xquery("cb", "SELECT name FROM Friends WHERE id=$dlg_var(friendId)", "f");
         $dlg_var(rtChannel) = 'users' + ':b' + $dlg_var(brandId) + ':c' + $dlg_var(companyId) + ':f' + $dlg_var(friendId) + ':' + $ci;
         jansson_set("string", "Owner", "f$dlg_var(friendId)", "$var(rtValue)");
-        jansson_set("string", "OwnerName", "$xavp(names=>friendName)", "$var(rtValue)");
+        jansson_set("string", "OwnerName", "$xavp(f=>name)", "$var(rtValue)");
     } else {
         # wholesale
         $dlg_var(rtChannel) = 'users' + ':b' + $dlg_var(brandId) + ':c' + $dlg_var(companyId) + ':w' + ':' + $ci;
         if ($dlg_var(direction) == 'inbound') {
             jansson_set("string", "Owner", "w$dlg_var(callee)", "$var(rtValue)");
+            jansson_set("string", "OwnerName", "$dlg_var(callee)", "$var(rtValue)");
         } else {
             jansson_set("string", "Owner", "w$dlg_var(caller)", "$var(rtValue)");
+            jansson_set("string", "OwnerName", "$dlg_var(caller)", "$var(rtValue)");
         }
     }
 
     # Set party
     if ($dlg_var(direction) == 'inbound') {
-        $dlg_var(party) = $dlg_var(caller);
+        route(GET_CALLER);
+        $dlg_var(party) = $var(number);
     } else {
         $dlg_var(party) = $dlg_var(callee);
     }


### PR DESCRIPTION

#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

- Get companyName and brandName before using its values.

  - No functional change as those fields are not used in KamUsers.

- Set ownerName for wholesale calls.

  - Fixes empty _Owner_ column for wholesale realtime section.

- Fix empty _Party_ column for inbound calls in client realtime section.

- Show user extension in _Owner_ column for vPBX realtime section.
