### PR TITLE
Revert ban ip filter addresses

### DIFF
--- a/doc/sphinx/administration_portal/brand/views/ipfilter_blocked_addresses.rst
+++ b/doc/sphinx/administration_portal/brand/views/ipfilter_blocked_addresses.rst
@@ -4,6 +4,5 @@ IP filter blocked addresses
 
 Addresses listed here have been banned at least once by *IP filter* security mechanism.
 
-.. warning:: **IPs are only blocked during 5 minutes**. See *Last time banned* to search for recently blocked
-             addresses and add them to :ref:`Authorized IP ranges` if they are legitimate sources (its traffic will
-             be allowed immediately).
+.. warning:: **IPs are blocked per request, not permanently**. See *Last time banned* to search for recently blocked
+             addresses and add them to :ref:`Authorized IP ranges` if they are legitimate sources.

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -1394,7 +1394,6 @@ route[FILTER_BY_SRC_ADDR] {
     }
 
     xwarn("[$dlg_var(cidhash)] FILTER-BY-SRC-ADDR: $si is not valid for company '$dlg_var(companyId)'\n");
-    $sht(ipban=>$si) = 1; # Ban IP for 5 minutes
     route(IPFILTER_BLOCKED_IP);
 
     if (!is_method("INVITE") || $dlg_var(type) == "retail") {


### PR DESCRIPTION

#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [ ] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

Revert #1421 changes.

#### Additional information

Maintainers of a given platform can register a phone in a client to make some tests. If that client has IP filter enabled, mantainer's IP can be banned. This IP may be used by maintainer in its own client.