### PR TITLE
kam: changes in antiflooding mechanism

### DIFF
--- a/doc/sphinx/administration_portal/platform/antiflood_banned_ips.rst
+++ b/doc/sphinx/administration_portal/platform/antiflood_banned_ips.rst
@@ -7,4 +7,4 @@ Addresses listed here have been banned at least once by *Antiflooding* mechanism
 .. warning:: **IPs are only blocked during 5 minutes**. Entries with *Last time banned* older than 5 minutes are not
              currently banned.
 
-See :ref:`SIP antiflooding` and :ref:`Antiflood trusted IPs` for further information.
+See :ref:`SIP antiflooding` for further information.

--- a/doc/sphinx/security_and_maintenance/security/antibruteforce.rst
+++ b/doc/sphinx/security_and_maintenance/security/antibruteforce.rst
@@ -23,7 +23,4 @@ After 12 hours, source is accepted again and:
 
 - If it reaches 100 again, it is banned for another 12 hours.
 
-
-This simple mechanism prevents brute-force attacks even from sources excluded from :ref:`SIP Antiflooding` mechanism.
-
 .. tip:: See :ref:`Brute-force attacks` for currently blocked sources.

--- a/doc/sphinx/security_and_maintenance/security/antiflooding.rst
+++ b/doc/sphinx/security_and_maintenance/security/antiflooding.rst
@@ -2,10 +2,10 @@
 SIP Antiflooding
 ################
 
-SIP Proxy included in IvozProvider installation for SIP signalling with clients (KamUsers) uses
+SIP Proxies included in IvozProvider installation for SIP signalling use
 `PIKE module <http://kamailio.org/docs/modules/5.1.x/modules/pike.html>`_ to avoid DoS attacks.
 
-This module keeps trace of all incoming initial request's IP source and blocks the ones that exceed the limit on a given time
+This module keeps trace of incoming request's IP address and blocks the ones that exceed the limit on a given time
 interval.
 
 .. warning:: **IPs are not blocked permanently**, they are blocked for 5 minutes. After this time, they are allowed again
@@ -17,25 +17,47 @@ Current configuration parameters are:
 
 - **Sampling time interval**: 2 seconds.
 
-- **Threshold per time unit**: 30 requests.
+- **Threshold per time unit**: 100 requests.
 
 
-This means that *any IP address that sends more than 30 requests in a 2-second-time-interval will be blocked (ignored)
-for 5 minutes. After this time, they will be unblocked and their request rate will be evaluated again*.
+This means that *any IP address that sends more than 100 requests in a 2-second-time-interval will be blocked (ignored)
+for 5 minutes. After this time, it will be unblocked and its request rate will be evaluated again*.
 
-Antiflooding excluded sources
-=============================
+.. note:: Be aware that some requests are not taken into account by antiflood, continue reading please.
 
-These sources are not evaluated against antiflood:
+Which requests are taken into account in KamUsers?
+==================================================
 
-- IvozProvider components
-- IPs in :ref:`Antiflood trusted IPs`
-- IPs in :ref:`Clients authorized IPs <client_authorized_ip_ranges>` (vPBX, retail, residential)
-- Wholesale clients' IP addresses
+Client side requests usually traverse 2 different phases:
 
-.. warning:: IPs and ranges added in :ref:`Clients authorized IPs <client_authorized_ip_ranges>` will be excluded from
-         antiflood, even if **Filter by IP address** is disabled.
+- Step 0: initial checks, endpoint identification and authentication.
 
