### PR TITLE
kamusers: drop invalid Diversion

### DIFF
--- a/doc/sphinx/administration_portal/client/residential/residential_devices.rst
+++ b/doc/sphinx/administration_portal/client/residential/residential_devices.rst
@@ -65,7 +65,7 @@ These are the configurable settings of *Residential devices*:
 
     Fallback Outgoing DDI
         External calls from this *residential device* will be presented with this DDI, **unless
-        the source presented matches a DDI belonging to the residential device**.
+        the source presented matches a DDI belonging to the residential client**.
 
     Allowed codec
         Like vPBX terminals, *residential devices* will talk only the selected codec.

--- a/doc/sphinx/administration_portal/client/retail/retail_accounts.rst
+++ b/doc/sphinx/administration_portal/client/retail/retail_accounts.rst
@@ -62,7 +62,7 @@ These are the configurable settings of *Retail accounts*:
 
     Fallback Outgoing DDI
         External calls from this *retail account* will be presented with this DDI, **unless
-        the source presented matches a DDI belonging to the retail account**.
+        the source presented matches a DDI belonging to the retail client**.
 
     From domain
         Request from IvozProvider to this account will include this domain in

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -946,7 +946,7 @@ route[ADAPT_DIVERSION] {
     }
 
     route(APPLY_TRANSFORMATION);
-    if ($dlg_var(type) == "retail" && !$var(is_from_inside)) {
+    if (!$var(is_from_inside) && $dlg_var(type) != 'wholesale') {
         # Check if Diversion is valid before proceeding
         route(VALIDATE_CLID_NUMBER);
         if ($dlg_var(valid_clid) == "no") {


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

Diversion related logic in AGIs (for vpbx/residential) is different from
Kamusers logic (for retail/wholesale).

This commit drops any Diversion header with an invalid number so that AGIs only
receive valid Diversion headers.