### PR TITLE
web/admin: skip record count on large tables in the dashboard

### DIFF
--- a/web/admin/application/configs/klear/klear.yaml
+++ b/web/admin/application/configs/klear/klear.yaml
@@ -109,11 +109,13 @@ production:
           title: ngettext('External call', 'External calls', 0)
           description: _("List of %s", ngettext('External call', 'External calls', 0))
           class: ui-silk-application-view-list-world
+          disabledCount: true
         BillableCallHistoricsList:
           title: ngettext('Historic external call', 'Historic external calls', 0)
           description: _("List of %s", ngettext('Historic external call', 'Historic external calls', 0))
           class: ui-silk-application-view-list-world
           showOnlyIf: false
+          disabledCount: true
         Infrastructure:
           title: _("Infrastructure")
           class: ui-silk-sitemap-color
@@ -258,6 +260,7 @@ production:
               title: ngettext('External call', 'External calls', 0)
               description: _("List of %s", ngettext('External call', 'External calls', 0))
               class: ui-silk-application-view-list-world
+              disabledCount: true
             CallCsvSchedulersBrandList:
               title: ngettext('Call CSV scheduler', 'Call CSV schedulers', 0)
               class: ui-silk-application-view-list-schedule
@@ -520,6 +523,7 @@ production:
               description: _("List of %s", ngettext('External call', 'External calls', 0))
               class: ui-silk-application-view-list-world
               showOnlyIf: ${auth.acls.BillableCalls.read}
+              disabledCount: true
             CallCsvSchedulersList:
               title: ngettext('Call CSV scheduler', 'Call CSV schedulers', 0)
               class: ui-silk-application-view-list-schedule


### PR DESCRIPTION
Record counts on large tables, such as external calls, slows down dashboard loading time significantly. Turn it off.

Requires klear to be updated:
- https://github.com/irontec/klearMatrix/commit/b718d8de1043d8c2acfdcaff227168cd7151c543
- https://github.com/irontec/klear/commit/df7044ed5e2a965cd813286a8c281b07fd3cf58d

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
<!-- Describe your changes in detail -->

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
