### PR TITLE
recordings: avoid race ignoring too recent recorded files

### DIFF
--- a/microservices/recordings/src/Recording/Encoder.php
+++ b/microservices/recordings/src/Recording/Encoder.php
@@ -20,6 +20,11 @@ class Encoder
     const RECORDING_SIZE_MIN = 512;
 
     /**
+     * Recording created this seconds ago will be ignored
+     */
+    const RECORDING_AGE_MIN = 10;
+
+    /**
      * @var TrunksCdrRepository
      */
     protected $trunksCdrRepository;
@@ -89,6 +94,13 @@ class Encoder
 
                 // Only handle files
                 if (!is_file($filenameabs)) {
+                    continue;
+                }
+
+                // Ignore recent files
+                $age = time() - filemtime($filenameabs);
+                if ($age <= self::RECORDING_AGE_MIN) {
+                    $this->logger->info(sprintf("[Recordings] Ignoring too young file %s [%d sec]\n", $filename, $age));
                     continue;
                 }
 


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
A race condition existis if the recording timer starts at the same time
a call has been answered and its recording has just been created.

The resulting file will have 0 bytes and the garbage handler of recordings
service will remove the file.

This PR adds a new condition to ignore recent created files
to give the chance to recording daemon to add data.


#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
