### PR TITLE
kamtrunks: End company calls from urlparam

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -2090,7 +2090,7 @@ event_route[xhttp:request] {
     if ($Rp == RPC_PORT) {
         xnotice("HTTP request from $si:$sp on $Rp, dispatch $hu command\n");
 
-        if ($hu == "/endCompanyCalls") {
+        if ($hu =~ "endCompanyCalls") {
             route(END_COMPANY_CALLS);
         } else {
             jsonrpc_dispatch();
@@ -2104,22 +2104,15 @@ event_route[xhttp:request] {
 }
 
 route[END_COMPANY_CALLS] {
-    sql_query("cb", "SELECT brandId, id FROM Companies", "ra");
-    $var(k) = 0;
-    while ($var(k) < $dbr(ra=>rows)) {
-        $var(brandId) = $dbr(ra=>[$var(k), 0]);
-        $var(companyId) = $dbr(ra=>[$var(k), 1]);
-        $var(regexp) = "ID\":\"b" + $var(brandId) + ':c' + $var(companyId) + '"';
-        if ($mb =~ $var(regexp)) {
-            jsonrpc_exec('{"jsonrpc": "2.0", "method": "dlg.profile_end", "params": ["activeCallsCompany", $var(companyId)], "id": 1}');
-            xinfo("jsonrpc response code: $jsonrpl(code) - the body is: $jsonrpl(body)\n");
-            break;
-        }
+    $var(companyId) = $(hu{s.select,1,?}{s.select,1,:}{s.rm,c}); # Extract 3 from http_url?account=b1:c3
+    xnotice("END-COMPANY-CALLS: Ending dialogs of company $var(companyId)\n");
 
-        $var(k) = $var(k) + 1;
+    jsonrpc_exec('{"jsonrpc": "2.0", "method": "dlg.profile_end", "params": ["activeCallsCompany", $var(companyId)], "id": 1}');
+    if ($jsonrpl(code) == "200") {
+        xinfo("END-COMPANY-CALLS: jsonrpc response code: $jsonrpl(code) - the body is: $jsonrpl(body)\n");
+    } else {
+        xerr("END-COMPANY-CALLS: jsonrpc response code: $jsonrpl(code) - the body is: $jsonrpl(body)\n");
     }
-
-    sql_result_free("ra");
 
     xhttp_reply("200", "OK", "text/html", "<html><body>Dialogs of company $var(companyId) ended</body></html>");
 }


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

Since https://github.com/irontec/cgrates/pull/3 Kamailio gets company from URL param instead of parsing http body.
