### PR TITLE
core: avoid detecting balance changes for equal values

### DIFF
--- a/library/Ivoz/Provider/Domain/Model/Carrier/Carrier.php
+++ b/library/Ivoz/Provider/Domain/Model/Carrier/Carrier.php
@@ -89,4 +89,10 @@ class Carrier extends CarrierAbstract implements CarrierInterface
 
         return parent::setProxyTrunk($proxyTrunks);
     }
+
+    protected function setBalance($balance = null)
+    {
+        $balance = round($balance, 4);
+        return parent::setBalance($balance);
+    }
 }

--- a/library/Ivoz/Provider/Domain/Model/Company/Company.php
+++ b/library/Ivoz/Provider/Domain/Model/Company/Company.php
@@ -451,4 +451,10 @@ class Company extends CompanyAbstract implements CompanyInterface
     {
         return $this->getType() === self::TYPE_WHOLESALE;
     }
+
+    protected function setBalance($balance = null)
+    {
+        $balance = round($balance, 4);
+        return parent::setBalance($balance);
+    }
 }

--- a/library/Ivoz/Provider/Infrastructure/Domain/Service/Carrier/SendTrunksLcrReloadRequest.php
+++ b/library/Ivoz/Provider/Infrastructure/Domain/Service/Carrier/SendTrunksLcrReloadRequest.php
@@ -30,6 +30,13 @@ class SendTrunksLcrReloadRequest implements CarrierLifecycleEventHandlerInterfac
      */
     public function execute(CarrierInterface $entity)
     {
+        $changeSet = $entity->getChangedFields();
+        if (in_array('balance', $changeSet)
+            && count($changeSet) === 1
+        ) {
+            return;
+        }
+
         $this->trunksClient->reloadLcr();
     }
 }


### PR DESCRIPTION
Prevents lots of unnecessary lcr.reload commands

<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

Database and CGRateS precision difference caused balance change logic for equal balances.

#### Additional information

Prevents lots of unnecessary lcr.reload commands and changelog entries.