### PR TITLE
kamusers: Allow registers from terminals with no user-extension

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -1008,7 +1008,7 @@ route[GENERATE_PUBLISH] {
         $avp(pubruri_callee)= "sip:" + $hdr(X-Info-Callee) + "@" + $fd;
     } else {
         sql_xquery("cb", "SELECT extension FROM kam_users WHERE name='$fU' AND domain='$fd'", "rp");
-        if ($xavp(rp=>extension) == $null) return; # No PUBLISH for calls from non-terminals
+        if ($xavp(rp=>extension) == $null) return; # No PUBLISH for calls from non-terminals (or from terminals with no user-extension)
 
         # Terminal calling
         # Set user extension as 'caller' instead of user in From header
@@ -1923,11 +1923,23 @@ route[CLASSIFY] {
             $dlg_var(brandId) = $xavp(ra=>brandId);
         } else {
             # Get needed information from From header
-            sql_xquery("cb", "SELECT C.brandId, C.id AS companyId, C.type FROM kam_users KU JOIN Companies C ON C.id=KU.companyId WHERE KU.name='$fU' AND KU.domain='$fd'", "ra");
+            $xavp(ra) = $null;
+            sql_xquery("cb", "SELECT C.brandId, C.id AS companyId, C.type, KU.type AS objectType, KU.objectId, KU.extension FROM kam_users KU JOIN Companies C ON C.id=KU.companyId WHERE KU.name='$fU' AND KU.domain='$fd'", "ra");
 
             $dlg_var(brandId) = $xavp(ra=>brandId);
             $dlg_var(companyId) = $xavp(ra=>companyId);
             $dlg_var(type) = $xavp(ra=>type);
+
+            # Drop calls from terminals belonging to no user or belonging to user with no extension
+            if ($xavp(ra=>objectType) == "terminal" && $xavp(ra=>extension) == $null) {
+                if ($xavp(ra=>objectId) == $null) {
+                   xwarn("[$dlg_var(cidhash)] Terminal with no user, forbidden\n");
+                } else {
+                   xwarn("[$dlg_var(cidhash)] Terminal linked to user with no extension, forbidden\n");
+                }
+                send_reply("403", "Forbidden");
+                exit;
+            }
         }
     }
 

--- a/schema/DoctrineMigrations/Version20200608161806.php
+++ b/schema/DoctrineMigrations/Version20200608161806.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20200608161806 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP VIEW `kam_users`');
+        $this->addSql('CREATE VIEW `kam_users` AS
+                            SELECT E.type, E.name, D.domain, E.password, E.companyId, E.id AS objectId, E.extension,
+                                E.externalIpCalls, E.maxCalls, CONCAT(T.id,0) AS caller_in, CONCAT(T.id,1) AS callee_in,
+                                CONCAT(T.id,2) AS caller_out, CONCAT(T.id,3) AS callee_out, E.t38Passthrough
+                            FROM (
+                                SELECT "terminal" as type, T.name, T.domainId, T.password, T.companyId,
+                                    U.transformationRuleSetId, U.id, E.number AS extension, COALESCE(U.externalIpCalls, 0) AS externalIpCalls, U.maxCalls, T.t38Passthrough
+                                    FROM Terminals T
+                                        LEFT JOIN Users U ON U.terminalId = T.id
+                                        LEFT JOIN Extensions E ON E.id=U.extensionId
+                                UNION
+                                    SELECT "friend" AS type, name, domainId, password, companyId, transformationRuleSetId,
+                                    id, NULL AS extension, NULL AS externalIpCalls, 0 AS maxCalls, t38Passthrough
+                                        FROM Friends
+                                UNION
+                                    SELECT "residential" AS type, name, domainId, password, companyId, transformationRuleSetId,
+                                    id, NULL AS extension, NULL AS externalIpCalls, RD.maxCalls, RD.t38Passthrough
+                                        FROM ResidentialDevices RD
+                                UNION
+                                    SELECT "retail" AS type, name, domainId, password, companyId, transformationRuleSetId,
+                                    id, NULL AS extension, NULL AS externalIpCalls, 0 AS maxCalls, RA.t38Passthrough
+                                        FROM RetailAccounts RA
+                            ) AS E
+                            INNER JOIN Companies C ON C.id = E.companyId
+                            INNER JOIN TransformationRuleSets T ON T.id = COALESCE(E.transformationRuleSetId, C.transformationRuleSetId)
+                            INNER JOIN Domains D ON D.id = E.domainId');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP VIEW `kam_users`');
+        $this->addSql('CREATE VIEW `kam_users` AS
+                            SELECT E.type, E.name, D.domain, E.password, E.companyId, E.id AS objectId, E.extension,
+                                E.externalIpCalls, E.maxCalls, CONCAT(T.id,0) AS caller_in, CONCAT(T.id,1) AS callee_in,
+                                CONCAT(T.id,2) AS caller_out, CONCAT(T.id,3) AS callee_out, E.t38Passthrough
+                            FROM (
+                                SELECT "terminal" as type, T.name, T.domainId, T.password, T.companyId,
+                                    U.transformationRuleSetId, U.id, E.number AS extension, U.externalIpCalls, U.maxCalls, T.t38Passthrough
+                                    FROM Terminals T
+                                        INNER JOIN Users U ON U.terminalId = T.id
+                                        INNER JOIN Extensions E ON E.id=U.extensionId
+                                UNION
+                                    SELECT "friend" AS type, name, domainId, password, companyId, transformationRuleSetId,
+                                    id, NULL AS extension, NULL AS externalIpCalls, 0 AS maxCalls, t38Passthrough
+                                        FROM Friends
+                                UNION
+                                    SELECT "residential" AS type, name, domainId, password, companyId, transformationRuleSetId,
+                                    id, NULL AS extension, NULL AS externalIpCalls, RD.maxCalls, RD.t38Passthrough
+                                        FROM ResidentialDevices RD
+                                UNION
+                                    SELECT "retail" AS type, name, domainId, password, companyId, transformationRuleSetId,
+                                    id, NULL AS extension, NULL AS externalIpCalls, 0 AS maxCalls, RA.t38Passthrough
+                                        FROM RetailAccounts RA
+                            ) AS E
+                            INNER JOIN Companies C ON C.id = E.companyId
+                            INNER JOIN TransformationRuleSets T ON T.id = COALESCE(E.transformationRuleSetId, C.transformationRuleSetId)
+                            INNER JOIN Domains D ON D.id = E.domainId');
+
+    }
+}


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

_kam_users_ view excluded:

- Terminals linked to no user.

- Terminals linked to users with no screen extension.

This meant that these terminals won't fulfill SIP authentication (as _kam_users_ is used in AUTH route).

This PR stops excluding these terminals so that they can authenticate (with valid credentials, of course), but they cannot make any call.

#### Additional information

The reason behind this change is that deactivating users by unsetting terminal or extension could be useful in some situations, but could lead to REGISTER flooding (depending on SIP phone retrial timeout in case of failure). This got even worse if TCP was used for these registrations.

With this change, they will REGISTER (and even SUBSCRIBE and get NOTIFY-ed), but they won't be allowed to make (or receive) any call.