### PR TITLE
microservices: forced realtime exit after shutdown

### DIFF
--- a/microservices/realtime/src/Services/AbstractWsServer.php
+++ b/microservices/realtime/src/Services/AbstractWsServer.php
@@ -96,6 +96,8 @@ abstract class AbstractWsServer
         $this
             ->server
             ->shutdown();
+
+        exit;
     }
 
     protected function bindWorkerEvents(


### PR DESCRIPTION
Redis listeners may continue to work after server shutdown in some circumstances

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
<!-- Describe your changes in detail -->

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
