### PR TITLE
Several Fax validations improved

### DIFF
--- a/asterisk/agi/src/Dialplan/FaxDial.php
+++ b/asterisk/agi/src/Dialplan/FaxDial.php
@@ -108,7 +108,7 @@ class FaxDial extends RouteHandlerAbstract
             "-sOutputFile=". $tifFile,
             $pdfFile
         ]);
-        $process->mustRun();
+        $process->run();
 
         /** @var FaxesInOutDto $faxOutDto */
         $faxOutDto = $this->entityTools->entityToDto($faxOut);

--- a/asterisk/config/dialplan/faxes.conf
+++ b/asterisk/config/dialplan/faxes.conf
@@ -10,6 +10,8 @@ exten => _[+*0-9]!,1,NoOp(Procesing outgoing Fax to ${EXTEN})
 [faxes-call-world]
 exten => _[+*0-9]!,1,NoOp(Calling external number)
     same => n,Dial(${DIAL_DST},${DIAL_TIMEOUT},${DIAL_OPTS}b(add-headers^${EXTEN}^1))
+
+exten => h,1,NoOp(Sending faxfile call ended with status ${DIALSTATUS})
     same => n,AGI(agi://127.0.0.1:4573/fastagi-runner.php?command=dialplan/faxdialstatus)
 
 [faxes-send]

--- a/library/Ivoz/Provider/Domain/Model/FaxesInOut/FaxesInOut.php
+++ b/library/Ivoz/Provider/Domain/Model/FaxesInOut/FaxesInOut.php
@@ -2,6 +2,7 @@
 
 namespace Ivoz\Provider\Domain\Model\FaxesInOut;
 
+use Assert\Assertion;
 use Ivoz\Core\Domain\Model\TempFileContainnerTrait;
 use Ivoz\Core\Domain\Service\FileContainerInterface;
 
@@ -84,12 +85,8 @@ class FaxesInOut extends FaxesInOutAbstract implements FileContainerInterface, F
 
     protected function setDst($dst = null)
     {
-        $dst = preg_replace(
-            '/[^0-9]/',
-            '',
-            $dst
-        );
-
+        $dst = str_replace(['+', ' '], '', $dst);
+        Assertion::regex($dst, '/^[0-9]+$/');
         return parent::setDst($dst);
     }
 }


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
Following commits fixes some scenarios that was not being validated:
a) Sending a file other than a PDF caused conversion errors not being handled
b) Sending a Fax to a destionation that does not answer keeps the faxfile in pending status forever
c) Sending a Fax to a only letters destination keeps the faxfile in pending status forever

Above error should be fixed in this PR commits

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
