### PR TITLE
Updated pdf generator

### DIFF
--- a/library/Ivoz/Provider/Domain/Service/Invoice/Generator.php
+++ b/library/Ivoz/Provider/Domain/Service/Invoice/Generator.php
@@ -156,7 +156,7 @@ class Generator
 
         $this->logger->debug(self::LOGGER_PREFIX . ' Preparing templates');
         $templateEngine = new Handlebars;
-        ;
+
         $header = $templateEngine->render($templateModel->getTemplateHeader(), $variables);
         $body = $templateEngine->render($templateModel->getTemplate(), $variables);
         $footer = $templateEngine->render($templateModel->getTemplateFooter(), $variables);
@@ -169,6 +169,9 @@ class Generator
         $snappy->setOption('header-spacing', 3);
         $snappy->setOption('footer-html', $footer);
         $snappy->setOption('footer-spacing', 3);
+        $snappy->setOption('load-error-handling', 'ignore');
+        $snappy->setOption('enable-local-file-access', true);
+
         $content = $snappy->getOutputFromHtml($body);
         $snappy->removeTemporaryFiles();
 

--- a/library/composer.json
+++ b/library/composer.json
@@ -42,6 +42,10 @@
         {
             "url": "https://github.com/mmadariaga/TestDoubleBundle.git",
             "type": "git"
+        },
+        {
+            "url": "https://github.com/mmadariaga/wkhtmltopdf-amd64.git",
+            "type": "git"
         }
     ],
     "autoload-dev": {
@@ -63,11 +67,11 @@
         "php": ">=7.0.19",
         "debach/zend-mp3": "1.8.*",
         "doctrine/doctrine-migrations-bundle": "^1.2",
-        "h4cc/wkhtmltopdf-amd64": "0.12.3",
-        "irontec/ivoz-provider-bundle": "^2.5",
         "irontec/ivoz-api-bundle": "^3.4",
         "irontec/ivoz-dev-tools": "^4.0",
+        "irontec/ivoz-provider-bundle": "^2.5",
         "knplabs/knp-snappy": "0.4.3",
+        "mmadariaga/wkhtmltopdf-amd64": "0.12.6",
         "mmoreram/gearman-bundle": "^4.1",
         "php-mime-mail-parser/php-mime-mail-parser": "^2.9",
         "phpxmlrpc/phpxmlrpc": "^4.0",

--- a/library/composer.lock
+++ b/library/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "316029fc0678fe6ee7cfd6baa2c7f1f3",
+    "content-hash": "5fa4853991ad813c4b82a1b6fb9519f8",
     "packages": [
         {
             "name": "api-platform/core",
@@ -1600,46 +1600,6 @@
             "time": "2019-07-01T23:21:34+00:00"
         },
         {
-            "name": "h4cc/wkhtmltopdf-amd64",
-            "version": "0.12.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/h4cc/wkhtmltopdf-amd64.git",
-                "reference": "b80ce6720349e98cebac7e8a19426455805fa7e1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/h4cc/wkhtmltopdf-amd64/zipball/b80ce6720349e98cebac7e8a19426455805fa7e1",
-                "reference": "b80ce6720349e98cebac7e8a19426455805fa7e1",
-                "shasum": ""
-            },
-            "bin": [
-                "bin/wkhtmltopdf-amd64"
-            ],
-            "type": "library",
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "LGPL Version 3"
-            ],
-            "authors": [
-                {
-                    "name": "Julius Beckmann",
-                    "email": "github@h4cc.de"
-                }
-            ],
-            "description": "Convert html to pdf using webkit (qtwebkit). Static linked linux binary for amd64 systems.",
-            "homepage": "http://wkhtmltopdf.org/",
-            "keywords": [
-                "binary",
-                "convert",
-                "pdf",
-                "snapshot",
-                "thumbnail",
-                "wkhtmltopdf"
-            ],
-            "time": "2016-02-02T19:38:55+00:00"
-        },
-        {
             "name": "incenteev/composer-parameter-handler",
             "version": "v2.1.4",
             "source": {
@@ -2270,6 +2230,43 @@
                 "symfony"
             ],
             "time": "2020-06-14T13:20:35+00:00"
+        },
+        {
+            "name": "mmadariaga/wkhtmltopdf-amd64",
+            "version": "0.12.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mmadariaga/wkhtmltopdf-amd64.git",
+                "reference": "8f0f434d50d0f2832cb8b7bd7204535bee8951b3"
+            },
+            "bin": [
+                "bin/wkhtmltopdf-amd64"
+            ],
+            "type": "library",
+            "license": [
+                "LGPL Version 3"
+            ],
+            "authors": [
+                {
+                    "name": "Julius Beckmann",
+                    "email": "github@h4cc.de"
+                },
+                {
+                    "name": "Mikel Madariaga",
+                    "email": "mikel@irontec.com"
+                }
+            ],
+            "description": "Convert html to pdf using webkit (qtwebkit). Static linked linux binary for amd64 systems.",
+            "homepage": "http://wkhtmltopdf.org/",
+            "keywords": [
+                "binary",
+                "convert",
+                "pdf",
+                "snapshot",
+                "thumbnail",
+                "wkhtmltopdf"
+            ],
+            "time": "2021-01-12T14:12:15+00:00"
         },
         {
             "name": "mmoreram/gearman-bundle",
@@ -8172,6 +8169,46 @@
             ],
             "description": "A tool to automatically fix PHP code style",
             "time": "2020-06-27T23:57:46+00:00"
