### PR TITLE
agis: ensure CFW services are only used by Residential clients

### DIFF
--- a/asterisk/agi/src/Agi/Action/ServiceAction.php
+++ b/asterisk/agi/src/Agi/Action/ServiceAction.php
@@ -11,6 +11,7 @@ use Ivoz\Core\Infrastructure\Persistence\Doctrine\Model\Helper\CriteriaHelper;
 use Ivoz\Provider\Domain\Model\BrandService\BrandServiceInterface;
 use Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSetting;
 use Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSettingInterface;
+use Ivoz\Provider\Domain\Model\Company\CompanyInterface;
 use Ivoz\Provider\Domain\Model\CompanyService\CompanyServiceInterface;
 use Ivoz\Provider\Domain\Model\Locution\Locution;
 use Ivoz\Provider\Domain\Model\Locution\LocutionDto;
@@ -425,6 +426,12 @@ class ServiceAction
         $caller = $this->channelInfo->getChannelCaller();
         $company = $caller->getCompany();
         $companyCountry = $company->getCountry();
+
+        // This Service is only available for Residential Clients
+        if ($company->getType() !== CompanyInterface::TYPE_RESIDENTIAL) {
+            $this->agi->error("Call Forward Service used by non-residential %s", $company);
+            return;
+        }
 
         /**
          * Extract Destination from dialed number


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
Call Forward Settings services assume the caller is a ResidentialAgent and uses its ID as ResidentialDeviceId in order to check, delete or add new Call Forward Settings.

If for some reason a User calls these services, the UserId will be used as ResidentialDeviceId, causing unexpected behaviors.

This PR adds a check to ensure the Agent's company is a ResidentialClient (so Agent can only be a ResidentialDevice).

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
