### PR TITLE
kamusers: drop kam_users view

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -164,7 +164,6 @@ loadmodule    "dmq.so"
 loadmodule    "htable.so"
 loadmodule    "sdpops.so"
 loadmodule    "auth.so"
-loadmodule    "auth_db.so"
 loadmodule    "domain.so"
 loadmodule    "xmlops.so"
 loadmodule    "regex.so"
@@ -323,14 +322,6 @@ modparam("tm", "contact_flows_avp", "tm_contact_flows")
 modparam("tm", "local_cancel_reason", 200)
 modparam("tm", "auto_inv_100_reason", "Trying")
 
-# AUTH_DB
-modparam("auth_db", "db_url", DBURL)
-modparam("auth_db", "calculate_ha1", 1)
-modparam("auth_db", "user_column", "name")
-modparam("auth_db", "password_column", "password")
-modparam("auth_db", "domain_column", "domain")
-modparam("auth_db", "use_domain", 1)
-
 #!ifdef WITH_ANTIFLOOD
 # PIKE
 modparam("pike", "sampling_time_unit", 2)
@@ -347,6 +338,7 @@ modparam("htable", "htable", "dialogs=>size=10;autoexpire=0")
 modparam("htable", "htable", "dmq=>size=8;autoexpire=10800;dmqreplicate=1;")
 modparam("htable", "htable", "srcban=>size=8;autoexpire=43200")
 modparam("htable", "htable", "badauthcnt=>size=8")
+modparam("htable", "htable", "aors=>size=10")
 modparam("htable", "enable_dmq", 1)
 
 # SANITY
