### PR TITLE
kam: fix jansson error that cause realtime empty fields

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -29,7 +29,7 @@
 # - options
 #!define WITH_REALTIME
 
-#!define DBURL "mysql://kamailio:ironsecret@data/ivozprovider"
+#!define DBURL "mysql://[kamailio]/ivozprovider"
 
 # Maximum call duration: 3 hours
 #!define MAX_DIALOG_TIMEOUT 10800
@@ -234,7 +234,7 @@ modparam("rtpengine", "rtp_inst_pvar", "$var(RTP_INSTANCE)")
 modparam("rtpengine", "setid_default", 0)
 
 # SQL OPS
-modparam("sqlops","sqlcon","cb=>mysql://kamailio:ironsecret@data/ivozprovider")
+modparam("sqlops","sqlcon","cb=>mysql://[kamailio]/ivozprovider")
 
 # ACC
 # -- transactions to syslog

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -55,7 +55,7 @@
 #!define WITH_ANTIFLOOD
 #!define WITH_REALTIME
 
-#!define DBURL "mysql://kamailio:ironsecret@data/ivozprovider"
+#!define DBURL "mysql://[kamailio]/ivozprovider"
 
 # Maximum call duration: 3 hours
 #!define MAX_DIALOG_TIMEOUT 10800
@@ -353,7 +353,7 @@ modparam("htable", "enable_dmq", 1)
 modparam("sanity", "autodrop", 0)
 
 # SQL OPS
-modparam("sqlops","sqlcon","cb=>mysql://kamailio:ironsecret@data/ivozprovider")
+modparam("sqlops","sqlcon","cb=>mysql://[kamailio]/ivozprovider")
 
 # DOMAIN
 modparam("domain", "db_url", DBURL)

--- a/profiles/proxy/etc/mysql/conf.d/kamailio.cnf
+++ b/profiles/proxy/etc/mysql/conf.d/kamailio.cnf
@@ -1,0 +1,5 @@
+[kamailio]
+host = data.ivozprovider.local
+user = kamailio
+password = ironsecret
+default-character-set = utf8


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

_sqlops_ module is (sometimes?) connecting MySQL using _latin1_swedish_ci_ to get Company names for realtime service, causing errors like these:

```jansson [jansson_funcs.c:160]: janssonmod_set(): value to add is not a string - "Company"```

and empty fields in realtime section.

#### Additional information

These PR forces new [kamailio] my.cnf group usage, that sets utf8 and seems to work.