### PR TITLE
web/admin: allow using brand level matchlists

### DIFF
--- a/web/admin/application/configs/klear/model/ExternalCallFilters.yaml
+++ b/web/admin/application/configs/klear/model/ExternalCallFilters.yaml
@@ -295,7 +295,7 @@ production:
           relatedProperty: matchlist
           related: \Ivoz\Provider\Domain\Model\MatchList\MatchList
           relatedFieldName: name
-          filterClass: IvozProvider_Klear_Filter_Company
+          filterClass: IvozProvider_Klear_Filter_CompanyOrBrand
       info:
         type: box
         text: _("Incoming numbers that match this lists will be always ACCEPTED without checking this filter configuration.")
@@ -311,7 +311,7 @@ production:
           relatedProperty: matchlist
           related: \Ivoz\Provider\Domain\Model\MatchList\MatchList
           relatedFieldName: name
-          filterClass: IvozProvider_Klear_Filter_Company
+          filterClass: IvozProvider_Klear_Filter_CompanyOrBrand
       info:
         type: box
         text: _("Incoming numbers that match this lists will be always REJECTED without checking this filter configuration.")

--- a/web/admin/application/configs/klear/model/ExternalCallFiltersResidential.yaml
+++ b/web/admin/application/configs/klear/model/ExternalCallFiltersResidential.yaml
@@ -68,7 +68,7 @@ production:
           relatedProperty: matchlist
           related: \Ivoz\Provider\Domain\Model\MatchList\MatchList
           relatedFieldName: name
-          filterClass: IvozProvider_Klear_Filter_Company
+          filterClass: IvozProvider_Klear_Filter_CompanyOrBrand
       info:
         type: box
         text: _("Incoming numbers that match this lists will be always REJECTED without checking this filter configuration.")

--- a/web/admin/application/library/IvozProvider/Klear/Filter/CompanyOrBrand.php
+++ b/web/admin/application/library/IvozProvider/Klear/Filter/CompanyOrBrand.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Class IvozProvider_Klear_Filter_CompanyOrBrand
+ *
+ * Filter results for the current emulated company or brand
+ *
+ * @note multiple filters inherit from this one
+ */
+class IvozProvider_Klear_Filter_CompanyOrBrand implements KlearMatrix_Model_Field_Select_Filter_Interface
+{
+    protected $_condition = array();
+
+    public function setRouteDispatcher(KlearMatrix_Model_RouteDispatcher $routeDispatcher)
+    {
+        $auth = Zend_Auth::getInstance();
+        if (!$auth->hasIdentity()) {
+            throw new Klear_Exception_Default("No company emulated");
+        }
+
+        $loggedUser = $auth->getIdentity();
+        $currentCompanyId = $loggedUser->companyId;
+        $currentBrandId = $loggedUser->brandId;
+
+        $this->_condition[] = "self::company = '" . $currentCompanyId . "'";
+        $this->_condition[] = "self::brand = '" . $currentBrandId . "'";
+
+        return true;
+    }
+
+    public function getCondition()
+    {
+        if (count($this->_condition) > 0) {
+            return ['(' . implode(" OR ", $this->_condition) . ')'];
+        }
+    }
+}


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
Brand level matchlists couldn't be selected in client external call filters.
