### PR TITLE
kam: print quality log messages on dialog end

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -234,6 +234,20 @@ modparam("rtpengine", "table_name", "kam_rtpengine")
 modparam("rtpengine", "setid_avp", "$avp(setid)")
 modparam("rtpengine", "rtp_inst_pvar", "$var(RTP_INSTANCE)")
 modparam("rtpengine", "setid_default", 0)
+modparam("rtpengine", "mos_average_pv", "$avp(mos_average)")
+modparam("rtpengine", "mos_average_packetloss_pv", "$avp(mos_average_packetloss)")
+modparam("rtpengine", "mos_average_jitter_pv", "$avp(mos_average_jitter)")
+modparam("rtpengine", "mos_average_roundtrip_pv", "$avp(mos_average_roundtrip)")
+modparam("rtpengine", "mos_A_label_pv", "$avp(mos_A_label)")
+modparam("rtpengine", "mos_average_A_pv", "$avp(mos_average_A)")
+modparam("rtpengine", "mos_average_packetloss_A_pv", "$avp(mos_average_packetloss_A)")
+modparam("rtpengine", "mos_average_jitter_A_pv", "$avp(mos_average_jitter_A)")
+modparam("rtpengine", "mos_average_roundtrip_A_pv", "$avp(mos_average_roundtrip_A)")
+modparam("rtpengine", "mos_B_label_pv", "$avp(mos_B_label)")
+modparam("rtpengine", "mos_average_B_pv", "$avp(mos_average_B)")
+modparam("rtpengine", "mos_average_packetloss_B_pv", "$avp(mos_average_packetloss_B)")
+modparam("rtpengine", "mos_average_jitter_B_pv", "$avp(mos_average_jitter_B)")
+modparam("rtpengine", "mos_average_roundtrip_B_pv", "$avp(mos_average_roundtrip_B)")
 
 # SQL OPS
 modparam("sqlops","sqlcon","cb=>mysql://[kamailio]/ivozprovider")
@@ -2046,10 +2060,50 @@ route[RTPENGINE] {
 
     $var(callid) = "call-id=trunks-" + $dlg_var(direction) + '-' + $dlg_var(callid);
 
-    xinfo("[$dlg_var(cidhash)] RTPENGINE: rtpengine_manage [$var(rtpengine_opts) $var(callid)]\n");
-    rtpengine_manage("$var(rtpengine_opts) $var(callid)");
+    route(QUALITYLABELS);
+
+    xinfo("[$dlg_var(cidhash)] RTPENGINE: rtpengine_manage [$var(rtpengine_opts) $var(callid) $var(label)]\n");
+    rtpengine_manage("$var(rtpengine_opts) $var(callid) $var(label)");
+
+    if (is_request() && is_method("BYE")) {
+        route(QUALITY);
+    }
 
     route(RECORD);
+}
+
+route[QUALITYLABELS] {
+    $var(label) = "";
+
+    if (is_request() && is_method("BYE")) {
+        $avp(mos_A_label) = 'Aleg_label';
+        $avp(mos_B_label) = 'Bleg_label';
+    }
+
+    if (!has_body("application/sdp")) return;
+    if ($dlg_var(confirmed) == 1) return;
+
+    if (is_request()) {
+        $var(label) = "label=Aleg_label";
+    } else {
+        $var(label) = "label=Bleg_label";
+    }
+}
+
+route[QUALITY] {
+    $var(tag) =  'trunks' + ':b' + $dlg_var(brandId) + ':c' + $dlg_var(companyId) + ':' + $(dlg_var(rtChannel){s.select,3,:});
+
+    xnotice("[$dlg_var(cidhash)] QUALITY: global mos $avp(mos_average) - pl $avp(mos_average_packetloss) % - jt $avp(mos_average_jitter) ms - rtt $avp(mos_average_roundtrip) ms ($var(tag))");
+
+    if ($dlg_var(direction) == 'inbound') {
+        # Call from carrier: A leg is inbound RTP flow (flow from carrier) / B leg is outbound RTP flow (flow to carrier)
+        xnotice("[$dlg_var(cidhash)] QUALITY: inbound mos $avp(mos_average_A) - pl $avp(mos_average_packetloss_A) % - jt $avp(mos_average_jitter_A) ms - rtt $avp(mos_average_roundtrip_A) ms ($var(tag))");
+        xnotice("[$dlg_var(cidhash)] QUALITY: outbound mos $avp(mos_average_B) - pl $avp(mos_average_packetloss_B) % - jt $avp(mos_average_jitter_B) ms - rtt $avp(mos_average_roundtrip_B) ms ($var(tag))");
+    } else {
+        # Call to carrier: A leg is outbound RTP flow (flow to carrier) / B leg is inbound RTP flow (flow from carrier)
+        xnotice("[$dlg_var(cidhash)] QUALITY: inbound mos $avp(mos_average_B) - pl $avp(mos_average_packetloss_B) % - jt $avp(mos_average_jitter_B) ms - rtt $avp(mos_average_roundtrip_B) ms ($var(tag))");
+        xnotice("[$dlg_var(cidhash)] QUALITY: outbound mos $avp(mos_average_A) - pl $avp(mos_average_packetloss_A) % - jt $avp(mos_average_jitter_A) ms - rtt $avp(mos_average_roundtrip_A) ms ($var(tag))");
+    }
 }
 
 route[RECORD] {

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -207,6 +207,20 @@ modparam("rtpengine", "table_name", "kam_rtpengine")
 modparam("rtpengine", "setid_avp", "$avp(setid)")
 modparam("rtpengine", "rtp_inst_pvar", "$var(RTP_INSTANCE)")
 modparam("rtpengine", "setid_default", 0)
+modparam("rtpengine", "mos_average_pv", "$avp(mos_average)")
+modparam("rtpengine", "mos_average_packetloss_pv", "$avp(mos_average_packetloss)")
+modparam("rtpengine", "mos_average_jitter_pv", "$avp(mos_average_jitter)")
+modparam("rtpengine", "mos_average_roundtrip_pv", "$avp(mos_average_roundtrip)")
+modparam("rtpengine", "mos_A_label_pv", "$avp(mos_A_label)")
+modparam("rtpengine", "mos_average_A_pv", "$avp(mos_average_A)")
+modparam("rtpengine", "mos_average_packetloss_A_pv", "$avp(mos_average_packetloss_A)")
+modparam("rtpengine", "mos_average_jitter_A_pv", "$avp(mos_average_jitter_A)")
+modparam("rtpengine", "mos_average_roundtrip_A_pv", "$avp(mos_average_roundtrip_A)")
+modparam("rtpengine", "mos_B_label_pv", "$avp(mos_B_label)")
+modparam("rtpengine", "mos_average_B_pv", "$avp(mos_average_B)")
+modparam("rtpengine", "mos_average_packetloss_B_pv", "$avp(mos_average_packetloss_B)")
+modparam("rtpengine", "mos_average_jitter_B_pv", "$avp(mos_average_jitter_B)")
+modparam("rtpengine", "mos_average_roundtrip_B_pv", "$avp(mos_average_roundtrip_B)")
 
 # DEBUGGER
 modparam("debugger", "mod_hash_size", 5)
@@ -2701,8 +2715,48 @@ route[RTPENGINE] {
         }
     }
 