-.. tip:: On a typical NAT scenario with hundreds of UACs sharing the same public IP address, this IP should be static and
-         should be added to :ref:`Clients authorized IPs <client_authorized_ip_ranges>` list to avoid been blocked by
-         antiflooding (e.g. after lights out, etc.)
+- Step 1: remaining logic.
+
+Antiflood will take into account:
+
+- SIP OPTIONS
+
+- Requests failing during step 0:
+
+  - Requests not using SIP domain in KamUsers (except wholesale).
+
+  - Requests from non-existing AoRs in KamUsers.
+
+  - Requests failing SIP authentication with wrong passwords in KamUsers.
+
+- Initial INVITE requests reaching step 1 (aka: new call establishments of legitimate clients).
+
+
+.. tip:: Note that antiflood will not take into account successful REGISTER/SUBSCRIBE cycles.
+
+Which requests are taken into account in KamTrunks?
+===================================================
+
+Antiflood will take into account:
+
+- SIP OPTIONS from non-DDIproviders.
+
+- Non-DDIproviders talking to KamTrunks.
+
+.. tip:: Note that antiflood will not take into account DDI Provider requests to KamTrunks.

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -27,6 +27,7 @@
 #!define DLG_FLAG 3
 
 # - options
+#!define WITH_ANTIFLOOD
 #!define WITH_REALTIME
 
 #!define DBURL "mysql://[kamailio]/ivozprovider"
@@ -169,6 +170,10 @@ loadmodule    "ipops.so"
 loadmodule    "ndb_redis.so"
 #!endif
 
+#!ifdef WITH_ANTIFLOOD
+loadmodule    "pike.so"
+#!endif
+
 #!ifdef WITH_REALTIME
 # REDIS
 modparam("ndb_redis", "server", "name=realtime;sentinel_group=mymaster;sentinel_master=1;sentinel=data.ivozprovider.local:26379")
@@ -270,7 +275,16 @@ modparam("dialog", "track_cseq_updates", 1)
 modparam("dialog", "detect_spirals", 0)
 modparam("dialog", "default_timeout", MAX_DIALOG_TIMEOUT)
 
+#!ifdef WITH_ANTIFLOOD
+# PIKE
+modparam("pike", "sampling_time_unit", 2)
+modparam("pike", "reqs_density_per_unit", 100)
+modparam("pike", "remove_latency", 120)
+
 # HTABLE
+# ip ban htable with autoexpire after 5 minutes
+modparam("htable", "htable", "ipban=>size=8;autoexpire=300")
+#!endif
 modparam("htable", "htable", "cgrconn=>size=1;")
 modparam("htable", "htable", "dmq=>size=8;autoexpire=10800;dmqreplicate=1;")
 modparam("htable", "enable_dmq", 1)
