### PR TITLE
kam: userId/friendId/faxId for inbound calls

### DIFF
--- a/debian/ivozprovider.postinst
+++ b/debian/ivozprovider.postinst
@@ -94,14 +94,18 @@ function setup_proxies()
     # Change ProxyTrunks ports if USERS_ADDRESS == TRUNKS_ADDRESS
     if [ -n "$USERS_ADDRESS" ] && [ "$USERS_ADDRESS" == "$TRUNKS_ADDRESS" ]; then
         sed -i -e '/#!define TRUNKS_SIP_PORT/c\#!define TRUNKS_SIP_PORT 7060' /etc/kamailio/proxyusers/kamailio.cfg
+        sed -i -e '/modparam("dmq", "notification_address"/c\modparam("dmq", "notification_address", "sip:trunks.ivozprovider.local:7060")' /etc/kamailio/proxyusers/kamailio.cfg
         sed -i -e '/#!define SIP_PORT/c\#!define SIP_PORT 7060' /etc/kamailio/proxytrunks/kamailio.cfg
         sed -i -e '/#!define SIPS_PORT/c\#!define SIPS_PORT 7061' /etc/kamailio/proxytrunks/kamailio.cfg
+        sed -i -e '/modparam("dmq", "server_address"/c\modparam("dmq", "server_address", "sip:trunks.ivozprovider.local:7060")' /etc/kamailio/proxytrunks/kamailio.cfg
         sed -i -e '/contact=sip:trunks.ivozprovider.local/c\contact=sip:trunks.ivozprovider.local:7060' /etc/asterisk/pjsip.conf
         sed -i -e '/endpoint_identifier_order=ip,contact,username,anonymous/c\endpoint_identifier_order=contact,ip,username,anonymous' /etc/asterisk/pjsip.conf
     else
         sed -i -e '/#!define TRUNKS_SIP_PORT/c\#!define TRUNKS_SIP_PORT 5060' /etc/kamailio/proxyusers/kamailio.cfg
+        sed -i -e '/modparam("dmq", "notification_address"/c\modparam("dmq", "notification_address", "sip:trunks.ivozprovider.local:5060")' /etc/kamailio/proxyusers/kamailio.cfg
         sed -i -e '/#!define SIP_PORT/c\#!define SIP_PORT 5060' /etc/kamailio/proxytrunks/kamailio.cfg
         sed -i -e '/#!define SIPS_PORT/c\#!define SIPS_PORT 5061' /etc/kamailio/proxytrunks/kamailio.cfg
+        sed -i -e '/modparam("dmq", "server_address"/c\modparam("dmq", "server_address", "sip:trunks.ivozprovider.local:5060")' /etc/kamailio/proxytrunks/kamailio.cfg
         sed -i -e '/contact=sip:trunks.ivozprovider.local/c\contact=sip:trunks.ivozprovider.local' /etc/asterisk/pjsip.conf
         sed -i -e '/endpoint_identifier_order=contact,ip,username,anonymous/c\endpoint_identifier_order=ip,contact,username,anonymous' /etc/asterisk/pjsip.conf
     fi

--- a/doc/sphinx/administration_portal/brand/calls/call_csv_schedulers.rst
+++ b/doc/sphinx/administration_portal/brand/calls/call_csv_schedulers.rst
@@ -124,9 +124,6 @@ These are the fields of the generated CSV files:
         Client DDI to which call will be assigned (callee for inbound calls, caller for outbound calls). Empty for
         wholesale clients.
 
-.. warning:: *endpointType* in vPBX clients will be empty for inbound calls. Outbound calls will have one value among
-             **User, Fax, Friend**.
-
 DDI Provider detection
 ======================
 

--- a/doc/sphinx/administration_portal/client/vpbx/calls/call_csv_schedulers.rst
+++ b/doc/sphinx/administration_portal/client/vpbx/calls/call_csv_schedulers.rst
@@ -86,7 +86,7 @@ These are the fields of the generated CSV files:
         Client DDI to which call will be assigned (callee for inbound calls, caller for outbound calls).
 
     endpointType
-        Possible values for outbound calls: User, Fax, Friend. **Empty for inbound calls**.
+        Possible values: User, Fax, Friend. **Empty for inbound calls**.
 
     endpointId
         Internal ID of specific endpoint (only when *endpointType* has a non-empty value).

