### PR TITLE
kam: antiflood improvements

### DIFF
--- a/doc/sphinx/security_and_maintenance/security/antiflooding.rst
+++ b/doc/sphinx/security_and_maintenance/security/antiflooding.rst
@@ -6,11 +6,11 @@ Both SIP Proxies included in IvozProvider installation, KamUsers for SIP signall
 signalling with providers, use `PIKE module <http://kamailio.org/docs/modules/5.1.x/modules/pike.html>`_ to avoid DoS
 attacks.
 
-This module keeps trace of all incoming request's IP source and blocks the ones that exceed the limit on a given time
+This module keeps trace of all incoming initial request's IP source and blocks the ones that exceed the limit on a given time
 interval.
 
-.. warning:: **IPs are not blocked permanently**, they are allowed again as soon as their incoming request don't exceed the limit
-         on upcoming time interval.
+.. warning:: **IPs are not blocked permanently**, they are blocked for 5 minutes. After this time, they are allowed again
+             as long as their incoming request rate don't exceed the limit.
 
 .. tip:: :ref:`Antiflood banned IPs` shows a list of addresses that have been banned at some point.
 
@@ -22,7 +22,7 @@ Current configuration parameters are:
 
 
 This means that *any IP address that sends more than 30 requests in a 2-second-time-interval will be blocked (ignored)
-until next 2-second-time-interval in which this origin tries less than 30 requests*.
+for 5 minutes. After this time, they will be unblocked and their request rate will be evaluated again*.
 
 Antiflooding excluded sources
 =============================

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -1575,11 +1575,26 @@ route[ANTIFLOOD] {
     if (!pike_check_req()) {
         xerr("[$dlg_var(cidhash)] ANTIFLOOD: ALERT: pike blocking $rm from $fu (IP:$si:$sp)\n");
         $sht(ipban=>$si) = 1;
+        route(ANTIFLOOD_BLOCKED_IP);
         exit;
     }
 #!endif
 
     return;
+}
+
+route[ANTIFLOOD_BLOCKED_IP]{
+    sql_xquery("cb", "SELECT COUNT(*) > 0 AS banned FROM BannedAddresses WHERE ip='$si' AND blocker='antiflood'", "ra");
+
+    if ($xavp(ra=>banned) == '1') {
+        # Not first time, just update timestamp
+        xinfo("[$dlg_var(cidhash)] ANTIFLOOD-BLOCKED-IP: Blocking again $si\n");
+        sql_xquery("cb", "UPDATE BannedAddresses SET lastTimeBanned=NOW() WHERE ip='$si' AND blocker='antiflood'", "rb");
+    } else {
+        # First time, insert
+        xinfo("[$dlg_var(cidhash)] ANTIFLOOD-BLOCKED-IP: First time blocking $si\n");
+        sql_xquery("cb", "INSERT INTO BannedAddresses (ip, blocker, lastTimeBanned) VALUES ('$si', 'antiflood', NOW())", "rb");
+    }
 }
 
 # This route sets following dlg_vars: brandId, companyId, type

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -1553,6 +1553,9 @@ route[ANTIFLOOD] {
     # Only external sources
     if ($var(is_from_inside)) return;
 
+    # No antiflood for within dialog requests
+    if (has_totag()) return;
+
     # Trusted sources
     if (allow_trusted($si, 'any') && $avp(trustedTag) == $null) {
         xinfo("[$dlg_var(cidhash)] ANTIFLOOD: $si is not checked against antiflood (IP added in antiflood trusted IPs)\n");

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -1737,6 +1737,9 @@ route[ANTIFLOOD] {
     # Inside request
     if (src_ip == myself || $var(is_from_inside)) return;
 
+    # No antiflood for within dialog requests
+    if (has_totag()) return;
+
     # Trusted sources
     if (allow_trusted($si, 'any')) {
         xinfo("[$dlg_var(cidhash)] ANTIFLOOD: $si is not checked against antiflood (IP added in kam_trusted)\n");


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

- #1326 introduced antiflood banned address new section. This PR populates this section with KamTrunks antiflood blocked address.

- No antiflood for within-dialog requests.