### PR TITLE
trunks: disable antiflooding mechanism

### DIFF
--- a/doc/sphinx/administration_portal/platform/antiflood_trusted_ips.rst
+++ b/doc/sphinx/administration_portal/platform/antiflood_trusted_ips.rst
@@ -5,8 +5,8 @@ Antiflood trusted IPs
 *********************
 
 IvozProvider comes with an *anti-flooding* mechanism to avoid that a single
-sender can deny the platform service by sending lots of requests. Both *proxies*
-(users and trunks) use this mechanism, that **limits the number of requests
+sender can deny the platform service by sending lots of requests. *Users proxy*
+(kamusers) uses this mechanism, that **limits the number of requests
 from an origin address in a time lapse**.
 
 .. warning:: When an origin reaches this limit, the proxy will stop sending
@@ -15,7 +15,7 @@ from an origin address in a time lapse**.
 
 Some origins are automatically excluded from this *anti-flooding* mechanism:
 
-- Application Servers from the platform.
+- IvozProvider components.
 
 - Client authorized IP addresses or ranges (see previous section).
 

--- a/doc/sphinx/security_and_maintenance/security/antiflooding.rst
+++ b/doc/sphinx/security_and_maintenance/security/antiflooding.rst
@@ -2,9 +2,8 @@
 SIP Antiflooding
 ################
 
-Both SIP Proxies included in IvozProvider installation, KamUsers for SIP signalling with clients and KamTrunks for SIP
-signalling with providers, use `PIKE module <http://kamailio.org/docs/modules/5.1.x/modules/pike.html>`_ to avoid DoS
-attacks.
+SIP Proxy included in IvozProvider installation for SIP signalling with clients (KamUsers) uses
+`PIKE module <http://kamailio.org/docs/modules/5.1.x/modules/pike.html>`_ to avoid DoS attacks.
 
 This module keeps trace of all incoming initial request's IP source and blocks the ones that exceed the limit on a given time
 interval.
@@ -29,19 +28,13 @@ Antiflooding excluded sources
 
 These sources are not evaluated against antiflood:
 
-- Both KamUsers and KamTrunks:
-    - IvozProvider components
-    - IPs in :ref:`Antiflood trusted IPs`
-
-- KamUsers:
-    - IPs in :ref:`Clients authorized IPs <client_authorized_ip_ranges>` (vPBX, retail, residential)
-    - Wholesale clients' IP addresses
+- IvozProvider components
+- IPs in :ref:`Antiflood trusted IPs`
+- IPs in :ref:`Clients authorized IPs <client_authorized_ip_ranges>` (vPBX, retail, residential)
+- Wholesale clients' IP addresses
 
 .. warning:: IPs and ranges added in :ref:`Clients authorized IPs <client_authorized_ip_ranges>` will be excluded from
          antiflood, even if **Filter by IP address** is disabled.
-
-- KamTrunks:
-    - DDI Providers' IP addresses
 
 .. tip:: On a typical NAT scenario with hundreds of UACs sharing the same public IP address, this IP should be static and
          should be added to :ref:`Clients authorized IPs <client_authorized_ip_ranges>` list to avoid been blocked by

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -27,7 +27,6 @@
 #!define DLG_FLAG 3
 
 # - options
-#!define WITH_ANTIFLOOD
 #!define WITH_REALTIME
 
 #!define DBURL "mysql://kamailio:ironsecret@data/ivozprovider"
@@ -173,10 +172,6 @@ loadmodule    "ipops.so"
 loadmodule    "ndb_redis.so"
 #!endif
 
-#!ifdef WITH_ANTIFLOOD
-loadmodule    "pike.so"
-#!endif
-
 #!ifdef WITH_REALTIME
 # REDIS
 modparam("ndb_redis", "server", "name=realtime;sentinel_group=mymaster;sentinel_master=1;sentinel=data.ivozprovider.local:26379")
@@ -278,16 +273,7 @@ modparam("dialog", "track_cseq_updates", 1)
 modparam("dialog", "detect_spirals", 0)
 modparam("dialog", "default_timeout", MAX_DIALOG_TIMEOUT)
 
-#!ifdef WITH_ANTIFLOOD
-# PIKE
-modparam("pike", "sampling_time_unit", 2)
-modparam("pike", "reqs_density_per_unit", 30)
-modparam("pike", "remove_latency", 120)
-
 # HTABLE
-# ip ban htable with autoexpire after 5 minutes
-modparam("htable", "htable", "ipban=>size=8;autoexpire=300")
-#!endif
 modparam("htable", "htable", "cgrconn=>size=1;")
 modparam("htable", "htable", "dmq=>size=8;autoexpire=10800;dmqreplicate=1;")
 modparam("htable", "enable_dmq", 1)
@@ -353,9 +339,7 @@ modparam("dialplan", "attrs_pvar", "$avp(s:appliedrule)")
 # PERMISSIONS
 modparam("permissions", "db_url", DBURL)
 modparam("permissions", "address_table", "kam_trunks_address") # Allowed addresses per DDI provider
