### PR TITLE
kam: remove skip media-relay logic

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -478,9 +478,6 @@ request_route {
         route(SELECT_NEXT_GW);
     } else { # carriers or bounced calls from myself
         if (uri == myself) {
-            if (src_ip == myself && remove_hf("X-Info-Skip-MediaRelay")) {
-                $dlg_var(skipMediaRelay) = 'yes';
-            }
             # Someone calling to my domain, dispatch to next hop
             remove_hf_re("^X-"); # Remove X-HEADERS from carriers
             route(GET_INFO_FROM_MATCHED_DDI);
@@ -535,18 +532,6 @@ route[CHECK_BOUNCE] {
     if ($xavp(ra=>type) != $null) {
         xinfo("[$dlg_var(cidhash)] CHECK-BOUNCE: Call is to one of my DDIs\n");
         $dlg_var(bounced) = '1';
-        $dlg_var(skipMediaRelay) = 'yes';
-
-        # Keep X-Info-Skip-MediaRelay header added by Users in bounced calls
-        if (is_present_hf("X-Info-Skip-MediaRelay"))
-            insert_hf("X-Info-Skip-MediaRelay: yes\r\n");
-
-        if ($dlg_var(type) == 'retail' || $dlg_var(type) == 'wholesale') {
-            if ($xavp(ra=>type) == 'retail') {
-                # Retail/Wholesale calling to retail DDI: skip media-relay in KamUsers
-                insert_hf("X-Info-Skip-KamUsers-MediaRelay: yes\r\n");
-            }
-        }
     }
 
 }
@@ -1028,10 +1013,6 @@ route[PARSE_X_HEADERS] {
         xnotice("[$dlg_var(cidhash)] PARSE-X-HEADERS: Related leg: $dlg_var(xcallid)\n");
     }
 
-    if (remove_hf("X-Info-Skip-MediaRelay")) {
-        $dlg_var(skipMediaRelay) = 'yes';
-    }
-
     if ($dlg_var(type) == 'wholesale') return;
 
     # Extract ddiId for cdr entry
@@ -1476,11 +1457,6 @@ route[SETUP_KAMUSERS_CALL] {
     insert_hf("X-Info-Type: $dlg_var(type)\r\n");
     insert_hf("X-Info-Callee: $rU\r\n");
 
-    # Add Skip-MediaRelay header when retail/wholesale calling to retail DDI (bouncing)
-    if ($var(is_from_inside) == 2 && is_present_hf("X-Info-Skip-KamUsers-MediaRelay")) {
-        insert_hf("X-Info-Skip-MediaRelay: yes\r\n");
-    }
-
     # Check DDI is routed to a retail account
     $xavp(ra) = $null;
     sql_xquery("cb", "SELECT RA.name AS username, DS.domain AS domain FROM DDIs D INNER JOIN RetailAccounts RA ON D.retailAccountId=RA.id INNER JOIN Domains DS ON RA.domainId=DS.id WHERE DDIE164='$rU'", "ra");
@@ -1490,9 +1466,6 @@ route[SETUP_KAMUSERS_CALL] {
 
     # Make To header equal to R-URI
     uac_replace_to("$ru");
-
-    # No media handling for this proxy2proxy dialog
-    $dlg_var(skipMediaRelay) = 'yes';
 }
 
 # Relay request
@@ -1960,7 +1933,6 @@ onsend_route {
 route[RTPENGINE] {
     if (!is_method("INVITE|UPDATE|ACK|BYE|CANCEL")) return;
     if (is_method("ACK") && !has_body("application/sdp")) return;
-    if ($dlg_var(skipMediaRelay) == 'yes') return;
 
     if ($(dlg_var(mediaRelaySetsId){s.len}) > 0 && $dlg_var(mediaRelaySetsId) != 0) {
         set_rtpengine_set("$(dlg_var(mediaRelaySetsId){s.int})");
@@ -1968,8 +1940,10 @@ route[RTPENGINE] {
 
     $var(rtpengine_opts) = 'replace-session-connection replace-origin ICE=remove RTP/AVP asymmetric trust-address';
 
-    xinfo("[$dlg_var(cidhash)] RTPENGINE: rtpengine_manage [$var(rtpengine_opts)]\n");
-    rtpengine_manage("$var(rtpengine_opts)");
+    $var(callid) = "call-id=trunks-" + $dlg_var(direction) + '-' + $dlg_var(callid);
+
+    xinfo("[$dlg_var(cidhash)] RTPENGINE: rtpengine_manage [$var(rtpengine_opts) $var(callid)]\n");
+    rtpengine_manage("$var(rtpengine_opts) $var(callid)");
 
     route(RECORD);
 }

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -1091,7 +1091,6 @@ route[DISPATCH_TO_TRUNKS] {
     insert_hf("X-Info-BrandId: $dlg_var(brandId)\r\n");
     insert_hf("X-Info-CompanyId: $dlg_var(companyId)\r\n");
     insert_hf("X-Info-Type: $dlg_var(type)\r\n");
-    insert_hf("X-Info-Skip-MediaRelay: yes\r\n");
 
     if ($dlg_var(type) == "retail") {
         insert_hf("X-Info-RetailAccountId: $dlg_var(retailAccountId)\r\n");
@@ -1236,7 +1235,6 @@ route[STATIC_LOCATION] {
         $rd = $fd;
         $du = "sip:users.ivozprovider.local";
         uac_replace_from("sip:" + $xavp(rb=>name) + "@" + $fd);
-        $dlg_var(skipMediaRelay) = 'yes';
         return;
     }
 
@@ -1407,10 +1405,6 @@ route[PARSE_X_HEADERS] {
     $var(header) = 'X-Info-Callee';
     route(PARSE_MANDATORY_X_HEADER);
     $dlg_var(callee) = $var(header-value);
-
-    if (remove_hf("X-Info-Skip-MediaRelay")) {
-        $dlg_var(skipMediaRelay) = 'yes';
-    }
 
     # Extract xcallid
     if (is_present_hf("X-Call-Id")) {
@@ -2552,7 +2546,6 @@ route[GET_CODEC_INFO] {
 route[RTPENGINE] {
     if (!is_method("INVITE|UPDATE|ACK|BYE|CANCEL")) return;
     if (is_method("ACK") && !has_body("application/sdp")) return;
-    if ($dlg_var(skipMediaRelay) == 'yes') return;
 
     if ($(dlg_var(mediaRelaySetsId){s.len}) > 0 && $dlg_var(mediaRelaySetsId) != 0) {
         set_rtpengine_set("$(dlg_var(mediaRelaySetsId){s.int})");
@@ -2589,8 +2582,10 @@ route[RTPENGINE] {
     }
     #!endif
 
-    xinfo("[$dlg_var(cidhash)] RTPENGINE: rtpengine_manage [$var(common_opts) $var(symmetry) $var(bridging) $var(interfaces) $dlg_var(codecs)]\n");
-    rtpengine_manage("$var(common_opts) $var(symmetry) $var(bridging) $var(interfaces) $dlg_var(codecs)");
+    $var(callid) = "call-id=users-" + $dlg_var(direction) + '-' + $dlg_var(callid);
+
+    xinfo("[$dlg_var(cidhash)] RTPENGINE: rtpengine_manage [$var(common_opts) $var(symmetry) $var(bridging) $var(interfaces) $dlg_var(codecs) $var(callid)]\n");
+    rtpengine_manage("$var(common_opts) $var(symmetry) $var(bridging) $var(interfaces) $dlg_var(codecs) $var(callid)");
 }
 
 route[LOCAL_PUBLISH] {


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

- KamUsers will always call rtpengine.
    
- KamTrunks will always call rtpengine.
    
- Both proxies will add "call-id=trunks|users-inbound|outbound-$ci" flag to avoid rtpengine collisions in bouncing scenarios.
    

#### Additional information

These changes:
    
 - Solve No NAT retail/wholesale calling to behind NAT retail DDI no audio.
    
- Solve some recording issues in skip scenarios.
    
- In KamUsers, guarantees each UAC sends RTP to media-relay linked to its client.
    
- In KamTrunks, guarantees RTP traverses media-relays linked to each client.