### PR TITLE
core: allow new call CSV scheduler filters

### DIFF
--- a/doc/sphinx/administration_portal/brand/calls/call_csv_schedulers.rst
+++ b/doc/sphinx/administration_portal/brand/calls/call_csv_schedulers.rst
@@ -35,25 +35,29 @@ When adding a new definition, these fields are shown:
         Only for *Direction: outbound* reports, allows filtering calls of one specific carrier.
 
     Client
-        Only for *Client type* different from *All*, allows selecting one specific client.
+        Only for *Client type* different from *All*, allows selecting one specific client of chosen type.
 
     DDI
-        Only for *Client type* different from *All*, allows selecting one specific DDI of chosen client.
+        Lists all DDIs of chosen client to get only calls from/to that specific DDI.
+
+    Endpoint type
+        Allows selecting one specific endpoint type of chosen client. Depending on client type, different values will
+        be listed.
 
     Residential device
-        Only for *Client type: residential*, allows selecting one specific residential device of chosen client.
+        Only for *Client type: residential* and *Endpoint type: residential device*, allows selecting one specific residential device of chosen client.
 
     Retail account
         Only for *Client type: retail*, allows selecting one specific retail account of chosen client.
 
     User
-        Only for *Client type: vpbx*, allows selecting one specific user of chosen client.
+        Only for *Client type: vpbx* and *Endpoint type: user*, allows selecting one specific user of chosen client.
 
     Fax
-        Only for *Client type: vpbx*, allows selecting one specific fax of chosen client.
+        Only for *Client type: vpbx/residential* and *Endpoint type: fax*, allows selecting one specific fax of chosen client.
 
     Friend
-        Only for *Client type: vpbx*, allows selecting one specific friend of chosen client.
+        Only for *Client type: vpbx* and *Endpoint type: friend*, allows selecting one specific friend of chosen client.
 
 
 Once created, some new fields and subsections are accesible:
@@ -148,3 +152,53 @@ The DDI Provider that allowed that match is saved as DDI Provider for that inbou
 
 - Matched DDI is linked to another DDI Provider that also matches source IP address. If this happens, linked DDI Provider
   is saved instead.
+
+
+Using CSV scheduler as a one-shot CSV generator
+===============================================
+
+*External Calls* section can filter list and export resulting rows to CSV, but filter criteria are much powerful in
+*Call CSV schedulers* section.
+
+That's why **it could be useful to use this section even if we are not interested in scheduling any recurring CSV**.
+
+.. note:: Scheduling a CSV to generate just a CSV could be useful as *Call CSV Schedulers* have more filtering criteria
+         than *External Calls* section.
+
+Imagine you need:
+
+- Start date: 2020/06/02 (included)
+
+- End date: 2020/06/14 (included)
+
+- Client: XXX (vpbx)
+
+- Inbound calls to YYY DDI answered by user ZZZ
+
+To achieve such a CSV using schedules section we would **create a scheduler** with these inputs:
+
+- Client Type: vpbx
+
+- Client: XXX
+
+- DDI: YYY
+
+- Endpoint Type: user
+
+- User: ZZZ
+
+- Direction: inbound.
+
+- Unit: days.
+
+- Frequency: 13
+
+.. tip:: Get sure you set *Unit* to days and *Frequency* to the amount of days wanted in resulting CSV. In the example,
+         from 2nd of June to 14th, both included, we have 13 days.
+
+Once generated, we would **edit Next execution time** from tomorrow's date to 2020/06/15, leaving time unchanged.
+
+.. tip:: Get sure you modify *Next execution* to the first day not wanted in resulting CSV.
+
+Then we will **wait a few minutes** until scheduler generates our CSV, **download** it and **delete the row to avoid recurrent
+CSV generation**.

--- a/doc/sphinx/administration_portal/client/residential/calls/call_csv_schedulers.rst
+++ b/doc/sphinx/administration_portal/client/residential/calls/call_csv_schedulers.rst
@@ -26,8 +26,14 @@ When adding a new definition, these fields are shown:
     DDI
         Allows selecting client's one specific DDI.
 
+    Endpoint type
+        Allows selecting one specific endpoint type between: residential device and fax.
+
     Residential device
-        Allows selecting client's one specific residential device.
+        Only for *Endpoint type: residential*, allows selecting one specific residential device.
+
+    Fax
+        Only for *Endpoint type: fax*, allows selecting one specific fax.
 
 
 Once created, some new fields and subsections are accesible:
@@ -80,7 +86,7 @@ These are the fields of the generated CSV files:
         Client DDI to which call will be assigned (callee for inbound calls, caller for outbound calls).
 
     endpointType
-        Fixed value: ResidentialDevice
+        Possible values: ResidentialDevice, Fax.
 
     endpointId
         Internal ID of specific residential device

--- a/doc/sphinx/administration_portal/client/vpbx/calls/call_csv_schedulers.rst
+++ b/doc/sphinx/administration_portal/client/vpbx/calls/call_csv_schedulers.rst
@@ -26,14 +26,17 @@ When adding a new definition, these fields are shown:
     DDI
         Allows selecting a client's specific DDI.
 
