### PR TITLE
web/admin: no trim for select fields

### DIFF
--- a/web/admin/application/configs/klear/model/Friends.yaml
+++ b/web/admin/application/configs/klear/model/Friends.yaml
@@ -159,7 +159,6 @@ production:
     allow:
       title: _('Allowed audio codecs')
       type: select
-      trim: both
       defaultValue: alaw
       maxLength: 100
       source:

--- a/web/admin/application/configs/klear/model/ResidentialDevices.yaml
+++ b/web/admin/application/configs/klear/model/ResidentialDevices.yaml
@@ -131,7 +131,6 @@ production:
     allow:
       title: _('Allowed audio codecs')
       type: select
-      trim: both
       defaultValue: alaw
       maxLength: 100
       source:

--- a/web/admin/application/configs/klear/model/Terminals.yaml
+++ b/web/admin/application/configs/klear/model/Terminals.yaml
@@ -54,7 +54,6 @@ production:
     allowAudio:
       title: _('Allowed audio codecs')
       type: select
-      trim: both
       defaultValue: alaw
       maxLength: 100
       source:
@@ -72,7 +71,6 @@ production:
     allowVideo:
       title: _('Allowed video codecs')
       type: select
-      trim: both
       maxLength: 100
       source:
         data: inline


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

Trimming select fields causes problems in VisualFilters scenarios:

- Hidden select field with trim.

- As it is hidden, it is set to null.

- null turns into '' after being trimmed.

