### PR TITLE
asterisk: enable realtime pjsip cache

### DIFF
--- a/asterisk/config/sorcery.conf
+++ b/asterisk/config/sorcery.conf
@@ -3,11 +3,11 @@
 ;
 
 [res_pjsip]
-endpoint/cache = memory_cache,expire_on_reload=yes,object_lifetime_maximum=120
 endpoint = config,pjsip.conf,criteria=type=endpoint
+endpoint/cache = memory_cache,expire_on_reload=yes,object_lifetime_maximum=120
 endpoint = realtime,ps_endpoints
-aor/cache = memory_cache,expire_on_reload=yes,object_lifetime_maximum=120
 aor = config,pjsip.conf,criteria=type=aor
+aor/cache = memory_cache,expire_on_reload=yes,object_lifetime_maximum=120
 aor = realtime,ps_aors
 voicemail = realtime,voicemail
 


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

Re-enable asterisk realtime PJSIP cache.

#### Additional information

Solves asterisk booting problems in environments with hundreds of endpoints.