### PR TITLE
agis: set max call duration to 3 hours

### DIFF
--- a/asterisk/agi/src/Agi/Action/ExternalNumberAction.php
+++ b/asterisk/agi/src/Agi/Action/ExternalNumberAction.php
@@ -133,7 +133,7 @@ class ExternalNumberAction
         // Call the PSJIP endpoint
         $this->agi->setVariable("DIAL_DST", "PJSIP/" . $number . '@proxytrunks');
         $this->agi->setVariable("DIAL_OPTS", $options);
-        $this->agi->setVariable("DIAL_TIMEOUT", "");
+        $this->agi->setVariable("DIAL_TIMEOUT", "10800");
         $this->agi->redirect('call-world', $number);
     }
 }

--- a/asterisk/agi/src/Agi/Action/FriendCallAction.php
+++ b/asterisk/agi/src/Agi/Action/FriendCallAction.php
@@ -82,7 +82,7 @@ class FriendCallAction
         $this->agi->setVariable("DIAL_EXT", $number);
         $this->agi->setVariable("DIAL_DST", "PJSIP/$endpointName");
         $this->agi->setVariable("__DIAL_ENDPOINT", $endpointName);
-        $this->agi->setVariable("DIAL_TIMEOUT", "");
+        $this->agi->setVariable("DIAL_TIMEOUT", "10800");
         $this->agi->setVariable("DIAL_OPTS", $options);
 
         // Redirect to the calling dialplan context

--- a/asterisk/agi/src/Agi/Action/ResidentialCallAction.php
+++ b/asterisk/agi/src/Agi/Action/ResidentialCallAction.php
@@ -126,7 +126,7 @@ class ResidentialCallAction
             }
         }
 
-        return ($timeout)?:"";
+        return ($timeout)?:"10800";
     }
 
     /**

--- a/asterisk/agi/src/Agi/Action/UserCallAction.php
+++ b/asterisk/agi/src/Agi/Action/UserCallAction.php
@@ -211,7 +211,7 @@ class UserCallAction
     {
         // Ignore user timeout if User call forwards are disabled
         if (!$this->allowCallForwards) {
-            return "";
+            return "10800";
         }
 
         $timeout = null;
@@ -235,7 +235,7 @@ class UserCallAction
             }
         }
 
-        return ($timeout)?:"";
+        return ($timeout)?:"10800";
     }
 
     /**


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
Set max call duration to 3 hours like already configured in Kamailio Proxies:
https://github.com/irontec/ivozprovider/blob/361284c5fa6edd9bddb5ac3f68f07076b88334ca/kamailio/users/config/kamailio.cfg#L60-L61


#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
