### PR TITLE
realtime: reload service on redis down instead of restarting it

### DIFF
--- a/microservices/realtime/src/Services/AbstractWsServer.php
+++ b/microservices/realtime/src/Services/AbstractWsServer.php
@@ -100,6 +100,13 @@ abstract class AbstractWsServer
         exit;
     }
 
+    public function reload()
+    {
+        $this
+            ->server
+            ->reload();
+    }
+
     protected function bindWorkerEvents(
         Sentinel $sentinel,
         int $redisPoolSize,
@@ -201,7 +208,6 @@ abstract class AbstractWsServer
         $this->logger->error(
             'worker stop shutdown'
         );
-        $this->shutdown();
     }
 
     protected function onWorkerError(

--- a/microservices/realtime/src/Services/WsServer.php
+++ b/microservices/realtime/src/Services/WsServer.php
@@ -203,10 +203,7 @@ class WsServer extends AbstractWsServer
             $this->logger->error(
                 "Sentinel shutdown"
             );
-            $this->shutdown();
-            Coroutine::sleep(1);
-
-            exit;
+            $this->reload();
         });
     }
 


### PR DESCRIPTION
Do not shutdown on redis master down/switch


#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
<!-- Describe your changes in detail -->

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
