### PR TITLE
kamusers: fix unsolicited NOTIFY MWI for residential devices with directConnectivity  

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -1188,7 +1188,7 @@ route[APPLY_RETAIL_CFW] {
 route[STATIC_LOCATION] {
     $var(static_location) = 0;
 
-    sql_xquery("cb", "SELECT type FROM kam_users WHERE companyId=$dlg_var(companyId) AND name='$rU' AND domain='$rd'", "ra");
+    sql_xquery("cb", "SELECT type FROM kam_users WHERE name='$rU' AND domain='$rd'", "ra");
     if ($xavp(ra=>type) == 'friend') {
         $var(table) = 'Friends';
     } else if ($xavp(ra=>type) == 'retail') {


### PR DESCRIPTION



#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

- $dlg_var(companyId) is $null in STATIC_LOCATION route for unsolicited NOTIFY MWI.

- This causes db_mysql module error and $var(static_location) being set to 0.

- This error is harmless except for terminals and residential devices with no direct
  connectivity, but misroutes NOTIFY for residential devices with directConnectivity

This commit removes $dlgvar(companyId) from where condition as all name+domain
combinations are unique in kam_users, fixing this misrouting.
