### PR TITLE
pkg: fix storage permissions on fresh install

### DIFF
--- a/debian/ivozprovider-profile-common.postinst
+++ b/debian/ivozprovider-profile-common.postinst
@@ -11,4 +11,7 @@ if [ -z "$2" ]; then
     echo >> /root/.bashrc
 fi
 
+# Change storage perms
+chmod 777 /opt/irontec/ivozprovider/storage
+
 :


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [X] Fixes an existing issue (Fixes #1451) <!-- Replace XXXX with issue id -->

#### Description
This is a regression from 2bf572708ab27dac3bb682ef3859f743330e9807 where storage permissions was changed to 777 after every upgrade. This causes some problems if the storage is distributed (DBRD, GlusterFS, and so on) and there are lots of files.

This PR revert the change only changing the root storage directory, so web interface can create required folders to upload images or logos.

#### Additional information

I still see some permissions problem in other cases. For example FaxFiles can be created from asterisk on incoming faxes and from the web interface for outgoing faxes. If the folders in storage are created during incoming faxes, outgoing ones that share storage path will fail to upload.