+        },
+        {
+            "name": "h4cc/wkhtmltopdf-amd64",
+            "version": "0.12.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/h4cc/wkhtmltopdf-amd64.git",
+                "reference": "b80ce6720349e98cebac7e8a19426455805fa7e1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/h4cc/wkhtmltopdf-amd64/zipball/b80ce6720349e98cebac7e8a19426455805fa7e1",
+                "reference": "b80ce6720349e98cebac7e8a19426455805fa7e1",
+                "shasum": ""
+            },
+            "bin": [
+                "bin/wkhtmltopdf-amd64"
+            ],
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL Version 3"
+            ],
+            "authors": [
+                {
+                    "name": "Julius Beckmann",
+                    "email": "github@h4cc.de"
+                }
+            ],
+            "description": "Convert html to pdf using webkit (qtwebkit). Static linked linux binary for amd64 systems.",
+            "homepage": "http://wkhtmltopdf.org/",
+            "keywords": [
+                "binary",
+                "convert",
+                "pdf",
+                "snapshot",
+                "thumbnail",
+                "wkhtmltopdf"
+            ],
+            "time": "2016-02-02T19:38:55+00:00"
         },
         {
             "name": "http-interop/http-middleware",

--- a/microservices/workers/composer.json
+++ b/microservices/workers/composer.json
@@ -54,7 +54,7 @@
     },
     "require": {
         "php": ">=7.0.19",
-        "h4cc/wkhtmltopdf-amd64": "0.12.3",
+        "mmadariaga/wkhtmltopdf-amd64": "0.12.6",
         "irontec/ivoz-provider-bundle": "^2.0",
         "knplabs/knp-snappy": "0.4.3",
         "mmoreram/gearman-bundle": "^4.1",

--- a/microservices/workers/composer.lock
+++ b/microservices/workers/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "2fd4ccad8e6111b68d6e8edb4aa69d83",
+    "content-hash": "bfb96334b5f49961aab00e7234d657d0",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -1318,42 +1318,6 @@
             }
         },
         {
-            "name": "h4cc/wkhtmltopdf-amd64",
-            "version": "0.12.3.0",
-            "dist": {
-                "type": "path",
-                "url": "../../library/vendor/h4cc/wkhtmltopdf-amd64",
-                "reference": "b80ce6720349e98cebac7e8a19426455805fa7e1",
-                "shasum": null
-            },
-            "bin": [
-                "bin/wkhtmltopdf-amd64"
-            ],
-            "type": "library",
-            "license": [
-                "LGPL Version 3"
-            ],
-            "authors": [
-                {
-                    "name": "Julius Beckmann",
-                    "email": "github@h4cc.de"
-                }
-            ],
-            "description": "Convert html to pdf using webkit (qtwebkit). Static linked linux binary for amd64 systems.",
-            "homepage": "http://wkhtmltopdf.org/",
-            "keywords": [
-                "binary",
-                "convert",
-                "pdf",
-                "snapshot",
-                "thumbnail",
-                "wkhtmltopdf"
-            ],
-            "transport-options": {
-                "symlink": true
-            }
-        },
-        {
             "name": "incenteev/composer-parameter-handler",
             "version": "2.1.4.0",
             "dist": {
@@ -1818,6 +1782,46 @@
                 "jws",
                 "jwt",
                 "rest"
+            ],
+            "transport-options": {
+                "symlink": true
+            }
+        },
+        {
+            "name": "mmadariaga/wkhtmltopdf-amd64",
+            "version": "0.12.6.0",
+            "dist": {
+                "type": "path",
+                "url": "../../library/vendor/mmadariaga/wkhtmltopdf-amd64",
+                "reference": "8f0f434d50d0f2832cb8b7bd7204535bee8951b3",
+                "shasum": null
+            },
+            "bin": [
+                "bin/wkhtmltopdf-amd64"
+            ],
+            "type": "library",
+            "license": [
+                "LGPL Version 3"
+            ],
+            "authors": [
+                {
+                    "name": "Julius Beckmann",
+                    "email": "github@h4cc.de"
+                },
+                {
+                    "name": "Mikel Madariaga",
+                    "email": "mikel@irontec.com"
+                }
+            ],
+            "description": "Convert html to pdf using webkit (qtwebkit). Static linked linux binary for amd64 systems.",
+            "homepage": "http://wkhtmltopdf.org/",
+            "keywords": [
+                "binary",
+                "convert",
+                "pdf",
+                "snapshot",
+                "thumbnail",
+                "wkhtmltopdf"
             ],
             "transport-options": {
                 "symlink": true

--- a/profiles/portal/etc/supervisor/conf.d/ivozprovider.conf
+++ b/profiles/portal/etc/supervisor/conf.d/ivozprovider.conf
@@ -1,0 +1,2 @@
+[supervisord]
+minfds=4096

--- a/schema/DoctrineMigrations/Version20210114122624.php
+++ b/schema/DoctrineMigrations/Version20210114122624.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Application\Migrations;
+
+use Ivoz\Core\Infrastructure\Persistence\Doctrine\LoggableMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20210114122624 extends LoggableMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $header = $this->connection->quote(
+            file_get_contents(
+                '/opt/irontec/ivozprovider/web/admin/templates/header.txt'
+            )
+        );
+        $footer = $this->connection->quote(
+            file_get_contents(
+                '/opt/irontec/ivozprovider/web/admin/templates/footer.txt'
+            )
+        );
+        $basicBody = $this->connection->quote(
+            file_get_contents(
+                '/opt/irontec/ivozprovider/web/admin/templates/basic.txt'
+            )
+        );
+        $detailedBody = $this->connection->quote(
+            file_get_contents(
+                '/opt/irontec/ivozprovider/web/admin/templates/detailed.txt'
+            )
+        );
+
+        $this->addSql(
+        "UPDATE `InvoiceTemplates` SET
+                  template = $basicBody,
+                  templateHeader = $header,
+                  templateFooter = $footer
+             WHERE `name` = 'Basic'"
+        );
+
+        $this->addSql(
+            "UPDATE `InvoiceTemplates` SET
+                  template = $detailedBody,
+                  templateHeader = $header,
+                  templateFooter = $footer
+             WHERE `name` = 'Detailed'"
+        );
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+    }
+}