+    Endpoint type
+        Allows selecting one specific endpoint type between: user, friend and fax.
+
     User
-        Allows selecting a client's specific user.
+        Only for *Endpoint type: user*, allows selecting one specific user.
 
     Fax
-        Allows selecting a client's specific fax.
+        Only for *Endpoint type: fax*, allows selecting one specific fax.
 
     Friend
-        Allows selecting a client's specific friend.
+        Only for *Endpoint type: friend*, allows selecting one specific friend.
 
 
 Once created, some new fields and subsections are accesible:
@@ -86,7 +89,7 @@ These are the fields of the generated CSV files:
         Client DDI to which call will be assigned (callee for inbound calls, caller for outbound calls).
 
     endpointType
-        Possible values: User, Fax, Friend. **Empty for inbound calls**.
+        Possible values: User, Fax, Friend.
 
     endpointId
         Internal ID of specific endpoint (only when *endpointType* has a non-empty value).

--- a/library/Ivoz/Provider/Domain/Model/CallCsvScheduler/CallCsvScheduler.php
+++ b/library/Ivoz/Provider/Domain/Model/CallCsvScheduler/CallCsvScheduler.php
@@ -98,15 +98,6 @@ class CallCsvScheduler extends CallCsvSchedulerAbstract implements SchedulerInte
 
         $isNotOutbound = $this->getCallDirection() !== self::CALLDIRECTION_OUTBOUND;
         if ($isNotOutbound) {
-            if ($this->getUser()) {
-                throw new \DomainException('Filter by user is only possible for outbound calls');
-            }
-            if ($this->getFriend()) {
-                throw new \DomainException('Filter by friend is only possible for outbound calls');
-            }
-            if ($this->getFax()) {
-                throw new \DomainException('Filter by fax is only possible for outbound calls');
-            }
             if ($this->getCarrier()) {
                 throw new \DomainException('Filter by carrier is only possible for outbound calls');
             }

--- a/library/Ivoz/Provider/Domain/Model/CallCsvScheduler/CallCsvScheduler.php
+++ b/library/Ivoz/Provider/Domain/Model/CallCsvScheduler/CallCsvScheduler.php
@@ -123,9 +123,9 @@ class CallCsvScheduler extends CallCsvSchedulerAbstract implements SchedulerInte
      */
     public function getTimezone()
     {
-        $timeZone = $this->getBrand()
-            ? $this->getBrand()->getDefaultTimezone()
-            : $this->getCompany()->getDefaultTimezone();
+        $timeZone = $this->getCompany()
+            ? $this->getCompany()->getDefaultTimezone()
+            : $this->getBrand()->getDefaultTimezone();
 
         return $timeZone;
     }

--- a/library/Ivoz/Provider/Domain/Model/CallCsvScheduler/CallCsvScheduler.php
+++ b/library/Ivoz/Provider/Domain/Model/CallCsvScheduler/CallCsvScheduler.php
@@ -153,7 +153,7 @@ class CallCsvScheduler extends CallCsvSchedulerAbstract implements SchedulerInte
             case 'week':
                 return new \DateInterval("P${frecuency}W");
             case 'day':
-                return \DateInterval::createFromDateString('1 day');
+                return new \DateInterval("P${frecuency}D");
         }
     }
 

