### PR TITLE
core: persist invoice scheduler errors properly

### DIFF
--- a/library/Ivoz/Provider/Domain/Service/Invoice/CreateByScheduler.php
+++ b/library/Ivoz/Provider/Domain/Service/Invoice/CreateByScheduler.php
@@ -48,6 +48,10 @@ class CreateByScheduler
                 $scheduler,
                 $invoice
             );
+            $this->setExecutionError->execute(
+                $scheduler,
+                null
+            );
         } catch (\Exception $e) {
             $error = $e->getMessage();
             $name = $scheduler->getName();

--- a/library/Ivoz/Provider/Domain/Service/InvoiceScheduler/SetExecutionError.php
+++ b/library/Ivoz/Provider/Domain/Service/InvoiceScheduler/SetExecutionError.php
@@ -29,13 +29,13 @@ class SetExecutionError
 
     /**
      * @param InvoiceSchedulerInterface $scheduler
-     * @param string $error
+     * @param string $error | null
      *
      * @return void
      */
     public function execute(
         InvoiceSchedulerInterface $scheduler,
-        string $error
+        $error = null
     ) {
         /** @var InvoiceSchedulerDto $invoiceSchedulerDto */
         $invoiceSchedulerDto = $this

--- a/library/Ivoz/Provider/Domain/Service/InvoiceScheduler/UpdateLastExecutionDate.php
+++ b/library/Ivoz/Provider/Domain/Service/InvoiceScheduler/UpdateLastExecutionDate.php
@@ -35,8 +35,7 @@ class UpdateLastExecutionDate
                     null,
                     new \DateTimeZone('UTC')
                 )
-            )
-            ->setLastExecutionError('');
+            );
 
         $this->entityTools->persistDto(
             $invoiceSchedulerDto,


### PR DESCRIPTION
Error messages were not being persisted in database

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
