### PR TITLE
i18n: Update locale-en.json to fix translation for "both"

### DIFF
--- a/web/user/app/languages/locale-en.json
+++ b/web/user/app/languages/locale-en.json
@@ -65,7 +65,7 @@
     "userNotRegistered": "User not registered",
     "internal": "Internal",
     "external": "External",
-    "both": "Ambos",
+    "both": "Both",
     "creadoCorrectamente": "Properly created",
     "saveCorrectamente": "Properly saved",
     "targetType": "Target type",


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [ ] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [ ] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
Fix English translation for call type: both.

#### Additional information

