### PR TITLE
friends: new always transform numbers option

### DIFF
--- a/doc/sphinx/administration_portal/client/vpbx/routing_endpoints/friends/internal_friends.rst
+++ b/doc/sphinx/administration_portal/client/vpbx/routing_endpoints/friends/internal_friends.rst
@@ -44,6 +44,10 @@ These are the configurable settings of *internal friends*:
     Fallback Outgoing DDI
         If called extension causes an external call, this DDI will be used as source number.
 
+    Always apply transformations
+        Numbers listed in Extensions section of both source and destination client will be considered as internal and
+        won't traverse numeric transformation rules. Enable this setting to force Numeric Transformation rules even on these numbers. 
+
 .. note:: Calls to *friends* are considered internal. That means that ACLs won't
           be checked when calling a friend, no matter if the origin of the call
           is a user or another friend.

--- a/doc/sphinx/administration_portal/client/vpbx/routing_endpoints/friends/remote_friends.rst
+++ b/doc/sphinx/administration_portal/client/vpbx/routing_endpoints/friends/remote_friends.rst
@@ -95,6 +95,10 @@ These are the configurable settings of *friends*:
         If set to 'yes', this SIP endpoint must be a **T.38 capable fax sender/receiver**. IvozProvider
         will act as a T.38 gateway, bridging fax-calls of a T.38 capable carrier and a T.38 capable device.
 
+    Always apply transformations
+        Both numbers listed in Extensions section and numbers matching any friend regexp will be considered as internal and
+        won't traverse numeric transformation rules.  Enable this setting to force Numeric Transformation rules even on these numbers. 
+
 .. note:: Calls to *friends* are considered internal. That means that ACLs won't
           be checked when calling a friend, no matter if the origin of the call
           is a user or another friend.
@@ -163,4 +167,3 @@ extension-user-terminal trio:
 
 - Only connects with *Users SIP Proxy*, like terminals. In fact, SIP traffic from
   friends are identical to any other user terminal traffic in format.
