### PR TITLE
agis: ignore user call timeout when call forwards are disabled

### DIFF
--- a/asterisk/agi/src/Agi/Action/UserCallAction.php
+++ b/asterisk/agi/src/Agi/Action/UserCallAction.php
@@ -205,6 +205,11 @@ class UserCallAction
      */
     private function getDialTimeout()
     {
+        // Ignore user timeout if User call forwards are disabled
+        if (!$this->allowCallForwards) {
+            return "";
+        }
+
         $timeout = null;
 
         // Get active NoAnswer call forwards


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
When users are called from HuntGroups, CallForwardSettings may be enabled or disabled based on HuntGroup configuration.

For this last case, the noAnswer timeout was being configured in the final call to the user, even if allowCallForwards are disabled.

This PR fixes that problem by removing call timeout when CallForwards are not allowed. 

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
