### PR TITLE
microservices: fixed duplicated resource import

### DIFF
--- a/microservices/balances/config/services.yml
+++ b/microservices/balances/config/services.yml
@@ -2,7 +2,6 @@
 # http://symfony.com/doc/current/service_container.html
 imports:
   - { resource: "@CoreBundle/Resources/config/services.yml" }
-  - { resource: "@CoreBundle/Resources/config/logger.yml" }
 
 services:
   _defaults:


### PR DESCRIPTION
It's already imported in cofig file through "@ProviderBundle/Resources/config/config.yml"

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
