### PR TITLE
agis: do not enter UserStatus when Call forwards are disabled

### DIFF
--- a/asterisk/agi/src/Agi/Action/UserCallAction.php
+++ b/asterisk/agi/src/Agi/Action/UserCallAction.php
@@ -164,7 +164,11 @@ class UserCallAction
         $this->agi->setVariable("DIAL_OPTS", $options);
 
         // Redirect to the calling dialplan context
-        $this->agi->redirect('call-user', $extension->getNumber());
+        if ($this->allowCallForwards) {
+            $this->agi->redirect('call-user-cfw', $extension->getNumber());
+        } else {
+            $this->agi->redirect('call-user', $extension->getNumber());
+        }
     }
 
     /**

--- a/asterisk/config/dialplan/default.conf
+++ b/asterisk/config/dialplan/default.conf
@@ -53,10 +53,14 @@ exten => _[+*0-9]!,1,NoOp(Call from queue ${QUEUE} to extension ${EXTEN})
 ;;------------------------------------[     Dial Contexts     ]--------------------------------------
 ;;---------------------------------------------------------------------------------------------------
 ;; Context for calling a user (and handle User call forwards after the call)
-[call-user]
+[call-user-cfw]
 exten => _[+*0-9]!,1,NoOp(Calling from ${CALLERID(all)} to ${DIAL_DST})
     same => n,Dial(${DIAL_DST},${DIAL_TIMEOUT},${DIAL_OPTS}b(add-headers^${EXTEN}^1))
     same => n,AGI(agi://127.0.0.1:4573/fastagi-runner.php?command=dialplan/userstatus)
+
+[call-user]
+exten => _[+*0-9]!,1,NoOp(Calling from ${CALLERID(all)} to ${DIAL_DST})
+    same => n,Dial(${DIAL_DST},${DIAL_TIMEOUT},${DIAL_OPTS}b(add-headers^${EXTEN}^1))
 
 ;; Context for Calling an external number through a trunk proxy
 [call-world]


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
This PR updates UserCallAction to use a different context when call forwards are disabled. This prevents reaching UserStatus AGI when Dial is not answered.

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
