### PR TITLE
web/rest: added text/csv response type to client /billable_calls

### DIFF
--- a/web/rest/client/config/api/raw/provider.yml
+++ b/web/rest/client/config/api/raw/provider.yml
@@ -6,7 +6,12 @@ Ivoz\Provider\Domain\Model\BillableCall\BillableCall:
   itemOperations:
     get: ~
   collectionOperations:
-    get: ~
+    get:
+      swagger_context:
+        produces:
+          - 'application/json'
+          - 'application/ld+json'
+          - 'text/csv'
   attributes:
     pagination_client_enabled: true
     access_control: '"ROLE_COMPANY_ADMIN" in roles && user.hasAccessPrivileges(_api_resource_class, request.getMethod())'


### PR DESCRIPTION
Fixed client API's /billable_calls response format documentation

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
