### PR TITLE
kamusers: anti brute-force attack mechanism

### DIFF
--- a/doc/sphinx/security_and_maintenance/security/antibruteforce.rst
+++ b/doc/sphinx/security_and_maintenance/security/antibruteforce.rst
@@ -1,0 +1,26 @@
+########################
+Anti brute-force attacks
+########################
+
+IvozProvider ships a simple anti brute-force attack in KamUsers that bans sources after continuous SIP auth failures.
+
+It works like this:
+
+- On SIP failures (invalid user or invalid password cases only), a counter is increased:
+
+  - Key: fromUsername@fromDomain::protocol:source_ip:source_port
+     - e.g. terminal@vpbx.domain.net::udp:1.2.3.4:24107
+
+- Counter is increased on every failure.
+
+- When counter reaches 100, that specific source (user + domain + proto + ip + port) is banned for 12 hours.
+
+
+After 12 hours, source is accepted again and:
+
+- Counter starts counting again from 80.
+
+- If it reaches 100 again, it is banned for another 12 hours.
+
+
+This simple mechanism prevents brute-force attacks from sources excluded from :ref:`SIP Antiflooding` mechanism.

--- a/doc/sphinx/security_and_maintenance/security/index.rst
+++ b/doc/sphinx/security_and_maintenance/security/index.rst
@@ -15,3 +15,4 @@ installations maintained by `Irontec <https://www.irontec.com>`_) security mecha
     authorized_ip_ranges
     concurrent_call_limit
     current_day_max_usage
+    antibruteforce

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -345,6 +345,8 @@ modparam("htable", "htable", "ipban=>size=8;autoexpire=300")
 # dialogs htable contains aleg, bleg and applicationserver per dialog
 modparam("htable", "htable", "dialogs=>size=10;autoexpire=0")
 modparam("htable", "htable", "dmq=>size=8;autoexpire=10800;dmqreplicate=1;")
+modparam("htable", "htable", "srcban=>size=8;autoexpire=43200")
+modparam("htable", "htable", "badauthcnt=>size=8")
 modparam("htable", "enable_dmq", 1)
 
 # SANITY
@@ -977,6 +979,12 @@ route[APPLY_TRANSFORMATION] {
 }
 
 route[REQINIT] {
+    # Banned sources
+    if ($sht(srcban=>$fU@$fd::$proto:$si:$sp) != $null) {
+        send_reply("403", "Forbidden [BS]");
+        exit;
+    }
+
     # Easy dropping for scanners
     if($ua =~ "friendly-scanner|sipcli|VaxSIPUserAgent|pplsip" || search("sipvicious")) {
         xwarn("REQINIT: Dropping scanner request ----> $rm from $si\n");
@@ -1492,7 +1500,18 @@ route[AUTH] {
     if (is_method("REGISTER") || from_uri==myself) {
         # authenticate requests
         if (!auth_check("$fd", "kam_users", "1")) {
-            xinfo("[$dlg_var(cidhash)] AUTH: Auth needed\n");
+            switch($rc) {
+                case -2:
+                    xinfo("[$dlg_var(cidhash)] AUTH: Auth needed ($fu from $proto:$si) - invalid_password\n");
+                    route(BAD_CREDENTIALS);
+                    break;
+                case -3:
+                    xinfo("[$dlg_var(cidhash)] AUTH: Auth needed ($fu from $proto:$si) - invalid_user\n");
+                    route(BAD_CREDENTIALS);
+                    break;
+                default:
+                    xinfo("[$dlg_var(cidhash)] AUTH: Auth needed ($fu from $proto:$si) - $rc\n");
+            }
             auth_challenge("$fd", "0");
             exit;
         }
@@ -1530,6 +1549,26 @@ route[AUTH] {
     }
 
     return;
+}
+
+route[BAD_CREDENTIALS] {
+    if ($sht(badauthcnt=>$fU@$fd::$proto:$si:$sp) == $null) {
+        # New failing source, add key to counter htable
+        xinfo("[$dlg_var(cidhash)] BAD-CREDENTIALS: $fU@$fd::$proto:$si:$sp => 1");
+        $sht(badauthcnt=>$fU@$fd::$proto:$si:$sp) = 1;
+        return;
+    }
+
+    # Existing failing source, increase counter
+    $var(currentVal) = $shtinc(badauthcnt=>$fU@$fd::$proto:$si:$sp);
+    xinfo("[$dlg_var(cidhash)] BAD-CREDENTIALS: $fU@$fd::$proto:$si:$sp => $var(currentVal)");
+
+    # Check if limit exceeded
+    if ($var(currentVal) >= 100) {
+        xwarn("[$dlg_var(cidhash)] BAD-CREDENTIALS: $fU@$fd::$proto:$si:$sp banned for 12 hours)");
+        $sht(srcban=>$fU@$fd::$proto:$si:$sp) = 1;
+        $sht(badauthcnt=>$fU@$fd::$proto:$si:$sp) = 80; # Start from 80 after ban expiration (faster re-ban)
+    }
 }
 
 # Handle within-dialog messages


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

This commit bans sources that fail in SIP auth for 100 times:

-  Ban expires after 12 hours and counter is reset to 80 (for faster re-ban after expiry).

- Source is defined as fromUsername@fromDomain::proto:source_ip:source_port combo.

#### Additional Information

This PR prevents brute-force-attacks from IP addresses excluded from antiflood mechanism.