--- a/doc/sphinx/administration_portal/platform/external_calls.rst
+++ b/doc/sphinx/administration_portal/platform/external_calls.rst
@@ -63,10 +63,10 @@ Each entry shows this information:
         Shows the call ID of the call for troubleshooting and CSV export.
 
     Endpoint Type
-        For retail client calls, shows "RetailAccount". Empty for remaining client types.
+        Possible values: RetailAccount, ResidentialDevice, User, Fax, Friend.
 
     Endpoint Id
-        For retail client calls, shows the retail account's id of the call. Empty for remaining client types.
+        Internal ID of specific endpoint (only when *endpointType* is non-empty).
 
 
 .. note:: An asynchronous process parses each external call and adds it to this list a few minutes after call hangup. Billing related fields, such as cost and price, will be empty for external incoming calls.

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -146,6 +146,7 @@ loadmodule    "sqlops.so"
 loadmodule    "rtpengine.so"
 loadmodule    "cfg_rpc.so"
 loadmodule    "dialog.so"
+loadmodule    "dmq.so"
 loadmodule    "htable.so"
 loadmodule    "sdpops.so"
 loadmodule    "acc.so"
@@ -181,6 +182,11 @@ loadmodule    "pike.so"
 modparam("ndb_redis", "server", "name=realtime;sentinel_group=mymaster;sentinel_master=1;sentinel=data.ivozprovider.local:26379")
 modparam("ndb_redis", "init_without_redis", 1)
 #!endif
+
+# DMQ
+modparam("dmq", "server_address", "sip:trunks.ivozprovider.local:5060")
+modparam("dmq", "notification_address", "sip:users.ivozprovider.local:5060")
+modparam("dmq", "ping_interval", 3600)
 
 # JSONRPC-S
 modparam("jsonrpcs", "fifo_name", "/tmp/kamailio_proxytrunks_fifo")
@@ -283,6 +289,8 @@ modparam("pike", "remove_latency", 120)
 modparam("htable", "htable", "ipban=>size=8;autoexpire=300")
 #!endif
 modparam("htable", "htable", "cgrconn=>size=1;")
+modparam("htable", "htable", "dmq=>size=8;autoexpire=10800;dmqreplicate=1;")
+modparam("htable", "enable_dmq", 1)
 
 # UAC
 modparam("uac", "auth_realm_avp","$avp(auth_realm)")
