### PR TITLE
Add SRTP support

### DIFF
--- a/doc/sphinx/administration_portal/client/residential/residential_devices.rst
+++ b/doc/sphinx/administration_portal/client/residential/residential_devices.rst
@@ -86,6 +86,10 @@ These are the configurable settings of *Residential devices*:
         If set to 'yes', this SIP endpoint must be a **T.38 capable fax sender/receiver**. IvozProvider
         will act as a T.38 gateway, bridging fax-calls of a T.38 capable carrier and a T.38 capable device.
 
+    RTP Encryption
+        If set to 'yes', call won't be established unless it's possible to encryption its audio. If set to 'no',
+        audio won't be encrypted.
+
 .. tip:: Residential device can be contacted due to calls to several DDIs. *DDI In* setting allows remote SIP endpoint to
          know which number caused each call, setting that number as destination (R-URI and To headers). This way, residential
          device can handle calls differently.

--- a/doc/sphinx/administration_portal/client/retail/retail_accounts.rst
+++ b/doc/sphinx/administration_portal/client/retail/retail_accounts.rst
@@ -77,6 +77,10 @@ These are the configurable settings of *Retail accounts*:
         If set to 'yes', this SIP endpoint must be a **T.38 capable fax sender/receiver**. IvozProvider
         will act as a T.38 gateway, bridging fax-calls of a T.38 capable carrier and a T.38 capable device.
 
+    RTP Encryption
+        If set to 'yes', call won't be established unless it's possible to encryption its audio. If set to 'no',
+        audio won't be encrypted.
+
 .. warning:: All retail accounts within a retail client will have the transcoding capabilities configured at client level.
 
 .. tip:: On retail account edit screen **id** field shows internal identification number assigned to the retail account.

--- a/doc/sphinx/administration_portal/client/vpbx/routing_endpoints/friends/remote_friends.rst
+++ b/doc/sphinx/administration_portal/client/vpbx/routing_endpoints/friends/remote_friends.rst
@@ -99,6 +99,10 @@ These are the configurable settings of *friends*:
         Both numbers listed in Extensions section and numbers matching any friend regexp will be considered as internal and
         won't traverse numeric transformation rules.  Enable this setting to force Numeric Transformation rules even on these numbers. 
 
+    RTP Encryption
+        If set to 'yes', call won't be established unless it's possible to encryption its audio. If set to 'no',
+        audio won't be encrypted.
+
 .. note:: Calls to *friends* are considered internal. That means that ACLs won't
           be checked when calling a friend, no matter if the origin of the call
           is a user or another friend.

--- a/doc/sphinx/administration_portal/client/vpbx/terminals.rst
+++ b/doc/sphinx/administration_portal/client/vpbx/terminals.rst
@@ -47,6 +47,10 @@ fields that must be filled.
         If set to 'yes', this SIP endpoint must be a **T.38 capable fax sender/receiver**. IvozProvider
         will act as a T.38 gateway, bridging fax-calls of a T.38 capable carrier and a T.38 capable device.
 
