### PR TITLE
web/admin: show carrier and carrier server status icon

### DIFF
--- a/doc/sphinx/administration_portal/brand/providers/carriers.rst
+++ b/doc/sphinx/administration_portal/brand/providers/carriers.rst
@@ -39,6 +39,10 @@ This are the fields that define a carrier:
         Selected address will be used as source address for signalling with this carrier. Brand operator can choose among
         addresses assigned by main operator via :ref:`Brands`. Read :ref:`Proxy Trunks` for further details.
 
+    Status
+        Non-responding carrier servers are inactivated until they respond to OPTIONS ping request. This icon is green if
+        every carrier server of given carrier is active, red if they are all inactive and yellow if just some of them are inactive.
+
 Cost calculation
 ****************
 
@@ -96,6 +100,10 @@ are used for placing outgoing calls by using :ref:`Outgoing routings`.
         For those providers that show origin in other headers (PAI/RPID), it is
         possible that request that From User have the account code being used
         and from domain their SIP domain. In case of doubt, leave empty.
+
+    Status
+        Non-responding carrier servers are inactivated until they respond to a OPTIONS ping request. This icon shows
+        if carrier server is active or inactive (and being pinged via OPTIONS message until gets back).
 
 .. tip:: There are many fields to establish *peering* with multiple kind of
    carriers, but usually with the name and SIP Proxy will be enough (for

--- a/library/Ivoz/Kam/Domain/Service/TrunksClientInterface.php
+++ b/library/Ivoz/Kam/Domain/Service/TrunksClientInterface.php
@@ -11,6 +11,7 @@ interface TrunksClientInterface
     const PERMISSIONS_ADDRESS_RELOAD_ACTION = 'permissions.addressReload';
     const UAC_REG_RELOAD_ACTION = 'uac.reg_reload';
     const UAC_REG_INFO_ACTION = 'uac.reg_info';
+    const LCR_DUMP_GWS_ACTION = 'lcr.dump_gws';
     const DLG_PROFILE_GET_SIZE = 'dlg.profile_get_size';
     const RTPENGINE_RELOAD_ACTION = 'rtpengine.reload';
     const CGRATES_ENABLED_ACTION = 'cfg.get';
@@ -23,6 +24,7 @@ interface TrunksClientInterface
         self::PERMISSIONS_ADDRESS_RELOAD_ACTION,
         self::UAC_REG_RELOAD_ACTION,
         self::UAC_REG_INFO_ACTION,
+        self::LCR_DUMP_GWS_ACTION,
         self::DLG_PROFILE_GET_SIZE,
         self::RTPENGINE_RELOAD_ACTION
     ];
@@ -59,6 +61,8 @@ interface TrunksClientInterface
     public function reloadUacReg();
 
     public function getUacRegistrationInfo($luuid): array;
+
+    public function getLcrGatewayInfo($gw_id): array;
 
     public function reloadRtpengine();
 }

--- a/library/Ivoz/Kam/Infrastructure/Kamailio/TrunksClient.php
+++ b/library/Ivoz/Kam/Infrastructure/Kamailio/TrunksClient.php
@@ -99,6 +99,41 @@ class TrunksClient implements TrunksClientInterface
         return (array) $response->result;
     }
 
