### PR TITLE
core: avoid 0 weight LcrRuleTarget

### DIFF
--- a/library/Ivoz/Kam/Domain/Service/TrunksLcrRuleTarget/TrunksLcrRuleTargetFactory.php
+++ b/library/Ivoz/Kam/Domain/Service/TrunksLcrRuleTarget/TrunksLcrRuleTargetFactory.php
@@ -78,7 +78,7 @@ class TrunksLcrRuleTargetFactory
 
         // Share route weight between all carrier servers inside the carrier
         // This way an even distribution between Carriers is achieved, no matter how many CarrierServers they have
-        $ponderatedWeight = floor(10 * $outgoingRouting->getWeight() / count($lcrGateways));
+        $ponderatedWeight = ceil(10 * $outgoingRouting->getWeight() / count($lcrGateways));
 
         $lcrRuleTargets = [];
         $lcrRules = $outgoingRouting->getLcrRules();

--- a/schema/tests/Provider/CarrierServer/CarrierServerLifeCycleTest.php
+++ b/schema/tests/Provider/CarrierServer/CarrierServerLifeCycleTest.php
@@ -177,9 +177,9 @@ class CarrierServerLifeCycleTest extends KernelTestCase
 
         $diff = $changelog->getData();
         $expectedSubset = [
-            'lcr_id' => '1',
+            'lcr_id' => 1,
             'priority' => 1,
-            'weight' => 3,
+            'weight' => 4,
             'ruleId' => 2,
             'gwId' => 3,
             'outgoingRoutingId' => 1,


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

If weight is zero in LcrRuleTarget Kamailio lcr module reload will fail.