+    RTP Encryption
+        If set to 'yes', call won't be established unless it's possible to encryption its audio. If set to 'no',
+        audio won't be encrypted.
+
 .. note:: For **most of devices** that doesn't require provisioning just
    filling **username** and **password** will be enough.
 

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -527,16 +527,21 @@ route[CHECK_BOUNCE] {
         return;
     #!endif
 
-    sql_xquery("cb", "SELECT COUNT(*) > 0 AS isMine FROM DDIs WHERE DDIE164='$rU'", "ra");
-    if ($xavp(ra=>isMine) == '1') {
+    $xavp(ra) = $null;
+    sql_xquery("cb", "SELECT C.type FROM DDIs D INNER JOIN Companies C ON C.id=D.companyId WHERE D.DDIE164='$rU'", "ra");
+    if ($xavp(ra=>type) != $null) {
         xinfo("[$dlg_var(cidhash)] CHECK-BOUNCE: Call is to one of my DDIs\n");
         $dlg_var(bounced) = '1';
         $dlg_var(skipMediaRelay) = 'yes';
 
-        # Keep X-Info-NAT header added by Users in bounced calls
-        if (is_present_hf("X-Info-NAT"))
-            insert_hf("X-Info-NAT: yes\r\n");
+        if ($dlg_var(type) == 'retail' || $dlg_var(type) == 'wholesale') {
+            if ($xavp(ra=>type) == 'retail') {
+                # Retail/Wholesale calling to retail DDI: skip media-relay in KamUsers
+                insert_hf("X-Info-Skip-KamUsers-MediaRelay: yes\r\n");
+            }
+        }
     }
+
 }
 
 route[REQINIT] {
@@ -1016,6 +1021,10 @@ route[PARSE_X_HEADERS] {
         xnotice("[$dlg_var(cidhash)] PARSE-X-HEADERS: Related leg: $dlg_var(xcallid)\n");
     }
 
+    if (remove_hf("X-Info-Skip-MediaRelay")) {
+        $dlg_var(skipMediaRelay) = 'yes';
+    }
+
     if ($dlg_var(type) == 'wholesale') return;
 
     # Extract ddiId for cdr entry
@@ -1414,7 +1423,6 @@ route[DISPATCH] {
     if ($dlg_var(type) == 'retail') {
         # Route to KamUsers
         xinfo("[$dlg_var(cidhash)] DISPATCH: Calling to retail account, route to KamUsers\n");
-        insert_hf("X-Info-Skip-MediaRelay: yes\r\n");
         route(SETUP_KAMUSERS_CALL);
         return;
     }
@@ -1461,6 +1469,11 @@ route[SETUP_KAMUSERS_CALL] {
     insert_hf("X-Info-Type: $dlg_var(type)\r\n");
     insert_hf("X-Info-Callee: $rU\r\n");
 
+    # Add Skip-MediaRelay header when retail/wholesale calling to retail DDI (bouncing)
+    if ($var(is_from_inside) == 2 && is_present_hf("X-Info-Skip-KamUsers-MediaRelay")) {
+        insert_hf("X-Info-Skip-MediaRelay: yes\r\n");
+    }
+
     # Check DDI is routed to a retail account
     $xavp(ra) = $null;
     sql_xquery("cb", "SELECT RA.name AS username, DS.domain AS domain FROM DDIs D INNER JOIN RetailAccounts RA ON D.retailAccountId=RA.id INNER JOIN Domains DS ON RA.domainId=DS.id WHERE DDIE164='$rU'", "ra");
@@ -1470,6 +1483,9 @@ route[SETUP_KAMUSERS_CALL] {
 
     # Make To header equal to R-URI
     uac_replace_to("$ru");
+
+    # No media handling for this proxy2proxy dialog
+    $dlg_var(skipMediaRelay) = 'yes';
 }
 
 # Relay request
@@ -1935,19 +1951,10 @@ route[RTPENGINE] {
         set_rtpengine_set("$(dlg_var(mediaRelaySetsId){s.int})");
     }
 
-    if (is_present_hf("X-Info-NAT")) {
-        # KamUsers SDPs may be from behind NAT retail accounts
-        $var(symmetry) = 'symmetric SIP-source-address';
-        xinfo("[$dlg_var(cidhash)] RTPENGINE: Behind NAT retail, do not trust SDP addresses\n");
-        remove_hf("X-Info-NAT");
-    } else {
-        $var(symmetry) = 'asymmetric trust-address';
-    }
+    $var(rtpengine_opts) = 'replace-session-connection replace-origin ICE=remove RTP/AVP asymmetric trust-address';
 
-    $var(rtpengine_opts) = 'replace-session-connection replace-origin ICE=remove RTP/AVP';
-
-    xinfo("[$dlg_var(cidhash)] RTPENGINE: rtpengine_manage [$var(rtpengine_opts) $var(symmetry)]\n");
-    rtpengine_manage("$var(rtpengine_opts) $var(symmetry)");
+    xinfo("[$dlg_var(cidhash)] RTPENGINE: rtpengine_manage [$var(rtpengine_opts)]\n");
+    rtpengine_manage("$var(rtpengine_opts)");
 
     route(RECORD);
 }

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -431,9 +431,6 @@ request_route {
     # Inspect new request
     route(CLASSIFY);
 
-    # Get codec capabilities for call
-    route(GET_CODEC_INFO);
-
     # Setup accounting
     route(ACCOUNTING);
 
@@ -1928,21 +1925,6 @@ onsend_route {
     if (is_method("ACK")) $dlg_var(confirmed) = '1';
 }
 
-route[GET_CODEC_INFO] {
-    $dlg_var(codecs) = "";
-    if ($dlg_var(type) != "retail" && $dlg_var(type) != "wholesale") return;
-
-    sql_query("cb", "SELECT Co.iden AS codec FROM CompaniesRelCodecs CRC JOIN Codecs Co ON Co.id=CRC.codecId JOIN Companies C ON C.id=CRC.companyId WHERE companyId='$dlg_var(companyId)'", "rb");
-    if ($dbr(rb=>rows) > 0) {
-        $var(i) = 0;
-        while($var(i) < $dbr(rb=>rows)) {
-            $dlg_var(codecs) = $dlg_var(codecs) + "transcode-" + $dbr(rb=>[$var(i),0]) + " ";
-            $var(i) = $var(i) + 1;
-        }
-    }
-    sql_result_free("rb");
-}
-
 route[RTPENGINE] {
     if (!is_method("INVITE|UPDATE|ACK|BYE|CANCEL")) return;
     if (is_method("ACK") && !has_body("application/sdp")) return;
@@ -1963,8 +1945,8 @@ route[RTPENGINE] {
 
     $var(rtpengine_opts) = 'replace-session-connection replace-origin ICE=remove RTP/AVP';
 
-    xinfo("[$dlg_var(cidhash)] RTPENGINE: rtpengine_manage [$var(rtpengine_opts) $var(symmetry) $dlg_var(codecs)]\n");
-    rtpengine_manage("$var(rtpengine_opts) $var(symmetry) $dlg_var(codecs)");
+    xinfo("[$dlg_var(cidhash)] RTPENGINE: rtpengine_manage [$var(rtpengine_opts) $var(symmetry)]\n");
+    rtpengine_manage("$var(rtpengine_opts) $var(symmetry)");
 
     route(RECORD);
 }

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -531,6 +531,7 @@ route[CHECK_BOUNCE] {
     if ($xavp(ra=>isMine) == '1') {
         xinfo("[$dlg_var(cidhash)] CHECK-BOUNCE: Call is to one of my DDIs\n");
         $dlg_var(bounced) = '1';
+        $dlg_var(skipMediaRelay) = 'yes';
 
         # Keep X-Info-NAT header added by Users in bounced calls
         if (is_present_hf("X-Info-NAT"))
@@ -1928,7 +1929,7 @@ onsend_route {
 route[RTPENGINE] {
     if (!is_method("INVITE|UPDATE|ACK|BYE|CANCEL")) return;
     if (is_method("ACK") && !has_body("application/sdp")) return;
-    if ($dlg_var(bounced) == '1') return;
+    if ($dlg_var(skipMediaRelay) == 'yes') return;
 
     if ($(dlg_var(mediaRelaySetsId){s.len}) > 0 && $dlg_var(mediaRelaySetsId) != 0) {
         set_rtpengine_set("$(dlg_var(mediaRelaySetsId){s.int})");

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -519,6 +519,9 @@ request_route {
 
     route(GET_CALL_INFO);
 
+    # Get codec capabilities for call
+    route(GET_CODEC_INFO);
+
     # Route by source
     if ($var(is_from_inside)) {
         route(REPLACES);
@@ -2532,6 +2535,21 @@ route[TRANSPORT_DETECT] {
     }
 }
 
+route[GET_CODEC_INFO] {
+    $dlg_var(codecs) = "";
+    if ($dlg_var(type) != "retail" && $dlg_var(type) != "wholesale") return;
+
+    sql_query("cb", "SELECT Co.iden AS codec FROM CompaniesRelCodecs CRC JOIN Codecs Co ON Co.id=CRC.codecId JOIN Companies C ON C.id=CRC.companyId WHERE companyId='$dlg_var(companyId)'", "rb");
+    if ($dbr(rb=>rows) > 0) {
+        $var(i) = 0;
+        while($var(i) < $dbr(rb=>rows)) {
+            $dlg_var(codecs) = $dlg_var(codecs) + "transcode-" + $dbr(rb=>[$var(i),0]) + " ";
+            $var(i) = $var(i) + 1;
+        }
+    }
+    sql_result_free("rb");
+}
+
 route[RTPENGINE] {
     if (!is_method("INVITE|UPDATE|ACK|BYE|CANCEL")) return;
     if (is_method("ACK") && !has_body("application/sdp")) return;
@@ -2573,8 +2591,8 @@ route[RTPENGINE] {
     }
     #!endif
 
-    xinfo("[$dlg_var(cidhash)] RTPENGINE: rtpengine_manage [$var(common_opts) $var(symmetry) $var(bridging) $var(interfaces)]\n");
-    rtpengine_manage("$var(common_opts) $var(symmetry) $var(bridging) $var(interfaces)");
+    xinfo("[$dlg_var(cidhash)] RTPENGINE: rtpengine_manage [$var(common_opts) $var(symmetry) $var(bridging) $var(interfaces) $dlg_var(codecs)]\n");
+    rtpengine_manage("$var(common_opts) $var(symmetry) $var(bridging) $var(interfaces) $dlg_var(codecs)");
 }
 
 route[LOCAL_PUBLISH] {

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -1233,7 +1233,7 @@ route[STATIC_LOCATION] {
         $rd = $fd;
         $du = "sip:users.ivozprovider.local";
         uac_replace_from("sip:" + $xavp(rb=>name) + "@" + $fd);
-        $avp(skip_mediarelay) = "1";
+        $dlg_var(skipMediaRelay) = 'yes';
         return;
     }
 
@@ -2554,7 +2554,6 @@ route[RTPENGINE] {
     if (!is_method("INVITE|UPDATE|ACK|BYE|CANCEL")) return;
     if (is_method("ACK") && !has_body("application/sdp")) return;
     if ($dlg_var(skipMediaRelay) == 'yes') return;
-    if ($avp(skip_mediarelay)) return;
 
     if ($(dlg_var(mediaRelaySetsId){s.len}) > 0 && $dlg_var(mediaRelaySetsId) != 0) {
         set_rtpengine_set("$(dlg_var(mediaRelaySetsId){s.int})");

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -1086,6 +1086,7 @@ route[DISPATCH_TO_TRUNKS] {
     insert_hf("X-Info-BrandId: $dlg_var(brandId)\r\n");
     insert_hf("X-Info-CompanyId: $dlg_var(companyId)\r\n");
     insert_hf("X-Info-Type: $dlg_var(type)\r\n");
+    insert_hf("X-Info-Skip-MediaRelay: yes\r\n");
 
     if ($dlg_var(type) == "retail") {
         insert_hf("X-Info-RetailAccountId: $dlg_var(retailAccountId)\r\n");
@@ -1102,9 +1103,6 @@ route[DISPATCH_TO_TRUNKS] {
             insert_hf("X-Info-Special: fax\r\n");
         }
     }
-
-    # No media handling for this proxy2proxy dialog
-    $dlg_var(skipMediaRelay) = 'yes';
 }
 
 route[DISPATCH_TO_AS] {
@@ -2095,11 +2093,6 @@ route[NATMANAGE] {
            send_reply("400", "Bad request");
            exit;
         }
-    }
-
-    if ($dlg_var(type) == 'retail' && !$var(is_from_inside)) {
-        xinfo("[$dlg_var(cidhash)] NATMANAGE: Add X-Info-NAT header\n");
-        insert_hf("X-Info-NAT: yes\r\n");
     }
 }
 

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -1302,6 +1302,10 @@ route[GET_CALL_INFO] {
         # Set AoR for maxcallsUser counting
         $avp(AoR) = $fU + '@' + $fd;
     }
+
+    if ($avp(rtpEncryption)) {
+        $dlg_var(srtp) = 'yes';
+    }
 }
 
 route[GET_RETAIL_CFW_SETTINGS] {
@@ -1584,7 +1588,7 @@ route[GET_INFO_FROM_ENDPOINT] {
     $xavp(endpoint) = $null;
 
     if ($avp(endpointType) == "Terminals") {
-        sql_xquery("cb", "SELECT U.id, E.number AS extension, U.externalIpCalls, U.maxCalls, T.companyId, U.transformationRuleSetId, T.t38Passthrough FROM Users U JOIN Terminals T ON U.terminalId=T.id JOIN Extensions E ON U.extensionId=E.id WHERE T.id='$avp(endpointId)'", "endpoint");
+        sql_xquery("cb", "SELECT U.id, E.number AS extension, U.externalIpCalls, U.maxCalls, T.companyId, U.transformationRuleSetId, T.t38Passthrough, T.rtpEncryption FROM Users U JOIN Terminals T ON U.terminalId=T.id JOIN Extensions E ON U.extensionId=E.id WHERE T.id='$avp(endpointId)'", "endpoint");
         if ($xavp(endpoint=>extension) == $null) {
             send_reply("404", "Not Here [TUE]");
             exit;
@@ -1594,14 +1598,14 @@ route[GET_INFO_FROM_ENDPOINT] {
         $avp(externalIpCalls) = $xavp(endpoint=>externalIpCalls); # used in FILTER_BY_SRC_ADDR
         $avp(maxCalls) = $xavp(endpoint=>maxCalls); # used in GET_CALL_INFO
     } else if ($avp(endpointType) == "ResidentialDevices") {
-        sql_xquery("cb", "SELECT id, companyId, transformationRuleSetId, t38Passthrough, maxCalls FROM ResidentialDevices WHERE id='$avp(endpointId)'", "endpoint");
+        sql_xquery("cb", "SELECT id, companyId, transformationRuleSetId, t38Passthrough, maxCalls, rtpEncryption FROM ResidentialDevices WHERE id='$avp(endpointId)'", "endpoint");
         $avp(maxCalls) = $xavp(endpoint=>maxCalls); # used in GET_CALL_INFO
     } else if ($avp(endpointType) == "Friends") {
-        sql_xquery("cb", "SELECT id, companyId, transformationRuleSetId, t38Passthrough, alwaysApplyTransformations FROM Friends WHERE id='$avp(endpointId)'", "endpoint");
+        sql_xquery("cb", "SELECT id, companyId, transformationRuleSetId, t38Passthrough, alwaysApplyTransformations, rtpEncryption FROM Friends WHERE id='$avp(endpointId)'", "endpoint");
         $avp(maxCalls) = 0; # used in GET_CALL_INFO
         $avp(alwaysApplyTransformations) = $xavp(endpoint=>alwaysApplyTransformations); # used in IS_INTERNAL
     } else {
-        sql_xquery("cb", "SELECT id, companyId, transformationRuleSetId, t38Passthrough FROM RetailAccounts WHERE id='$avp(endpointId)'", "endpoint");
+        sql_xquery("cb", "SELECT id, companyId, transformationRuleSetId, t38Passthrough, rtpEncryption FROM RetailAccounts WHERE id='$avp(endpointId)'", "endpoint");
         $avp(maxCalls) = 0; # used in GET_CALL_INFO
     }
 
@@ -1609,6 +1613,7 @@ route[GET_INFO_FROM_ENDPOINT] {
     $avp(objectId) = $xavp(endpoint=>id); # used in GET_CALL_INFO
     $avp(endpointTransformationRuleSetId) = $xavp(endpoint=>transformationRuleSetId); # used in GET_CALL_INFO
     $avp(t38Passthrough) = $xavp(endpoint=>t38Passthrough); # used in DISPATCH_TO_TRUNKS
+    $avp(rtpEncryption) = $xavp(endpoint=>rtpEncryption); # used in GET_CALL_INFO
 }
 
 # Sets $avp(endpointType), $avp(endpointId) and $avp(password)
@@ -2550,13 +2555,15 @@ route[RTPENGINE] {
     if ($dlg_var(ws) == 'yes' || isbflagset(FLB_WEBSOCKETS)) {
         if ($proto == 'ws' || $proto == 'wss') {
             # WSS UAC talking, convert to UDP
-            $var(wsopts) = 'ICE=remove RTP/AVP rtcp-mux-demux';
+            $var(bridging) = 'ICE=remove RTP/AVP rtcp-mux-demux';
         } else {
             # Talking to WSS UAC, convert from UDP
-            $var(wsopts) = 'ICE=force UDP/TLS/RTP/SAVPF SDES-off rtcp-mux-offer';
+            $var(bridging) = 'ICE=force UDP/TLS/RTP/SAVPF SDES-off rtcp-mux-offer';
         }
+    } else if ($dlg_var(srtp) == 'yes' && $var(is_from_inside)) {
+        $var(bridging) ='ICE=remove RTP/SAVP';
     } else {
-        $var(wsopts) ='ICE=remove RTP/AVP';
+        $var(bridging) ='ICE=remove RTP/AVP';
     }
 
     $var(interfaces) = "";
@@ -2566,8 +2573,8 @@ route[RTPENGINE] {
     }
     #!endif
 
-    xinfo("[$dlg_var(cidhash)] RTPENGINE: rtpengine_manage [$var(common_opts) $var(symmetry) $var(wsopts) $var(interfaces)]\n");
-    rtpengine_manage("$var(common_opts) $var(symmetry) $var(wsopts) $var(interfaces)");
+    xinfo("[$dlg_var(cidhash)] RTPENGINE: rtpengine_manage [$var(common_opts) $var(symmetry) $var(bridging) $var(interfaces)]\n");
+    rtpengine_manage("$var(common_opts) $var(symmetry) $var(bridging) $var(interfaces)");
 }
 
 route[LOCAL_PUBLISH] {

--- a/library/Ivoz/Provider/Domain/Model/Friend/FriendAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Friend/FriendAbstract.php
@@ -110,6 +110,11 @@ abstract class FriendAbstract
     protected $alwaysApplyTransformations = false;
 
     /**
+     * @var boolean
+     */
+    protected $rtpEncryption = false;
+
+    /**
      * @var \Ivoz\Provider\Domain\Model\Company\CompanyInterface
      */
     protected $company;
@@ -162,7 +167,8 @@ abstract class FriendAbstract
         $directConnectivity,
         $ddiIn,
         $t38Passthrough,
-        $alwaysApplyTransformations
+        $alwaysApplyTransformations,
+        $rtpEncryption
     ) {
         $this->setName($name);
         $this->setDescription($description);
@@ -176,6 +182,7 @@ abstract class FriendAbstract
         $this->setDdiIn($ddiIn);
         $this->setT38Passthrough($t38Passthrough);
         $this->setAlwaysApplyTransformations($alwaysApplyTransformations);
+        $this->setRtpEncryption($rtpEncryption);
     }
 
     abstract public function getId();
@@ -258,7 +265,8 @@ abstract class FriendAbstract
             $dto->getDirectConnectivity(),
             $dto->getDdiIn(),
             $dto->getT38Passthrough(),
-            $dto->getAlwaysApplyTransformations()
+            $dto->getAlwaysApplyTransformations(),
+            $dto->getRtpEncryption()
         );
 
         $self
@@ -310,6 +318,7 @@ abstract class FriendAbstract
             ->setDdiIn($dto->getDdiIn())
             ->setT38Passthrough($dto->getT38Passthrough())
             ->setAlwaysApplyTransformations($dto->getAlwaysApplyTransformations())
+            ->setRtpEncryption($dto->getRtpEncryption())
             ->setCompany($fkTransformer->transform($dto->getCompany()))
             ->setDomain($fkTransformer->transform($dto->getDomain()))
             ->setTransformationRuleSet($fkTransformer->transform($dto->getTransformationRuleSet()))
@@ -348,6 +357,7 @@ abstract class FriendAbstract
             ->setDdiIn(self::getDdiIn())
             ->setT38Passthrough(self::getT38Passthrough())
             ->setAlwaysApplyTransformations(self::getAlwaysApplyTransformations())
+            ->setRtpEncryption(self::getRtpEncryption())
             ->setCompany(\Ivoz\Provider\Domain\Model\Company\Company::entityToDto(self::getCompany(), $depth))
             ->setDomain(\Ivoz\Provider\Domain\Model\Domain\Domain::entityToDto(self::getDomain(), $depth))
             ->setTransformationRuleSet(\Ivoz\Provider\Domain\Model\TransformationRuleSet\TransformationRuleSet::entityToDto(self::getTransformationRuleSet(), $depth))
@@ -380,6 +390,7 @@ abstract class FriendAbstract
             'ddiIn' => self::getDdiIn(),
             't38Passthrough' => self::getT38Passthrough(),
             'alwaysApplyTransformations' => self::getAlwaysApplyTransformations(),
+            'rtpEncryption' => self::getRtpEncryption(),
             'companyId' => self::getCompany()->getId(),
             'domainId' => self::getDomain() ? self::getDomain()->getId() : null,
             'transformationRuleSetId' => self::getTransformationRuleSet() ? self::getTransformationRuleSet()->getId() : null,
@@ -881,6 +892,34 @@ abstract class FriendAbstract
     public function getAlwaysApplyTransformations(): bool
     {
         return $this->alwaysApplyTransformations;
+    }
+
+    /**
+     * Set rtpEncryption
+     *
+     * @param boolean $rtpEncryption
+     *
+     * @return static
+     */
+    protected function setRtpEncryption($rtpEncryption)
+    {
+        Assertion::notNull($rtpEncryption, 'rtpEncryption value "%s" is null, but non null value was expected.');
+        Assertion::between(intval($rtpEncryption), 0, 1, 'rtpEncryption provided "%s" is not a valid boolean value.');
+        $rtpEncryption = (bool) $rtpEncryption;
+
+        $this->rtpEncryption = $rtpEncryption;
+
+        return $this;
+    }
+
+    /**
+     * Get rtpEncryption
+     *
+     * @return boolean
+     */
+    public function getRtpEncryption(): bool
+    {
+        return $this->rtpEncryption;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/Friend/FriendDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Friend/FriendDtoAbstract.php
@@ -96,6 +96,11 @@ abstract class FriendDtoAbstract implements DataTransferObjectInterface
     private $alwaysApplyTransformations = false;
 
     /**
+     * @var boolean
+     */
+    private $rtpEncryption = false;
+
+    /**
      * @var integer
      */
     private $id;
@@ -180,6 +185,7 @@ abstract class FriendDtoAbstract implements DataTransferObjectInterface
             'ddiIn' => 'ddiIn',
             't38Passthrough' => 't38Passthrough',
             'alwaysApplyTransformations' => 'alwaysApplyTransformations',
+            'rtpEncryption' => 'rtpEncryption',
             'id' => 'id',
             'companyId' => 'company',
             'domainId' => 'domain',
@@ -214,6 +220,7 @@ abstract class FriendDtoAbstract implements DataTransferObjectInterface
             'ddiIn' => $this->getDdiIn(),
             't38Passthrough' => $this->getT38Passthrough(),
             'alwaysApplyTransformations' => $this->getAlwaysApplyTransformations(),
+            'rtpEncryption' => $this->getRtpEncryption(),
             'id' => $this->getId(),
             'company' => $this->getCompany(),
             'domain' => $this->getDomain(),
@@ -578,6 +585,26 @@ abstract class FriendDtoAbstract implements DataTransferObjectInterface
     public function getAlwaysApplyTransformations()
     {
         return $this->alwaysApplyTransformations;
+    }
+
+    /**
+     * @param boolean $rtpEncryption
+     *
+     * @return static
+     */
+    public function setRtpEncryption($rtpEncryption = null)
+    {
+        $this->rtpEncryption = $rtpEncryption;
+
+        return $this;
+    }
+
+    /**
+     * @return boolean | null
+     */
+    public function getRtpEncryption()
+    {
+        return $this->rtpEncryption;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/Friend/FriendInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/Friend/FriendInterface.php
@@ -243,6 +243,13 @@ interface FriendInterface extends LoggableEntityInterface
     public function getAlwaysApplyTransformations(): bool;
 
     /**
+     * Get rtpEncryption
+     *
+     * @return boolean
+     */
+    public function getRtpEncryption(): bool;
+
+    /**
      * Set company
      *
      * @param \Ivoz\Provider\Domain\Model\Company\CompanyInterface $company

--- a/library/Ivoz/Provider/Domain/Model/ResidentialDevice/ResidentialDeviceAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/ResidentialDevice/ResidentialDeviceAbstract.php
@@ -111,6 +111,11 @@ abstract class ResidentialDeviceAbstract
     protected $t38Passthrough = 'no';
 
     /**
+     * @var boolean
+     */
+    protected $rtpEncryption = false;
+
+    /**
      * @var \Ivoz\Provider\Domain\Model\Brand\BrandInterface
      */
     protected $brand;
@@ -158,7 +163,8 @@ abstract class ResidentialDeviceAbstract
         $directConnectivity,
         $ddiIn,
         $maxCalls,
-        $t38Passthrough
+        $t38Passthrough,
+        $rtpEncryption
     ) {
         $this->setName($name);
         $this->setDescription($description);
@@ -172,6 +178,7 @@ abstract class ResidentialDeviceAbstract
         $this->setDdiIn($ddiIn);
         $this->setMaxCalls($maxCalls);
         $this->setT38Passthrough($t38Passthrough);
+        $this->setRtpEncryption($rtpEncryption);
     }
 
     abstract public function getId();
@@ -254,7 +261,8 @@ abstract class ResidentialDeviceAbstract
             $dto->getDirectConnectivity(),
             $dto->getDdiIn(),
             $dto->getMaxCalls(),
-            $dto->getT38Passthrough()
+            $dto->getT38Passthrough(),
+            $dto->getRtpEncryption()
         );
 
         $self
@@ -305,6 +313,7 @@ abstract class ResidentialDeviceAbstract
             ->setDdiIn($dto->getDdiIn())
             ->setMaxCalls($dto->getMaxCalls())
             ->setT38Passthrough($dto->getT38Passthrough())
+            ->setRtpEncryption($dto->getRtpEncryption())
             ->setBrand($fkTransformer->transform($dto->getBrand()))
             ->setDomain($fkTransformer->transform($dto->getDomain()))
             ->setCompany($fkTransformer->transform($dto->getCompany()))
@@ -342,6 +351,7 @@ abstract class ResidentialDeviceAbstract
             ->setDdiIn(self::getDdiIn())
             ->setMaxCalls(self::getMaxCalls())
             ->setT38Passthrough(self::getT38Passthrough())
+            ->setRtpEncryption(self::getRtpEncryption())
             ->setBrand(\Ivoz\Provider\Domain\Model\Brand\Brand::entityToDto(self::getBrand(), $depth))
             ->setDomain(\Ivoz\Provider\Domain\Model\Domain\Domain::entityToDto(self::getDomain(), $depth))
             ->setCompany(\Ivoz\Provider\Domain\Model\Company\Company::entityToDto(self::getCompany(), $depth))
@@ -373,6 +383,7 @@ abstract class ResidentialDeviceAbstract
             'ddiIn' => self::getDdiIn(),
             'maxCalls' => self::getMaxCalls(),
             't38Passthrough' => self::getT38Passthrough(),
+            'rtpEncryption' => self::getRtpEncryption(),
             'brandId' => self::getBrand()->getId(),
             'domainId' => self::getDomain() ? self::getDomain()->getId() : null,
             'companyId' => self::getCompany()->getId(),
@@ -870,6 +881,34 @@ abstract class ResidentialDeviceAbstract
     public function getT38Passthrough(): string
     {
         return $this->t38Passthrough;
+    }
+
+    /**
+     * Set rtpEncryption
+     *
+     * @param boolean $rtpEncryption
+     *
+     * @return static
+     */
+    protected function setRtpEncryption($rtpEncryption)
+    {
+        Assertion::notNull($rtpEncryption, 'rtpEncryption value "%s" is null, but non null value was expected.');
+        Assertion::between(intval($rtpEncryption), 0, 1, 'rtpEncryption provided "%s" is not a valid boolean value.');
+        $rtpEncryption = (bool) $rtpEncryption;
+
+        $this->rtpEncryption = $rtpEncryption;
+
+        return $this;
+    }
+
+    /**
+     * Get rtpEncryption
+     *
+     * @return boolean
+     */
+    public function getRtpEncryption(): bool
+    {
+        return $this->rtpEncryption;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/ResidentialDevice/ResidentialDeviceDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/ResidentialDevice/ResidentialDeviceDtoAbstract.php
@@ -96,6 +96,11 @@ abstract class ResidentialDeviceDtoAbstract implements DataTransferObjectInterfa
     private $t38Passthrough = 'no';
 
     /**
+     * @var boolean
+     */
+    private $rtpEncryption = false;
+
+    /**
      * @var integer
      */
     private $id;
@@ -180,6 +185,7 @@ abstract class ResidentialDeviceDtoAbstract implements DataTransferObjectInterfa
             'ddiIn' => 'ddiIn',
             'maxCalls' => 'maxCalls',
             't38Passthrough' => 't38Passthrough',
+            'rtpEncryption' => 'rtpEncryption',
             'id' => 'id',
             'brandId' => 'brand',
             'domainId' => 'domain',
@@ -213,6 +219,7 @@ abstract class ResidentialDeviceDtoAbstract implements DataTransferObjectInterfa
             'ddiIn' => $this->getDdiIn(),
             'maxCalls' => $this->getMaxCalls(),
             't38Passthrough' => $this->getT38Passthrough(),
+            'rtpEncryption' => $this->getRtpEncryption(),
             'id' => $this->getId(),
             'brand' => $this->getBrand(),
             'domain' => $this->getDomain(),
@@ -577,6 +584,26 @@ abstract class ResidentialDeviceDtoAbstract implements DataTransferObjectInterfa
     public function getT38Passthrough()
     {
         return $this->t38Passthrough;
+    }
+
+    /**
+     * @param boolean $rtpEncryption
+     *
+     * @return static
+     */
+    public function setRtpEncryption($rtpEncryption = null)
+    {
+        $this->rtpEncryption = $rtpEncryption;
+
+        return $this;
+    }
+
+    /**
+     * @return boolean | null
+     */
+    public function getRtpEncryption()
+    {
+        return $this->rtpEncryption;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/ResidentialDevice/ResidentialDeviceInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/ResidentialDevice/ResidentialDeviceInterface.php
@@ -239,6 +239,13 @@ interface ResidentialDeviceInterface extends LoggableEntityInterface
     public function getT38Passthrough(): string;
 
     /**
+     * Get rtpEncryption
+     *
+     * @return boolean
+     */
+    public function getRtpEncryption(): bool;
+
+    /**
      * Set brand
      *
      * @param \Ivoz\Provider\Domain\Model\Brand\BrandInterface $brand

--- a/library/Ivoz/Provider/Domain/Model/RetailAccount/RetailAccountAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/RetailAccount/RetailAccountAbstract.php
@@ -68,6 +68,11 @@ abstract class RetailAccountAbstract
     protected $t38Passthrough = 'no';
 
     /**
+     * @var boolean
+     */
+    protected $rtpEncryption = false;
+
+    /**
      * @var \Ivoz\Provider\Domain\Model\Brand\BrandInterface
      */
     protected $brand;
@@ -103,13 +108,15 @@ abstract class RetailAccountAbstract
         $description,
         $directConnectivity,
         $ddiIn,
-        $t38Passthrough
+        $t38Passthrough,
+        $rtpEncryption
     ) {
         $this->setName($name);
         $this->setDescription($description);
         $this->setDirectConnectivity($directConnectivity);
         $this->setDdiIn($ddiIn);
         $this->setT38Passthrough($t38Passthrough);
+        $this->setRtpEncryption($rtpEncryption);
     }
 
     abstract public function getId();
@@ -185,7 +192,8 @@ abstract class RetailAccountAbstract
             $dto->getDescription(),
             $dto->getDirectConnectivity(),
             $dto->getDdiIn(),
-            $dto->getT38Passthrough()
+            $dto->getT38Passthrough(),
+            $dto->getRtpEncryption()
         );
 
         $self
@@ -228,6 +236,7 @@ abstract class RetailAccountAbstract
             ->setDirectConnectivity($dto->getDirectConnectivity())
             ->setDdiIn($dto->getDdiIn())
             ->setT38Passthrough($dto->getT38Passthrough())
+            ->setRtpEncryption($dto->getRtpEncryption())
             ->setBrand($fkTransformer->transform($dto->getBrand()))
             ->setDomain($fkTransformer->transform($dto->getDomain()))
             ->setCompany($fkTransformer->transform($dto->getCompany()))
@@ -257,6 +266,7 @@ abstract class RetailAccountAbstract
             ->setDirectConnectivity(self::getDirectConnectivity())
             ->setDdiIn(self::getDdiIn())
             ->setT38Passthrough(self::getT38Passthrough())
+            ->setRtpEncryption(self::getRtpEncryption())
             ->setBrand(\Ivoz\Provider\Domain\Model\Brand\Brand::entityToDto(self::getBrand(), $depth))
             ->setDomain(\Ivoz\Provider\Domain\Model\Domain\Domain::entityToDto(self::getDomain(), $depth))
             ->setCompany(\Ivoz\Provider\Domain\Model\Company\Company::entityToDto(self::getCompany(), $depth))
@@ -280,6 +290,7 @@ abstract class RetailAccountAbstract
             'directConnectivity' => self::getDirectConnectivity(),
             'ddiIn' => self::getDdiIn(),
             't38Passthrough' => self::getT38Passthrough(),
+            'rtpEncryption' => self::getRtpEncryption(),
             'brandId' => self::getBrand()->getId(),
             'domainId' => self::getDomain() ? self::getDomain()->getId() : null,
             'companyId' => self::getCompany()->getId(),
@@ -578,6 +589,34 @@ abstract class RetailAccountAbstract
     public function getT38Passthrough(): string
     {
         return $this->t38Passthrough;
+    }
+
+    /**
+     * Set rtpEncryption
+     *
+     * @param boolean $rtpEncryption
+     *
+     * @return static
+     */
+    protected function setRtpEncryption($rtpEncryption)
+    {
+        Assertion::notNull($rtpEncryption, 'rtpEncryption value "%s" is null, but non null value was expected.');
+        Assertion::between(intval($rtpEncryption), 0, 1, 'rtpEncryption provided "%s" is not a valid boolean value.');
+        $rtpEncryption = (bool) $rtpEncryption;
+
+        $this->rtpEncryption = $rtpEncryption;
+
+        return $this;
+    }
+
+    /**
+     * Get rtpEncryption
+     *
+     * @return boolean
+     */
+    public function getRtpEncryption(): bool
+    {
+        return $this->rtpEncryption;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/RetailAccount/RetailAccountDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/RetailAccount/RetailAccountDtoAbstract.php
@@ -61,6 +61,11 @@ abstract class RetailAccountDtoAbstract implements DataTransferObjectInterface
     private $t38Passthrough = 'no';
 
     /**
+     * @var boolean
+     */
+    private $rtpEncryption = false;
+
+    /**
      * @var integer
      */
     private $id;
@@ -133,6 +138,7 @@ abstract class RetailAccountDtoAbstract implements DataTransferObjectInterface
             'directConnectivity' => 'directConnectivity',
             'ddiIn' => 'ddiIn',
             't38Passthrough' => 't38Passthrough',
+            'rtpEncryption' => 'rtpEncryption',
             'id' => 'id',
             'brandId' => 'brand',
             'domainId' => 'domain',
@@ -158,6 +164,7 @@ abstract class RetailAccountDtoAbstract implements DataTransferObjectInterface
             'directConnectivity' => $this->getDirectConnectivity(),
             'ddiIn' => $this->getDdiIn(),
             't38Passthrough' => $this->getT38Passthrough(),
+            'rtpEncryption' => $this->getRtpEncryption(),
             'id' => $this->getId(),
             'brand' => $this->getBrand(),
             'domain' => $this->getDomain(),
@@ -381,6 +388,26 @@ abstract class RetailAccountDtoAbstract implements DataTransferObjectInterface
     public function getT38Passthrough()
     {
         return $this->t38Passthrough;
+    }
+
+    /**
+     * @param boolean $rtpEncryption
+     *
+     * @return static
+     */
+    public function setRtpEncryption($rtpEncryption = null)
+    {
+        $this->rtpEncryption = $rtpEncryption;
+
+        return $this;
+    }
+
+    /**
+     * @return boolean | null
+     */
+    public function getRtpEncryption()
+    {
+        return $this->rtpEncryption;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/RetailAccount/RetailAccountInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/RetailAccount/RetailAccountInterface.php
@@ -142,6 +142,13 @@ interface RetailAccountInterface extends LoggableEntityInterface
     public function getT38Passthrough(): string;
 
     /**
+     * Get rtpEncryption
+     *
+     * @return boolean
+     */
+    public function getRtpEncryption(): bool;
+
+    /**
      * Set brand
      *
      * @param \Ivoz\Provider\Domain\Model\Brand\BrandInterface $brand

--- a/library/Ivoz/Provider/Domain/Model/Terminal/TerminalAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Terminal/TerminalAbstract.php
@@ -65,6 +65,11 @@ abstract class TerminalAbstract
     protected $t38Passthrough = 'no';
 
     /**
+     * @var boolean
+     */
+    protected $rtpEncryption = false;
+
+    /**
      * @var \Ivoz\Provider\Domain\Model\Company\CompanyInterface
      */
     protected $company;
@@ -90,13 +95,15 @@ abstract class TerminalAbstract
         $allowAudio,
         $directMediaMethod,
         $password,
-        $t38Passthrough
+        $t38Passthrough,
+        $rtpEncryption
     ) {
         $this->setDisallow($disallow);
         $this->setAllowAudio($allowAudio);
         $this->setDirectMediaMethod($directMediaMethod);
         $this->setPassword($password);
         $this->setT38Passthrough($t38Passthrough);
+        $this->setRtpEncryption($rtpEncryption);
     }
 
     abstract public function getId();
@@ -172,7 +179,8 @@ abstract class TerminalAbstract
             $dto->getAllowAudio(),
             $dto->getDirectMediaMethod(),
             $dto->getPassword(),
-            $dto->getT38Passthrough()
+            $dto->getT38Passthrough(),
+            $dto->getRtpEncryption()
         );
 
         $self
@@ -211,6 +219,7 @@ abstract class TerminalAbstract
             ->setMac($dto->getMac())
             ->setLastProvisionDate($dto->getLastProvisionDate())
             ->setT38Passthrough($dto->getT38Passthrough())
+            ->setRtpEncryption($dto->getRtpEncryption())
             ->setCompany($fkTransformer->transform($dto->getCompany()))
             ->setDomain($fkTransformer->transform($dto->getDomain()))
             ->setTerminalModel($fkTransformer->transform($dto->getTerminalModel()));
@@ -237,6 +246,7 @@ abstract class TerminalAbstract
             ->setMac(self::getMac())
             ->setLastProvisionDate(self::getLastProvisionDate())
             ->setT38Passthrough(self::getT38Passthrough())
+            ->setRtpEncryption(self::getRtpEncryption())
             ->setCompany(\Ivoz\Provider\Domain\Model\Company\Company::entityToDto(self::getCompany(), $depth))
             ->setDomain(\Ivoz\Provider\Domain\Model\Domain\Domain::entityToDto(self::getDomain(), $depth))
             ->setTerminalModel(\Ivoz\Provider\Domain\Model\TerminalModel\TerminalModel::entityToDto(self::getTerminalModel(), $depth));
@@ -257,6 +267,7 @@ abstract class TerminalAbstract
             'mac' => self::getMac(),
             'lastProvisionDate' => self::getLastProvisionDate(),
             't38Passthrough' => self::getT38Passthrough(),
+            'rtpEncryption' => self::getRtpEncryption(),
             'companyId' => self::getCompany()->getId(),
             'domainId' => self::getDomain() ? self::getDomain()->getId() : null,
             'terminalModelId' => self::getTerminalModel() ? self::getTerminalModel()->getId() : null
@@ -523,6 +534,34 @@ abstract class TerminalAbstract
     public function getT38Passthrough(): string
     {
         return $this->t38Passthrough;
+    }
+
+    /**
+     * Set rtpEncryption
+     *
+     * @param boolean $rtpEncryption
+     *
+     * @return static
+     */
+    protected function setRtpEncryption($rtpEncryption)
+    {
+        Assertion::notNull($rtpEncryption, 'rtpEncryption value "%s" is null, but non null value was expected.');
+        Assertion::between(intval($rtpEncryption), 0, 1, 'rtpEncryption provided "%s" is not a valid boolean value.');
+        $rtpEncryption = (bool) $rtpEncryption;
+
+        $this->rtpEncryption = $rtpEncryption;
+
+        return $this;
+    }
+
+    /**
+     * Get rtpEncryption
+     *
+     * @return boolean
+     */
+    public function getRtpEncryption(): bool
+    {
+        return $this->rtpEncryption;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/Terminal/TerminalDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Terminal/TerminalDtoAbstract.php
@@ -56,6 +56,11 @@ abstract class TerminalDtoAbstract implements DataTransferObjectInterface
     private $t38Passthrough = 'no';
 
     /**
+     * @var boolean
+     */
+    private $rtpEncryption = false;
+
+    /**
      * @var integer
      */
     private $id;
@@ -112,6 +117,7 @@ abstract class TerminalDtoAbstract implements DataTransferObjectInterface
             'mac' => 'mac',
             'lastProvisionDate' => 'lastProvisionDate',
             't38Passthrough' => 't38Passthrough',
+            'rtpEncryption' => 'rtpEncryption',
             'id' => 'id',
             'companyId' => 'company',
             'domainId' => 'domain',
@@ -134,6 +140,7 @@ abstract class TerminalDtoAbstract implements DataTransferObjectInterface
             'mac' => $this->getMac(),
             'lastProvisionDate' => $this->getLastProvisionDate(),
             't38Passthrough' => $this->getT38Passthrough(),
+            'rtpEncryption' => $this->getRtpEncryption(),
             'id' => $this->getId(),
             'company' => $this->getCompany(),
             'domain' => $this->getDomain(),
@@ -334,6 +341,26 @@ abstract class TerminalDtoAbstract implements DataTransferObjectInterface
     public function getT38Passthrough()
     {
         return $this->t38Passthrough;
+    }
+
+    /**
+     * @param boolean $rtpEncryption
+     *
+     * @return static
+     */
+    public function setRtpEncryption($rtpEncryption = null)
+    {
+        $this->rtpEncryption = $rtpEncryption;
+
+        return $this;
+    }
+
+    /**
+     * @return boolean | null
+     */
+    public function getRtpEncryption()
+    {
+        return $this->rtpEncryption;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/Terminal/TerminalInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/Terminal/TerminalInterface.php
@@ -122,6 +122,13 @@ interface TerminalInterface extends LoggableEntityInterface
     public function getT38Passthrough(): string;
 
     /**
+     * Get rtpEncryption
+     *
+     * @return boolean
+     */
+    public function getRtpEncryption(): bool;
+
+    /**
      * Set company
      *
      * @param \Ivoz\Provider\Domain\Model\Company\CompanyInterface $company

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/Friend.FriendAbstract.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/Friend.FriendAbstract.orm.yml
@@ -143,6 +143,12 @@ Ivoz\Provider\Domain\Model\Friend\FriendAbstract:
       options:
         default: '0'
       column: alwaysApplyTransformations
+    rtpEncryption:
+      type: boolean
+      nullable: false
+      options:
+        default: '0'
+      column: rtpEncryption
   manyToOne:
     company:
       targetEntity: \Ivoz\Provider\Domain\Model\Company\CompanyInterface

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/ResidentialDevice.ResidentialDeviceAbstract.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/ResidentialDevice.ResidentialDeviceAbstract.orm.yml
@@ -133,6 +133,12 @@ Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDeviceAbstract:
         comment: '[enum:yes|no]'
         default: 'no'
       column: t38Passthrough
+    rtpEncryption:
+      type: boolean
+      nullable: false
+      options:
+        default: '0'
+      column: rtpEncryption
   manyToOne:
     brand:
       targetEntity: Ivoz\Provider\Domain\Model\Brand\BrandInterface

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/RetailAccount.RetailAccountAbstract.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/RetailAccount.RetailAccountAbstract.orm.yml
@@ -77,6 +77,12 @@ Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountAbstract:
         comment: '[enum:yes|no]'
         default: 'no'
       column: t38Passthrough
+    rtpEncryption:
+      type: boolean
+      nullable: false
+      options:
+        default: '0'
+      column: rtpEncryption
   manyToOne:
     brand:
       targetEntity: Ivoz\Provider\Domain\Model\Brand\BrandInterface

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/Terminal.TerminalAbstract.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/Terminal.TerminalAbstract.orm.yml
@@ -78,6 +78,12 @@ Ivoz\Provider\Domain\Model\Terminal\TerminalAbstract:
         comment: '[enum:yes|no]'
         default: 'no'
       column: t38Passthrough
+    rtpEncryption:
+      type: boolean
+      nullable: false
+      options:
+        default: '0'
+      column: rtpEncryption
   manyToOne:
     company:
       targetEntity: \Ivoz\Provider\Domain\Model\Company\CompanyInterface

--- a/schema/DoctrineMigrations/Version20200904135939.php
+++ b/schema/DoctrineMigrations/Version20200904135939.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Application\Migrations;
+
+use Ivoz\Core\Infrastructure\Persistence\Doctrine\LoggableMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20200904135939 extends LoggableMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE Friends ADD rtpEncryption TINYINT(1) DEFAULT \'0\' NOT NULL');
+        $this->addSql('ALTER TABLE Terminals ADD rtpEncryption TINYINT(1) DEFAULT \'0\' NOT NULL');
+        $this->addSql('ALTER TABLE RetailAccounts ADD rtpEncryption TINYINT(1) DEFAULT \'0\' NOT NULL');
+        $this->addSql('ALTER TABLE ResidentialDevices ADD rtpEncryption TINYINT(1) DEFAULT \'0\' NOT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE Friends DROP rtpEncryption');
+        $this->addSql('ALTER TABLE ResidentialDevices DROP rtpEncryption');
+        $this->addSql('ALTER TABLE RetailAccounts DROP rtpEncryption');
+        $this->addSql('ALTER TABLE Terminals DROP rtpEncryption');
+    }
+}

--- a/web/admin/application/configs/klear/FriendsList.yaml
+++ b/web/admin/application/configs/klear/FriendsList.yaml
@@ -46,6 +46,7 @@ production:
           outgoingDdi: true
           interCompany: true
           alwaysApplyTransformations: true
+          rtpEncryption: true
         order:
           name: true
           domain: true
@@ -101,6 +102,7 @@ production:
           allow: true
           fromDomain: true
           ddiIn: true
+          rtpEncryption: true
         order: &friends_orderLink
           directConnectivity: true
           name: true
@@ -156,6 +158,7 @@ production:
             fromDomain: 2
             ddiIn: 2
             t38Passthrough: 2
+            rtpEncryption: 2
       shortcutOption: N
 
     friendsEdit_screen: &friendsEdit_screenLink

--- a/web/admin/application/configs/klear/ResidentialDevicesList.yaml
+++ b/web/admin/application/configs/klear/ResidentialDevicesList.yaml
@@ -48,6 +48,7 @@ production:
           maxCalls: true
           t38Passthrough: true
           outgoingDdi: true
+          rtpEncryption: true
         order:
           name: true
           domain: true
@@ -102,6 +103,7 @@ production:
           fromDomain: true
           ddiIn: true
           maxCalls: true
+          rtpEncryption: true
         order: &residentialDevices_orderLink
           name: true
           description: true
@@ -154,6 +156,7 @@ production:
             ddiIn: 3
             t38Passthrough: 3
             maxCalls: 3
+            rtpEncryption: 3
     residentialDevicesEdit_screen: &residentialDevicesEdit_screenLink
       <<: *ResidentialDevices
       controller: edit

--- a/web/admin/application/configs/klear/RetailAccountsList.yaml
+++ b/web/admin/application/configs/klear/RetailAccountsList.yaml
@@ -40,6 +40,7 @@ production:
           ddiIn: true
           t38Passthrough: true
           outgoingDdi: true
+          rtpEncryption: true
         order:
           name: true
           domain: true
@@ -87,6 +88,7 @@ production:
           transformationRuleSet: true
           fromDomain: true
           ddiIn: true
+          rtpEncryption: true
         order: &retailAccounts_orderLink
           id: true
           name: true
@@ -133,6 +135,7 @@ production:
             fromDomain: 3
             ddiIn: 3
             t38Passthrough: 3
+            rtpEncryption: 3
 
     retailAccountsEdit_screen: &retailAccountsEdit_screenLink
       <<: *RetailAccounts

--- a/web/admin/application/configs/klear/TerminalsList.yaml
+++ b/web/admin/application/configs/klear/TerminalsList.yaml
@@ -35,6 +35,7 @@ production:
           t38Passthrough: true
           allowAudio: true
           allowVideo: true
+          rtpEncryption: true
         options:
           title: _("Options")
           screens:
@@ -92,6 +93,7 @@ production:
           allowAudio: true
           allowVideo: true
           directMediaMethod: true
+          rtpEncryption: true
       fixedPositions: &TerminalsFixedPositions_link
         group0:
           label: _("Login Info")
@@ -108,6 +110,7 @@ production:
             allowVideo: 4
             directMediaMethod: 4
             t38Passthrough: 4
+            rtpEncryption: 4
         group2:
           label: _("Provisioning Info")
           colsPerRow: 12

--- a/web/admin/application/configs/klear/model/Friends.yaml
+++ b/web/admin/application/configs/klear/model/Friends.yaml
@@ -239,6 +239,7 @@ production:
                 - language
                 - transformationRuleSet
                 - callACL
+                - rtpEncryption
           'no':
             title: _('Register')
             visualFilter:
@@ -256,6 +257,7 @@ production:
                 - language
                 - transformationRuleSet
                 - callACL
+                - rtpEncryption
           'intervpbx':
             title: _('Inter vPBX')
             visualFilter:
@@ -272,6 +274,7 @@ production:
                 - transformationRuleSet
                 - callACL
                 - t38Passthrough
+                - rtpEncryption
               show:
                 - interCompany
     interCompany:
@@ -360,6 +363,23 @@ production:
         position: left
         icon: help
         text: _("Enable to force numeric transformation on numbers in Extensions or numbers matching any Friend regexp. Otherwise, those numbers won't traverse numeric transformations rules.")
+        label: _("Need help?")
+    rtpEncryption:
+      title: _('RTP encryption')
+      type: select
+      defaultValue: 0
+      source:
+        data: inline
+        values:
+          '0':
+            title: _("No")
+          '1':
+            title: _("Yes")
+      info:
+        type: box
+        position: left
+        icon: help
+        text: _("Enable to force audio encryption. Call won't be established unless it is encrypted.")
         label: _("Need help?")
 staging:
   _extends: production

--- a/web/admin/application/configs/klear/model/ResidentialDevices.yaml
+++ b/web/admin/application/configs/klear/model/ResidentialDevices.yaml
@@ -286,6 +286,23 @@ production:
         values:
           'yes': _('Yes')
           'no': _('No')
+    rtpEncryption:
+      title: _('RTP encryption')
+      type: select
+      defaultValue: 0
+      source:
+        data: inline
+        values:
+          '0':
+            title: _("No")
+          '1':
+            title: _("Yes")
+      info:
+        type: box
+        position: left
+        icon: help
+        text: _("Enable to force audio encryption. Call won't be established unless it is encrypted.")
+        label: _("Need help?")
 staging:
   _extends: production
 testing:

--- a/web/admin/application/configs/klear/model/RetailAccounts.yaml
+++ b/web/admin/application/configs/klear/model/RetailAccounts.yaml
@@ -192,6 +192,23 @@ production:
         values:
           'yes': _('Yes')
           'no': _('No')
+    rtpEncryption:
+      title: _('RTP encryption')
+      type: select
+      defaultValue: 0
+      source:
+        data: inline
+        values:
+          '0':
+            title: _("No")
+          '1':
+            title: _("Yes")
+      info:
+        type: box
+        position: left
+        icon: help
+        text: _("Enable to force audio encryption. Call won't be established unless it is encrypted.")
+        label: _("Need help?")
 staging:
   _extends: production
 testing:

--- a/web/admin/application/configs/klear/model/Terminals.yaml
+++ b/web/admin/application/configs/klear/model/Terminals.yaml
@@ -153,6 +153,23 @@ production:
         values:
           'yes': _('Yes')
           'no': _('No')
+    rtpEncryption:
+      title: _('RTP encryption')
+      type: select
+      defaultValue: 0
+      source:
+        data: inline
+        values:
+          '0':
+            title: _("No")
+          '1':
+            title: _("Yes")
+      info:
+        type: box
+        position: left
+        icon: help
+        text: _("Enable to force audio encryption. Call won't be established unless it is encrypted.")
+        label: _("Need help?")
 staging:
   _extends: production
 testing:

--- a/web/admin/application/languages/ca_ES/ca_ES.po
+++ b/web/admin/application/languages/ca_ES/ca_ES.po
@@ -922,6 +922,13 @@ msgstr ""
 "d’enregistrament de trucades al portal del client."
 
 msgid ""
+"Enable to force audio encryption. Call won't be established unless it is "
+"encrypted."
+msgstr ""
+"Activar para forzar el cifrado del audio. La llamada no se establecerá en "
+"caso de no ser posible cifrar su audio."
+
+msgid ""
 "Enable to force numeric transformation on numbers in Extensions or numbers "
 "matching any Friend regexp. Otherwise, those numbers won't traverse numeric "
 "transformations rules."
@@ -2237,6 +2244,9 @@ msgstr[1] "Membres de la cua"
 
 msgid "R-URI pattern"
 msgstr "Patró R-URI"
+
+msgid "RTP encryption"
+msgstr "Cifrar RTP"
 
 msgid "Random"
 msgstr "Aleatori"

--- a/web/admin/application/languages/en_US/en_US.po
+++ b/web/admin/application/languages/en_US/en_US.po
@@ -911,6 +911,13 @@ msgstr ""
 "recordings section."
 
 msgid ""
+"Enable to force audio encryption. Call won't be established unless it is "
+"encrypted."
+msgstr ""
+"Enable to force audio encryption. Call won't be established unless it is "
+"encrypted."
+
+msgid ""
 "Enable to force numeric transformation on numbers in Extensions or numbers "
 "matching any Friend regexp. Otherwise, those numbers won't traverse numeric "
 "transformations rules."
@@ -2220,6 +2227,9 @@ msgstr[1] "Queue Members"
 
 msgid "R-URI pattern"
 msgstr "R-URI pattern"
+
+msgid "RTP encryption"
+msgstr "RTP encryption"
 
 msgid "Random"
 msgstr "Random"

--- a/web/admin/application/languages/es_ES/es_ES.po
+++ b/web/admin/application/languages/es_ES/es_ES.po
@@ -925,6 +925,13 @@ msgstr ""
 "portal del cliente"
 
 msgid ""
+"Enable to force audio encryption. Call won't be established unless it is "
+"encrypted."
+msgstr ""
+"Activar para forzar el cifrado del audio. La llamada no se establecerá en "
+"caso de no ser posible cifrar su audio."
+
+msgid ""
 "Enable to force numeric transformation on numbers in Extensions or numbers "
 "matching any Friend regexp. Otherwise, those numbers won't traverse numeric "
 "transformations rules."
@@ -2250,6 +2257,9 @@ msgstr[1] "Miembros de cola"
 
 msgid "R-URI pattern"
 msgstr "Patrón R-URI"
+
+msgid "RTP encryption"
+msgstr "Cifrar RTP"
 
 msgid "Random"
 msgstr "Aleatoriamente"

--- a/web/admin/application/languages/it_IT/it_IT.po
+++ b/web/admin/application/languages/it_IT/it_IT.po
@@ -925,6 +925,13 @@ msgstr ""
 "registrazioni chiamate del portale del cliente."
 
 msgid ""
+"Enable to force audio encryption. Call won't be established unless it is "
+"encrypted."
+msgstr ""
+"Enable to force audio encryption. Call won't be established unless it is "
+"encrypted."
+
+msgid ""
 "Enable to force numeric transformation on numbers in Extensions or numbers "
 "matching any Friend regexp. Otherwise, those numbers won't traverse numeric "
 "transformations rules."
@@ -2255,6 +2262,9 @@ msgstr[1] "Membri coda"
 
 msgid "R-URI pattern"
 msgstr "Schema R-URI"
+
+msgid "RTP encryption"
+msgstr "RTP encryption"
 
 msgid "Random"
 msgstr "Random"

--- a/web/rest/client/features/provider/terminal/postTerminal.feature
+++ b/web/rest/client/features/provider/terminal/postTerminal.feature
@@ -37,6 +37,7 @@ Feature: Create terminals
           "mac": null,
           "lastProvisionDate": "1970-03-04 11:12:13",
           "t38Passthrough": "no",
+          "rtpEncryption": false,
           "id": 4,
           "terminalModel": 1
       }

--- a/web/rest/client/features/provider/terminal/putTerminal.feature
+++ b/web/rest/client/features/provider/terminal/putTerminal.feature
@@ -37,6 +37,7 @@ Feature: Update terminals
           "mac": "aabbccddeeff",
           "lastProvisionDate": "1970-01-01 10:10:10",
           "t38Passthrough": "no",
+          "rtpEncryption": false,
           "id": 1,
           "terminalModel": 2
       }


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

This PR adds SRTP optional support to:

- Terminals.
- Friends.
- Retail accounts.
- Residential devices.

These elements will now have a Encrypt RTP toggle. Enabling this setting makes SRTP mandatory (calls wont' be established unless it is possible to encrypt its media).