### PR TITLE
kamusers: fix R-URI without dlg_vars

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -1733,9 +1733,8 @@ route[WITHINDLG] {
     route(ADAPT_REFERTO);
 
     # Fix overridden R-URI if needed
-    if (!$var(is_from_inside) && src_ip != myself && $dlg_var(contact) != $null && uri != $dlg_var(contact)) {
-        xwarn("[$dlg_var(cidhash)] WITHINDLG: Fix overridden contact ($ru -> $dlg_var(contact))\n");
-        $ru = $dlg_var(contact);
+    if (!$var(is_from_inside) && src_ip != myself) {
+        route(FIX_RURI);
     }
 
     # sequential request withing a dialog should
@@ -2189,7 +2188,8 @@ route[CHECK_SPECIAL] {
 }
 
 route[SAVE_CONTACT] {
-    if (!is_present_hf("Contact") || $dlg_var(contact) != $null) return;
+    if (!is_present_hf("Contact")) return;
+    if (!is_method("INVITE")) return;
 
     if ($ct =~ "<.*>") {
         # Contact has < >
@@ -2199,8 +2199,23 @@ route[SAVE_CONTACT] {
         $var(contact) = $ct;
     }
 
-    # Save inside contact in $dlg_var(contact)
-    $dlg_var(contact) = $var(contact);
+    if (is_request()) {
+        if ($sht(dialogs=>$ci::contact::$ft) != $null) return;
+        $sht(dialogs=>$ci::contact::$ft) = $var(contact);
+        xinfo("[$dlg_var(cidhash)] SAVE-CONTACT: Saving '$var(contact)' for $ci::contact::$ft\n");
+    } else {
+        if ($sht(dialogs=>$ci::contact::$tt) != $null) return;
+        $sht(dialogs=>$ci::contact::$tt) = $var(contact);
+        xinfo("[$dlg_var(cidhash)] SAVE-CONTACT: Saving '$var(contact)' for $ci::contact::$tt\n");
+    }
+}
+
+route[FIX_RURI] {
+    if ($sht(dialogs=>$ci::contact::$tt) == $null) return; # No saved contact found
+    if (uri == $sht(dialogs=>$ci::contact::$tt)) return; # R-URI is OK
+
+    xwarn("[$dlg_var(cidhash)] FIX-RURI: Fix overridden contact ($ru -> $sht(dialogs=>$ci::contact::$tt))\n");
+    $ru = $sht(dialogs=>$ci::contact::$tt);
 }
 
 #!ifdef WITH_REALTIME


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [x] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

SAVE_CONTACT and FIX_RURI logic was broken under these circumstances:

- retail/wholesale calling to retail DDI.

- call was bounced to in trunks.

- dialog was handled twice in users.

- two dialog structures (one inbound, one outbound).

Accessing to dlg_vars in within-dialog requests always returns first dialog structure value (e.g. $dlg_var(direction) always outbound).

This causes R-URI being mangled incorrectly when callee hangs up (as saved contact from the other side was retrieved). This lead to BYE (and all within-dlg) misrouting.

This commit changes implementation so that no dlg_var is used.
