### PR TITLE
Add From User in remote Friends

### DIFF
--- a/doc/sphinx/administration_portal/client/vpbx/routing_endpoints/friends/remote_friends.rst
+++ b/doc/sphinx/administration_portal/client/vpbx/routing_endpoints/friends/remote_friends.rst
@@ -82,6 +82,10 @@ These are the configurable settings of *friends*:
     Allowed codecs
         Like a terminal, *friends* will talk the selected codec.
 
+    From user
+        Request from IvozProvider to this friend will include this user in
+        the From header.
+
     From domain
         Request from IvozProvider to this friend will include this domain in
         the From header.

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -848,10 +848,15 @@ route[SET_CALLER] {
 
 # Sets $var(transformated) in new PAI or existing PAI (modifies From in initial requests too)
 route[SET_PAI] {
-
     if (is_request() && !has_totag()) {
-        if ($fU != $var(transformated)) {
-            $var(newfromuri) = 'sip:' + $var(transformated) + '@' + $fd;
+        if ($(avp(friendFromUser){s.len}) > 0 && $var(is_from_inside)) {
+            $var(newfromuser) = $avp(friendFromUser);
+        } else {
+            $var(newfromuser) = $var(transformated);
+        }
+
+        if ($fU != $var(newfromuser)) {
+            $var(newfromuri) = 'sip:' + $var(newfromuser) + '@' + $fd;
             uac_replace_from("$var(newfromuri)");
         }
     }
@@ -1602,9 +1607,10 @@ route[GET_INFO_FROM_ENDPOINT] {
         sql_xquery("cb", "SELECT id, companyId, transformationRuleSetId, t38Passthrough, maxCalls, rtpEncryption FROM ResidentialDevices WHERE id='$avp(endpointId)'", "endpoint");
         $avp(maxCalls) = $xavp(endpoint=>maxCalls); # used in GET_CALL_INFO
     } else if ($avp(endpointType) == "Friends") {
-        sql_xquery("cb", "SELECT id, companyId, transformationRuleSetId, t38Passthrough, alwaysApplyTransformations, rtpEncryption FROM Friends WHERE id='$avp(endpointId)'", "endpoint");
+        sql_xquery("cb", "SELECT id, companyId, transformationRuleSetId, t38Passthrough, alwaysApplyTransformations, rtpEncryption, from_user FROM Friends WHERE id='$avp(endpointId)'", "endpoint");
         $avp(maxCalls) = 0; # used in GET_CALL_INFO
         $avp(alwaysApplyTransformations) = $xavp(endpoint=>alwaysApplyTransformations); # used in IS_INTERNAL
+        $avp(friendFromUser) = $(xavp(endpoint=>from_user){s.trim}); # used in SET_PAI
     } else {
         sql_xquery("cb", "SELECT id, companyId, transformationRuleSetId, t38Passthrough, rtpEncryption FROM RetailAccounts WHERE id='$avp(endpointId)'", "endpoint");
         $avp(maxCalls) = 0; # used in GET_CALL_INFO

--- a/library/Ivoz/Provider/Domain/Model/Friend/Friend.php
+++ b/library/Ivoz/Provider/Domain/Model/Friend/Friend.php
@@ -78,6 +78,8 @@ class Friend extends FriendAbstract implements FriendInterface
             $this->setDdiIn(FriendInterface::DDIIN_YES);
             // Set From Domain from target company
             $this->setFromDomain($this->getInterCompany()->getDomainUsers());
+            // Empty From User
+            $this->setFromUser(null);
         } else {
             $this->setInterCompany(null);
         }

--- a/library/Ivoz/Provider/Domain/Model/Friend/FriendAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Friend/FriendAbstract.php
@@ -81,6 +81,12 @@ abstract class FriendAbstract
     protected $updateCallerid = 'yes';
 
     /**
+     * column: from_user
+     * @var string | null
+     */
+    protected $fromUser;
+
+    /**
      * column: from_domain
      * @var string | null
      */
@@ -274,6 +280,7 @@ abstract class FriendAbstract
             ->setIp($dto->getIp())
             ->setPort($dto->getPort())
             ->setPassword($dto->getPassword())
+            ->setFromUser($dto->getFromUser())
             ->setFromDomain($dto->getFromDomain())
             ->setCompany($fkTransformer->transform($dto->getCompany()))
             ->setDomain($fkTransformer->transform($dto->getDomain()))
@@ -313,6 +320,7 @@ abstract class FriendAbstract
             ->setDirectMediaMethod($dto->getDirectMediaMethod())
             ->setCalleridUpdateHeader($dto->getCalleridUpdateHeader())
             ->setUpdateCallerid($dto->getUpdateCallerid())
+            ->setFromUser($dto->getFromUser())
             ->setFromDomain($dto->getFromDomain())
             ->setDirectConnectivity($dto->getDirectConnectivity())
             ->setDdiIn($dto->getDdiIn())
@@ -352,6 +360,7 @@ abstract class FriendAbstract
             ->setDirectMediaMethod(self::getDirectMediaMethod())
             ->setCalleridUpdateHeader(self::getCalleridUpdateHeader())
             ->setUpdateCallerid(self::getUpdateCallerid())
+            ->setFromUser(self::getFromUser())
             ->setFromDomain(self::getFromDomain())
             ->setDirectConnectivity(self::getDirectConnectivity())
             ->setDdiIn(self::getDdiIn())
@@ -385,6 +394,7 @@ abstract class FriendAbstract
             'direct_media_method' => self::getDirectMediaMethod(),
             'callerid_update_header' => self::getCalleridUpdateHeader(),
             'update_callerid' => self::getUpdateCallerid(),
+            'from_user' => self::getFromUser(),
             'from_domain' => self::getFromDomain(),
             'directConnectivity' => self::getDirectConnectivity(),
             'ddiIn' => self::getDdiIn(),
@@ -744,6 +754,34 @@ abstract class FriendAbstract
     public function getUpdateCallerid(): string
     {
         return $this->updateCallerid;
+    }
+
+    /**
+     * Set fromUser
+     *
+     * @param string $fromUser | null
+     *
+     * @return static
+     */
+    protected function setFromUser($fromUser = null)
+    {
+        if (!is_null($fromUser)) {
+            Assertion::maxLength($fromUser, 190, 'fromUser value "%s" is too long, it should have no more than %d characters, but has %d characters.');
+        }
+
+        $this->fromUser = $fromUser;
+
+        return $this;
+    }
+
+    /**
+     * Get fromUser
+     *
+     * @return string | null
+     */
+    public function getFromUser()
+    {
+        return $this->fromUser;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/Friend/FriendDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Friend/FriendDtoAbstract.php
@@ -73,6 +73,11 @@ abstract class FriendDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
+    private $fromUser;
+
+    /**
+     * @var string
+     */
     private $fromDomain;
 
     /**
@@ -180,6 +185,7 @@ abstract class FriendDtoAbstract implements DataTransferObjectInterface
             'directMediaMethod' => 'directMediaMethod',
             'calleridUpdateHeader' => 'calleridUpdateHeader',
             'updateCallerid' => 'updateCallerid',
+            'fromUser' => 'fromUser',
             'fromDomain' => 'fromDomain',
             'directConnectivity' => 'directConnectivity',
             'ddiIn' => 'ddiIn',
@@ -215,6 +221,7 @@ abstract class FriendDtoAbstract implements DataTransferObjectInterface
             'directMediaMethod' => $this->getDirectMediaMethod(),
             'calleridUpdateHeader' => $this->getCalleridUpdateHeader(),
             'updateCallerid' => $this->getUpdateCallerid(),
+            'fromUser' => $this->getFromUser(),
             'fromDomain' => $this->getFromDomain(),
             'directConnectivity' => $this->getDirectConnectivity(),
             'ddiIn' => $this->getDdiIn(),
@@ -485,6 +492,26 @@ abstract class FriendDtoAbstract implements DataTransferObjectInterface
     public function getUpdateCallerid()
     {
         return $this->updateCallerid;
+    }
+
+    /**
+     * @param string $fromUser
+     *
+     * @return static
+     */
+    public function setFromUser($fromUser = null)
+    {
+        $this->fromUser = $fromUser;
+
+        return $this;
+    }
+
+    /**
+     * @return string | null
+     */
+    public function getFromUser()
+    {
+        return $this->fromUser;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/Friend/FriendInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/Friend/FriendInterface.php
@@ -208,6 +208,13 @@ interface FriendInterface extends LoggableEntityInterface
     public function getUpdateCallerid(): string;
 
     /**
+     * Get fromUser
+     *
+     * @return string | null
+     */
+    public function getFromUser();
+
+    /**
      * Get fromDomain
      *
      * @return string | null

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/Friend.FriendAbstract.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/Friend.FriendAbstract.orm.yml
@@ -103,6 +103,13 @@ Ivoz\Provider\Domain\Model\Friend\FriendAbstract:
         comment: '[enum:yes|no]'
         default: 'yes'
       column: update_callerid
+    fromUser:
+      type: string
+      nullable: true
+      length: 190
+      options:
+        fixed: false
+      column: from_user
     fromDomain:
       type: string
       nullable: true

--- a/schema/DoctrineMigrations/Version20201005171626.php
+++ b/schema/DoctrineMigrations/Version20201005171626.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Application\Migrations;
+
+use Ivoz\Core\Infrastructure\Persistence\Doctrine\LoggableMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20201005171626 extends LoggableMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE Friends ADD from_user VARCHAR(190) DEFAULT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE Friends DROP from_user');
+    }
+}

--- a/web/admin/application/configs/klear/FriendsList.yaml
+++ b/web/admin/application/configs/klear/FriendsList.yaml
@@ -32,6 +32,7 @@ production:
           directMediaMethod: true
           updateCallerid: true
           fromDomain: true
+          fromUser: true
           calleridUpdateHeader: true
           directConnectivity: true
           ip: true
@@ -101,6 +102,7 @@ production:
           outgoingDdi: true
           allow: true
           fromDomain: true
+          fromUser: true
           ddiIn: true
           rtpEncryption: true
         order: &friends_orderLink
@@ -115,9 +117,10 @@ production:
           language: true
           callACL: true
           outgoingDdi: true
-          allow: true
           transformationRuleSet: true
+          fromUser: true
           fromDomain: true
+          allow: true
           ddiIn: true
           status: true
           t38Passthrough: true
@@ -154,8 +157,9 @@ production:
           label: _("Advanced Configuration")
           colsPerRow: 4
           fields:
-            allow: 2
+            fromUser: 2
             fromDomain: 2
+            allow: 2
             ddiIn: 2
             t38Passthrough: 2
             rtpEncryption: 2

--- a/web/admin/application/configs/klear/model/Friends.yaml
+++ b/web/admin/application/configs/klear/model/Friends.yaml
@@ -212,6 +212,12 @@ production:
     fromDomain:
       title: _('From domain')
       type: text
+      trim: both
+      maxLength: 190
+    fromUser:
+      title: _('From user')
+      type: text
+      trim: both
       maxLength: 190
     directConnectivity:
       title: _('Connectivity mode')
@@ -234,6 +240,7 @@ production:
                 - transport
                 - ddiIn
                 - allow
+                - fromUser
                 - fromDomain
                 - language
                 - transformationRuleSet
@@ -252,6 +259,7 @@ production:
                 - password
                 - ddiIn
                 - allow
+                - fromUser
                 - fromDomain
                 - language
                 - transformationRuleSet
@@ -268,6 +276,7 @@ production:
                 - password
                 - ddiIn
                 - allow
+                - fromUser
                 - fromDomain
                 - language
                 - transformationRuleSet


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

non-intervpbx friends now have a new field: **From User**.

If non-empty, its value will be included as username of From header in INVITE initial requests from IvozProvider. If empty, its value will be equal to source in PAI header (as it is now).
