### PR TITLE
core: ensure numeric only fax dst

### DIFF
--- a/library/Ivoz/Provider/Domain/Model/FaxesInOut/FaxesInOut.php
+++ b/library/Ivoz/Provider/Domain/Model/FaxesInOut/FaxesInOut.php
@@ -81,4 +81,15 @@ class FaxesInOut extends FaxesInOutAbstract implements FileContainerInterface, F
             $this->getDstCountry()->getCountryCode() .
             $this->getDst();
     }
+
+    protected function setDst($dst = null)
+    {
+        $dst = preg_replace(
+            '/[^0-9]/',
+            '',
+            $dst
+        );
+
+        return parent::setDst($dst);
+    }
 }


### PR DESCRIPTION
Replace any non numeric valur on faxesInOut destination

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [X] Fixes an existing issue (Fixes #1529)