@@ -361,6 +369,11 @@ request_route {
 
     # Calculate cidhash if not set
     route(CIDHASH);
+
+    if (is_method("KDMQ") && $var(is_from_inside)) {
+        dmq_handle_message();
+        exit;
+    }
 
     if (is_method("OPTIONS")) {
         force_rport();
@@ -1894,6 +1907,18 @@ event_route[dialog:start] {
 event_route[dialog:end] {
     # Dialog end, print stats
     xinfo("[$dlg_var(cidhash)] $dlg_var(direction) call ended for company '$dlg_var(companyId)' [$ci]\n");
+
+    if ($dlg_var(direction) == 'inbound') {
+        if ($sht(dmq=>$ci::user) != $null) {
+            $dlg_var(userId) = $sht(dmq=>$ci::user);
+            xinfo("[$dlg_var(cidhash)] Received via DMQ: userId => $dlg_var(userId)");
+        }
+
+        if ($sht(dmq=>$ci::friend) != $null) {
+            $dlg_var(friendId) = $sht(dmq=>$ci::friend);
+            xinfo("[$dlg_var(cidhash)] Received via DMQ: friendId => $dlg_var(friendId)");
+        }
+    }
 
     #!ifdef WITH_REALTIME
     $var(rtEvent) = 'Terminated';

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -1358,7 +1358,7 @@ route[APPLY_TRANSFORMATION] {
 }
 
 route[GET_INFO_FROM_MATCHED_DDI] {
-    sql_xquery("cb", "SELECT c.mediaRelaySetsId, c.maxCalls AS maxCallsCompany, b.maxCalls AS maxCallsBrand, d.recordCalls, c.distributeMethod, AppS.ip AS asAddress, d.routeType, d.residentialDeviceId, d.retailAccountId FROM DDIs d JOIN Companies c ON d.companyId=c.id LEFT JOIN ApplicationServers AppS ON AppS.id=c.applicationServerId JOIN Brands b ON c.brandId=b.id WHERE d.DDIE164='$rU'", "ra");
+    sql_xquery("cb", "SELECT c.mediaRelaySetsId, c.maxCalls AS maxCallsCompany, b.maxCalls AS maxCallsBrand, d.recordCalls, c.distributeMethod, AppS.ip AS asAddress, d.routeType, d.residentialDeviceId, d.retailAccountId, d.faxId FROM DDIs d JOIN Companies c ON d.companyId=c.id LEFT JOIN ApplicationServers AppS ON AppS.id=c.applicationServerId JOIN Brands b ON c.brandId=b.id WHERE d.DDIE164='$rU'", "ra");
 
     # Matched DDI
     $dlg_var(maxCallsCompany) = $xavp(ra=>maxCallsCompany);
@@ -1392,6 +1392,8 @@ route[GET_INFO_FROM_MATCHED_DDI] {
             send_reply("404", "Not Here");
             exit;
         }
+    } else if ($xavp(ra=>routeType) == 'fax') {
+        $dlg_var(faxId) = $xavp(ra=>faxId);
     }
 }
 

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -160,6 +160,7 @@ loadmodule    "sqlops.so"
 loadmodule    "cfg_rpc.so"
 loadmodule    "dialog.so"
 loadmodule    "acc.so"
+loadmodule    "dmq.so"
 loadmodule    "htable.so"
 loadmodule    "sdpops.so"
 loadmodule    "auth.so"
@@ -194,6 +195,11 @@ loadmodule    "pike.so"
 #!ifdef WITH_REALTIME
 loadmodule    "ndb_redis.so"
 #!endif
+
+# DMQ
+modparam("dmq", "server_address", "sip:users.ivozprovider.local:5060")
+modparam("dmq", "notification_address", "sip:trunks.ivozprovider.local:5060")
+modparam("dmq", "ping_interval", 3600)
 
 # RTPENGINE
 modparam("rtpengine", "db_url", DBURL)
@@ -338,6 +344,8 @@ modparam("htable", "htable", "ipban=>size=8;autoexpire=300")
 
 # dialogs htable contains aleg, bleg and applicationserver per dialog
 modparam("htable", "htable", "dialogs=>size=10;autoexpire=0")
+modparam("htable", "htable", "dmq=>size=8;autoexpire=10800;dmqreplicate=1;")
+modparam("htable", "enable_dmq", 1)
 
 # SANITY
 modparam("sanity", "autodrop", 0)
@@ -413,6 +421,11 @@ request_route {
     route(IS_FROM_INSIDE);
 
     route(CIDHASH);
+
+    if (is_method("KDMQ") && $var(is_from_inside)) {
+        dmq_handle_message();
+        exit;
+    }
 
     if (is_method("OPTIONS")) {
         force_rport();
@@ -2124,6 +2137,9 @@ onreply_route {
     # Silent NAT-handling OPTIONS replies
     if (is_method("OPTIONS") && $fu == "sip:pinger@kamailio.org") exit;
 
+    # Silent KDMQ replies
+    if (is_method("KDMQ")) exit;
+
     xnotice("[$dlg_var(cidhash)] Response: '$rs $rr' to '$cs $rm' from '$fu' ($si:$sp) [$proto]\n");
     route(IS_FROM_INSIDE);
 }
@@ -2288,6 +2304,15 @@ event_route[dialog:start] {
         route(REALTIME);
     }
     #!endif
+
+    if ($dlg_var(xcallid) != $null && $sht(dmq=>$dlg_var(xcallid)::user) == $null && $sht(dmq=>$dlg_var(xcallid)::friend) == $null) {
+        if ($dlg_var(userId) != $null) {
+            $sht(dmq=>$dlg_var(xcallid)::user) = $dlg_var(userId);
+        }
+        if ($dlg_var(friendId) != $null) {
+            $sht(dmq=>$dlg_var(xcallid)::friend) = $dlg_var(friendId);
+        }
+    }
 }
 
 # Executed when dialog is ended with BYE or timeout


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

Since #1305 outbound external calls have userId and friendId set in BillableCalls. But external inbound calls didn't, as KamTrunks does not know who is going to answer the call.

This PR uses Kamailio DMQ to send that information from KamUsers to KamTrunks for **vPBX external inbound calls**. userId and friendId will be set to **first interlocutor id**.

#### Additional Information

Inbound calls to DDIs routed to virtual fax will have _faxId_ set accordingly too.