### PR TITLE
Diversion related minor improvements

### DIFF
--- a/asterisk/agi/src/Agi/Action/CallForwardAction.php
+++ b/asterisk/agi/src/Agi/Action/CallForwardAction.php
@@ -77,6 +77,7 @@ class CallForwardAction
         $forwarder = $this->cfw->getUser();
         if ($forwarder) {
             $caller = new UserAgent($this->agi, $forwarder);
+            $this->agi->setVariable("_USERID", $forwarder->getId());
         } else {
             $forwarder = $this->cfw->getResidentialDevice();
 
@@ -87,6 +88,7 @@ class CallForwardAction
             }
 
             $caller = new ResidentialAgent($this->agi, $forwarder);
+            $this->agi->setVariable("_RESIDENTIALDEVICEID", $forwarder->getId());
         }
 
         // Set the new caller

--- a/asterisk/agi/src/Dialplan/Users.php
+++ b/asterisk/agi/src/Dialplan/Users.php
@@ -136,10 +136,14 @@ class Users extends RouteHandlerAbstract
             $transfererURI = str_replace($endpointName, $user->getExtensionNumber(), $transfererURI);
             $this->agi->setVariable("__SIPREFERREDBYHDR", $transfererURI);
         } elseif (!empty($forwarder)) {
-            // Update Diversion Header with User Outgoing DDI
-            $this->agi->setRedirecting('from-name,i', $user->getFullName());
-            $this->agi->setRedirecting('from-num,i', $user->getExtensionNumber());
-            $this->agi->setRedirecting('count,i', 1);
+            // Get channel origin
+            $origin = $this->channelInfo->getChannelOrigin();
+            // Update Diversion Header with User extension (unless its forwarding itself)
+            if (!$caller->isEqual($origin)) {
+                $this->agi->setRedirecting('from-name,i', $user->getFullName());
+                $this->agi->setRedirecting('from-num,i', $user->getExtensionNumber());
+                $this->agi->setRedirecting('count,i', 1);
+            }
         } else {
             // For now, origin is also the caller user
             $this->channelInfo->setChannelOrigin($caller);

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -1024,14 +1024,6 @@ route[PARSE_X_HEADERS] {
         $dlg_var(faxId) = $var(header-value);
     }
 
-    # Extract ddiId for cdr entry
-    $var(header) = 'X-Info-DdiId';
-    route(PARSE_OPTIONAL_X_HEADER);
-    if ($var(header-value) != '') {
-        xinfo("[$dlg_var(cidhash)] X-HEADERS-OTHER: '$var(header)' header found: $var(header-value)\n");
-        $dlg_var(ddiId) = $var(header-value);
-    }
-
     # Extract xcallid
     $var(header) = 'X-Call-Id';
     route(PARSE_OPTIONAL_X_HEADER);
@@ -1041,6 +1033,12 @@ route[PARSE_X_HEADERS] {
     }
 
     if ($dlg_var(type) == 'wholesale') return;
+
+    # Extract ddiId for cdr entry
+    $var(header) = 'X-Info-DdiId';
+    route(PARSE_MANDATORY_X_HEADER);
+    xinfo("[$dlg_var(cidhash)] X-HEADERS-OTHER: '$var(header)' header found: $var(header-value)\n");
+    $dlg_var(ddiId) = $var(header-value);
 
     # Extract X-Info-Special header
     $var(header) = 'X-Info-Special';

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -699,7 +699,12 @@ route[ADAPT_CALLER] {
     # First of all: do I have to mangle caller?
     if (!$var(is_from_inside)) {
         if ($dlg_var(type) == "retail" && !is_present_hf("P-Asserted-Identity") && !is_present_hf("Remote-Party-ID")) {
-            route(FORCE_FALLBACK_DDI);
+            if (is_request() && !has_totag()) {
+                route(GET_FALLBACK_DDI);
+                $dlg_var(caller) = $var(fallback_ddi);
+                $var(transformated) = $var(fallback_ddi);
+                route(SET_PAI);
+            }
             return;
         }
 
@@ -751,22 +756,35 @@ route[ADAPT_CALLER] {
     if ($var(is_from_inside)) {
         route(SET_PAI);
     } else {
-        $var(number) = $var(transformated);
-        route(CALLER_CHECK);
-        $var(transformated) = $var(number);
-        route(SET_CALLER);
-    }
+        if (is_request() && !has_totag()) {
+            if ($dlg_var(type) == "retail" && $dlg_var(valid_clid) != 'yes') {
+                route(VALIDATE_CLID_NUMBER);
+                if ($dlg_var(valid_clid) == "no") {
+                    route(GET_FALLBACK_DDI);
+                    $var(transformated) = $var(fallback_ddi);
+                }
+            }
 
-    if (is_request() && !has_totag() && !$var(is_from_inside)) {
-        # Save caller in e164 for accounting
-        $dlg_var(caller) = $var(transformated);
+            # Save caller in e164 for accounting
+            $dlg_var(caller) = $var(transformated);
+        }
+        route(SET_CALLER);
     }
 }
 
-route[FORCE_FALLBACK_DDI] {
-    $var(number) = $null;
-    route(CALLER_CHECK);
-    append_hf("P-Asserted-Identity: <sip:$var(number)@$fd>\r\n");
+# Sets fallback DDI in $var(fallback_ddi)
+route[GET_FALLBACK_DDI] {
+    sql_xquery("cb", "SELECT D.id, DDIE164 FROM RetailAccounts RA INNER JOIN Companies C ON C.id = RA.companyId INNER JOIN DDIs D ON D.id = COALESCE(RA.outgoingDdiId, C.outgoingDdiId) WHERE RA.id = $dlg_var(retailAccountId)", "ra");
+
+    $var(fallback_ddi) = $xavp(ra=>DDIE164);
+    if (!$var(fallback_ddi)) {
+        xerr("[$dlg_var(cidhash)] GET-FALLBACK-DDI: No fallback DDI for retail account $dlg_var(retailAccountId)\n");
+        send_reply("403", "Forbidden (invalid CLID)");
+        exit;
+    }
+
+    xwarn("[$dlg_var(cidhash)] GET-FALLBACK-DDI: Force $var(fallback_ddi) for retail account $dlg_var(retailAccountId)\n");
+    append_hf("X-Info-DdiId: $xavp(ra=>id)\r\n");
 }
 
 # Sets caller in $var(number) seeking in PAI/RPID/From (in this order)
@@ -914,9 +932,7 @@ route[ADAPT_DIVERSION] {
     route(APPLY_TRANSFORMATION);
     if ($dlg_var(type) == "retail" && !$var(is_from_inside)) {
         # Check if Diversion is valid before proceeding
-        $var(number) = $var(transformated);
         route(VALIDATE_CLID_NUMBER);
-
         if ($dlg_var(valid_clid) == "no") {
             xwarn("[$dlg_var(cidhash)] ADAPT-DIVERSION: Remove Diversion headers as $var(number) is not valid for retail account $dlg_var(retailAccountId)\n");
             remove_hf("Diversion");
@@ -928,43 +944,16 @@ route[ADAPT_DIVERSION] {
     $dlg_var(diversion) = $var(transformated);
 }
 
-# Evaluates if $var(number) is valid for $dlg_var(companyId). If not, $var(number) is set to fallback DDI
-route[CALLER_CHECK] {
-    if (!is_request() || has_totag()) return;
-
-    if ($dlg_var(type) != "retail" || $dlg_var(valid_clid) == "yes") return;
-
-    if ($var(number) != $null) {
-        route(VALIDATE_CLID_NUMBER);
-        if ($dlg_var(valid_clid) == "yes") return;
-    }
-
-    sql_xquery("cb", "SELECT D.id, DDIE164 FROM RetailAccounts RA INNER JOIN Companies C ON C.id = RA.companyId INNER JOIN DDIs D ON D.id = COALESCE(RA.outgoingDdiId, C.outgoingDdiId) WHERE RA.id = $dlg_var(retailAccountId)", "ra");
-
-    $var(fallback_ddi) = $xavp(ra=>DDIE164);
-    if (!$var(fallback_ddi)) {
-        xerr("[$dlg_var(cidhash)] CALLER-CHECK: No fallback DDI for retail account $dlg_var(retailAccountId)\n");
-        send_reply("403", "Forbidden (invalid CLID)");
-        exit;
-    }
-
-    xwarn("[$dlg_var(cidhash)] CALLER-CHECK: Force $var(fallback_ddi) as PAI/RPID ($var(number)) is not valid for retail account $dlg_var(retailAccountId)\n");
-    $var(number) = $var(fallback_ddi);
-    $dlg_var(caller) = $var(fallback_ddi);
-    append_hf("X-Info-DdiId: $xavp(ra=>id)\r\n");
-}
-
-# Sets $dlg_var(valid_clid) to "yes" if $var(number) is valid for $dlg_var(companyId), to "no" otherwise
+# Sets $dlg_var(valid_clid) to "yes" if $var(transformated) is valid for $dlg_var(companyId), to "no" otherwise
 route[VALIDATE_CLID_NUMBER] {
-
-    sql_query("cb", "SELECT id, DDIE164 FROM DDIs WHERE companyId='$dlg_var(companyId)' AND DDIE164='$var(number)'", "rc");
+    sql_query("cb", "SELECT id, DDIE164 FROM DDIs WHERE companyId='$dlg_var(companyId)' AND DDIE164='$var(transformated)'", "rc");
 
     if ($dbr(rc=>rows) > 0) {
-        xinfo("[$dlg_var(cidhash)] VALIDATE-CLID-NUMBER: $var(number) is VALID for company $dlg_var(companyId)\n");
+        xinfo("[$dlg_var(cidhash)] VALIDATE-CLID-NUMBER: $var(transformated) is VALID for company $dlg_var(companyId)\n");
         $dlg_var(valid_clid) = "yes";
         append_hf("X-Info-DdiId: $dbr(rc=>[0,0])\r\n");
     } else {
-        xwarn("[$dlg_var(cidhash)] VALIDATE-CLID-NUMBER: $var(number) is NOT VALID for company $dlg_var(companyId)\n");
+        xwarn("[$dlg_var(cidhash)] VALIDATE-CLID-NUMBER: $var(transformated) is NOT VALID for company $dlg_var(companyId)\n");
         $dlg_var(valid_clid) = "no";
     }
 

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -869,6 +869,21 @@ route[ADAPT_DIVERSION] {
 # In all initial INVITE requests
     if (!is_present_hf("Diversion")) return;
 
+    if (!$var(is_from_inside) && $dlg_var(type) != 'wholesale') {
+        if ($dlg_var(userId) != $null) {
+            xwarn("[$dlg_var(cidhash)] ADAPT-DIVERSION: Remove Diversion header in user call\n");
+            remove_hf("Diversion");
+            return;
+        } else {
+            # Diversion without PAI/RPID from friend/retail/residential
+            if (!is_present_hf("P-Asserted-Identity") && !is_present_hf("Remote-Party-ID")) {
+                xwarn("[$dlg_var(cidhash)] ADAPT-DIVERSION: Remove Diversion as no PAI/RPID header found\n");
+                remove_hf("Diversion");
+                return;
+            }
+        }
+    }
+
     # Only adapt first Diversion header
     $var(number) = $(di{uri.user});
     if ($var(number) == $null) {

--- a/library/Ivoz/Kam/Domain/Model/TrunksCdr/TrunksCdr.php
+++ b/library/Ivoz/Kam/Domain/Model/TrunksCdr/TrunksCdr.php
@@ -9,8 +9,6 @@ class TrunksCdr extends TrunksCdrAbstract implements TrunksCdrInterface
 {
     use TrunksCdrTrait;
 
-    const DIRECTION_OUTBOUND = 'outbound';
-
     /**
      * Get id
      * @codeCoverageIgnore

--- a/library/Ivoz/Kam/Domain/Model/TrunksCdr/TrunksCdrAbstract.php
+++ b/library/Ivoz/Kam/Domain/Model/TrunksCdr/TrunksCdrAbstract.php
@@ -76,6 +76,7 @@ abstract class TrunksCdrAbstract
     protected $parserScheduledAt;
 
     /**
+     * comment: enum:inbound|outbound
      * @var string | null
      */
     protected $direction;
@@ -730,6 +731,13 @@ abstract class TrunksCdrAbstract
      */
     protected function setDirection($direction = null)
     {
+        if (!is_null($direction)) {
+            Assertion::choice($direction, [
+                TrunksCdrInterface::DIRECTION_INBOUND,
+                TrunksCdrInterface::DIRECTION_OUTBOUND
+            ], 'directionvalue "%s" is not an element of the valid values: %s');
+        }
+
         $this->direction = $direction;
 
         return $this;

--- a/library/Ivoz/Kam/Domain/Model/TrunksCdr/TrunksCdrInterface.php
+++ b/library/Ivoz/Kam/Domain/Model/TrunksCdr/TrunksCdrInterface.php
@@ -6,6 +6,10 @@ use Ivoz\Core\Domain\Model\EntityInterface;
 
 interface TrunksCdrInterface extends EntityInterface
 {
+    const DIRECTION_INBOUND = 'inbound';
+    const DIRECTION_OUTBOUND = 'outbound';
+
+
     public function isOutboundCall();
 
     /**

--- a/library/Ivoz/Kam/Infrastructure/Persistence/Doctrine/Mapping/TrunksCdr.TrunksCdrAbstract.orm.yml
+++ b/library/Ivoz/Kam/Infrastructure/Persistence/Doctrine/Mapping/TrunksCdr.TrunksCdrAbstract.orm.yml
@@ -89,6 +89,7 @@ Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdrAbstract:
       length: null
       options:
         fixed: false
+        comment: '[enum:inbound|outbound]'
     cgrid:
       type: string
       nullable: true

--- a/library/Ivoz/Provider/Domain/Service/BillableCall/CreateOrUpdateByTrunksCdr.php
+++ b/library/Ivoz/Provider/Domain/Service/BillableCall/CreateOrUpdateByTrunksCdr.php
@@ -8,6 +8,7 @@ use Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdrInterface;
 use Ivoz\Provider\Domain\Model\BillableCall\BillableCall;
 use Ivoz\Provider\Domain\Model\BillableCall\BillableCallInterface;
 use Ivoz\Provider\Domain\Model\Carrier\CarrierInterface;
+use Ivoz\Provider\Domain\Model\Ddi\DdiInterface;
 
 class CreateOrUpdateByTrunksCdr
 {
@@ -52,9 +53,18 @@ class CreateOrUpdateByTrunksCdr
             $trunksCdr
         );
 
-        $caller = $trunksCdrDto->getDiversion()
-            ? $trunksCdrDto->getDiversion()
-            : $trunksCdrDto->getCaller();
+        /**
+         * @var DdiInterface $ddi
+         */
+        $ddi = $trunksCdr->getDdi();
+
+        $isOutbound = $trunksCdrDto->getDirection() === TrunksCdrInterface::DIRECTION_OUTBOUND;
+
+        if ($isOutbound && !is_null($ddi)) {
+            $caller = $ddi->getDdie164();
+        } else {
+            $caller = $trunksCdrDto->getCaller();
+        }
 
         $billableCallDto
             ->setTrunksCdrId(

--- a/schema/DoctrineMigrations/Version20200513164526.php
+++ b/schema/DoctrineMigrations/Version20200513164526.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Application\Migrations;
+
+use Ivoz\Core\Infrastructure\Persistence\Doctrine\LoggableMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20200513164526 extends LoggableMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE kam_trunks_cdrs CHANGE direction direction VARCHAR(255) DEFAULT NULL COMMENT \'[enum:inbound|outbound]\'');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE kam_trunks_cdrs CHANGE direction direction VARCHAR(255) DEFAULT NULL COLLATE utf8_general_ci');
+    }
+}


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

- Avoid undesired Diversion related requests in KamUsers.
  - Diversion headers with no PAI/RPID are dropped.

- Ensure _X-Info-DdiId_ is correctly set in retail calls.

- Drop outbound non-wholesale calls with no _X-Info-DdiId_ header.

- _BillableCalls.caller_ is now set using _kam_trunks_cdrs.ddiId_ for outbound calls (instead of  _kam_trunks_cdrs.diversion_).

  - This way it is always a DDI belonging to a client (except for wholesale clients).

- Fix AGI userId/residentialDeviceId bug for web call-forwards.

- Calls to your extension will never add a Diversion header (even if your terminal has a call forward).
  - Calling to your forwarded extension will be equal to calling to call forward target.