--- a/library/Ivoz/Provider/Domain/Model/CallCsvScheduler/CallCsvSchedulerDto.php
+++ b/library/Ivoz/Provider/Domain/Model/CallCsvScheduler/CallCsvSchedulerDto.php
@@ -226,8 +226,8 @@ class CallCsvSchedulerDto extends CallCsvSchedulerDtoAbstract
      */
     public function getResidentialEndpointType()
     {
-        if ($this->getUserId()) {
-            return 'user';
+        if ($this->getResidentialDeviceId()) {
+            return 'residentialDevice';
         }
 
         if ($this->getFaxId()) {

--- a/library/Ivoz/Provider/Domain/Service/InvoiceScheduler/NextExecutionResolverTrait.php
+++ b/library/Ivoz/Provider/Domain/Service/InvoiceScheduler/NextExecutionResolverTrait.php
@@ -20,7 +20,6 @@ trait NextExecutionResolverTrait
      */
     protected function setFallbackNextExecution(SchedulerInterface $scheduler, TimezoneInterface $timeZone)
     {
-        $frecuency = $scheduler->getFrequency() -1;
         $unit = $scheduler->getUnit();
 
         $dateTimeZone = new \DateTimeZone($timeZone->getTz());
@@ -29,7 +28,6 @@ trait NextExecutionResolverTrait
             null,
             $dateTimeZone
         );
-        $nextExecution->modify("+${frecuency} ${unit}s");
 
         switch ($unit) {
             case 'year':

--- a/library/spec/Ivoz/Provider/Domain/Service/InvoiceScheduler/NextExecutionResolverSpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Service/InvoiceScheduler/NextExecutionResolverSpec.php
@@ -53,7 +53,6 @@ class NextExecutionResolverSpec extends ObjectBehavior
             [
                 'getBrand' => $brand,
                 'getNextExecution' => null,
-                'getFrequency' => 1,
                 'getUnit' => 'month'
             ]
         );

--- a/web/admin/application/configs/klear/CallCsvSchedulersBrandList.yaml
+++ b/web/admin/application/configs/klear/CallCsvSchedulersBrandList.yaml
@@ -41,6 +41,9 @@ production:
           user: false
           fax: false
           friend: false
+          retail: false
+          residential: false
+          vpbx: false
       fixedPositions: &callCsvSchedulersNew_fixedPositions
         group0:
           label: _("Basic Information")
@@ -101,6 +104,10 @@ production:
           user: false
           fax: false
           friend: false
+          retail: false
+          residential: false
+          vpbx: false
+          companyType: false
       fixedPositions:
         <<: *callCsvSchedulersNew_fixedPositions
   dialogs:

--- a/web/admin/application/configs/klear/CallCsvSchedulersList.yaml
+++ b/web/admin/application/configs/klear/CallCsvSchedulersList.yaml
@@ -88,11 +88,14 @@ production:
           carrier: true
           ddiProvider: true
           companyType: true
+          retail: true
+          residential: true
+          vpbx: true
           ddi: ${auth.companyWholesale}
           endpointType: ${auth.companyNotVPBX}
           residentialEndpointType: ${auth.companyNotResidential}
           user: ${auth.companyNotVPBX}
-          fax: ${auth.companyNotVPBX}
+          fax: ${auth.companyFeatures.faxes.disabled}
           friend: ${auth.companyNotVPBX}
         order:
           name: 1
@@ -135,11 +138,11 @@ production:
             vpbx: 1
             retail: 1
             residential: 1
-            endpointType: 1
-            retailAccount: 1
-            residentialDevice: 1
-            residentialEndpointType: 1
             ddi: 1
+            retailAccount: 1
+            residentialEndpointType: 1
+            residentialDevice: 1
+            endpointType: 1
             user: 1
             fax: 1
             friend: 1
@@ -168,6 +171,17 @@ production:
           carrier: true
           ddiProvider: true
           ddi: ${auth.companyWholesale}
+          retail: true
+          residential: true
+          companyType: true
+          vpbx: true
+          retailAccount: ${auth.companyNotRetail}
+          residentialDevice: ${auth.companyNotResidential}
+          endpointType: ${auth.companyNotVPBX}
+          residentialEndpointType: ${auth.companyNotResidential}
+          user: ${auth.companyNotVPBX}
+          fax: ${auth.companyFeatures.faxes.disabled}
+          friend: ${auth.companyNotVPBX}
       fixedPositions:
         <<: *callCsvSchedulersFixedPositions_Link
 

--- a/web/admin/application/configs/klear/model/CallCsvSchedulers.yaml
+++ b/web/admin/application/configs/klear/model/CallCsvSchedulers.yaml
@@ -257,7 +257,7 @@ production:
         'null': _("All")
         config:
           entity: \Ivoz\Provider\Domain\Model\RetailAccount\RetailAccount
-          filterClass: IvozProvider_Klear_Filter_Brand
+          filterClass: IvozProvider_Klear_Filter_BrandCompanies
           fieldName:
             fields:
               - name
@@ -274,7 +274,7 @@ production:
         'null': _("All")
         config:
           entity: \Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDevice
-          filterClass: IvozProvider_Klear_Filter_Brand
+          filterClass: IvozProvider_Klear_Filter_BrandCompanies
           fieldName:
             fields:
               - name

--- a/web/admin/application/library/IvozProvider/Klear/Filter/BrandCompanies.php
+++ b/web/admin/application/library/IvozProvider/Klear/Filter/BrandCompanies.php
@@ -15,6 +15,23 @@ class IvozProvider_Klear_Filter_BrandCompanies implements KlearMatrix_Model_Fiel
 
     public function setRouteDispatcher(KlearMatrix_Model_RouteDispatcher $routeDispatcher)
     {
+        $file = $routeDispatcher->getParam('file');
+        $clientFilteredScreens = [
+            'CallCsvSchedulersList'
+        ];
+
+        if (in_array($file, $clientFilteredScreens)) {
+            $auth = Zend_Auth::getInstance();
+            if (!$auth->hasIdentity()) {
+                throw new Klear_Exception_Default('Unable to get user identity');
+            }
+
+            $loggedUser = $auth->getIdentity();
+            $currentCompanyId = $loggedUser->companyId;
+            $this->_condition[] = "self::company in (" . $currentCompanyId . ")";
+
+            return true;
+        }
 
         // Get ModelName and your Controller
         $currentItemName = $routeDispatcher->getCurrentItemName();


### PR DESCRIPTION
Allow inbound call CSV schedulers to be filtered by user/friend/fax

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