@@ -350,6 +364,8 @@ request_route {
 
     # Calculate cidhash if not set
     route(CIDHASH);
+
+    route(ANTIFLOOD);
 
     if (is_method("KDMQ") && $var(is_from_inside)) {
         dmq_handle_message();
@@ -533,6 +549,14 @@ route[CHECK_BOUNCE] {
 }
 
 route[REQINIT] {
+    #!ifdef WITH_ANTIFLOOD
+    # Banned addresses
+    if($sht(ipban=>$si) != $null) {
+        xinfo("REQINIT: request from blocked IP - $rm from $fu (IP:$si:$sp)\n");
+        exit;
+    }
+    #!endif
+
     # Easy dropping for scanners
     if($ua =~ "friendly-scanner|sipcli|VaxSIPUserAgent|pplsip" || search("sipvicious")) {
         xwarn("REQINIT: Dropping scanner request ----> $rm from $si\n");
@@ -1531,6 +1555,47 @@ route[RELAY] {
         sl_reply_error();
 
     exit;
+}
+
+route[ANTIFLOOD] {
+#!ifdef WITH_ANTIFLOOD
+    # Only external sources
+    if ($var(is_from_inside)) return;
+
+    # No antiflood for within dialog requests
+    if (has_totag()) return;
+
+    # Allowed sources by DDI provider
+    $var(group) = allow_source_address_group();
+    if ($var(group) != -1) {
+        xinfo("[$dlg_var(cidhash)] ANTIFLOOD: $si is not checked against antiflood (allowed source for ddiProviderId '$var(group)')\n");
+        return;
+    }
+
+    # Evaluate PIKE
+    if (!pike_check_req()) {
+        xwarn("[$dlg_var(cidhash)] ANTIFLOOD: ALERT: pike blocking $rm from $fu (IP:$si:$sp)\n");
+        $sht(ipban=>$si) = 1;
+        route(ANTIFLOOD_BLOCKED_IP);
+        exit;
+    }
+#!endif
+
+    return;
+}
+
+route[ANTIFLOOD_BLOCKED_IP]{
+    sql_xquery("cb", "SELECT COUNT(*) > 0 AS banned FROM BannedAddresses WHERE ip='$si' AND blocker='antiflood'", "ra");
+
+    if ($xavp(ra=>banned) == '1') {
+        # Not first time, just update timestamp
+        xinfo("[$dlg_var(cidhash)] ANTIFLOOD-BLOCKED-IP: Blocking again $si\n");
+        sql_xquery("cb", "UPDATE BannedAddresses SET lastTimeBanned=NOW() WHERE ip='$si' AND blocker='antiflood'", "rb");
+    } else {
+        # First time, insert
+        xinfo("[$dlg_var(cidhash)] ANTIFLOOD-BLOCKED-IP: First time blocking $si\n");
+        sql_xquery("cb", "INSERT INTO BannedAddresses (ip, blocker, lastTimeBanned) VALUES ('$si', 'antiflood', NOW())", "rb");
+    }
 }
 
 # This route sets following dlg_vars: brandId, companyId, type

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -271,7 +271,7 @@ modparam("registrar", "default_q", 1000)
 # PERMISSIONS
 modparam("permissions", "db_url", DBURL)
 modparam("permissions", "address_table", "kam_users_address") # Allowed networks per non-wholesale clients
-modparam("permissions", "trusted_table", "kam_trusted") # IPs excluded from pike checking and wholesale IPs
+modparam("permissions", "trusted_table", "kam_trusted") # Wholesale IPs
 modparam("permissions", "db_mode", 1)
 modparam("permissions", "grp_col", "companyId")
 modparam("permissions", "max_subnets", 4096)
@@ -326,7 +326,7 @@ modparam("tm", "auto_inv_100_reason", "Trying")
 #!ifdef WITH_ANTIFLOOD
 # PIKE
 modparam("pike", "sampling_time_unit", 2)
-modparam("pike", "reqs_density_per_unit", 30)
+modparam("pike", "reqs_density_per_unit", 100)
 modparam("pike", "remove_latency", 120)
 
 # HTABLE
@@ -417,8 +417,6 @@ request_route {
 
     route(CIDHASH);
 
-    route(ANTIFLOOD);
-
     if (is_method("KDMQ") && $var(is_from_inside)) {
         dmq_handle_message();
         exit;
@@ -426,6 +424,7 @@ request_route {
 
     if (is_method("OPTIONS")) {
         force_rport();
+        route(ANTIFLOOD);
         send_reply("200", "I'm here!");
         exit;
     }
@@ -443,6 +442,7 @@ request_route {
         }
 
         xwarn("[$dlg_var(cidhash)] ----> $rm from $si is not from a known transaction, drop\n");
+        route(ANTIFLOOD);
         exit;
     }
 
@@ -506,6 +506,9 @@ request_route {
         dlg_manage();
     }
 
+    # Antiflooding for new calls establishments
+    route(ANTIFLOOD);
+
     # Calculate cidhash if not set
     route(CIDHASH);
 
@@ -565,12 +568,14 @@ route[IS_FROM_INSIDE] {
 route[FILTER_METHODS] {
     if (!is_method("INVITE|REGISTER|SUBSCRIBE|PUBLISH|NOTIFY")) {
         xwarn("[$dlg_var(cidhash)] FILTER-METHODS: $rm not supported\n");
+        route(ANTIFLOOD);
         send_reply("501", "Not Implemented");
         exit;
     }
 
     if ($avp(wholesaleId) != $null && !is_method("INVITE")) {
         xwarn("[$dlg_var(cidhash)] CHECK-WHOLESALE: $rm not supported for wholesale client\n");
+        route(ANTIFLOOD);
         send_reply("501", "Not Implemented");
         exit;
     }
@@ -999,13 +1004,14 @@ route[REQINIT] {
     #!ifdef WITH_ANTIFLOOD
     # Banned addresses
     if($sht(ipban=>$si) != $null) {
-        xwarn("REQINIT: request from blocked IP - $rm from $fu (IP:$si:$sp)\n");
+        xinfo("REQINIT: request from blocked IP - $rm from $fu (IP:$si:$sp)\n");
         exit;
     }
     #!endif
 
     # Banned sources
     if ($sht(srcban=>$fU@$fd::$si) != $null) {
+        route(ANTIFLOOD);
         send_reply("403", "Forbidden [BS]");
         exit;
     }
@@ -1013,54 +1019,64 @@ route[REQINIT] {
     # Easy dropping for scanners
     if($ua =~ "friendly-scanner|sipcli|VaxSIPUserAgent|pplsip" || search("sipvicious")) {
         xwarn("REQINIT: Dropping scanner request ----> $rm from $si\n");
+        route(ANTIFLOOD);
         exit;
     }
 
     # Malformed SIP message?
     if(!sanity_check("5607", "7")) {
         xwarn("REQINIT: Dropping malformed SIP message from $si:$sp\n");
+        route(ANTIFLOOD);
         exit;
     }
 
     # SQL injection control
     if($fd != $null && $fd =~ "(\=)|(\-\-)|(')|(\#)|(\%27)|(\%24)") {
         xwarn("REQINIT: Someone from $si is doing an sql injection attack, drop");
+        route(ANTIFLOOD);
         exit;
     }
 
     if($fU != $null && $fU =~ "(\=)|(\-\-)|(')|(\#)|(\%27)|(\%24)") {
         xwarn("REQINIT: Someone from $si is doing an sql injection attack, drop");
+        route(ANTIFLOOD);
         exit;
     }
 
     if($tU != $null && $tU =~ "(\=)|(\-\-)|(')|(\#)|(\%27)|(\%24)") {
         xwarn("REQINIT: Someone from $si is doing an sql injection attack, drop");
+        route(ANTIFLOOD);
         exit;
     }
 
     if($td != $null && $td =~ "(\=)|(\-\-)|(')|(\#)|(\%27)|(\%24)") {
         xwarn("REQINIT: Someone from $si is doing an sql injection attack, drop");
+        route(ANTIFLOOD);
         exit;
     }
 
     if($rU != $null && $rU =~ "(\=)|(\-\-)|(')|(\#)|(\%27)|(\%24)") {
         xwarn("REQINIT: Someone from $si is doing an sql injection attack, drop");
+        route(ANTIFLOOD);
         exit;
     }
 
     if($rd != $null && $rd =~ "(\=)|(\-\-)|(')|(\#)|(\%27)|(\%24)") {
         xwarn("REQINIT: Someone from $si is doing an sql injection attack, drop");
+        route(ANTIFLOOD);
         exit;
     }
 
     if($au != $null && $au =~ "(\=)|(\-\-)|(')|(\#)|(\%27)|(\%24)") {
         xwarn("REQINIT: Someone from $si is doing an sql injection attack, drop");
+        route(ANTIFLOOD);
         exit;
     }
 
     # Max forwards?
     if (!mf_process_maxfwd_header("10")) {
         xwarn("REQINIT: Too many hops for SIP message from $si:$sp\n");
+        route(ANTIFLOOD);
         send_reply("483","Too Many Hops");
         exit;
     }
@@ -1544,12 +1560,14 @@ route[PREAUTH] {
 
     if (from_uri != myself) {
         xwarn("[$dlg_var(cidhash)] AUTH: $fd is not my domain, 403 forbidden\n");
+        route(ANTIFLOOD);
         send_reply("403","Forbidden");
         exit;
     }
 
     if (uri != myself) {
         xwarn("[$dlg_var(cidhash)] AUTH: $rd is not my domain, 404 Not here\n");
+        route(ANTIFLOOD);
         send_reply("404", "Invalid domain in R-URI");
         exit;
     }
@@ -1557,12 +1575,14 @@ route[PREAUTH] {
     # Domain strict checking
     if (!is_uri_host_local()) {
         xwarn("[$dlg_var(cidhash)] AUTH: $rd is my IP but domains should be used, reject\n");
+        route(ANTIFLOOD);
         send_reply("488", "Domain needed");
         exit;
     }
 
     if (!is_from_local()) {
         xwarn("[$dlg_var(cidhash)] AUTH: $fd is my IP but domains should be used, reject\n");
+        route(ANTIFLOOD);
         send_reply("488", "Domain needed");
         exit;
     }
@@ -1582,6 +1602,7 @@ route[AUTH] {
             return;
         } else {
             xwarn("[$dlg_var(cidhash)] AUTH: $avp(endpointType)#$avp(endpointId) talking from $si instead of $xavp(friend=>ip), forbidden");
+            route(ANTIFLOOD);
             send_reply("403", "Forbidden [FS]");
             exit;
         }
@@ -1589,12 +1610,14 @@ route[AUTH] {
 
     if ($avp(password) == $null) {
         xerr("[$dlg_var(cidhash)] AUTH: No password for $avp(endpointType)#$avp(endpointId), error");
+        route(ANTIFLOOD);
         send_reply("403", "Forbidden [NP]");
         exit;
     }
 
     if (is_method("REGISTER") || from_uri==myself) {
         # authenticate requests
+        $var(skipAntiflood) = 0;
         if(!pv_auth_check("$fd", "$avp(password)", "0", "1")) {
             switch($rc) {
                 case -2:
@@ -1605,9 +1628,14 @@ route[AUTH] {
                     xnotice("[$dlg_var(cidhash)] AUTH: Auth needed ($fu from $proto:$si) - invalid_user\n");
                     route(BAD_CREDENTIALS);
                     break;
+                case -5:
+                    xnotice("[$dlg_var(cidhash)] AUTH: Auth needed ($fu from $proto:$si) - no_credentials\n");
+                    $var(skipAntiflood) = 1;
+                    break;
                 default:
                     xnotice("[$dlg_var(cidhash)] AUTH: Auth needed ($fu from $proto:$si) - $rc\n");
             }
+            if (!$var(skipAntiflood)) route(ANTIFLOOD);
             auth_challenge("$fd", "0");
             exit;
         }
@@ -1723,6 +1751,7 @@ route[GET_ENDPOINT] {
     }
 
     if (!$var(found)) {
+        route(ANTIFLOOD);
         send_reply("404", "Not Here [GE]");
         exit;
     }
@@ -1942,22 +1971,6 @@ route[ANTIFLOOD] {
     # Inside request
     if (src_ip == myself || $var(is_from_inside)) return;
 
-    # No antiflood for within dialog requests
-    if (has_totag()) return;
-
-    # Trusted sources
-    if (allow_trusted($si, 'any')) {
-        xinfo("[$dlg_var(cidhash)] ANTIFLOOD: $si is not checked against antiflood (IP added in kam_trusted)\n");
-        return;
-    }
-
-    # Allowed sources by company
-    $var(group) = allow_source_address_group();
-    if ($var(group) != -1) {
-        xinfo("[$dlg_var(cidhash)] ANTIFLOOD: $si is not checked against antiflood (allowed source for companyId '$var(group)')\n");
-        return;
-    }
-
     # Evaluate PIKE
     if (!pike_check_req()) {
         xwarn("[$dlg_var(cidhash)] ANTIFLOOD: ALERT: pike blocking $rm from $fu (IP:$si:$sp)\n");
@@ -2075,6 +2088,7 @@ route[NATDETECT] {
                 # Sets ;alias only if received ip and port differ from those in contact URI
                 if (is_present_hf("Contact") && !set_contact_alias()) {
                    xerr("[$dlg_var(cidhash)] NATDETECT: Error in aliasing contact $ct\n");
+                   route(ANTIFLOOD);
                    send_reply("400", "Bad request");
                    exit;
                 }


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

This PR increases threshold from 15 request in 2-second-interval to 100 requests in same time interval.

**KAMUSERS**

- no source IP exceptions

Antiflood will take into account:

- failing requests during endpoint identification and authentication phase

- initial call establishments of legitimate UACs

**KAMTRUNKS**

- This partially reverts commit cbbea39.

- Antiflood will only count initial requests from non-DDIproviders.

#### Additional Information

This PR makes unnecessary to add client IP ranges to skip Antiflood after lights-out events.