### PR TITLE
microservices: fix sync balances

### DIFF
--- a/library/DataFixtures/ORM/ProviderCarrier.php
+++ b/library/DataFixtures/ORM/ProviderCarrier.php
@@ -26,6 +26,7 @@ class ProviderCarrier extends Fixture implements DependentFixtureInterface
             $this->setDescription("CarrierDescription");
             $this->setName("CarrierName");
             $this->setExternallyRated(false);
+            $this->setCalculateCost(true);
             $this->setBrand($fixture->getReference('_reference_ProviderBrand1'));
             $this->setTransformationRuleSet($fixture->getReference('_reference_ProviderTransformationRuleSet70'));
             $this->setProxyTrunk($fixture->getReference('_reference_ProviderProxyTrunk1'));

--- a/library/Ivoz/Cgr/Infrastructure/Cgrates/Service/CarrierBalanceService.php
+++ b/library/Ivoz/Cgr/Infrastructure/Cgrates/Service/CarrierBalanceService.php
@@ -36,7 +36,14 @@ class CarrierBalanceService extends AbstractBalanceService implements CarrierBal
      */
     public function getBalances($brandId, array $carrierIds)
     {
-        return parent::getAccountsBalances($brandId, $carrierIds, self::ACCOUNT_PREFIX);
+        $payload = parent::getAccountsBalances($brandId, $carrierIds, self::ACCOUNT_PREFIX);
+        $balances = [];
+        foreach ($payload->result as $balance) {
+            $balances += $this->balanceReducer($balance);
+        }
+        $payload->result = $balances;
+
+        return $payload;
     }
 
     /**
@@ -48,16 +55,11 @@ class CarrierBalanceService extends AbstractBalanceService implements CarrierBal
         $carrierIds = [$carrierId];
         $payload = $this->getBalances($brandId, $carrierIds);
 
-        $balanceSum = [];
-        foreach ($payload->result as $balance) {
-            $balanceSum += $this->balanceReducer($balance);
-        }
-
-        if (!array_key_exists($carrierId, $balanceSum)) {
+        if (!array_key_exists($carrierId, $payload->result)) {
             throw new \Exception('Balance not found');
         }
 
-        return $balanceSum[$carrierId];
+        return $payload->result[$carrierId];
     }
 
     /**

--- a/library/Ivoz/Cgr/Infrastructure/Cgrates/Service/CompanyBalanceService.php
+++ b/library/Ivoz/Cgr/Infrastructure/Cgrates/Service/CompanyBalanceService.php
@@ -38,11 +38,11 @@ class CompanyBalanceService extends AbstractBalanceService implements CompanyBal
     {
         $payload = parent::getAccountsBalances($brandId, $companyIds, self::ACCOUNT_PREFIX);
 
-        $balanceSum = [];
+        $balances = [];
         foreach ($payload->result as $balance) {
-            $balanceSum += $this->balanceReducer($balance);
+            $balances += $this->balanceReducer($balance);
         }
-        $payload->result = $balanceSum;
+        $payload->result = $balances;
 
         return $payload;
     }
@@ -53,18 +53,13 @@ class CompanyBalanceService extends AbstractBalanceService implements CompanyBal
      */
     public function getBalance($brandId, $companyId)
     {
-        $payload = parent::getAccountsBalances($brandId, [$companyId], self::ACCOUNT_PREFIX);
+        $payload = $this->getBalances($brandId, [$companyId]);
 
-        $balanceSum = [];
-        foreach ($payload->result as $balance) {
-            $balanceSum += $this->balanceReducer($balance);
-        }
-
-        if (!array_key_exists($companyId, $balanceSum)) {
+        if (!array_key_exists($companyId, $payload->result)) {
             throw new \Exception('Balance not found');
         }
 
-        return $balanceSum[$companyId];
+        return $payload->result[$companyId];
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/Carrier/CarrierRepository.php
+++ b/library/Ivoz/Provider/Domain/Model/Carrier/CarrierRepository.php
@@ -13,7 +13,7 @@ interface CarrierRepository extends ObjectRepository, Selectable
     /**
      * @return array
      */
-    public function getCarrierIdsGroupByBrand();
+    public function getCarrierIdsWithCalculatecostGroupByBrand();
 
     public function getCarrierIdsByBrandAdmin(AdministratorInterface $admin): array;
     /**

--- a/library/Ivoz/Provider/Domain/Service/Carrier/SyncBalances.php
+++ b/library/Ivoz/Provider/Domain/Service/Carrier/SyncBalances.php
@@ -35,7 +35,7 @@ class SyncBalances
     {
         $this->logger->info('Companies balances are about to be synced');
 
-        $targetCarriers = $this->carrierRepository->getCarrierIdsGroupByBrand();
+        $targetCarriers = $this->carrierRepository->getCarrierIdsWithCalculatecostGroupByBrand();
         foreach ($targetCarriers as $brandId => $carriers) {
             $this->updateCarriers($brandId, $carriers);
         }

--- a/library/Ivoz/Provider/Domain/Service/Carrier/SyncBalances.php
+++ b/library/Ivoz/Provider/Domain/Service/Carrier/SyncBalances.php
@@ -75,6 +75,9 @@ class SyncBalances
     private function persistBalances(array $carriersBalance)
     {
         foreach ($carriersBalance as $carrierId => $balance) {
+            if (is_null($balance)) {
+                continue;
+            }
 
             /** @var CarrierInterface | null $carrier */
             $carrier = $this->carrierRepository->find($carrierId);

--- a/library/Ivoz/Provider/Domain/Service/Company/SyncBalances.php
+++ b/library/Ivoz/Provider/Domain/Service/Company/SyncBalances.php
@@ -107,6 +107,9 @@ class SyncBalances
     private function persistBalances(array $companiesBalance)
     {
         foreach ($companiesBalance as $companyId => $balance) {
+            if (is_null($balance)) {
+                continue;
+            }
 
             /** @var CompanyInterface | null $company */
             $company = $this->companyRepository->find($companyId);

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/CarrierDoctrineRepository.php
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/CarrierDoctrineRepository.php
@@ -27,10 +27,10 @@ class CarrierDoctrineRepository extends ServiceEntityRepository implements Carri
     /**
      * @return array
      */
-    public function getCarrierIdsGroupByBrand()
+    public function getCarrierIdsWithCalculatecostGroupByBrand()
     {
         /** @var CarrierInterface[] $carriers */
-        $carriers = $this->findAll();
+        $carriers = $this->findBy(['calculateCost' => 1]);
         $response = [];
 
         foreach ($carriers as $carrier) {

--- a/library/spec/Ivoz/Provider/Domain/Service/Carrier/SyncBalancesSpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Service/Carrier/SyncBalancesSpec.php
@@ -71,7 +71,7 @@ class SyncBalancesSpec extends ObjectBehavior
         $this->updateCarriers(1, [1]);
     }
 
-    function it_iterates_over_all_carriers()
+    function it_iterates_over_carriers_with_calculateCost()
     {
         $carrierId = 1;
         $this->prepareExecution(

--- a/library/spec/Ivoz/Provider/Domain/Service/Carrier/SyncBalancesSpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Service/Carrier/SyncBalancesSpec.php
@@ -80,7 +80,7 @@ class SyncBalancesSpec extends ObjectBehavior
 
         $this
             ->carrierRepository
-            ->getCarrierIdsGroupByBrand()
+            ->getCarrierIdsWithCalculatecostGroupByBrand()
             ->willReturn([
                 1 => [$carrierId]
             ])

--- a/schema/tests/Provider/Carrier/CarrierRepositoryTest.php
+++ b/schema/tests/Provider/Carrier/CarrierRepositoryTest.php
@@ -22,13 +22,13 @@ class CarrierRepositoryTest extends KernelTestCase
      */
     public function test_runner()
     {
-        $this->it_finds_carrier_ids_group_by_brand();
+        $this->it_finds_carrier_ids_with_calculatecost_group_by_brand();
         $this->it_finds_ids_by_brand_admin();
         $this->it_finds_ids_by_brand_and_proxyTrunk();
         $this->it_finds_ids_by_proxyTrunk();
     }
 
-    public function it_finds_carrier_ids_group_by_brand()
+    public function it_finds_carrier_ids_with_calculatecost_group_by_brand()
     {
         /** @var CarrierDoctrineRepository $repository */
         $repository = $this

--- a/schema/tests/Provider/Carrier/CarrierRepositoryTest.php
+++ b/schema/tests/Provider/Carrier/CarrierRepositoryTest.php
@@ -35,7 +35,7 @@ class CarrierRepositoryTest extends KernelTestCase
             ->em
             ->getRepository(Carrier::class);
 
-        $result = $repository->getCarrierIdsGroupByBrand();
+        $result = $repository->getCarrierIdsWithCalculatecostGroupByBrand();
 
         $this->assertNotEmpty($result);
     }

--- a/web/admin/application/library/IvozProvider/Klear/Ghost/Carriers.php
+++ b/web/admin/application/library/IvozProvider/Klear/Ghost/Carriers.php
@@ -89,6 +89,13 @@ class IvozProvider_Klear_Ghost_Carriers extends KlearMatrix_Model_Field_Ghost_Ab
                 $carrierDto->getId()
             );
 
+            // If numeric amount, round to 2 decimals value
+            if (is_numeric($balance)) {
+                $amount = sprintf("%0.2f", floatval($balance));
+            } else {
+                $amount = 0;
+            }
+
             $currencySymbol = $dataGateway->remoteProcedureCall(
                 Carrier::class,
                 $carrierDto->getId(),
@@ -98,7 +105,7 @@ class IvozProvider_Klear_Ghost_Carriers extends KlearMatrix_Model_Field_Ghost_Ab
 
             return sprintf(
                 "%s %s",
-                $balance,
+                $amount,
                 $currencySymbol
             );
         } catch (Exception $exception) {

--- a/web/admin/application/library/IvozProvider/Klear/Ghost/Companies.php
+++ b/web/admin/application/library/IvozProvider/Klear/Ghost/Companies.php
@@ -54,10 +54,17 @@ class IvozProvider_Klear_Ghost_Companies extends KlearMatrix_Model_Field_Ghost_A
             /** @var DataGateway $dataGateway */
             $dataGateway = \Zend_Registry::get('data_gateway');
 
-            $amount = $this->fetchCompanyBalance->getBalance(
+            $balance = $this->fetchCompanyBalance->getBalance(
                 $companyDto->getBrandId(),
                 $companyDto->getId()
             );
+
+            // If numeric amount, round to 2 decimals value
+            if (is_numeric($balance)) {
+                $amount = sprintf("%0.2f", floatval($balance));
+            } else {
+                $amount = 0;
+            }
 
             $currencySymbol = $dataGateway->remoteProcedureCall(
                 Company::class,

--- a/web/rest/brand/features/provider/carrier/getCarrier.feature
+++ b/web/rest/brand/features/provider/carrier/getCarrier.feature
@@ -42,7 +42,7 @@ Feature: Retrieve carriers
           "description": "CarrierDescription",
           "name": "CarrierName",
           "externallyRated": false,
-          "calculateCost": false,
+          "calculateCost": true,
           "id": 1,
           "transformationRuleSet": {
               "description": "Generic transformation for Spain",


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

- sync balances microservice was not saving correct balance values in Carriers.balance

- sync balances microservice was logging error messages for carriers with calculateCost disabled

- sync balances microservice was saving 0 balances when CGRateS returned null (or empty) balancemaps.

#### Additional information

- As a side effect, balance ghosts have been adapted to show 0 for empty balancemaps.