### PR TITLE
core: truncate entity error messages

### DIFF
--- a/library/Ivoz/Provider/Domain/Model/CallCsvScheduler/CallCsvScheduler.php
+++ b/library/Ivoz/Provider/Domain/Model/CallCsvScheduler/CallCsvScheduler.php
@@ -181,4 +181,17 @@ class CallCsvScheduler extends CallCsvSchedulerAbstract implements SchedulerInte
 
         return $dto;
     }
+
+    protected function setLastExecutionError($lastExecutionError = null)
+    {
+        if (!is_null($lastExecutionError)) {
+            $lastExecutionError = substr(
+                $lastExecutionError,
+                0,
+                300
+            );
+        }
+
+        return parent::setLastExecutionError($lastExecutionError);
+    }
 }

--- a/library/Ivoz/Provider/Domain/Model/Invoice/Invoice.php
+++ b/library/Ivoz/Provider/Domain/Model/Invoice/Invoice.php
@@ -154,4 +154,17 @@ class Invoice extends InvoiceAbstract implements FileContainerInterface, Invoice
 
         return $newScheduledInvoice || $modifiedInvoice;
     }
+
+    protected function setStatusMsg($statusMsg = null)
+    {
+        if (!is_null($statusMsg)) {
+            $statusMsg = substr(
+                $statusMsg,
+                0,
+                140
+            );
+        }
+
+        return parent::setStatusMsg($statusMsg);
+    }
 }

--- a/library/Ivoz/Provider/Domain/Model/InvoiceScheduler/InvoiceScheduler.php
+++ b/library/Ivoz/Provider/Domain/Model/InvoiceScheduler/InvoiceScheduler.php
@@ -51,7 +51,6 @@ class InvoiceScheduler extends InvoiceSchedulerAbstract implements SchedulerInte
         return parent::setFrequency($frequency);
     }
 
-
     public function getSchedulerDateTimeZone(): \DateTimeZone
     {
         $timezone = $this->getBrand()->getDefaultTimezone();
@@ -77,5 +76,18 @@ class InvoiceScheduler extends InvoiceSchedulerAbstract implements SchedulerInte
             case 'week':
                 return new \DateInterval("P${frecuency}W");
         }
+    }
+
+    protected function setLastExecutionError($lastExecutionError = null)
+    {
+        if (!is_null($lastExecutionError)) {
+            $lastExecutionError = substr(
+                $lastExecutionError,
+                0,
+                300
+            );
+        }
+
+        return parent::setLastExecutionError($lastExecutionError);
     }
 }


### PR DESCRIPTION
Long errors messages were breaking entity updates

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->