-modparam("permissions", "trusted_table", "kam_trusted") # IPs excluded from pike checking and wholesale IPs
-modparam("permissions", "db_mode", 1)
-modparam("permissions", "peer_tag_avp", "$avp(trustedTag)")
+modparam("permissions", "trusted_table", "kam_trusted") # Not used but necessary
 
 # JSONRPCS
 modparam("jsonrpcs", "transport", 1)
@@ -383,7 +367,11 @@ request_route {
 
     xnotice("[$dlg_var(cidhash)] Request: $rm '$ru' ($cs $rm) from '$fu' ($proto:$si:$sp) [$ci]\n");
 
-    route(ANTIFLOOD);
+    if (!$var(is_from_inside) && !has_totag() && !allow_source_address()) {
+        xwarn("[$dlg_var(cidhash)] Inbound initial request from $si, not recognized as a valid DDI Provider, 403 Forbidden\n");
+        send_reply("403", "Forbidden");
+        exit;
+    }
 
     # CANCEL processing
     if (is_method("CANCEL")) {
@@ -1518,58 +1506,6 @@ route[RELAY] {
         sl_reply_error();
 
     exit;
-}
-
-route[ANTIFLOOD] {
-#!ifdef WITH_ANTIFLOOD
-    # Only external sources
-    if ($var(is_from_inside)) return;
-
-    # No antiflood for within dialog requests
-    if (has_totag()) return;
-
-    # Trusted sources
-    if (allow_trusted($si, 'any') && $avp(trustedTag) == $null) {
-        xinfo("[$dlg_var(cidhash)] ANTIFLOOD: $si is not checked against antiflood (IP added in antiflood trusted IPs)\n");
-        return;
-    }
-    # Allowed sources by DDI provider
-    $var(group) = allow_source_address_group();
-    if ($var(group) != -1) {
-        xinfo("[$dlg_var(cidhash)] ANTIFLOOD: $si is not checked against antiflood (allowed source for ddiProviderId '$var(group)')\n");
-        return;
-    }
-
-    # Evaluate PIKE
-    if($sht(ipban=>$si) != $null) {
-        # ip is already blocked
-        xerr("[$dlg_var(cidhash)] ANTIFLOOD: request from blocked IP - $rm from $fu (IP:$si:$sp)\n");
-        exit;
-    }
-
-    if (!pike_check_req()) {
-        xerr("[$dlg_var(cidhash)] ANTIFLOOD: ALERT: pike blocking $rm from $fu (IP:$si:$sp)\n");
-        $sht(ipban=>$si) = 1;
-        route(ANTIFLOOD_BLOCKED_IP);
-        exit;
-    }
-#!endif
-
-    return;
-}
-
-route[ANTIFLOOD_BLOCKED_IP]{
-    sql_xquery("cb", "SELECT COUNT(*) > 0 AS banned FROM BannedAddresses WHERE ip='$si' AND blocker='antiflood'", "ra");
-
-    if ($xavp(ra=>banned) == '1') {
-        # Not first time, just update timestamp
-        xinfo("[$dlg_var(cidhash)] ANTIFLOOD-BLOCKED-IP: Blocking again $si\n");
-        sql_xquery("cb", "UPDATE BannedAddresses SET lastTimeBanned=NOW() WHERE ip='$si' AND blocker='antiflood'", "rb");
-    } else {
-        # First time, insert
-        xinfo("[$dlg_var(cidhash)] ANTIFLOOD-BLOCKED-IP: First time blocking $si\n");
-        sql_xquery("cb", "INSERT INTO BannedAddresses (ip, blocker, lastTimeBanned) VALUES ('$si', 'antiflood', NOW())", "rb");
-    }
 }
 
 # This route sets following dlg_vars: brandId, companyId, type


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

With latest change done via d11177e4ad0ae711bbc3e318d2ec127864dbfaaf antiflood in trunks is excluded for:

- IvozProvider internal elements  (it has always been)
- DdiProviderAddresses (it has always been)
- Carrier (only applied for within dialog requets, that are excluded now)

This means that only applies for invalid sources that will be rejected with 403 Forbidden in GET_TRANSFORMATIONS_IN: 
https://github.com/irontec/ivozprovider/blob/b62e94fbf68e5b70f4e22bdd6c0620bb9a0ec45e/kamailio/trunks/config/kamailio.cfg#L1081

This PR removes antiflood mechanism for KamTrunks and adds a simple logic in its place that rejects with 403 Forbidden any inbound initial request from a source IP no in kam_trunks_address (checked with _allow_source_address()_ that makes no underlying query).

#### Additional information

As side effect:

- pike.so module is not loaded anymore in KamTrunks
- WITH_ANTIFLOOD define is removed in KamTrunks
- _allow_trusted()_ is not used anymore in KamTrunks
- ANTIFLOOD_BLOCKED_IP added in 5a913c063cbcd85ff3558789e00f8052ddba117a is removed too