### PR TITLE
kamusers: mitigate BLF locking in Trying state

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -379,6 +379,7 @@ modparam("presence", "max_expires", 3600)
 modparam("presence", "db_update_period", 100)
 modparam("presence", "subs_db_mode", 2)
 modparam("presence", "db_table_lock_type", 0)
+modparam("presence", "clean_period", 15)
 
 # PRESENCE XML
 modparam("presence_xml", "db_url", DBURL)

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -696,13 +696,6 @@ route[GET_DDI_PREFIX] {
     sql_query("cb", "SELECT ODRP.prefix, ODRP.id FROM OutgoingDDIRulesPatterns ODRP INNER JOIN OutgoingDDIRules ODR ON ODR.id = ODRP.outgoingDDIRuleId INNER JOIN Companies C ON C.id = ODR.companyId INNER JOIN Users U ON U.companyId = C.id WHERE ODR.id = COALESCE(U.outgoingDDIRuleId, C.outgoingDDIRuleId) AND U.id ='$dlg_var(userId)' AND ODRP.type = 'prefix' ORDER BY priority", "rb");
     route(SEARCH_AND_STRIP_PREFIX);
 
-    # Prevent multiple ddi prefix usage
-    if ($rU =~ "\*") {
-        xwarn("[$dlg_var(cidhash)] GET-DDI-PREFIX: Destination cannot contain '*' after stripping ddi prefix\n");
-        send_reply("404", "Invalid destination");
-        exit;
-    }
-
     # Add headers if ddi prefix matched
     if ($var(prefix) != "") {
         xinfo("[$dlg_var(cidhash)] GET-DDI-PREFIX: Detected ddi prefix '$var(prefix)', new destination: $rU\n");

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -514,16 +514,18 @@ request_route {
     # Handle NOTIFY, SUBSCRIBE and PUBLISH
     route(PRESENCE);
 
-    # Set caller and callee to generate PUBLISH
-    route(GENERATE_PUBLISH);
-
-    # From now on, everything is for INVITEs: track dialog
-    if (!is_known_dlg() || $si == $var(trunksAddress) || src_ip == myself) {
-        dlg_manage();
-    }
+    # -- From now on, everything is for INVITEs --
 
     # Antiflooding for new calls establishments
     route(ANTIFLOOD);
+
+    # Set caller and callee to generate PUBLISH
+    route(GENERATE_PUBLISH);
+
+    # Track dialog
+    if (!is_known_dlg() || $si == $var(trunksAddress) || src_ip == myself) {
+        dlg_manage();
+    }
 
     # Calculate cidhash if not set
     route(CIDHASH);


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

- _Trying_ state only applies for caller parties.
- As soon as _dlg_manage()_ is called for vpbx initial INVITEs from UACs, a PUBLISH with _Trying_ state is sent to every active watcher.
- If finally this request is not sent (rejected by antiflood, etc.), no PUBLISH is generated with _terminated_ state.
- BLF lights remain red for 3 hours (dialog max lifetime).

This PR:

- Fixes call rejections done after _dlg_manage()_:
  - Antiflood moved upwards.
  - Doble '*' check removed.
- Removes expired presentity entries every 10 seconds (instead of 100 seconds).

#### Additional information

This PR together with https://github.com/irontec/kamailio/pull/3 mitigates any future Trying lock from 3 hours to 30 seconds (20 seconds of _Trying_ state lifetime + 10 seconds of expired presentity cleanup).