### PR TITLE
agi: fake ringing for external ringall huntgroups

### DIFF
--- a/asterisk/agi/src/Agi/Wrapper.php
+++ b/asterisk/agi/src/Agi/Wrapper.php
@@ -153,6 +153,11 @@ class Wrapper
         return $this;
     }
 
+    public function ringing()
+    {
+        return $this->fastagi->exec("Ringing", "");
+    }
+
     /**
      *
      * @param LocutionInterface|null $locution

--- a/asterisk/agi/src/Dialplan/HuntGroupMember.php
+++ b/asterisk/agi/src/Dialplan/HuntGroupMember.php
@@ -6,6 +6,7 @@ use Agi\Action\ExternalNumberAction;
 use Agi\Action\UserCallAction;
 use Agi\Wrapper;
 use Doctrine\ORM\EntityManagerInterface;
+use Ivoz\Provider\Domain\Model\HuntGroup\HuntGroupInterface;
 use Ivoz\Provider\Domain\Model\HuntGroupsRelUser\HuntGroupsRelUser;
 use Ivoz\Provider\Domain\Model\HuntGroupsRelUser\HuntGroupsRelUserInterface;
 use Ivoz\Provider\Domain\Model\HuntGroupsRelUser\HuntGroupsRelUserRepository;
@@ -74,6 +75,9 @@ class HuntGroupMember extends RouteHandlerAbstract
                 ->setAllowCallForwards($huntgroup->getAllowCallForwards())
                 ->process();
         } else {
+            if ($huntgroup->getStrategy() === HuntGroupInterface::STRATEGY_RINGALL) {
+                $this->agi->ringing();
+            }
             $this->externalNumberCallAction
                 ->setDestination($huntgroupsRelUser->getNumberValueE164())
                 ->process();


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

This PR adds fake ringing in ringall huntgroups containing at least one external number.

#### Additional information

This solves multiple early-media not being connected to caller, leading to no ringing tone in such scenarios.