### PR TITLE
kamusers: copy fix contact logic from trunks

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -522,6 +522,7 @@ request_route {
         route(REPLACES);
         route(PARSE_X_HEADERS);
         route(MAXCALLS_USER);
+        route(SAVE_CONTACT);
         route(LOOKUP);
     } else {
         route(FILTER_BY_SRC_ADDR);
@@ -1710,6 +1711,12 @@ route[WITHINDLG] {
 
     route(ADAPT_REFERTO);
 
+    # Fix overridden R-URI if needed
+    if (!$var(is_from_inside) && $dlg_var(contact) != $null && uri != $dlg_var(contact)) {
+        xwarn("[$dlg_var(cidhash)] WITHINDLG: Fix overridden contact ($ru -> $dlg_var(contact))\n");
+        $ru = $dlg_var(contact);
+    }
+
     # sequential request withing a dialog should
     # take the path determined by record-routing
     if (loose_route()) {
@@ -2151,6 +2158,21 @@ route[CHECK_SPECIAL] {
     }
 }
 
+route[SAVE_CONTACT] {
+    if (!is_present_hf("Contact") || $dlg_var(contact) != $null) return;
+
+    if ($ct =~ "<.*>") {
+        # Contact has < >
+        $var(contact) = $(ct{s.select,0,>});
+        $var(contact) = $(var(contact){s.select,1,<});
+    } else {
+        $var(contact) = $ct;
+    }
+
+    # Save inside contact in $dlg_var(contact)
+    $dlg_var(contact) = $var(contact);
+}
+
 #!ifdef WITH_REALTIME
 route[REALTIME] {
     if ($dlg_var(skipRealtime) == "yes") return;
@@ -2289,6 +2311,10 @@ onreply_route[MANAGE_REPLY] {
 
     if (is_method("INVITE") && t_check_status("3[0-9]{2}")) {
         route(ADAPT_CONTACT);
+    }
+
+    if (t_check_status("2[0-9]{2}") && ($var(is_from_inside) == 1)) {
+        route(SAVE_CONTACT);
     }
 
     # Manage NAT


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

KamTrunks fixes wrong R-URI in within dialog requests with a logic added a lot of time ago. This PR copies this logic to KamUsers.
