### PR TITLE
kam: avoid empty pointer free warning log

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -977,75 +977,57 @@ route[SELECT_NEXT_GW] {
 
 route[PARSE_X_HEADERS] {
     # Extract routing tag
-    $var(header) = 'X-Info-RoutingTag';
-    route(PARSE_OPTIONAL_X_HEADER);
-    if ($var(header-value) != '') {
-        xinfo("[$dlg_var(cidhash)] X-HEADERS-OTHER: '$var(header)' header found: $var(header-value)\n");
-        $dlg_var(routingTag) = $var(header-value);
+    if (is_present_hf("X-Info-RoutingTag")) {
+        $dlg_var(routingTag) = $hdr(X-Info-RoutingTag);
+        xinfo("[$dlg_var(cidhash)] PARSE-X-HEADERS: 'X-Info-RoutingTag' header found: $dlg_var(routingTag)\n");
     }
 
     # Extract routing tag Id
-    $var(header) = 'X-Info-RoutingTagId';
-    route(PARSE_OPTIONAL_X_HEADER);
-    if ($var(header-value) != '') {
-        xinfo("[$dlg_var(cidhash)] X-HEADERS-OTHER: '$var(header)' header found: $var(header-value)\n");
-        $dlg_var(routingTagId) = $var(header-value);
+    if (is_present_hf("X-Info-RoutingTagId")) {
+        $dlg_var(routingTagId) = $hdr(X-Info-RoutingTagId);
+        xinfo("[$dlg_var(cidhash)] PARSE-X-HEADERS: 'X-Info-RoutingTagId' header found: $dlg_var(routingTagId)\n");
     }
 
     # Extract Record header
-    $var(header) = 'X-Info-Record';
-    route(PARSE_OPTIONAL_X_HEADER);
-    if ($var(header-value) == 'yes') {
-        xinfo("[$dlg_var(cidhash)] X-HEADERS-OTHER: '$var(header)' header found, call will be recorded\n");
+    if (is_present_hf("X-Info-Record") && $hdr(X-Info-Record) == 'yes') {
+        xinfo("[$dlg_var(cidhash)] PARSE-X-HEADERS: 'X-Info-Record' header found (value: yes), call will be recorded\n");
         $avp(recordCall) = 'yes';
     }
 
     # Extract RetailAccountId for cdr entry
-    $var(header) = 'X-Info-RetailAccountId';
-    route(PARSE_OPTIONAL_X_HEADER);
-    if ($var(header-value) != '') {
-        xinfo("[$dlg_var(cidhash)] X-HEADERS-OTHER: '$var(header)' header found: $var(header-value)\n");
-        $dlg_var(retailAccountId) = $var(header-value);
+    if (is_present_hf("X-Info-RetailAccountId")) {
+        $dlg_var(retailAccountId) = $hdr(X-Info-RetailAccountId);
+        xinfo("[$dlg_var(cidhash)] PARSE-X-HEADERS: 'X-Info-RetailAccountId' header found: $dlg_var(retailAccountId)\n");
     }
 
     # Extract ResidentialDeviceId for cdr entry
-    $var(header) = 'X-Info-ResidentialDeviceId';
-    route(PARSE_OPTIONAL_X_HEADER);
-    if ($var(header-value) != '') {
-        xinfo("[$dlg_var(cidhash)] X-HEADERS-OTHER: '$var(header)' header found: $var(header-value)\n");
-        $dlg_var(residentialDeviceId) = $var(header-value);
+    if (is_present_hf("X-Info-ResidentialDeviceId")) {
+        $dlg_var(residentialDeviceId) = $hdr(X-Info-ResidentialDeviceId);
+        xinfo("[$dlg_var(cidhash)] PARSE-X-HEADERS: 'X-Info-ResidentialDeviceId' header found: $dlg_var(residentialDeviceId)\n");
     }
 
     # Extract UserId for cdr entry
-    $var(header) = 'X-Info-UserId';
-    route(PARSE_OPTIONAL_X_HEADER);
-    if ($var(header-value) != '') {
-        xinfo("[$dlg_var(cidhash)] X-HEADERS-OTHER: '$var(header)' header found: $var(header-value)\n");
-        $dlg_var(userId) = $var(header-value);
+    if (is_present_hf("X-Info-UserId")) {
+        $dlg_var(userId) = $hdr(X-Info-UserId);
+        xinfo("[$dlg_var(cidhash)] PARSE-X-HEADERS: 'X-Info-UserId' header found: $dlg_var(userId)\n");
     }
 
     # Extract FriendId for cdr entry
-    $var(header) = 'X-Info-FriendId';
-    route(PARSE_OPTIONAL_X_HEADER);
-    if ($var(header-value) != '') {
-        xinfo("[$dlg_var(cidhash)] X-HEADERS-OTHER: '$var(header)' header found: $var(header-value)\n");
-        $dlg_var(friendId) = $var(header-value);
+    if (is_present_hf("X-Info-FriendId")) {
+        $dlg_var(friendId) = $hdr(X-Info-FriendId);
+        xinfo("[$dlg_var(cidhash)] PARSE-X-HEADERS: 'X-Info-FriendId' header found: $dlg_var(friendId)\n");
     }
 
     # Extract FaxId for cdr entry
-    $var(header) = 'X-Info-FaxId';
-    route(PARSE_OPTIONAL_X_HEADER);
-    if ($var(header-value) != '') {
-        xinfo("[$dlg_var(cidhash)] X-HEADERS-OTHER: '$var(header)' header found: $var(header-value)\n");
-        $dlg_var(faxId) = $var(header-value);
+    if (is_present_hf("X-Info-FaxId")) {
+        $dlg_var(faxId) = $hdr(X-Info-FaxId);
+        xinfo("[$dlg_var(cidhash)] PARSE-X-HEADERS: 'X-Info-FaxId' header found: $dlg_var(faxId)\n");
     }
 
     # Extract xcallid
-    $var(header) = 'X-Call-Id';
-    route(PARSE_OPTIONAL_X_HEADER);
-    if ($var(header-value) != '') {
-        $dlg_var(xcallid) = $var(header-value);
-        xnotice("[$dlg_var(cidhash)] X-HEADERS-OTHER: Related leg: $dlg_var(xcallid)\n");
+    if (is_present_hf("X-Call-Id")) {
+        $dlg_var(xcallid) = $hdr(X-Call-Id);
+        xnotice("[$dlg_var(cidhash)] PARSE-X-HEADERS: Related leg: $dlg_var(xcallid)\n");
     }
 
     if ($dlg_var(type) == 'wholesale') return;
@@ -1053,35 +1035,25 @@ route[PARSE_X_HEADERS] {
     # Extract ddiId for cdr entry
     $var(header) = 'X-Info-DdiId';
     route(PARSE_MANDATORY_X_HEADER);
-    xinfo("[$dlg_var(cidhash)] X-HEADERS-OTHER: '$var(header)' header found: $var(header-value)\n");
+    xinfo("[$dlg_var(cidhash)] PARSE-X-HEADERS: '$var(header)' header found: $var(header-value)\n");
     $dlg_var(ddiId) = $var(header-value);
 
     # Extract X-Info-Special header
-    $var(header) = 'X-Info-Special';
-    route(PARSE_OPTIONAL_X_HEADER);
-    if ($var(header-value) == 'fax') {
-        xinfo("[$dlg_var(cidhash)] X-HEADERS-OTHER: X-Info-Special header found (value: fax)\n");
+    if (is_present_hf("X-Info-Special") && $hdr(X-Info-Special) == 'fax') {
+        xinfo("[$dlg_var(cidhash)] PARSE-X-HEADERS: 'X-Info-Special' header found (value: fax)\n");
         $avp(fax) = '1';
     }
-}
 
-# Header might not be present and, if present, might be empty
-route[PARSE_OPTIONAL_X_HEADER] {
-    if (is_present_hf($var(header))) {
-        $var(header-value) = $hdr($var(header));
-        remove_hf($var(header));
-    } else {
-        $var(header-value) = '';
-    }
+    # Remove all X headers
+    remove_hf_re("^X-");
 }
 
 # Header MUST be present and with not null value
 route[PARSE_MANDATORY_X_HEADER] {
-    if (is_present_hf($var(header)) && $(hdr($var(header)){s.len})) {
+    if ($(hdr($var(header)){s.len})) {
         $var(header-value) = $hdr($var(header));
-        remove_hf($var(header));
     } else {
-        xerr("[$dlg_var(cidhash)] PARSE-MANDATORY-X-HEADER: $var(header) not present or not valid, aborting\n");
+        xerr("[$dlg_var(cidhash)] PARSE-MANDATORY-X-HEADER: '$var(header)' not present or not valid, aborting\n");
         send_reply("500", "Missing $var(header)");
         exit;
     }
@@ -1985,10 +1957,9 @@ event_route[tm:local-request] {
 
     # OPTIONS (ping inactive carrier server)
     if (is_method("OPTIONS") && $fU == 'lcr') {
-        $var(header) = 'X-Info-Gateway';
-        route(PARSE_MANDATORY_X_HEADER);
-        $avp(gateway) = $var(header-value);
+        $avp(gateway) = $hdr(X-Info-Gateway);
         route(GET_INFO_FROM_GATEWAY);
+        remove_hf('X-Info-Gateway');
 
         xinfo("Ping inactive carrier server $avp(carrierServer) (carrier: $avp(carrier))");
         t_on_reply("LCR_PING");

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -1415,31 +1415,21 @@ route[PARSE_X_HEADERS] {
     }
 
     # Extract xcallid
-    $var(header) = 'X-Call-Id';
-    route(PARSE_OPTIONAL_X_HEADER);
-    if ($var(header-value) != '') {
-        $dlg_var(xcallid) = $var(header-value);
+    if (is_present_hf("X-Call-Id")) {
+        $dlg_var(xcallid) = $hdr(X-Call-Id);
         xnotice("[$dlg_var(cidhash)] PARSE-X-HEADERS: Related leg: $dlg_var(xcallid)\n");
     }
-}
 
-# Header might not be present and, if present, might be empty
-route[PARSE_OPTIONAL_X_HEADER] {
-    if (is_present_hf($var(header))) {
-        $var(header-value) = $hdr($var(header));
-        remove_hf($var(header));
-    } else {
-        $var(header-value) = '';
-    }
+    # Remove all X headers
+    remove_hf_re("^X-");
 }
 
 # Header MUST be present and with not null value
 route[PARSE_MANDATORY_X_HEADER] {
-    if (is_present_hf($var(header)) && $(hdr($var(header)){s.len})) {
+    if ($(hdr($var(header)){s.len})) {
         $var(header-value) = $hdr($var(header));
-        remove_hf($var(header));
     } else {
-        xerr("[$dlg_var(cidhash)] PARSE-MANDATORY-X-HEADER: $var(header) not present or not valid, aborting\n");
+        xerr("[$dlg_var(cidhash)] PARSE-MANDATORY-X-HEADER: '$var(header)' not present or not valid, aborting\n");
         send_reply("500", "Missing $var(header)");
         exit;
     }
@@ -1620,7 +1610,7 @@ route[WITHINDLG] {
 }
 
 route[REFER] {
-    if (is_present_hf("Refer-to") && $(hdr(Refer-to){s.len})) {
+    if (is_present_hf("Refer-to")) {
         xinfo("[$dlg_var(cidhash)] REFER: $fU transfers call to $hdr(Refer-to)\n");
         $dlg_var(referee) = $hdr(Refer-to);
     } else {


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

Using these functions with vars:

- is_present_hf($var(header))
- remove_hf($var(header)

Causes warning messages like this:

WARNING: <core> [core/mem/q_malloc.c:476]: qm_free(): WARNING: free(0) called from core: core/action.c: do_action(1126)


This PR avoids using them to prevent those warning messages.

#### Additional information

There should be no logic change.