### PR TITLE
kam: skip media-relay logic rewritten

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -437,6 +437,9 @@ request_route {
     # Add record-route to INVITE requests
     record_route();
 
+    # Handle skip media-relay scenarios
+    route(SKIPMEDIARELAY);
+
     # Easy routing
     if ($var(is_from_inside) == 1) { # kamusers or AS calls
         # IvozProvider calling, route to corresponding GW
@@ -478,9 +481,6 @@ request_route {
         route(SELECT_NEXT_GW);
     } else { # carriers or bounced calls from myself
         if (uri == myself) {
-            if (src_ip == myself && remove_hf("X-Info-Skip-MediaRelay")) {
-                $dlg_var(skipMediaRelay) = 'yes';
-            }
             # Someone calling to my domain, dispatch to next hop
             remove_hf_re("^X-"); # Remove X-HEADERS from carriers
             route(GET_INFO_FROM_MATCHED_DDI);
@@ -499,6 +499,29 @@ request_route {
     }
 
     route(RELAY);
+}
+
+route[SKIPMEDIARELAY] {
+    if (ds_is_from_list("1")) {
+        # AS
+        xdbg("[$dlg_var(cidhash)] From AS, force media handling\n");
+    } else if ($si == $var(usersAddress) && $sp == "5060") {
+        # USERS
+        xdbg("[$dlg_var(cidhash)] From Users, skip media handling\n");
+        $dlg_var(skipMediaRelay) = 'yes';
+    } else if (src_ip == myself) {
+        # TRUNKS
+        xdbg("[$dlg_var(cidhash)] From Trunks, skip media handling\n");
+        $dlg_var(skipMediaRelay) = 'yes';
+    } else {
+        # CARRIER
+        if ($dlg_var(type) == 'retail') {
+            xdbg("[$dlg_var(cidhash)] From Carrier to retail, skip media handling\n");
+            $dlg_var(skipMediaRelay) = 'yes';
+        } else {
+            xdbg("[$dlg_var(cidhash)] From Carrier to non-retail, force media handling\n");
+        }
+    }
 }
 
 # This route sets $var(is_from_inside)
@@ -535,18 +558,6 @@ route[CHECK_BOUNCE] {
     if ($xavp(ra=>type) != $null) {
         xinfo("[$dlg_var(cidhash)] CHECK-BOUNCE: Call is to one of my DDIs\n");
         $dlg_var(bounced) = '1';
-        $dlg_var(skipMediaRelay) = 'yes';
-
-        # Keep X-Info-Skip-MediaRelay header added by Users in bounced calls
-        if (is_present_hf("X-Info-Skip-MediaRelay"))
-            insert_hf("X-Info-Skip-MediaRelay: yes\r\n");
-
-        if ($dlg_var(type) == 'retail' || $dlg_var(type) == 'wholesale') {
-            if ($xavp(ra=>type) == 'retail') {
-                # Retail/Wholesale calling to retail DDI: skip media-relay in KamUsers
-                insert_hf("X-Info-Skip-KamUsers-MediaRelay: yes\r\n");
-            }
-        }
     }
 
 }
@@ -1028,10 +1039,6 @@ route[PARSE_X_HEADERS] {
         xnotice("[$dlg_var(cidhash)] PARSE-X-HEADERS: Related leg: $dlg_var(xcallid)\n");
     }
 
-    if (remove_hf("X-Info-Skip-MediaRelay")) {
-        $dlg_var(skipMediaRelay) = 'yes';
-    }
-
     if ($dlg_var(type) == 'wholesale') return;
 
     # Extract ddiId for cdr entry
@@ -1476,11 +1483,6 @@ route[SETUP_KAMUSERS_CALL] {
     insert_hf("X-Info-Type: $dlg_var(type)\r\n");
     insert_hf("X-Info-Callee: $rU\r\n");
 
-    # Add Skip-MediaRelay header when retail/wholesale calling to retail DDI (bouncing)
-    if ($var(is_from_inside) == 2 && is_present_hf("X-Info-Skip-KamUsers-MediaRelay")) {
-        insert_hf("X-Info-Skip-MediaRelay: yes\r\n");
-    }
-
     # Check DDI is routed to a retail account
     $xavp(ra) = $null;
     sql_xquery("cb", "SELECT RA.name AS username, DS.domain AS domain FROM DDIs D INNER JOIN RetailAccounts RA ON D.retailAccountId=RA.id INNER JOIN Domains DS ON RA.domainId=DS.id WHERE DDIE164='$rU'", "ra");
@@ -1490,9 +1492,6 @@ route[SETUP_KAMUSERS_CALL] {
 
     # Make To header equal to R-URI
     uac_replace_to("$ru");
-
-    # No media handling for this proxy2proxy dialog
-    $dlg_var(skipMediaRelay) = 'yes';
 }
 
 # Relay request

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -504,8 +504,11 @@ request_route {
     route(GENERATE_PUBLISH);
 
     # From now on, everything is for INVITEs: track dialog
-    if (!is_known_dlg() || $si == $var(trunksAddress) || src_ip == myself) {
+    if (!is_known_dlg()) {
         dlg_manage();
+    } else if ($si == $var(trunksAddress) || src_ip == myself) {
+        dlg_manage();
+        $dlg_var(skipMediaRelay) = 'yes'; # bounced call second processing (intervpbx call or retail/wholesale calling to retail DDI)
     }
 
     # Calculate cidhash if not set
@@ -1086,7 +1089,6 @@ route[DISPATCH_TO_TRUNKS] {
     insert_hf("X-Info-BrandId: $dlg_var(brandId)\r\n");
     insert_hf("X-Info-CompanyId: $dlg_var(companyId)\r\n");
     insert_hf("X-Info-Type: $dlg_var(type)\r\n");
-    insert_hf("X-Info-Skip-MediaRelay: yes\r\n");
 
     if ($dlg_var(type) == "retail") {
         insert_hf("X-Info-RetailAccountId: $dlg_var(retailAccountId)\r\n");
@@ -1231,7 +1233,6 @@ route[STATIC_LOCATION] {
         $rd = $fd;
         $du = "sip:users.ivozprovider.local";
         uac_replace_from("sip:" + $xavp(rb=>name) + "@" + $fd);
-        $dlg_var(skipMediaRelay) = 'yes';
         return;
     }
 
@@ -1402,10 +1403,6 @@ route[PARSE_X_HEADERS] {
     $var(header) = 'X-Info-Callee';
     route(PARSE_MANDATORY_X_HEADER);
     $dlg_var(callee) = $var(header-value);
-
-    if (remove_hf("X-Info-Skip-MediaRelay")) {
-        $dlg_var(skipMediaRelay) = 'yes';
-    }
 
     # Extract xcallid
     if (is_present_hf("X-Call-Id")) {


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

No intended functional change.

#### Additional information

- KamUsers will always call rtpengine except in known_dlgs:
  - Intervpbx bounced call second processing
  - Retail/wholesale call to retail DDI second processing

- KamTrunks will always call rtpengine except:
  - calls from kamusers
  - calls from carriers to retail DDIs
  - second processing of bounced calls