+    public function getLcrGatewayInfo($gw_id): array
+    {
+        $response = $this->sendRequest(
+            self::LCR_DUMP_GWS_ACTION,
+            [$gw_id]
+        );
+
+        if (!isset($response->result)) {
+            return [];
+        }
+
+        /**
+         * Expected response format
+         * {
+         *   lcr_id: 1
+         *   gw_id: 21
+         *   gw_index: 2
+         *   gw_name: b1c1s14
+         *   scheme: sip:
+         *   ip_addr: 0.0.0.0
+         *   hostname: example.com
+         *   port: 5060
+         *   params:
+         *   transport: ;transport=udp
+         *   strip: 0
+         *   prefix:
+         *   tag:
+         *   flags: 14
+         *   state: 0
+         *   defunct_until: 0
+         * }
+         */
+        return (array) $response->result;
+    }
+
     public function reloadRtpengine()
     {
         return $this->germanClient->send(

--- a/web/admin/application/configs/klear/CarrierServersList.yaml
+++ b/web/admin/application/configs/klear/CarrierServersList.yaml
@@ -44,6 +44,7 @@ production:
         order:
           sipProxy: true
           outboundProxy: true
+          statusIcon: true
       options:
         title: _("Options")
         screens:
@@ -65,6 +66,7 @@ production:
           ip: true
           hostname: true
           port: true
+          statusIcon: true
         order: &carrierServersOrder_Link
           sipProxy: true
           authNeeded: true
@@ -115,6 +117,7 @@ production:
           ip: true
           hostname: true
           port: true
+          statusIcon: true
         order:
           <<: *carrierServersOrder_Link
       fixedPositions:

--- a/web/admin/application/configs/klear/CarriersList.yaml
+++ b/web/admin/application/configs/klear/CarriersList.yaml
@@ -45,6 +45,8 @@ production:
           transformationRuleSet: true
           proxyTrunks: true
           balance: true
+          proxyTrunk: true
+          statusIcon: true
         blacklist:
           externallyRated: true
           calculateCost: true
@@ -85,6 +87,7 @@ production:
           balance: true
           acd: true
           asr: true
+          statusIcon: true
       fixedPositions: &carriersNew_fixedPositionsLink
         group0:
           label: _("Basic Configuration")
@@ -126,6 +129,7 @@ production:
           balance: true
           acd: true
           asr: true
+          statusIcon: true
       fixedPositions:
         <<: *carriersNew_fixedPositionsLink
 

--- a/web/admin/application/configs/klear/model/CarrierServers.yaml
+++ b/web/admin/application/configs/klear/model/CarrierServers.yaml
@@ -158,6 +158,13 @@ production:
         icon: help
         text: _("Use this instead in From header domain")
         label: _("Need help?")
+    statusIcon:
+      title: _('Status')
+      type: ghost
+      dirty: true
+      source:
+        class: IvozProvider_Klear_Ghost_CarrierServerStatus
+        method: getCarrierServerStatusIcon
 staging:
   _extends: production
 testing:

--- a/web/admin/application/configs/klear/model/Carriers.yaml
+++ b/web/admin/application/configs/klear/model/Carriers.yaml
@@ -142,6 +142,13 @@ production:
         icon: help
         text: "<a href='https://en.wikipedia.org/wiki/Answer-seizure_ratio' target='_blank'>Answer-Seizure Ratio</a>"
         label: _("Need help?")
+    statusIcon:
+      title: _('Status')
+      type: ghost
+      dirty: true
+      source:
+        class: IvozProvider_Klear_Ghost_CarrierServerStatus
+        method: getCarrierStatusIcon
 staging:
   _extends: production
 testing:

--- a/web/admin/application/library/IvozProvider/Klear/Ghost/CarrierServerStatus.php
+++ b/web/admin/application/library/IvozProvider/Klear/Ghost/CarrierServerStatus.php
@@ -1,0 +1,123 @@
+<?php
+
+use Ivoz\Core\Application\Service\DataGateway;
+use Ivoz\Kam\Domain\Model\TrunksLcrGateway\TrunksLcrGatewayDto;
+use Ivoz\Kam\Domain\Model\TrunksLcrGateway\TrunksLcrGateway;
+use Ivoz\Provider\Domain\Model\CarrierServer\CarrierServerDto;
+use Ivoz\Provider\Domain\Model\CarrierServer\CarrierServer;
+use Ivoz\Provider\Domain\Model\Carrier\CarrierDto;
+use Ivoz\Kam\Domain\Service\TrunksClientInterface;
+
+class IvozProvider_Klear_Ghost_CarrierServerStatus extends KlearMatrix_Model_Field_Ghost_Abstract
+{
+    /**
+     * Get CarrierServer Status
+     * @param CarrierServerDto $carrierServerDto
+     * @return string HTML code to display carrier server status
+     * @throws Zend_Exception
+     */
+    public function getCarrierServerStatusIcon($carrierServerDto)
+    {
+        if (!$carrierServerDto->getId()) {
+            return '<span class="ui-silk inline ui-silk-error" title="No carrier server assigned"></span>';
+        }
+
+        /** @var DataGateway $dataGateway */
+        $dataGateway = \Zend_Registry::get('data_gateway');
+
+        /** @var TrunksLcrGatewayDto $kamTrunksLcrGateway */
+        $kamTrunksLcrGateway = $dataGateway->findOneBy(
+            TrunksLcrGateway::class,
+            [
+                "TrunksLcrGateway.carrierServer = :carrierServerId",
+                ["carrierServerId" => $carrierServerDto->getId()]
+            ]
+        );
+
+        if (!$kamTrunksLcrGateway) {
+            return '<span class="ui-silk inline ui-silk-error" title="No carrier server assigned"></span>';
+        }
+
+        $trunksClient = \Zend_Registry::get('container')->get(
+            TrunksClientInterface::class
+        );
+
+        $dumpGw = $trunksClient->getLcrGatewayInfo(
+            $kamTrunksLcrGateway->getId()
+        );
+
+        $status = $dumpGw['state'] ?? '';
+
+        if ($status === 0) {
+            $response = '<span class="ui-silk inline ui-silk-tick" title="Active"></span>';
+        } else {
+            $response = '<span class="ui-silk inline ui-silk-exclamation" title="Inactive""></span>';
+        }
+
+        return $response;
+    }
+
+    /**
+     * Get Carrier Status
+     * @param CarrierDto $carrierDto
+     * @return string HTML code to display carrier status
+     * @throws Zend_Exception
+     */
+    public function getCarrierStatusIcon($carrierDto)
+    {
+        if (!$carrierDto->getId()) {
+            return '<span class="ui-silk inline ui-silk-error" title="No carrier assigned"></span>';
+        }
+
+        /** @var DataGateway $dataGateway */
+        $dataGateway = \Zend_Registry::get('data_gateway');
+
+        /** @var CarrierServerDto $carrierServers */
+        $carrierServers = $dataGateway->findBy(
+            CarrierServer::class,
+            [
+                "CarrierServer.carrier = :carrierId",
+                ["carrierId" => $carrierDto->getId()]
+
+            ]
+        );
+
+        $status = 0;
+        foreach ($carrierServers as $carrierServer) {
+            /** @var TrunksLcrGatewayDto $kamTrunksLcrGateway */
+            $kamTrunksLcrGateway = $dataGateway->findOneBy(
+                TrunksLcrGateway::class,
+                [
+                    "TrunksLcrGateway.carrierServer = :carrierServerId",
+                    ["carrierServerId" => $carrierServer->getId()]
+
+                ]
+            );
+
+            if (!$kamTrunksLcrGateway) {
+                return '<span class="ui-silk inline ui-silk-error" title="No carrier server assigned"></span>';
+            }
+
+            $trunksClient = \Zend_Registry::get('container')->get(
+                TrunksClientInterface::class
+            );
+
+            $dumpGw = $trunksClient->getLcrGatewayInfo(
+                $kamTrunksLcrGateway->getId()
+            );
+            // 0: active - 2: inactive (defaults to inactive)
+            $status += $dumpGw['state'] ?? 2;
+        }
+
+
+        if ($status === 0) {
+            $response = '<span class="ui-silk inline ui-silk-tick" title="All servers active"></span>';
+        } elseif ($status === 2*count($carrierServers)) {
+            $response = '<span class="ui-silk inline ui-silk-exclamation" title="All server inactive"></span>';
+        } else {
+            $response = '<span class="ui-silk inline ui-silk-error" title="'. $status / 2 .' of ' .count($carrierServers). ' servers inactive"></span>';
+        }
+
+        return $response;
+    }
+}


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

Non-responding carrier servers are inactivated until they respond to OPTIONS ping request.

This PR adds this information to web portal:

- CarrierServers: green/red icon.

- Carriers: icon is green if every carrier server of given carrier are active, red if they are all inactive and yellow if just some of then are inactive.

#### Additional information

This PR needs _lcr.dump_gws_ command being patched to retrieve just one gateway (see irontec/kamailio@e19074d7cc2da074ba123e9d28969d3d978f78ee)