### PR TITLE
provisioning: add support for certificate chains

### DIFF
--- a/web/admin/templates/provisioning/SnomD375/generic.cfg
+++ b/web/admin/templates/provisioning/SnomD375/generic.cfg
@@ -3,9 +3,11 @@
 <certificates>
 <?php
 $cert = file_get_contents("/etc/ssl/certs/snom.crt");
-$cert = str_replace("-----BEGIN CERTIFICATE-----\n", "", $cert);
-$cert = str_replace("-----END CERTIFICATE-----\n", "", $cert);
-echo $cert;
+if (preg_match_all("/-----BEGIN CERTIFICATE-----(.*?)-----END CERTIFICATE-----/s", $cert, $matches)) {
+    foreach ($matches[1] as $match) {
+        echo '<certificate type="base64">' . $match . '</certificate>';
+    }
+}
 ?>
 </certificates>
 <phone-settings e="2">

--- a/web/admin/templates/provisioning/SnomD717/generic.cfg
+++ b/web/admin/templates/provisioning/SnomD717/generic.cfg
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <settings>
 <certificates>
-<certificate type="base64">
 <?php
 $cert = file_get_contents("/etc/ssl/certs/snom.crt");
-$cert = str_replace("-----BEGIN CERTIFICATE-----\n", "", $cert);
-$cert = str_replace("-----END CERTIFICATE-----\n", "", $cert);
-echo $cert;
+if (preg_match_all("/-----BEGIN CERTIFICATE-----(.*?)-----END CERTIFICATE-----/s", $cert, $matches)) {
+    foreach ($matches[1] as $match) {
+        echo '<certificate type="base64">' . $match . '</certificate>';
+    }
+}
 ?>
-</certificate>
 </certificates>
 <phone-settings e="2">
 <update_policy perm="">auto_update</update_policy>

--- a/web/admin/templates/provisioning/SnomD735/generic.cfg
+++ b/web/admin/templates/provisioning/SnomD735/generic.cfg
@@ -3,9 +3,11 @@
 <certificates>
 <?php
 $cert = file_get_contents("/etc/ssl/certs/snom.crt");
-$cert = str_replace("-----BEGIN CERTIFICATE-----\n", "", $cert);
-$cert = str_replace("-----END CERTIFICATE-----\n", "", $cert);
-echo $cert;
+if (preg_match_all("/-----BEGIN CERTIFICATE-----(.*?)-----END CERTIFICATE-----/s", $cert, $matches)) {
+    foreach ($matches[1] as $match) {
+        echo '<certificate type="base64">' . $match . '</certificate>';
+    }
+}
 ?>
 </certificates>
 <phone-settings e="2">

--- a/web/admin/templates/provisioning/SnomD785/generic.cfg
+++ b/web/admin/templates/provisioning/SnomD785/generic.cfg
@@ -3,9 +3,11 @@
 <certificates>
 <?php
 $cert = file_get_contents("/etc/ssl/certs/snom.crt");
-$cert = str_replace("-----BEGIN CERTIFICATE-----\n", "", $cert);
-$cert = str_replace("-----END CERTIFICATE-----\n", "", $cert);
-echo $cert;
+if (preg_match_all("/-----BEGIN CERTIFICATE-----(.*?)-----END CERTIFICATE-----/s", $cert, $matches)) {
+    foreach ($matches[1] as $match) {
+        echo '<certificate type="base64">' . $match . '</certificate>';
+    }
+}
 ?>
 </certificates>
 <phone-settings e="2">


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
Add support for certificate chains for Snom provisioning certificates. With this change, a <certificate> section is added to provisioning for each certificate added into snom.crt

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