-    xlog("$var(log_level)", "[$dlg_var(cidhash)] RTPENGINE: rtpengine_manage [$var(common_opts) $var(symmetry) $var(bridging) $var(interfaces) $dlg_var(codecs) $var(callid)]\n");
-    rtpengine_manage("$var(common_opts) $var(symmetry) $var(bridging) $var(interfaces) $dlg_var(codecs) $var(callid)");
+    route(QUALITYLABELS);
+
+    xlog("$var(log_level)", "[$dlg_var(cidhash)] RTPENGINE: rtpengine_manage [$var(common_opts) $var(symmetry) $var(bridging) $var(interfaces) $dlg_var(codecs) $var(callid) $var(label)]\n");
+    rtpengine_manage("$var(common_opts) $var(symmetry) $var(bridging) $var(interfaces) $dlg_var(codecs) $var(callid) $var(label)");
+
+    if (is_request() && is_method("BYE")) {
+        route(QUALITY);
+    }
+}
+
+route[QUALITYLABELS] {
+    $var(label) = "";
+
+    if (is_request() && is_method("BYE")) {
+        $avp(mos_A_label) = 'Aleg_label';
+        $avp(mos_B_label) = 'Bleg_label';
+    }
+
+    if (!has_body("application/sdp")) return;
+    if ($dlg_var(confirmed) == 1) return;
+
+    if (is_request()) {
+        $var(label) = "label=Aleg_label";
+    } else {
+        $var(label) = "label=Bleg_label";
+    }
+}
+
+route[QUALITY] {
+    $var(tag) =  'users' + ':b' + $dlg_var(brandId) + ':c' + $dlg_var(companyId) + ':' + $(dlg_var(rtChannel){s.select,3,:});
+
+    xnotice("[$dlg_var(cidhash)] QUALITY: global mos $avp(mos_average) - pl $avp(mos_average_packetloss) % - jt $avp(mos_average_jitter) ms - rtt $avp(mos_average_roundtrip) ms ($var(tag))");
+
+    if ($dlg_var(direction) == 'outbound') {
+        # Call from UAC: A leg is inbound RTP flow (flow from UAC) / B leg is outbound RTP flow (flow to UAC)
+        xnotice("[$dlg_var(cidhash)] QUALITY: inbound mos $avp(mos_average_A) - pl $avp(mos_average_packetloss_A) % - jt $avp(mos_average_jitter_A) ms - rtt $avp(mos_average_roundtrip_A) ms ($var(tag))");
+        xnotice("[$dlg_var(cidhash)] QUALITY: outbound mos $avp(mos_average_B) - pl $avp(mos_average_packetloss_B) % - jt $avp(mos_average_jitter_B) ms - rtt $avp(mos_average_roundtrip_B) ms ($var(tag))");
+    } else {
+        # Call to UAC: A leg is outbound RTP flow (flow to UAC) / B leg is inbound RTP flow (flow from UAC)
+        xnotice("[$dlg_var(cidhash)] QUALITY: inbound mos $avp(mos_average_B) - pl $avp(mos_average_packetloss_B) % - jt $avp(mos_average_jitter_B) ms - rtt $avp(mos_average_roundtrip_B) ms ($var(tag))");
+        xnotice("[$dlg_var(cidhash)] QUALITY: outbound mos $avp(mos_average_A) - pl $avp(mos_average_packetloss_A) % - jt $avp(mos_average_jitter_A) ms- rtt $avp(mos_average_roundtrip_A) ms ($var(tag))");
+    }
 }
 
 route[LOCAL_PUBLISH] {


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

Print 3 log messages on dialog end in both proxies:

- inbound mos value: RTP flow from external elements (UAC/carrier) to IvozProvider.
- outbound mos value: RTP flow from IvozProvider to external elements (UAC/carrier).
- global mos value: inbound RTP flow + outbound RTP flow.

#### Additional information

Just print 3 log messages per dialog in both proxies, no database storage or further calculations yet.