### PR TITLE
Bounced outgoing calls: zero cost and no carrierId

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -1262,6 +1262,8 @@ route[SET_CALLER] {
 }
 
 route[GET_TRANSFORMATIONS_OUT] {
+    if ($dlg_var(bounced) == '1') return; # Skip transformation in bounced calls
+
     sql_xquery("cb", "SELECT CONCAT(transformationRuleSetId, 0) AS caller_in, CONCAT(transformationRuleSetId, 1) AS callee_in, CONCAT(transformationRuleSetId, 2) AS caller_out, CONCAT(transformationRuleSetId, 3) AS callee_out FROM Carriers WHERE id=$dlg_var(carrierId)", "ra");
 
     $dlg_var(tr_caller_in) = $xavp(ra=>caller_in);
@@ -1503,6 +1505,8 @@ route[RELAY] {
         xinfo("[$dlg_var(cidhash)] RELAY: Bounce call to myself\n");
         $du = "sip:trunks.ivozprovider.local:" + SIP_PORT;
         $rd = "trunks.ivozprovider.local";
+        $dlg_var(carrierId) = $null;
+        $dlg_var(calculateCost) = "0";
     }
 
     if ($(du{uri.host}) != $null) {
@@ -1683,13 +1687,13 @@ route[RT_NEWCALL] {
 
     # Set rtChannel and carrier / ddiProvider
     if($dlg_var(direction) == 'outbound') {
-        if ($dlg_var(bounced) != '1') {
+        if ($dlg_var(carrierId) != $null) {
             sql_xquery("cb", "SELECT name FROM Carriers WHERE id=$dlg_var(carrierId)", "cs");
             $dlg_var(rtChannel) = 'trunks' + ':b' + $dlg_var(brandId) + ':c' + $dlg_var(companyId) + ':cr' + $dlg_var(carrierId) + ':' + $ci;
             jansson_set("string", "Carrier", "$xavp(cs=>name)", "$var(rtValue)");
         } else {
             $dlg_var(rtChannel) = 'trunks' + ':b' + $dlg_var(brandId) + ':c' + $dlg_var(companyId) + ':cr0:' + $ci;
-            jansson_set("string", "Carrier", "bounced", "$var(rtValue)");
+            jansson_set("string", "Carrier", "", "$var(rtValue)");
         }
     } else {
         if ($dlg_var(ddiProviderId) != $null) {
@@ -1698,7 +1702,7 @@ route[RT_NEWCALL] {
             jansson_set("string", "DdiProvider", "$xavp(dp=>name)", "$var(rtValue)");
         } else {
             $dlg_var(rtChannel) = 'trunks' + ':b' + $dlg_var(brandId) + ':c' + $dlg_var(companyId) + ':dp0:' + $ci;
-            jansson_set("string", "DdiProvider", "bounced", "$var(rtValue)");
+            jansson_set("string", "DdiProvider", "", "$var(rtValue)");
         }
     }
 

--- a/library/Ivoz/Provider/Domain/Service/BillableCall/UpdateByTpCdr.php
+++ b/library/Ivoz/Provider/Domain/Service/BillableCall/UpdateByTpCdr.php
@@ -155,6 +155,9 @@ class UpdateByTpCdr implements TrunksCdrWasMigratedSubscriberInterface
             $billableCallDto->setCost(
                 $carrierRunTpCdr->getCost()
             );
+        } elseif ($trunksCdr->getBounced()) {
+            $billableCallDto
+                ->setCost(0);
         }
 
         $this->entityTools->persistDto(


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

Bounced calls are external outgoing calls to existing numbers in DDIs table. They are not delivered to any carrier, but carrier selection is made as if they were to make sure that an outgoing routing exist to place these calls.

Apart from that, even though carrier was not reached:

- _carrierId_ was set to selected carrier.

- Carrier balance was decremented.

- Call cost was calculated using that carrier's active pricing plan.

This PR changes this behaviour. From now on:

- _carrierId_ will be NULL for these calls (both in _kam_trunks_cdrs_ and _BillableCalls_ tables).

- No carrier balance will be decremented.

- Call cost will be set to 0.

#### Additional information

This way:

- CDRs of specific carrier won't include bounced calls, as they are not delivered to any carrier.

- Call cost will be 0, as no price will be charged by any carrier.

- Carrier balance won't be decremented with calls not delivered to any carrier.

Notes:

- Past calls database registries won't be modified.

- External calls section won't show any carrier for these calls.

- Active calls god/brand sections won't show any carrier for these calls.