@@ -482,8 +474,20 @@ request_route {
     # Remove preloaded route headers
     remove_hf("Route");
 
+    # Handle PUA generated PUBLISH
+    route(LOCAL_PUBLISH);
+
+    # Checks prior to authentication
+    route(PREAUTH);
+
+    # Get request endpoint
+    route(GET_ENDPOINT);
+
     # Manage authentication
     route(AUTH);
+
+    # Get request endpoint
+    route(GET_INFO_FROM_ENDPOINT);
 
     # Filter by source address for outbound non-INVITE requests
     if (!is_method("INVITE")) route(FILTER_BY_SRC_ADDR);
@@ -511,15 +515,15 @@ request_route {
     # Add record-route to INVITE requests
     record_route();
 
+    route(GET_CALL_INFO);
+
     # Route by source
     if ($var(is_from_inside)) {
         route(REPLACES);
         route(PARSE_X_HEADERS);
-        route(GET_INFO_FROM_CALLEE);
         route(MAXCALLS_USER);
         route(LOOKUP);
     } else {
-        route(GET_INFO_FROM_CALLER);
         route(FILTER_BY_SRC_ADDR);
         route(ADAPT_RURI_IN);
         route(ADAPT_DIVERSION);
@@ -1014,23 +1018,16 @@ route[REQINIT] {
 }
 
 route[GENERATE_PUBLISH] {
-    if ($avp(wholesaleId) != $null) return;
-
-    sql_xquery("cb", "SELECT C.type FROM Companies C JOIN Domains D ON D.id=C.domainId WHERE D.domain='$fd'", "ra");
-    if ($xavp(ra=>type) != 'vpbx') return; # Skip logic for non vpbx clients
+    if ($avp(endpointType) != 'Terminals') return; # Skip logic for non terminal calls
 
     if ($var(is_from_inside)) {
         # Set X-Info-Callee as 'callee' instead of user in To header
         $avp(pubruri_callee)= "sip:" + $hdr(X-Info-Callee) + "@" + $fd;
     } else {
-        sql_xquery("cb", "SELECT extension FROM kam_users WHERE name='$fU' AND domain='$fd'", "rp");
-        if ($xavp(rp=>extension) == $null) return; # No PUBLISH for calls from non-terminals
-
-        # Terminal calling
         # Set user extension as 'caller' instead of user in From header
-        $avp(pubruri_caller)= "sip:" + $xavp(rp=>extension) + "@" + $fd;
+        $avp(pubruri_caller)= "sip:" + $avp(extension) + "@" + $fd;
 
-        $dlg_var(caller) = $xavp(rp=>extension); # Set accounting dlg_var too
+        $dlg_var(caller) = $avp(extension); # Set accounting dlg_var too
     }
 }
 
@@ -1204,19 +1201,12 @@ route[APPLY_RETAIL_CFW] {
 route[STATIC_LOCATION] {
     $var(static_location) = 0;
 
-    sql_xquery("cb", "SELECT type FROM kam_users WHERE name='$rU' AND domain='$rd'", "ra");
-    if ($xavp(ra=>type) == 'friend') {
-        $var(table) = 'Friends';
-    } else if ($xavp(ra=>type) == 'retail') {
-        $var(table) = 'RetailAccounts';
-    } else if ($xavp(ra=>type) == 'residential') {
-        $var(table) = 'ResidentialDevices';
-    } else {
+    if ($avp(endpointType) == 'Terminals') {
         $var(ddi_in) = 'no'; # Terminals need AoR in R-URI
         return;
     }
 
-    sql_xquery("cb", "SELECT name, domain, directConnectivity, ip, port, transport, ddiIn FROM $var(table) t LEFT JOIN Domains D ON t.domainId=D.id WHERE t.name='$rU' AND D.domain='$rd'", "rb");
+    sql_xquery("cb", "SELECT name, domain, directConnectivity, ip, port, transport, ddiIn FROM $avp(endpointType) t LEFT JOIN Domains D ON t.domainId=D.id WHERE t.id='$avp(endpointId)'", "rb");
     $var(ddi_in) = $xavp(rb=>ddiIn);
 
     if ($xavp(rb=>directConnectivity) == 'no') return;
@@ -1226,6 +1216,7 @@ route[STATIC_LOCATION] {
     if ($xavp(rb=>directConnectivity) == 'intervpbx') {
         xinfo("[$dlg_var(cidhash)] STATIC-LOCATION: Inter-vPBX call\n");
         $rd = $fd;
+        $du = "sip:users.ivozprovider.local";
         uac_replace_from("sip:" + $xavp(rb=>name) + "@" + $fd);
         $avp(skip_mediarelay) = "1";
         return;
@@ -1241,15 +1232,15 @@ route[STATIC_LOCATION] {
         $ru = $ru + ';transport=' + $xavp(rb=>transport);
     }
 
-    xinfo("[$dlg_var(cidhash)] STATIC-LOCATION: Call for static $xavp(ra=>type), route to '$ru'\n");
+    xinfo("[$dlg_var(cidhash)] STATIC-LOCATION: Call for static endpoint, route to '$ru'\n");
 
     setbflag(FLB_NATB); # Assume behind NAT (port-forwarding direct connectivity)
 
     return;
 }
 
-route[GET_INFO_FROM_COMPANY] {
-    sql_xquery("cb", "SELECT C.mediaRelaySetsId, CONCAT(C.transformationRuleSetId,0) AS caller_in, CONCAT(C.transformationRuleSetId,1) AS callee_in, CONCAT(C.transformationRuleSetId,2) AS caller_out, CONCAT(C.transformationRuleSetId,3) AS callee_out FROM Companies C JOIN Brands B ON B.id=C.brandId WHERE C.id='$dlg_var(companyId)'", "ra");
+route[GET_CALL_INFO] {
+    sql_xquery("cb", "SELECT C.mediaRelaySetsId, C.distributeMethod, AppS.ip AS asAddress, C.onDemandRecord, CONCAT(C.transformationRuleSetId,0) AS caller_in, CONCAT(C.transformationRuleSetId,1) AS callee_in, CONCAT(C.transformationRuleSetId,2) AS caller_out, CONCAT(C.transformationRuleSetId,3) AS callee_out FROM Companies C LEFT JOIN ApplicationServers AppS ON AppS.id=C.applicationServerId WHERE C.id='$dlg_var(companyId)'", "ra");
 
     $dlg_var(mediaRelaySetsId) = $xavp(ra=>mediaRelaySetsId);
 
@@ -1257,43 +1248,49 @@ route[GET_INFO_FROM_COMPANY] {
     $dlg_var(tr_callee_in) = $xavp(ra=>callee_in);
     $dlg_var(tr_caller_out) = $xavp(ra=>caller_out);
     $dlg_var(tr_callee_out) = $xavp(ra=>callee_out);
-}
 
-route[GET_INFO_FROM_CALLEE] {
-    # Get needed information from To header
-    sql_xquery("cb", "SELECT KU.type AS calleeType, KU.objectId, KU.maxCalls, KU.caller_in, KU.callee_in, KU.caller_out, KU.callee_out, C.mediaRelaySetsId, C.onDemandRecord FROM kam_users KU LEFT JOIN Companies C ON C.id=KU.companyId LEFT JOIN ApplicationServers AppS ON AppS.id=C.applicationServerId WHERE KU.name='$rU' AND KU.domain='$rd'", "ra");
-
-    if ($xavp(ra=>calleeType) == 'terminal') {
-        $dlg_var(userId) = $xavp(ra=>objectId); # user
-    } else if($xavp(ra=>calleeType) == 'friend') {
-        $dlg_var(friendId) = $xavp(ra=>objectId); # friend
-    } else if($xavp(ra=>calleeType) == 'retail') {
-        $dlg_var(retailAccountId) = $xavp(ra=>objectId); # retail
-    } else {
-        $dlg_var(residentialDeviceId) = $xavp(ra=>objectId); # residential
-    }
-
-    # Transformations
-    $dlg_var(tr_caller_in) = $xavp(ra=>caller_in);
-    $dlg_var(tr_callee_in) = $xavp(ra=>callee_in);
-    $dlg_var(tr_caller_out) = $xavp(ra=>caller_out);
-    $dlg_var(tr_callee_out) = $xavp(ra=>callee_out);
+    if ($dlg_var(type) == 'wholesale') return;
 
     if ($xavp(ra=>onDemandRecord) != '0') {
         $dlg_var(onDemandRecord) = '1';
     }
 
-    # Remaining info
-    $dlg_var(maxcallsUser) = $xavp(ra=>maxCalls);
-    $dlg_var(mediaRelaySetsId) = $xavp(ra=>mediaRelaySetsId);
-
-    # Get retail call-forward settings
-    if ($dlg_var(type) == 'retail') {
-        route(GET_RETAIL_CFW_SETTINGS);
+    if ($avp(endpointType) == "Terminals") {
+        $dlg_var(userId) = $avp(objectId); # user
+    } else if($avp(endpointType) == "Friends") {
+        $dlg_var(friendId) = $avp(objectId); # friend
+    } else if($avp(endpointType) == "RetailAccounts") {
+        $dlg_var(retailAccountId) = $avp(objectId); # retail
+    } else {
+        $dlg_var(residentialDeviceId) = $avp(objectId); # residential
     }
 
-    # Set AoR for maxcallsUser counting
-    $avp(AoR) = $tU + '@' + $td;
+    if ($avp(endpointTransformationRuleSetId) != $null) {
+        $dlg_var(endpointTransformationRuleSetId) = $avp(endpointTransformationRuleSetId);
+        $dlg_var(tr_caller_in) = $dlg_var(endpointTransformationRuleSetId) + "0";
+        $dlg_var(tr_callee_in) = $dlg_var(endpointTransformationRuleSetId) + "1";
+        $dlg_var(tr_caller_out) = $dlg_var(endpointTransformationRuleSetId) + "2";
+        $dlg_var(tr_callee_out) = $dlg_var(endpointTransformationRuleSetId) + "3";
+    }
+
+    if ($var(is_from_inside)) {
+        # Remaining info
+        $dlg_var(maxcallsUser) = $avp(maxCalls);
+
+        # Get retail call-forward settings
+        if ($dlg_var(type) == 'retail') {
+            route(GET_RETAIL_CFW_SETTINGS);
+        }
+
+        # Set AoR for maxcallsUser counting
+        $avp(AoR) = $tU + '@' + $td;
+    } else {
+        $avp(distributeMethod) = $xavp(ra=>distributeMethod);
+        $avp(asAddress) = $xavp(ra=>asAddress);
+
+        # Set AoR for maxcallsUser counting
+        $avp(AoR) = $fU + '@' + $fd;
+    }
 }
 
 route[GET_RETAIL_CFW_SETTINGS] {
@@ -1312,56 +1309,15 @@ route[GET_RETAIL_CFW_SETTINGS] {
     t_on_failure("MANAGE_FAILURE_RETAIL");
 }
 
-route[GET_INFO_FROM_CALLER] {
-    if ($dlg_var(type) == 'wholesale') {
-        route(GET_INFO_FROM_COMPANY);
-    } else {
-        route(GET_INFO_FROM_FROM);
-    }
-}
-
-route[GET_INFO_FROM_FROM] {
-    # Get needed information from terminal name
-    sql_xquery("cb", "SELECT KU.type AS callerType, KU.objectId, KU.caller_in, KU.callee_in, KU.caller_out, KU.callee_out, C.mediaRelaySetsId, C.distributeMethod, AppS.ip AS asAddress, C.onDemandRecord, KU.t38Passthrough FROM kam_users KU LEFT JOIN Companies C ON C.id=KU.companyId JOIN Brands B ON C.brandId=B.id LEFT JOIN ApplicationServers AppS ON AppS.id=C.applicationServerId WHERE KU.name='$fU' AND KU.domain='$fd'", "ra");
-
-    if ($xavp(ra=>callerType) == 'terminal') {
-        $dlg_var(userId) = $xavp(ra=>objectId); # user
-    } else if($xavp(ra=>callerType) == 'friend') {
-        $dlg_var(friendId) = $xavp(ra=>objectId); # friend
-    } else if($xavp(ra=>callerType) == 'retail') {
-        $dlg_var(retailAccountId) = $xavp(ra=>objectId); # retail
-    } else {
-        $dlg_var(residentialDeviceId) = $xavp(ra=>objectId); # residential
-    }
-
-    $dlg_var(tr_caller_in) = $xavp(ra=>caller_in);
-    $dlg_var(tr_callee_in) = $xavp(ra=>callee_in);
-    $dlg_var(tr_caller_out) = $xavp(ra=>caller_out);
-    $dlg_var(tr_callee_out) = $xavp(ra=>callee_out);
-
-    $avp(distributeMethod) = $xavp(ra=>distributeMethod);
-    $avp(asAddress) = $xavp(ra=>asAddress);
-    $dlg_var(mediaRelaySetsId) = $xavp(ra=>mediaRelaySetsId);
-    $avp(t38Passthrough) = $xavp(ra=>t38Passthrough);
-
-    if ($xavp(ra=>onDemandRecord) != '0') {
-        $dlg_var(onDemandRecord) = '1';
-    }
-
-    # Set AoR for maxcallsUser counting
-    $avp(AoR) = $fU + '@' + $fd;
-}
-
 route[FILTER_BY_SRC_ADDR] {
-    if (src_ip == myself) return; # For bounced calls (e.g. inter-vpbx calls) and pua PUBLISH
-    if ($var(is_from_inside)) return;
+    if ($var(is_from_inside) || src_ip == myself) return;
     if ($dlg_var(type) == 'wholesale') return;
 
     # Get needed info
     $xavp(rt) = $null;
-    sql_xquery("cb", "SELECT C.brandId, C.id AS companyId, C.ipFilter, KU.externalIpCalls FROM kam_users KU JOIN Companies C ON C.id=KU.companyId WHERE KU.name='$fU' AND KU.domain='$fd'", "rt");
+    sql_xquery("cb", "SELECT C.brandId, C.ipFilter FROM Companies C JOIN Brands B ON B.id=C.brandId WHERE C.id='$avp(companyId)'", "rt");
     $dlg_var(brandId) = $xavp(rt=>brandId);
-    $dlg_var(companyId) = $xavp(rt=>companyId);
+    $dlg_var(companyId) = $avp(companyId);
 
     if (!$xavp(rt=>ipFilter)) {
         xinfo("[$dlg_var(cidhash)] FILTER-BY-SRC-ADDR: IP filter is disabled for company '$dlg_var(companyId)'\n");
@@ -1376,7 +1332,7 @@ route[FILTER_BY_SRC_ADDR] {
     }
 
     # Roadwarrior logic
-    if ($xavp(rt=>externalIpCalls) > 0) {
+    if ($avp(externalIpCalls) > 0) {
         if (!is_method("INVITE")) {
             xinfo("[$dlg_var(cidhash)] FILTER-BY-SRC-ADDR: non-invite request from roadwarrior '$fU@$fd', allow and proceed\n");
             return;
@@ -1384,9 +1340,9 @@ route[FILTER_BY_SRC_ADDR] {
 
         # Roadwarrior INVITE request
         get_profile_size("outgoingCallsPerAor", "$fU@$fd", "$var(currentOutgoingCalls)");
-        xinfo("[$dlg_var(cidhash)] FILTER-BY-SRC-ADDR: '$fU@$fd' has $var(currentOutgoingCalls) out of $xavp(rt=>externalIpCalls) outgoing calls\n");
+        xinfo("[$dlg_var(cidhash)] FILTER-BY-SRC-ADDR: '$fU@$fd' has $var(currentOutgoingCalls) out of $avp(externalIpCalls) outgoing calls\n");
 
-        if ($var(currentOutgoingCalls) < $xavp(rt=>externalIpCalls)) {
+        if ($var(currentOutgoingCalls) < $avp(externalIpCalls)) {
             xinfo("[$dlg_var(cidhash)] FILTER-BY-SRC-ADDR: Allow roadwarrior call\n");
             set_dlg_profile("outgoingCallsPerAor", "$fU@$fd");
             return;
@@ -1500,6 +1456,39 @@ route[IS_INTERNAL] {
     return;
 }
 
+# Authentication prechecks
+route[PREAUTH] {
+    if (src_ip == myself || $var(is_from_inside)) return;
+    if ($avp(wholesaleId) != $null) return; # Wholesale clients don't use domains
+
+    # External subscriber (non-wholesale) calling
+
+    if (from_uri != myself) {
+        xerr("[$dlg_var(cidhash)] AUTH: $fd is not my domain, 403 forbidden\n");
+        send_reply("403","Forbidden");
+        exit;
+    }
+
+    if (uri != myself) {
+        xerr("[$dlg_var(cidhash)] AUTH: $rd is not my domain, 404 Not here\n");
+        send_reply("404", "Invalid domain in R-URI");
+        exit;
+    }
+
+    # Domain strict checking
+    if (!is_uri_host_local()) {
+        xwarn("[$dlg_var(cidhash)] AUTH: $rd is my IP but domains should be used, reject\n");
+        send_reply("488", "Domain needed");
+        exit;
+    }
+
+    if (!is_from_local()) {
+        xwarn("[$dlg_var(cidhash)] AUTH: $fd is my IP but domains should be used, reject\n");
+        send_reply("488", "Domain needed");
+        exit;
+    }
+}
+
 # Authentication route
 route[AUTH] {
     if (src_ip == myself || $var(is_from_inside)) return;
@@ -1507,7 +1496,7 @@ route[AUTH] {
 
     if (is_method("REGISTER") || from_uri==myself) {
         # authenticate requests
-        if (!auth_check("$fd", "kam_users", "1")) {
+        if(!pv_auth_check("$fd", "$avp(password)", "0", "1")) {
             switch($rc) {
                 case -2:
                     xinfo("[$dlg_var(cidhash)] AUTH: Auth needed ($fu from $proto:$si) - invalid_password\n");
@@ -1529,34 +1518,115 @@ route[AUTH] {
         consume_credentials();
     }
 
-    # If caller is not local subscriber, reject (both AS and subscribers use my domain in from-domain)
-    if (from_uri!=myself) {
-        xerr("[$dlg_var(cidhash)] $fd is not my domain, 403 forbidden\n");
-        send_reply("403","Forbidden");
-        exit;
-    }
-
-    # Check R-URI is for my domain
-    if (uri!=myself) {
-        xerr("[$dlg_var(cidhash)] R-URI not for my domain, 404 Not here\n");
-        send_reply("404", "Invalid domain in R-URI");
-        exit;
-    }
-
-    # Domain strict checking
-    if ( uri == myself && !is_uri_host_local() ) {
-        xwarn("[$dlg_var(cidhash)] $rd is my IP but domains should be used, reject\n");
-        send_reply("488", "Domain needed");
-        exit;
-    }
-
-    if ( from_uri == myself && !is_from_local() ) {
-        xwarn("[$dlg_var(cidhash)] $fd is my IP but domains should be used, reject\n");
-        send_reply("488", "Domain needed");
-        exit;
-    }
-
     return;
+}
+
+route[GET_INFO_FROM_ENDPOINT] {
+    if ($avp(wholesaleId) != $null) return; # No endpoint for wholesale clients
+
+    $xavp(endpoint) = $null;
+
+    if ($avp(endpointType) == "Terminals") {
+        sql_xquery("cb", "SELECT U.id, E.number AS extension, U.externalIpCalls, U.maxCalls, T.companyId, U.transformationRuleSetId, T.t38Passthrough FROM Users U JOIN Terminals T ON U.terminalId=T.id JOIN Extensions E ON U.extensionId=E.id WHERE T.id='$avp(endpointId)'", "endpoint");
+        if ($xavp(endpoint=>extension) == $null) {
+            send_reply("404", "Not Here [TUE]");
+            exit;
+        }
+
+        $avp(extension) = $xavp(endpoint=>extension); # used in FILTER_BY_SRC_ADDR
+        $avp(externalIpCalls) = $xavp(endpoint=>externalIpCalls); # used in FILTER_BY_SRC_ADDR
+        $avp(maxCalls) = $xavp(endpoint=>maxCalls); # used in GET_CALL_INFO
+    } else if ($avp(endpointType) == "ResidentialDevices") {
+        sql_xquery("cb", "SELECT id, companyId, transformationRuleSetId, t38Passthrough, maxCalls FROM ResidentialDevices WHERE id='$avp(endpointId)'", "endpoint");
+        $avp(maxCalls) = $xavp(endpoint=>maxCalls); # used in GET_CALL_INFO
+    } else {
+        sql_xquery("cb", "SELECT id, companyId, transformationRuleSetId, t38Passthrough FROM $avp(endpointType) WHERE id='$avp(endpointId)'", "endpoint");
+        $avp(maxCalls) = 0; # used in GET_CALL_INFO
+    }
+
+    $avp(companyId) = $xavp(endpoint=>companyId); # used in CLASSIFY and FILTER_BY_SRC_ADDR
+    $avp(objectId) = $xavp(endpoint=>id); # used in GET_CALL_INFO
+    $avp(endpointTransformationRuleSetId) = $xavp(endpoint=>transformationRuleSetId); # used in GET_CALL_INFO
+    $avp(t38Passthrough) = $xavp(endpoint=>t38Passthrough); # used in DISPATCH_TO_TRUNKS
+}
+
+# Sets $avp(endpointType), $avp(endpointId) and $avp(password)
+route[GET_ENDPOINT] {
+    if ($avp(wholesaleId) != $null) return; # No endpoint for wholesale clients
+
+    $var(found) = 0;
+
+    if ($var(is_from_inside)) {
+        $var(username) = $tU;
+        $var(domain) = $td;
+    } else {
+        $var(username) = $fU;
+        $var(domain) = $fd;
+    }
+
+    $var(aor) = $var(username) + '@' + $var(domain);
+
+    while (!$var(found)) {
+        # cached?
+        if ($sht(aors=>$var(aor)) != $null) {
+            $xavp(endpoint) = $null;
+            sql_xquery("cb", "SELECT T.id, T.password FROM $sht(aors=>$var(aor)) T JOIN Domains D ON D.id=T.domainId WHERE T.name='$var(username)' AND D.domain='$var(domain)'", "endpoint");
+            if ($xavp(endpoint=>id) != $null) {
+                $var(found) = 1;
+                break;
+            }
+            $sht(aors=>$var(aor)) = $null;
+        }
+
+        # terminal
+        $xavp(endpoint) = $null;
+        sql_xquery("cb", "SELECT T.id, T.password FROM Terminals T JOIN Domains D ON D.id=T.domainId WHERE T.name='$var(username)' AND D.domain='$var(domain)'", "endpoint");
+        if ($xavp(endpoint=>id) != $null) {
+            $sht(aors=>$var(aor)) = "Terminals";
+            $var(found) = 1;
+            break;
+        }
+
+        # retail
+        $xavp(endpoint) = $null;
+        sql_xquery("cb", "SELECT T.id, T.password FROM RetailAccounts T JOIN Domains D ON D.id=T.domainId WHERE T.name='$var(username)' AND D.domain='$var(domain)'", "endpoint");
+        if ($xavp(endpoint=>id) != $null) {
+            $sht(aors=>$var(aor)) = "RetailAccounts";
+            $var(found) = 1;
+            break;
+        }
+
+        # friend
+        $xavp(endpoint) = $null;
+        sql_xquery("cb", "SELECT T.id, T.password FROM Friends T JOIN Domains D ON D.id=T.domainId WHERE T.name='$var(username)' AND D.domain='$var(domain)'", "endpoint");
+        if ($xavp(endpoint=>id) != $null) {
+            $sht(aors=>$var(aor)) = "Friends";
+            $var(found) = 1;
+            break;
+        }
+
+        # residential
+        $xavp(endpoint) = $null;
+        sql_xquery("cb", "SELECT T.id, T.password FROM ResidentialDevices T JOIN Domains D ON D.id=T.domainId WHERE T.name='$var(username)' AND D.domain='$var(domain)'", "endpoint");
+        if ($xavp(endpoint=>id) != $null) {
+            $sht(aors=>$var(aor)) = "ResidentialDevices";
+            $var(found) = 1;
+            break;
+        }
+
+        break;
+    }
+
+    if (!$var(found)) {
+        send_reply("404", "Not Here [GE]");
+        exit;
+    }
+
+    $avp(endpointType) = $sht(aors=>$var(aor));
+    $avp(endpointId) = $xavp(endpoint=>id);
+    $avp(password) = $xavp(endpoint=>password);
+
+    xinfo("[$dlg_var(cidhash)] GET-ENDPOINT: $avp(endpointType)#$avp(endpointId)");
 }
 
 route[BAD_CREDENTIALS] {
@@ -1959,18 +2029,13 @@ route[CLASSIFY] {
         $dlg_var(type) = $var(header-value);
     } else {
         if ($avp(wholesaleId) != $null) {
-            $dlg_var(type) = 'wholesale';
-            $dlg_var(companyId) = $avp(wholesaleId);
-            sql_xquery("cb", "SELECT brandId FROM Companies WHERE id='$dlg_var(companyId)'", "ra");
-            $dlg_var(brandId) = $xavp(ra=>brandId);
-        } else {
-            # Get needed information from From header
-            sql_xquery("cb", "SELECT C.brandId, C.id AS companyId, C.type FROM kam_users KU JOIN Companies C ON C.id=KU.companyId WHERE KU.name='$fU' AND KU.domain='$fd'", "ra");
-
-            $dlg_var(brandId) = $xavp(ra=>brandId);
-            $dlg_var(companyId) = $xavp(ra=>companyId);
-            $dlg_var(type) = $xavp(ra=>type);
+            $avp(companyId) = $avp(wholesaleId);
         }
+
+        sql_xquery("cb", "SELECT brandId, type FROM Companies WHERE id='$avp(companyId)'", "ra");
+        $dlg_var(brandId) = $xavp(ra=>brandId);
+        $dlg_var(companyId) = $avp(companyId);
+        $dlg_var(type) = $xavp(ra=>type);
     }
 
     # Generate CDR only for vpbx calls
@@ -2404,6 +2469,21 @@ route[RTPENGINE] {
 
     xinfo("[$dlg_var(cidhash)] RTPENGINE: rtpengine_manage [$var(common_opts) $var(symmetry) $var(wsopts) $var(interfaces)]\n");
     rtpengine_manage("$var(common_opts) $var(symmetry) $var(wsopts) $var(interfaces)");
+}
+
+route[LOCAL_PUBLISH] {
+    if(!is_method("PUBLISH") || src_ip != myself) return;
+
+    if (!t_newtran()) {
+        sl_reply_error();
+        exit;
+    }
+
+    if(is_method("PUBLISH")) {
+        handle_publish();
+        t_release();
+    }
+    exit;
 }
 
 route[PRESENCE] {

--- a/schema/DoctrineMigrations/Version20200710151403.php
+++ b/schema/DoctrineMigrations/Version20200710151403.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20200710151403 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP VIEW `kam_users`');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE VIEW `kam_users` AS
+                            SELECT E.type, E.name, D.domain, E.password, E.companyId, E.id AS objectId, E.extension,
+                                E.externalIpCalls, E.maxCalls, CONCAT(T.id,0) AS caller_in, CONCAT(T.id,1) AS callee_in,
+                                CONCAT(T.id,2) AS caller_out, CONCAT(T.id,3) AS callee_out, E.t38Passthrough
+                            FROM (
+                                SELECT "terminal" as type, T.name, T.domainId, T.password, T.companyId,
+                                    U.transformationRuleSetId, U.id, E.number AS extension, U.externalIpCalls, U.maxCalls, T.t38Passthrough
+                                    FROM Terminals T
+                                        INNER JOIN Users U ON U.terminalId = T.id
+                                        INNER JOIN Extensions E ON E.id=U.extensionId
+                                UNION
+                                    SELECT "friend" AS type, name, domainId, password, companyId, transformationRuleSetId,
+                                    id, NULL AS extension, NULL AS externalIpCalls, 0 AS maxCalls, t38Passthrough
+                                        FROM Friends
+                                UNION
+                                    SELECT "residential" AS type, name, domainId, password, companyId, transformationRuleSetId,
+                                    id, NULL AS extension, NULL AS externalIpCalls, RD.maxCalls, RD.t38Passthrough
+                                        FROM ResidentialDevices RD
+                                UNION
+                                    SELECT "retail" AS type, name, domainId, password, companyId, transformationRuleSetId,
+                                    id, NULL AS extension, NULL AS externalIpCalls, 0 AS maxCalls, RA.t38Passthrough
+                                        FROM RetailAccounts RA
+                            ) AS E
+                            INNER JOIN Companies C ON C.id = E.companyId
+                            INNER JOIN TransformationRuleSets T ON T.id = COALESCE(E.transformationRuleSetId, C.transformationRuleSetId)
+                            INNER JOIN Domains D ON D.id = E.domainId');
+    }
+}


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
_kam_users_ view is not a good option in high rates escenarios.

This PR removes this view and changes KamUsers config file to obtain information from regular tables.

#### Additional information

No functional change.