-

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -1393,6 +1393,10 @@ route[PARSE_MANDATORY_X_HEADER] {
 route[IS_INTERNAL] {
     $avp(is_internal) = '0';
     if ($dlg_var(type) != "vpbx") return; # No internal concept for non-vpbx calls
+    if ($avp(alwaysApplyTransformations) || $dlg_var(alwaysApplyTransformations)) {
+        $dlg_var(alwaysApplyTransformations) = "1";
+        return;
+    }
 
     # Is a service?
     if ($(var(number){s.substr,0,1}) == '*' && !$var(is_from_inside)) {
@@ -1559,8 +1563,12 @@ route[GET_INFO_FROM_ENDPOINT] {
     } else if ($avp(endpointType) == "ResidentialDevices") {
         sql_xquery("cb", "SELECT id, companyId, transformationRuleSetId, t38Passthrough, maxCalls FROM ResidentialDevices WHERE id='$avp(endpointId)'", "endpoint");
         $avp(maxCalls) = $xavp(endpoint=>maxCalls); # used in GET_CALL_INFO
+    } else if ($avp(endpointType) == "Friends") {
+        sql_xquery("cb", "SELECT id, companyId, transformationRuleSetId, t38Passthrough, alwaysApplyTransformations FROM Friends WHERE id='$avp(endpointId)'", "endpoint");
+        $avp(maxCalls) = 0; # used in GET_CALL_INFO
+        $avp(alwaysApplyTransformations) = $xavp(endpoint=>alwaysApplyTransformations); # used in IS_INTERNAL
     } else {
-        sql_xquery("cb", "SELECT id, companyId, transformationRuleSetId, t38Passthrough FROM $avp(endpointType) WHERE id='$avp(endpointId)'", "endpoint");
+        sql_xquery("cb", "SELECT id, companyId, transformationRuleSetId, t38Passthrough FROM RetailAccounts WHERE id='$avp(endpointId)'", "endpoint");
         $avp(maxCalls) = 0; # used in GET_CALL_INFO
     }
 

--- a/library/Ivoz/Provider/Domain/Model/Friend/FriendAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Friend/FriendAbstract.php
@@ -105,6 +105,11 @@ abstract class FriendAbstract
     protected $t38Passthrough = 'no';
 
     /**
+     * @var boolean
+     */
+    protected $alwaysApplyTransformations = false;
+
+    /**
      * @var \Ivoz\Provider\Domain\Model\Company\CompanyInterface
      */
     protected $company;
@@ -156,7 +161,8 @@ abstract class FriendAbstract
         $updateCallerid,
         $directConnectivity,
         $ddiIn,
-        $t38Passthrough
+        $t38Passthrough,
+        $alwaysApplyTransformations
     ) {
         $this->setName($name);
         $this->setDescription($description);
@@ -169,6 +175,7 @@ abstract class FriendAbstract
         $this->setDirectConnectivity($directConnectivity);
         $this->setDdiIn($ddiIn);
         $this->setT38Passthrough($t38Passthrough);
+        $this->setAlwaysApplyTransformations($alwaysApplyTransformations);
     }
 
     abstract public function getId();
@@ -250,7 +257,8 @@ abstract class FriendAbstract
             $dto->getUpdateCallerid(),
             $dto->getDirectConnectivity(),
             $dto->getDdiIn(),
-            $dto->getT38Passthrough()
+            $dto->getT38Passthrough(),
+            $dto->getAlwaysApplyTransformations()
         );
 
         $self
@@ -301,6 +309,7 @@ abstract class FriendAbstract
             ->setDirectConnectivity($dto->getDirectConnectivity())
             ->setDdiIn($dto->getDdiIn())
             ->setT38Passthrough($dto->getT38Passthrough())
+            ->setAlwaysApplyTransformations($dto->getAlwaysApplyTransformations())
             ->setCompany($fkTransformer->transform($dto->getCompany()))
             ->setDomain($fkTransformer->transform($dto->getDomain()))
             ->setTransformationRuleSet($fkTransformer->transform($dto->getTransformationRuleSet()))
@@ -338,6 +347,7 @@ abstract class FriendAbstract
             ->setDirectConnectivity(self::getDirectConnectivity())
             ->setDdiIn(self::getDdiIn())
             ->setT38Passthrough(self::getT38Passthrough())
+            ->setAlwaysApplyTransformations(self::getAlwaysApplyTransformations())
             ->setCompany(\Ivoz\Provider\Domain\Model\Company\Company::entityToDto(self::getCompany(), $depth))
             ->setDomain(\Ivoz\Provider\Domain\Model\Domain\Domain::entityToDto(self::getDomain(), $depth))
             ->setTransformationRuleSet(\Ivoz\Provider\Domain\Model\TransformationRuleSet\TransformationRuleSet::entityToDto(self::getTransformationRuleSet(), $depth))
@@ -369,6 +379,7 @@ abstract class FriendAbstract
             'directConnectivity' => self::getDirectConnectivity(),
             'ddiIn' => self::getDdiIn(),
             't38Passthrough' => self::getT38Passthrough(),
+            'alwaysApplyTransformations' => self::getAlwaysApplyTransformations(),
             'companyId' => self::getCompany()->getId(),
             'domainId' => self::getDomain() ? self::getDomain()->getId() : null,
             'transformationRuleSetId' => self::getTransformationRuleSet() ? self::getTransformationRuleSet()->getId() : null,
@@ -842,6 +853,34 @@ abstract class FriendAbstract
     public function getT38Passthrough(): string
     {
         return $this->t38Passthrough;
+    }
+
+    /**
+     * Set alwaysApplyTransformations
+     *
+     * @param boolean $alwaysApplyTransformations
+     *
+     * @return static
+     */
+    protected function setAlwaysApplyTransformations($alwaysApplyTransformations)
+    {
+        Assertion::notNull($alwaysApplyTransformations, 'alwaysApplyTransformations value "%s" is null, but non null value was expected.');
+        Assertion::between(intval($alwaysApplyTransformations), 0, 1, 'alwaysApplyTransformations provided "%s" is not a valid boolean value.');
+        $alwaysApplyTransformations = (bool) $alwaysApplyTransformations;
+
+        $this->alwaysApplyTransformations = $alwaysApplyTransformations;
+
+        return $this;
+    }
+
+    /**
+     * Get alwaysApplyTransformations
+     *
+     * @return boolean
+     */
+    public function getAlwaysApplyTransformations(): bool
+    {
+        return $this->alwaysApplyTransformations;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/Friend/FriendDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Friend/FriendDtoAbstract.php
@@ -91,6 +91,11 @@ abstract class FriendDtoAbstract implements DataTransferObjectInterface
     private $t38Passthrough = 'no';
 
     /**
+     * @var boolean
+     */
+    private $alwaysApplyTransformations = false;
+
+    /**
      * @var integer
      */
     private $id;
@@ -174,6 +179,7 @@ abstract class FriendDtoAbstract implements DataTransferObjectInterface
             'directConnectivity' => 'directConnectivity',
             'ddiIn' => 'ddiIn',
             't38Passthrough' => 't38Passthrough',
+            'alwaysApplyTransformations' => 'alwaysApplyTransformations',
             'id' => 'id',
             'companyId' => 'company',
             'domainId' => 'domain',
@@ -207,6 +213,7 @@ abstract class FriendDtoAbstract implements DataTransferObjectInterface
             'directConnectivity' => $this->getDirectConnectivity(),
             'ddiIn' => $this->getDdiIn(),
             't38Passthrough' => $this->getT38Passthrough(),
+            'alwaysApplyTransformations' => $this->getAlwaysApplyTransformations(),
             'id' => $this->getId(),
             'company' => $this->getCompany(),
             'domain' => $this->getDomain(),
@@ -551,6 +558,26 @@ abstract class FriendDtoAbstract implements DataTransferObjectInterface
     public function getT38Passthrough()
     {
         return $this->t38Passthrough;
+    }
+
+    /**
+     * @param boolean $alwaysApplyTransformations
+     *
+     * @return static
+     */
+    public function setAlwaysApplyTransformations($alwaysApplyTransformations = null)
+    {
+        $this->alwaysApplyTransformations = $alwaysApplyTransformations;
+
+        return $this;
+    }
+
+    /**
+     * @return boolean | null
+     */
+    public function getAlwaysApplyTransformations()
+    {
+        return $this->alwaysApplyTransformations;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/Friend/FriendInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/Friend/FriendInterface.php
@@ -236,6 +236,13 @@ interface FriendInterface extends LoggableEntityInterface
     public function getT38Passthrough(): string;
 
     /**
+     * Get alwaysApplyTransformations
+     *
+     * @return boolean
+     */
+    public function getAlwaysApplyTransformations(): bool;
+
+    /**
      * Set company
      *
      * @param \Ivoz\Provider\Domain\Model\Company\CompanyInterface $company

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/Friend.FriendAbstract.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/Friend.FriendAbstract.orm.yml
@@ -137,6 +137,12 @@ Ivoz\Provider\Domain\Model\Friend\FriendAbstract:
         comment: '[enum:yes|no]'
         default: 'no'
       column: t38Passthrough
+    alwaysApplyTransformations:
+      type: boolean
+      nullable: false
+      options:
+        default: '0'
+      column: alwaysApplyTransformations
   manyToOne:
     company:
       targetEntity: \Ivoz\Provider\Domain\Model\Company\CompanyInterface

--- a/schema/DoctrineMigrations/Version20200716075035.php
+++ b/schema/DoctrineMigrations/Version20200716075035.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Application\Migrations;
+
+use Ivoz\Core\Infrastructure\Persistence\Doctrine\LoggableMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20200716075035 extends LoggableMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE Friends ADD alwaysApplyTransformations TINYINT(1) DEFAULT \'0\' NOT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE Friends DROP alwaysApplyTransformations');
+    }
+}

--- a/web/admin/application/configs/klear/FriendsList.yaml
+++ b/web/admin/application/configs/klear/FriendsList.yaml
@@ -45,6 +45,7 @@ production:
           t38Passthrough: true
           outgoingDdi: true
           interCompany: true
+          alwaysApplyTransformations: true
         order:
           name: true
           domain: true
@@ -118,6 +119,7 @@ production:
           ddiIn: true
           status: true
           t38Passthrough: true
+          alwaysApplyTransformations: true
       fixedPositions: &friends_FixedPositionsLink
         group0:
           label: _("Basic Configuration")
@@ -130,10 +132,10 @@ production:
             name: 6
             password: 6
             interCompany: 10
-            __empty1: 2
             transport: 4
             ip: 5
             port: 3
+            alwaysApplyTransformations: 8
         group1:
           label: _("Geographic Configuration")
           colsPerRow: 12

--- a/web/admin/application/configs/klear/model/Friends.yaml
+++ b/web/admin/application/configs/klear/model/Friends.yaml
@@ -344,6 +344,23 @@ production:
         values:
           'yes': _('Yes')
           'no': _('No')
+    alwaysApplyTransformations:
+      title: _('Always apply transformations')
+      type: select
+      defaultValue: 0
+      source:
+        data: inline
+        values:
+          '0':
+            title: _("No")
+          '1':
+            title: _("Yes")
+      info:
+        type: box
+        position: left
+        icon: help
+        text: _("Enable to force numeric transformation on numbers in Extensions or numbers matching any Friend regexp. Otherwise, those numbers won't traverse numeric transformations rules.")
+        label: _("Need help?")
 staging:
   _extends: production
 testing:

--- a/web/admin/application/languages/ca_ES/ca_ES.po
+++ b/web/admin/application/languages/ca_ES/ca_ES.po
@@ -171,6 +171,9 @@ msgstr "Còdecs de vídeo permesos"
 msgid "Always"
 msgstr "Sempre"
 
+msgid "Always apply transformations"
+msgstr "Aplicar siempre transformaciones numéricas"
+
 msgid "Amount"
 msgstr "Quantitat"
 
@@ -914,6 +917,14 @@ msgid ""
 msgstr ""
 "Activa aquesta opció per mostrar el botó d’eliminació a la secció "
 "d’enregistrament de trucades al portal del client."
+
+msgid ""
+"Enable to force numeric transformation on numbers in Extensions or numbers "
+"matching any Friend regexp. Otherwise, those numbers won't traverse numeric "
+"transformations rules."
+msgstr ""
+"Habilitar para forzar las tranformaciones numéricas para los números "
+"considerados internos."
 
 msgid "Enabled"
 msgstr "Habilitat"

--- a/web/admin/application/languages/en_US/en_US.po
+++ b/web/admin/application/languages/en_US/en_US.po
@@ -166,6 +166,9 @@ msgstr "Allowed video codecs"
 msgid "Always"
 msgstr "Always"
 
+msgid "Always apply transformations"
+msgstr "Always apply transformations"
+
 msgid "Amount"
 msgstr "Amount"
 
@@ -903,6 +906,15 @@ msgid ""
 msgstr ""
 "Enable this option to display delete button in Client's portal call "
 "recordings section."
+
+msgid ""
+"Enable to force numeric transformation on numbers in Extensions or numbers "
+"matching any Friend regexp. Otherwise, those numbers won't traverse numeric "
+"transformations rules."
+msgstr ""
+"Enable to force numeric transformation on numbers in Extensions or numbers "
+"matching any Friend regexp. Otherwise, those numbers won't traverse numeric "
+"transformations rules."
 
 msgid "Enabled"
 msgstr "Enabled"

--- a/web/admin/application/languages/es_ES/es_ES.po
+++ b/web/admin/application/languages/es_ES/es_ES.po
@@ -170,6 +170,9 @@ msgstr "Codecs video permitidos"
 msgid "Always"
 msgstr "Siempre"
 
+msgid "Always apply transformations"
+msgstr "Aplicar siempre transformaciones numéricas"
+
 msgid "Amount"
 msgstr "Cantidad"
 
@@ -917,6 +920,14 @@ msgstr ""
 "Habilite esta opción para mostrar el botón eliminar en la sección "
 "Grabaciones de llamadas del portal de clienteGrabaciones de llamadas del "
 "portal del cliente"
+
+msgid ""
+"Enable to force numeric transformation on numbers in Extensions or numbers "
+"matching any Friend regexp. Otherwise, those numbers won't traverse numeric "
+"transformations rules."
+msgstr ""
+"Habilitar para forzar las tranformaciones numéricas para los números "
+"considerados internos."
 
 msgid "Enabled"
 msgstr "Activado"

--- a/web/admin/application/languages/it_IT/it_IT.po
+++ b/web/admin/application/languages/it_IT/it_IT.po
@@ -172,6 +172,9 @@ msgstr "Codec video consentiti"
 msgid "Always"
 msgstr "Always"
 
+msgid "Always apply transformations"
+msgstr "Always apply transformations"
+
 msgid "Amount"
 msgstr "Paese"
 
@@ -917,6 +920,15 @@ msgid ""
 msgstr ""
 "Abilitare questa opzione per visualizzare il pulsante Elimina nella sezione "
 "registrazioni chiamate del portale del cliente."
+
+msgid ""
+"Enable to force numeric transformation on numbers in Extensions or numbers "
+"matching any Friend regexp. Otherwise, those numbers won't traverse numeric "
+"transformations rules."
+msgstr ""
+"Enable to force numeric transformation on numbers in Extensions or numbers "
+"matching any Friend regexp. Otherwise, those numbers won't traverse numeric "
+"transformations rules."
 
 msgid "Enabled"
 msgstr "Abilitato"


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

When sending requests to a friend or receiving requests from a friend caller and callee headers are inspected looking for numbers that must be transformed using Friend's numeric transformation.

Until now, internal numbers were not transformed:

- Numbers in Extension section.

- Numbers matching Friend's regexps.


This PR makes this configurable, so that you can modify numbers even if they seem internal.

#### Additional information

This PR enables adding prefixes to local extensions or dialing 801 but calling to SOMEPREFIX801 that were not possible because internal numbers didn't traverse numeric transformation logic.