### PR TITLE
kam: adapt recordings to new rtpengine callid flag

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -1956,7 +1956,7 @@ route[RECORD] {
     # First 200 OK to initial INVITE
     if (is_reply() && t_check_status("2[0-9]{2}")) {
         xinfo("[$dlg_var(cidhash)] RTPENGINE: Start recording this call ('$rs $rr' for initial $rm)\n");
-        start_recording();
+        start_recording("$var(callid)");
         $dlg_var(recordingCall) = 'yes'; # Save to avoid start_recording twice if retrans
     }
 }

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -1830,15 +1830,17 @@ route[ONDEMANDRECORD] {
         exit;
     }
 
+    $var(callid) = "call-id=users-" + $dlg_var(direction) + '-' + $dlg_var(callid);
+
     if ($dlg_var(recording) != 'yes') {
         xinfo("[$dlg_var(cidhash)] ONDEMANDRECORD: Start recording call\n");
-        start_recording();
+        start_recording("$var(callid)");
         $dlg_var(recording) = 'yes';
 
         send_reply("200", "Record On");
     } else {
         xinfo("[$dlg_var(cidhash)] ONDEMANDRECORD: Stop recording call\n");
-        stop_recording();
+        stop_recording("$var(callid)");
         $dlg_var(recording) = 'no';
 
         send_reply("200", "Record Off");

--- a/microservices/recordings/src/Recording/Encoder.php
+++ b/microservices/recordings/src/Recording/Encoder.php
@@ -114,7 +114,7 @@ class Encoder
         // Check each recording file
         foreach ($files as $filename) {
             // Store valid files
-            if (preg_match("/(.*)-\w+-mix.wav/", $filename, $matches)) {
+            if (preg_match("/\w+-\w+-(.*)-\w+-mix.wav/", $filename, $matches)) {
                 $file = $matches[0];
                 $callid = urldecode($matches[1]);
             } else {


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

- start_recording() and stop_recording() need callid= flag.
- recordings microservice needs to be updated with new recording file name.
