### PR TITLE
Set missing multilang destination values

### DIFF
--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/DestinationDoctrineRepository.php
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/DestinationDoctrineRepository.php
@@ -36,7 +36,7 @@ class DestinationDoctrineRepository extends ServiceEntityRepository implements D
     public function insertIgnoreFromArray(array $destinations)
     {
         $destinationInsert =
-            'INSERT IGNORE INTO Destinations (prefix, name_en, name_es, brandId) VALUES '
+            'INSERT IGNORE INTO Destinations (prefix, name_en, name_es, name_ca, name_it, brandId) VALUES '
             . implode(",", $destinations);
 
         $nativeQuery = new NativeQuery($this->_em);

--- a/microservices/workers/src/Worker/Rates.php
+++ b/microservices/workers/src/Worker/Rates.php
@@ -273,13 +273,14 @@ class Rates
                 );
                 $csvLines[$k]['rateIncrement'] = intval($line['rateIncrement']);
 
+                $destinationName = utf8_encode($line['destinationName']);
                 $destinations[] = sprintf(
                     '("%s", "%s", "%s", "%s", "%s", "%d" )',
                     $line['destinationPrefix'],
-                    $line['destinationName'],
-                    $line['destinationName'],
-                    $line['destinationName'],
-                    $line['destinationName'],
+                    $destinationName,
+                    $destinationName,
+                    $destinationName,
+                    $destinationName,
                     $brandId
                 );
 

--- a/microservices/workers/src/Worker/Rates.php
+++ b/microservices/workers/src/Worker/Rates.php
@@ -274,8 +274,10 @@ class Rates
                 $csvLines[$k]['rateIncrement'] = intval($line['rateIncrement']);
 
                 $destinations[] = sprintf(
-                    '("%s",  "%s",  "%s", "%d" )',
+                    '("%s", "%s", "%s", "%s", "%s", "%d" )',
                     $line['destinationPrefix'],
+                    $line['destinationName'],
+                    $line['destinationName'],
                     $line['destinationName'],
                     $line['destinationName'],
                     $brandId

--- a/schema/DoctrineMigrations/Version20200608091055.php
+++ b/schema/DoctrineMigrations/Version20200608091055.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20200608091055 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql(
+            "UPDATE Destinations SET name_ca = name_es WHERE name_ca IS NULL"
+        );
+        $this->addSql(
+            "UPDATE Destinations SET name_it = name_en WHERE name_it IS NULL"
+        );
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+
+    }
+}

--- a/web/admin/application/controllers/ImportDestinationRatesCustomFileController.php
+++ b/web/admin/application/controllers/ImportDestinationRatesCustomFileController.php
@@ -263,7 +263,7 @@ class ImportDestinationRatesCustomFileController extends Zend_Controller_Action
         foreach ($lines as $line) {
             $table.= "<tr>";
             foreach ($line as $idPart => $part) {
-                $table.="<td class='ui-widget-content'>" . $part . "</td>";
+                $table.="<td class='ui-widget-content'>" . utf8_encode($part) . "</td>";
             }
             $table.= "</tr>";
         }


### PR DESCRIPTION
- Italian and Catalan values were empty on Destinations table. Fixed importer
- Fixed encoding related issues as well (for instance Ñ character was breaking the importer)

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [X] Fixes an existing issue (Fixes #1403)
