### PR TITLE
kamusers: several websockets fixes

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -2521,7 +2521,7 @@ route[TRANSPORT_DETECT] {
     if (!is_method("INVITE")) return;
 
     if (is_request() && !has_totag()) {
-        if ($rP == 'ws' || $rP == 'wss' || $proto == 'ws' || $proto == 'wss' || $xavp(ulattrs=>transport) == 'ws' || $xavp(ulattrs=>transport) == 'wss') {
+        if ($proto == 'ws' || $proto == 'wss' || $xavp(ulattrs=>transport) == 'ws' || $xavp(ulattrs=>transport) == 'wss') {
             setbflag(FLB_WEBSOCKETS);
         }
     }

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -2550,10 +2550,10 @@ route[RTPENGINE] {
     if ($dlg_var(ws) == 'yes' || isbflagset(FLB_WEBSOCKETS)) {
         if ($proto == 'ws' || $proto == 'wss') {
             # WSS UAC talking, convert to UDP
-            $var(wsopts) = 'ICE=remove RTP/AVP';
+            $var(wsopts) = 'ICE=remove RTP/AVP rtcp-mux-demux';
         } else {
             # Talking to WSS UAC, convert from UDP
-            $var(wsopts) = 'ICE=force UDP/TLS/RTP/SAVPF SDES-off';
+            $var(wsopts) = 'ICE=force UDP/TLS/RTP/SAVPF SDES-off rtcp-mux-offer';
         }
     } else {
         $var(wsopts) ='ICE=remove RTP/AVP';

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -2550,10 +2550,10 @@ route[RTPENGINE] {
     if ($dlg_var(ws) == 'yes' || isbflagset(FLB_WEBSOCKETS)) {
         if ($proto == 'ws' || $proto == 'wss') {
             # WSS UAC talking, convert to UDP
-            $var(wsopts) = 'ICE=remove RTP/AVP DTLS=no';
+            $var(wsopts) = 'ICE=remove RTP/AVP';
         } else {
             # Talking to WSS UAC, convert from UDP
-            $var(wsopts) = 'ICE=force RTP/SAVPF DTLS=passive';
+            $var(wsopts) = 'ICE=force UDP/TLS/RTP/SAVPF SDES-off';
         }
     } else {
         $var(wsopts) ='ICE=remove RTP/AVP';

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -2471,7 +2471,6 @@ branch_route[MANAGE_BRANCH] {
 # Executed when dialog is confirmed with 2XX response code
 event_route[dialog:start] {
     if(isbflagset(FLB_WEBSOCKETS)) {
-        xwarn("[$dlg_var(cidhash)] Answered dialog involves websockets\n");
         $dlg_var(ws) = 'yes';
     }
 
@@ -2523,7 +2522,6 @@ route[TRANSPORT_DETECT] {
 
     if (is_request() && !has_totag()) {
         if ($rP == 'ws' || $rP == 'wss' || $proto == 'ws' || $proto == 'wss' || $xavp(ulattrs=>transport) == 'ws' || $xavp(ulattrs=>transport) == 'wss') {
-            xwarn("[$dlg_var(cidhash)] TRANSPORT-DETECT: Websockets, set FLB_WEBSOCKETS\n");
             setbflag(FLB_WEBSOCKETS);
         }
     }
@@ -2550,11 +2548,11 @@ route[RTPENGINE] {
     }
 
     if ($dlg_var(ws) == 'yes' || isbflagset(FLB_WEBSOCKETS)) {
-        if ($proto == 'ws' || $proto == 'wss' ) {
-            xinfo("[$dlg_var(cidhash)] RTPENGINE: Is through $proto, convert to udp\n");
+        if ($proto == 'ws' || $proto == 'wss') {
+            # WSS UAC talking, convert to UDP
             $var(wsopts) = 'ICE=remove RTP/AVP DTLS=no';
         } else {
-            xinfo("[$dlg_var(cidhash)] RTPENGINE: Is through $proto (non-ws), convert to wss\n");
+            # Talking to WSS UAC, convert from UDP
             $var(wsopts) = 'ICE=force RTP/SAVPF DTLS=passive';
         }
     } else {


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

Several WebRTC/websockets changes:

- add rtcp-mux options to WSS dialogs
- SRTP without DTLS no longer supported in WebRTC

#### Additional information
Non-functional changes:
- local proto is equal to remote proto
-  less logs for wss dialogs
