### PR TITLE
core: corrected bodyType parsing in CSV scheduler emails

### DIFF
--- a/library/Ivoz/Provider/Domain/Service/CallCsvReport/EmailSender.php
+++ b/library/Ivoz/Provider/Domain/Service/CallCsvReport/EmailSender.php
@@ -81,6 +81,7 @@ class EmailSender implements CallCsvReportLifecycleEventHandlerInterface
 
         $fromName = $notificationTemplateContent->getFromName();
         $fromAddress = $notificationTemplateContent->getFromAddress();
+        $bodyType = $notificationTemplateContent->getBodyType();
         $body = $this->parseVariables(
             $callCsvReport,
             $notificationTemplateContent->getBody()
@@ -96,7 +97,7 @@ class EmailSender implements CallCsvReportLifecycleEventHandlerInterface
         );
 
         $mail = new Message();
-        $mail->setBody($body)
+        $mail->setBody($body, $bodyType)
             ->setSubject($subject)
             ->setFromAddress($fromAddress)
             ->setFromName($fromName)


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
Fixes a regression introduced by commit [9542131711a99b45f315d0bbd1687849d8afdd27](https://github.com/irontec/ivozprovider/commit/9542131711a99b45f315d0bbd1687849d8afdd27) that caused the Body Type to be ignored for Call CSV scheduled reports. HTML emails would go out with a 'text/plain' header that caused email clients to render it as plaintext instead of HTML (tested with Thunderbird v68.10.0).
Thanks @Kaian for the excellent support!

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