--- a/web/admin/templates/basic.txt
+++ b/web/admin/templates/basic.txt
@@ -3,11 +3,11 @@
 <head>
     <style>
         body {
-            font-size: 11px;
-            font-family: Helvetica Neue,Helvetica,Arial,sans-serif;
+            font-size: 14px;
+            font-family: 'DejaVu Sans',Helvetica,Arial,sans-serif;
         }
         h2 {
-            font-size: 15px;
+            font-size: 18px;
         }
         div{
             page-break-inside: avoid;
@@ -17,7 +17,7 @@
             text-align: center;
             margin: 25px 0 0;
             font-weight: bold;
-            font-size: 20px;
+            font-size: 23px;
             border: none;
             padding-bottom: 5px;
             border-bottom: 1px solid black;
@@ -109,7 +109,7 @@
             font-weight: bold;
         }
         #subheader .left p {
-            font-size: 32px;
+            font-size: 35px;
             margin-top: 0;
         }
         #subheader .right {
@@ -121,12 +121,12 @@
             margin: 0px;
             padding: 0;
             font-weight: bold;
-            font-size: 17px;
+            font-size: 20px;
         }
         #subheader .right p.date {
             margin: 0;
             padding: 0;
-            font-size: 13px;
+            font-size: 16px;
         }
         #content > div.table {
             text-align: center;

--- a/web/admin/templates/detailed.txt
+++ b/web/admin/templates/detailed.txt
@@ -3,11 +3,11 @@
 <head>
     <style>
         body {
-            font-size: 11px;
-            font-family: Helvetica Neue,Helvetica,Arial,sans-serif;
+            font-size: 14px;
+            font-family: 'DejaVu Sans',Helvetica,Arial,sans-serif;
         }
         h2 {
-            font-size: 15px;
+            font-size: 18px;
         }
         div{
             page-break-inside: avoid;
@@ -17,7 +17,7 @@
             text-align: center;
             margin: 25px 0 0;
             font-weight: bold;
-            font-size: 20px;
+            font-size: 23px;
             border: none;
             padding-bottom: 5px;
             border-bottom: 1px solid black;
@@ -109,7 +109,7 @@
             font-weight: bold;
         }
         #subheader .left p {
-            font-size: 32px;
+            font-size: 35px;
             margin-top: 0;
         }
         #subheader .right {
@@ -121,12 +121,12 @@
             margin: 0px;
             padding: 0;
             font-weight: bold;
-            font-size: 17px;
+            font-size: 20px;
         }
         #subheader .right p.date {
             margin: 0;
             padding: 0;
-            font-size: 13px;
+            font-size: 16px;
         }
         #content > div.table {
             text-align: center;

--- a/web/admin/templates/header.txt
+++ b/web/admin/templates/header.txt
@@ -3,11 +3,11 @@
 <head>
     <style>
         body {
-            font-size: 11px;
-            font-family: Helvetica Neue,Helvetica,Arial,sans-serif;
-            padding-top: 45px;
+            font-size: 14px;
+            font-family: 'DejaVu Sans',Helvetica,Arial,sans-serif;
+            padding: 30px 0 15px;
             border-bottom: 1px solid red;
-            margin: 45px 8px 0;
+            margin: 45px 8px;
         }
         .bold {
             font-weight: bold!important;


### PR DESCRIPTION
Updated wkhtmltopdf library version in order to avoid some segmentation fault errors. PDF font sizes are smaller in the latest version so CSS styles have been changed.


#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
