### PR TITLE
kamusers: ban ipfilter addresses for 5 minutes

### DIFF
--- a/doc/sphinx/administration_portal/brand/views/ipfilter_blocked_addresses.rst
+++ b/doc/sphinx/administration_portal/brand/views/ipfilter_blocked_addresses.rst
@@ -4,5 +4,6 @@ IP filter blocked addresses
 
 Addresses listed here have been banned at least once by *IP filter* security mechanism.
 
-.. warning:: **IPs are blocked per request, not permanently**. See *Last time banned* to search for recently blocked
-             addresses and add them to :ref:`Authorized IP ranges` if they are legitimate sources.
+.. warning:: **IPs are only blocked during 5 minutes**. See *Last time banned* to search for recently blocked
+             addresses and add them to :ref:`Authorized IP ranges` if they are legitimate sources (its traffic will
+             be allowed immediately).

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -1386,6 +1386,7 @@ route[FILTER_BY_SRC_ADDR] {
     }
 
     xwarn("[$dlg_var(cidhash)] FILTER-BY-SRC-ADDR: $si is not valid for company '$dlg_var(companyId)'\n");
+    $sht(ipban=>$si) = 1; # Ban IP for 5 minutes
     route(IPFILTER_BLOCKED_IP);
 
     if (!is_method("INVITE") || $dlg_var(type) == "retail") {


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

Requests rejected by IP filter mechanism were not banned at all. This PR banned invalid IP address for 5 minutes instead of per request.

#### Additional information

If address is granted adding to any client or to trusted list, its will be allowed immediately.