### PR TITLE
core: set invoice id by iterating chunks in order to avoid lock timeouts

### DIFF
--- a/library/Ivoz/Provider/Domain/Service/Invoice/Generator.php
+++ b/library/Ivoz/Provider/Domain/Service/Invoice/Generator.php
@@ -188,8 +188,6 @@ class Generator
         $invoiceTz = new \DateTimeZone(
             $company->getDefaultTimezone()->getTz()
         );
-        $utcTz = new \DateTimeZone('UTC');
-
         $currencySymbol = $company->getCurrencySymbol();
 
         $callsPerType = [];

--- a/microservices/workers/src/Worker/Invoices.php
+++ b/microservices/workers/src/Worker/Invoices.php
@@ -115,7 +115,7 @@ class Invoices
             $this->logger->info("[INVOICER] Status = created");
         } catch (\Exception $e) {
             $this->logger->info("[INVOICER] Status = error");
-            $this->logger->error("[INVOICER] Error was: ".$e->getMessage());
+            $this->logger->error("[INVOICER] Error was: " . $e->getMessage());
 
             if (!isset($invoiceDto)) {
                 exit(1);


### PR DESCRIPTION
Long queries don't play well with percona cluster

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
<!-- Describe your changes in detail -->

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
