### PR TITLE
Transfomations e164 regression

### DIFF
--- a/library/Ivoz/Provider/Domain/Service/TransformationRule/GenerateInRules.php
+++ b/library/Ivoz/Provider/Domain/Service/TransformationRule/GenerateInRules.php
@@ -74,17 +74,6 @@ class GenerateInRules
         $ruleDto
             ->setTransformationRuleSetId($entity->getId())
             ->setType($type)
-            ->setDescription("From national in e164 without plus to e164")
-            ->setPriority(4)
-            ->setMatchExpr("^34([0-9]+)$")
-            ->setReplaceExpr($countryCode . '\1');
-
-        $this->entityPersister->persistDto($ruleDto);
-
-        $ruleDto = new TransformationRuleDto();
-        $ruleDto
-            ->setTransformationRuleSetId($entity->getId())
-            ->setType($type)
             ->setDescription("From national to e164")
             ->setPriority(5)
             ->setMatchExpr("^([0-9]+)$")

--- a/schema/DoctrineMigrations/Version20200625094153.php
+++ b/schema/DoctrineMigrations/Version20200625094153.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20200625094153 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // Remove E.164 without plus -> E.164 with plus incoming transformation in all
+        // countries but Spain (for customer retro-compatibility)
+        $this->addSql("DELETE FROM TransformationRules
+                        WHERE description = 'From national in e164 without plus to e164'
+                          AND transformationRuleSetId <= 253
+                          AND transformationRuleSetId != 70");
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // This migration can not be undone
+
+    }
+}


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
This PR is a partial regression from #1197 removing the Transformation Rules created in default Country Transformation Rule Sets and the Rules generator.

These rules allow dialing numbers in E.164 without plus format in Country rule sets that can lead to undesired behaviors if there are National numbers that start with the Country Code. An example of this is any Italian mobile starting with 39 that is also the Italy Country Code.

Before: Dialing 397000111 was transformed to +397000111 assuming the initial 39 was Italy CC
After: Dialing 397000111 will be transformed to +39397000111 without E.164 without plus rule 

Thanks @nitefood for reporting and debugging this.

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
