### PR TITLE
kamtrunks: do not inactivate stopper gateways

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -829,12 +829,6 @@ route[ADD_LCR_CARRIERSERVER]{
 }
 
 route[SELECT_NEXT_GW] {
-    # Save route stopper condition to avoid gateway inactivation
-    if ($(avp(gw_uri_avp)[0]) != $null) {
-        $var(rule_id) = $(avp(gw_uri_avp)[0]{s.select,-1,|});
-        sql_xquery("cb", "SELECT O.stopper FROM kam_trunks_lcr_rules K JOIN OutgoingRouting O ON O.id=K.outgoingRoutingId WHERE K.id=$var(rule_id)", "OutgoingRouting");
-    }
-
     # Evaluate gateway rules
     if (!next_gw()) {
         xwarn("[$dlg_var(cidhash)] SELECT-NEXT-GW: NO next GW, send 503 No gateways");
@@ -1685,6 +1679,16 @@ route[RT_NEWCALL] {
 }
 #!endif
 
+# Do not inactivate carriers that are stopper in any OutgoingRouting
+route[INACTIVATE_GW] {
+    sql_query("cb", "SELECT O.id FROM OutgoingRouting O LEFT JOIN OutgoingRoutingRelCarriers ORRC ON O.id=ORRC.outgoingRoutingId WHERE O.stopper=1 AND ( O.carrierId=$dlg_var(carrierId) OR ORRC.carrierId=$dlg_var(carrierId) )", "isStopper");
+    if ($dbr(isStopper=>rows) == 0) {
+        xwarn("[$dlg_var(cidhash)] INACTIVATE-GW: $T_reply_code: Inactivate carrier server $dlg_var(carrierServerId) (carrier: $dlg_var(carrierId)) (no reply received)\n");
+        inactivate_gw(); # Inactivate GW temporally (until it answers OPTIONS)
+    }
+    sql_result_free("isStopper");
+}
+
 # Reply generic route (all replies goes through this route)
 onreply_route {
     route(CIDHASH);
@@ -1772,9 +1776,8 @@ failure_route[MANAGE_FAILURE_GW] {
     } else if (t_check_status("422")) {
         xwarn("[$dlg_var(cidhash)] MANAGE-FAILURE-GW: Session Interval Too Small, forward to AS (reply code: $T_reply_code)\n");
         exit;
-    } else if (t_check_status("408") && t_branch_timeout() && !$xavp(OutgoingRouting=>stopper)) {
-        xwarn("[$dlg_var(cidhash)] MANAGE-FAILURE-GW: $T_reply_code: Inactivate carrier server $dlg_var(carrierServerId) (carrier: $dlg_var(carrierId)) (no reply received)\n");
-        inactivate_gw(); # Inactivate GW temporally (until it answers OPTIONS)
+    } else if (t_check_status("408") && t_branch_timeout()) {
+        route(INACTIVATE_GW);
     } else if (t_check_status("3[0-9]{2}")) {
         xwarn("[$dlg_var(cidhash)] MANAGE-FAILURE-GW: $T_reply_code: Not allowed from GW\n");
     }


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
A carrier may be used both in stopper rule and in non-stopper one.

With previous logic, non stopper rule may inactivate a carrier that is stopper
in another rule. As inactivated gateways are not taken into account in new calls,
stopper rule may be skipped.

This commit avoids inactivating a carrier that is stopper in any rule.
