### PR TITLE
kam: add carrier/ddiprovider mediarelayset relationship

### DIFF
--- a/doc/sphinx/administration_portal/brand/providers/carriers.rst
+++ b/doc/sphinx/administration_portal/brand/providers/carriers.rst
@@ -39,9 +39,15 @@ This are the fields that define a carrier:
         Selected address will be used as source address for signalling with this carrier. Brand operator can choose among
         addresses assigned by main operator via :ref:`Brands`. Read :ref:`Proxy Trunks` for further details.
 
+    Media relay set
+        Media-relays can be grouped in sets to reserve capacities or on a geographical purpose. Selected set will be used
+        in calls through this specific carrier. This field in only seen by Global administrator (aka God).
+
     Status
         Non-responding carrier servers are inactivated until they respond to OPTIONS ping request. This icon is green if
         every carrier server of given carrier is active, red if they are all inactive and yellow if just some of them are inactive.
+
+.. hint:: If you want carrier-side media handled by the same mediarelay set than client-side, select "Client's default".
 
 Cost calculation
 ****************

--- a/doc/sphinx/administration_portal/brand/providers/ddi_providers.rst
+++ b/doc/sphinx/administration_portal/brand/providers/ddi_providers.rst
@@ -25,6 +25,12 @@ This are the fields that define a carrier:
         Selected address will be used as source address for signalling with this DDI provider. Brand operator can choose among
         addresses assigned by main operator via :ref:`Brands`. Read :ref:`Proxy Trunks` for further details.
 
+    Media relay set
+        Media-relays can be grouped in sets to reserve capacities or on a geographical purpose. Selected set will be used
+        in calls through this specific DDI Provider. This field in only seen by Global administrator (aka God).
+
+.. hint:: If you want carrier-side media handled by the same mediarelay set than client-side, select "Client's default".
+
 DDI Provider Addresses
 **********************
 

--- a/doc/sphinx/administration_portal/platform/infrastructure/media_relay_sets.rst
+++ b/doc/sphinx/administration_portal/platform/infrastructure/media_relay_sets.rst
@@ -4,7 +4,7 @@ Media relay sets
 Media relays are in charge of bridging RTP traffic of established calls. Like
 the Application Servers, they can scale horizontally as much as required.
 
-Media relays are organized in groups so they can be assigned to a client. Each
+Media relays are organized in groups so they can be assigned to a client/provider. Each
 element of the group has a **metric** that allows non-equal load balancing
 within the same group (i.e. media-relay1 metric 1; media-relay2 metric 2:
 the second media relay will handle two times the calls than the first one).

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -932,13 +932,20 @@ route[SELECT_NEXT_GW] {
     }
 
     # Obtain info about selected GW
-    sql_xquery("cb", "SELECT C.externallyRated, C.calculateCost, CS.sendPAI, CS.sendRPID, CS.authNeeded, CS.authUser, CS.authPassword, CS.carrierId, CS.fromUser, CS.fromDomain, PT.ip FROM CarrierServers CS JOIN Carriers C ON CS.carrierId=C.id LEFT JOIN ProxyTrunks PT ON PT.id=C.proxyTrunkId WHERE CS.id=$avp(carrierServerId)", "ra");
+    sql_xquery("cb", "SELECT C.mediaRelaySetsId, C.externallyRated, C.calculateCost, CS.sendPAI, CS.sendRPID, CS.authNeeded, CS.authUser, CS.authPassword, CS.carrierId, CS.fromUser, CS.fromDomain, PT.ip FROM CarrierServers CS JOIN Carriers C ON CS.carrierId=C.id LEFT JOIN ProxyTrunks PT ON PT.id=C.proxyTrunkId WHERE CS.id=$avp(carrierServerId)", "ra");
 
     if ( $(xavp(ra=>carrierId){s.len}) ) {
         $dlg_var(carrierId) = $xavp(ra=>carrierId);
         $dlg_var(carrierServerId) = $avp(carrierServerId);
         $dlg_var(calculateCost) = $xavp(ra=>calculateCost);
         xinfo("[$dlg_var(cidhash)] SELECT-NEXT-GW: carrierId: $dlg_var(carrierId) (externallyRated: $xavp(ra=>externallyRated))\n");
+        if ($xavp(ra=>mediaRelaySetsId) != $null) {
+            $dlg_var(mediaRelaySetsId) = $xavp(ra=>mediaRelaySetsId);
+            xinfo("[$dlg_var(cidhash)] SELECT-NEXT-GW: carrier#$dlg_var(carrierId) has non-NULL mediaRelaySetsId ($dlg_var(mediaRelaySetsId)), use it\n");
+        } else {
+            $dlg_var(mediaRelaySetsId) = $dlg_var(companyMediaRelaySetsId);
+            xinfo("[$dlg_var(cidhash)] SELECT-NEXT-GW: carrier#$dlg_var(carrierId) has NULL mediaRelaySetsId, use company's set ($dlg_var(mediaRelaySetsId))\n");
+        }
     } else {
         xerr("[$dlg_var(cidhash)] SELECT-NEXT-GW: Error obtaining 'carrierId' for carrierServerId '$avp(carrierServerId)'\n");
         send_reply("500", "Server Internal Error");
@@ -1188,6 +1195,10 @@ route[GET_TRANSFORMATIONS_IN] {
         send_reply("404", "Not Here");
         exit;
     }
+
+    # Get mediaRelaySetsId from selected DDIProvider
+    sql_xquery("cb", "SELECT mediaRelaySetsId FROM DDIProviders WHERE id='$dlg_var(ddiProviderId)'", "dp");
+    $dlg_var(ddiProviderMediaRelaySetsId) = $xavp(dp=>mediaRelaySetsId);
 }
 
 # This route apply transformations to rU, PAI and Diversion to E.164
@@ -1403,7 +1414,13 @@ route[GET_INFO_FROM_MATCHED_DDI] {
     $dlg_var(distributeMethod) = $xavp(ra=>distributeMethod);
     $avp(asAddress) = $xavp(ra=>asAddress);
 
-    $dlg_var(mediaRelaySetsId) = $xavp(ra=>mediaRelaySetsId);
+    if ($dlg_var(ddiProviderMediaRelaySetsId) != $null) {
+        $dlg_var(mediaRelaySetsId) = $dlg_var(ddiProviderMediaRelaySetsId);
+        xinfo("[$dlg_var(cidhash)] GET-INFO-FROM-MATCHED-DDI: ddiProvider#$dlg_var(ddiProviderId) has non-NULL mediaRelaySetsId ($dlg_var(mediaRelaySetsId)), use it\n");
+    } else {
+        $dlg_var(mediaRelaySetsId) = $xavp(ra=>mediaRelaySetsId);
+        xinfo("[$dlg_var(cidhash)] GET-INFO-FROM-MATCHED-DDI: ddiProvider#$dlg_var(ddiProviderId) has NULL mediaRelaySetsId, use company's set ($dlg_var(mediaRelaySetsId))\n");
+    }
 
     # Save endpointId for CDR accounting
     if ($xavp(ra=>routeType) == 'retail') {
@@ -1432,7 +1449,7 @@ route[GET_INFO_FROM_COMPANY] {
 
     $dlg_var(cgrReqType) = '*' + $xavp(ra=>billingMethod);
     $dlg_var(companyDomain) = $xavp(ra=>domain);
-    $dlg_var(mediaRelaySetsId) = $xavp(ra=>mediaRelaySetsId);
+    $dlg_var(companyMediaRelaySetsId) = $xavp(ra=>mediaRelaySetsId);
     $dlg_var(maxCallsCompany) = $xavp(ra=>maxCallsCompany);
     $dlg_var(maxCallsBrand) = $xavp(ra=>maxCallsBrand);
 
@@ -2107,6 +2124,7 @@ route[RTPENGINE] {
     if (!is_request() && is_method("INVITE|UPDATE") && t_check_status("[12][0-9]{2}") && !has_body("application/sdp")) return;
 
     if ($(dlg_var(mediaRelaySetsId){s.len}) > 0 && $dlg_var(mediaRelaySetsId) != 0) {
+        xinfo("[$dlg_var(cidhash)] RTPENGINE: mediaRelaySetsId: $dlg_var(mediaRelaySetsId)\n");
         set_rtpengine_set("$(dlg_var(mediaRelaySetsId){s.int})");
     }
 

--- a/library/Ivoz/Provider/Domain/Model/Carrier/CarrierAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Carrier/CarrierAbstract.php
@@ -58,6 +58,11 @@ abstract class CarrierAbstract
      */
     protected $proxyTrunk;
 
+    /**
+     * @var \Ivoz\Provider\Domain\Model\MediaRelaySet\MediaRelaySetInterface | null
+     */
+    protected $mediaRelaySets;
+
 
     use ChangelogTrait;
 
@@ -151,6 +156,7 @@ abstract class CarrierAbstract
             ->setTransformationRuleSet($fkTransformer->transform($dto->getTransformationRuleSet()))
             ->setCurrency($fkTransformer->transform($dto->getCurrency()))
             ->setProxyTrunk($fkTransformer->transform($dto->getProxyTrunk()))
+            ->setMediaRelaySets($fkTransformer->transform($dto->getMediaRelaySets()))
         ;
 
         $self->initChangelog();
@@ -178,7 +184,8 @@ abstract class CarrierAbstract
             ->setBrand($fkTransformer->transform($dto->getBrand()))
             ->setTransformationRuleSet($fkTransformer->transform($dto->getTransformationRuleSet()))
             ->setCurrency($fkTransformer->transform($dto->getCurrency()))
-            ->setProxyTrunk($fkTransformer->transform($dto->getProxyTrunk()));
+            ->setProxyTrunk($fkTransformer->transform($dto->getProxyTrunk()))
+            ->setMediaRelaySets($fkTransformer->transform($dto->getMediaRelaySets()));
 
 
 
@@ -201,7 +208,8 @@ abstract class CarrierAbstract
             ->setBrand(\Ivoz\Provider\Domain\Model\Brand\Brand::entityToDto(self::getBrand(), $depth))
             ->setTransformationRuleSet(\Ivoz\Provider\Domain\Model\TransformationRuleSet\TransformationRuleSet::entityToDto(self::getTransformationRuleSet(), $depth))
             ->setCurrency(\Ivoz\Provider\Domain\Model\Currency\Currency::entityToDto(self::getCurrency(), $depth))
-            ->setProxyTrunk(\Ivoz\Provider\Domain\Model\ProxyTrunk\ProxyTrunk::entityToDto(self::getProxyTrunk(), $depth));
+            ->setProxyTrunk(\Ivoz\Provider\Domain\Model\ProxyTrunk\ProxyTrunk::entityToDto(self::getProxyTrunk(), $depth))
+            ->setMediaRelaySets(\Ivoz\Provider\Domain\Model\MediaRelaySet\MediaRelaySet::entityToDto(self::getMediaRelaySets(), $depth));
     }
 
     /**
@@ -218,7 +226,8 @@ abstract class CarrierAbstract
             'brandId' => self::getBrand()->getId(),
             'transformationRuleSetId' => self::getTransformationRuleSet() ? self::getTransformationRuleSet()->getId() : null,
             'currencyId' => self::getCurrency() ? self::getCurrency()->getId() : null,
-            'proxyTrunkId' => self::getProxyTrunk() ? self::getProxyTrunk()->getId() : null
+            'proxyTrunkId' => self::getProxyTrunk() ? self::getProxyTrunk()->getId() : null,
+            'mediaRelaySetsId' => self::getMediaRelaySets() ? self::getMediaRelaySets()->getId() : null
         ];
     }
     // @codeCoverageIgnoreStart
@@ -458,6 +467,30 @@ abstract class CarrierAbstract
     public function getProxyTrunk()
     {
         return $this->proxyTrunk;
+    }
+
+    /**
+     * Set mediaRelaySets
+     *
+     * @param \Ivoz\Provider\Domain\Model\MediaRelaySet\MediaRelaySetInterface $mediaRelaySets | null
+     *
+     * @return static
+     */
+    protected function setMediaRelaySets(\Ivoz\Provider\Domain\Model\MediaRelaySet\MediaRelaySetInterface $mediaRelaySets = null)
+    {
+        $this->mediaRelaySets = $mediaRelaySets;
+
+        return $this;
+    }
+
+    /**
+     * Get mediaRelaySets
+     *
+     * @return \Ivoz\Provider\Domain\Model\MediaRelaySet\MediaRelaySetInterface | null
+     */
+    public function getMediaRelaySets()
+    {
+        return $this->mediaRelaySets;
     }
 
     // @codeCoverageIgnoreEnd

--- a/library/Ivoz/Provider/Domain/Model/Carrier/CarrierDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Carrier/CarrierDtoAbstract.php
@@ -61,6 +61,11 @@ abstract class CarrierDtoAbstract implements DataTransferObjectInterface
     private $proxyTrunk;
 
     /**
+     * @var \Ivoz\Provider\Domain\Model\MediaRelaySet\MediaRelaySetDto | null
+     */
+    private $mediaRelaySets;
+
+    /**
      * @var \Ivoz\Provider\Domain\Model\OutgoingRouting\OutgoingRoutingDto[] | null
      */
     private $outgoingRoutings = null;
@@ -112,7 +117,8 @@ abstract class CarrierDtoAbstract implements DataTransferObjectInterface
             'brandId' => 'brand',
             'transformationRuleSetId' => 'transformationRuleSet',
             'currencyId' => 'currency',
-            'proxyTrunkId' => 'proxyTrunk'
+            'proxyTrunkId' => 'proxyTrunk',
+            'mediaRelaySetsId' => 'mediaRelaySets'
         ];
     }
 
@@ -132,6 +138,7 @@ abstract class CarrierDtoAbstract implements DataTransferObjectInterface
             'transformationRuleSet' => $this->getTransformationRuleSet(),
             'currency' => $this->getCurrency(),
             'proxyTrunk' => $this->getProxyTrunk(),
+            'mediaRelaySets' => $this->getMediaRelaySets(),
             'outgoingRoutings' => $this->getOutgoingRoutings(),
             'outgoingRoutingsRelCarriers' => $this->getOutgoingRoutingsRelCarriers(),
             'servers' => $this->getServers(),
@@ -451,6 +458,52 @@ abstract class CarrierDtoAbstract implements DataTransferObjectInterface
     public function getProxyTrunkId()
     {
         if ($dto = $this->getProxyTrunk()) {
+            return $dto->getId();
+        }
+
+        return null;
+    }
+
+    /**
+     * @param \Ivoz\Provider\Domain\Model\MediaRelaySet\MediaRelaySetDto $mediaRelaySets
+     *
+     * @return static
+     */
+    public function setMediaRelaySets(\Ivoz\Provider\Domain\Model\MediaRelaySet\MediaRelaySetDto $mediaRelaySets = null)
+    {
+        $this->mediaRelaySets = $mediaRelaySets;
+
+        return $this;
+    }
+
+    /**
+     * @return \Ivoz\Provider\Domain\Model\MediaRelaySet\MediaRelaySetDto | null
+     */
+    public function getMediaRelaySets()
+    {
+        return $this->mediaRelaySets;
+    }
+
+    /**
+     * @param mixed | null $id
+     *
+     * @return static
+     */
+    public function setMediaRelaySetsId($id)
+    {
+        $value = !is_null($id)
+            ? new \Ivoz\Provider\Domain\Model\MediaRelaySet\MediaRelaySetDto($id)
+            : null;
+
+        return $this->setMediaRelaySets($value);
+    }
+
+    /**
+     * @return mixed | null
+     */
+    public function getMediaRelaySetsId()
+    {
+        if ($dto = $this->getMediaRelaySets()) {
             return $dto->getId();
         }
 

--- a/library/Ivoz/Provider/Domain/Model/Carrier/CarrierInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/Carrier/CarrierInterface.php
@@ -93,6 +93,13 @@ interface CarrierInterface extends LoggableEntityInterface
     public function getProxyTrunk();
 
     /**
+     * Get mediaRelaySets
+     *
+     * @return \Ivoz\Provider\Domain\Model\MediaRelaySet\MediaRelaySetInterface | null
+     */
+    public function getMediaRelaySets();
+
+    /**
      * @return bool
      */
     public function isInitialized(): bool;

--- a/library/Ivoz/Provider/Domain/Model/DdiProvider/DdiProviderAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/DdiProvider/DdiProviderAbstract.php
@@ -43,6 +43,11 @@ abstract class DdiProviderAbstract
      */
     protected $proxyTrunk;
 
+    /**
+     * @var \Ivoz\Provider\Domain\Model\MediaRelaySet\MediaRelaySetInterface | null
+     */
+    protected $mediaRelaySets;
+
 
     use ChangelogTrait;
 
@@ -133,6 +138,7 @@ abstract class DdiProviderAbstract
             ->setBrand($fkTransformer->transform($dto->getBrand()))
             ->setTransformationRuleSet($fkTransformer->transform($dto->getTransformationRuleSet()))
             ->setProxyTrunk($fkTransformer->transform($dto->getProxyTrunk()))
+            ->setMediaRelaySets($fkTransformer->transform($dto->getMediaRelaySets()))
         ;
 
         $self->initChangelog();
@@ -157,7 +163,8 @@ abstract class DdiProviderAbstract
             ->setExternallyRated($dto->getExternallyRated())
             ->setBrand($fkTransformer->transform($dto->getBrand()))
             ->setTransformationRuleSet($fkTransformer->transform($dto->getTransformationRuleSet()))
-            ->setProxyTrunk($fkTransformer->transform($dto->getProxyTrunk()));
+            ->setProxyTrunk($fkTransformer->transform($dto->getProxyTrunk()))
+            ->setMediaRelaySets($fkTransformer->transform($dto->getMediaRelaySets()));
 
 
 
@@ -177,7 +184,8 @@ abstract class DdiProviderAbstract
             ->setExternallyRated(self::getExternallyRated())
             ->setBrand(\Ivoz\Provider\Domain\Model\Brand\Brand::entityToDto(self::getBrand(), $depth))
             ->setTransformationRuleSet(\Ivoz\Provider\Domain\Model\TransformationRuleSet\TransformationRuleSet::entityToDto(self::getTransformationRuleSet(), $depth))
-            ->setProxyTrunk(\Ivoz\Provider\Domain\Model\ProxyTrunk\ProxyTrunk::entityToDto(self::getProxyTrunk(), $depth));
+            ->setProxyTrunk(\Ivoz\Provider\Domain\Model\ProxyTrunk\ProxyTrunk::entityToDto(self::getProxyTrunk(), $depth))
+            ->setMediaRelaySets(\Ivoz\Provider\Domain\Model\MediaRelaySet\MediaRelaySet::entityToDto(self::getMediaRelaySets(), $depth));
     }
 
     /**
@@ -191,7 +199,8 @@ abstract class DdiProviderAbstract
             'externallyRated' => self::getExternallyRated(),
             'brandId' => self::getBrand()->getId(),
             'transformationRuleSetId' => self::getTransformationRuleSet() ? self::getTransformationRuleSet()->getId() : null,
-            'proxyTrunkId' => self::getProxyTrunk() ? self::getProxyTrunk()->getId() : null
+            'proxyTrunkId' => self::getProxyTrunk() ? self::getProxyTrunk()->getId() : null,
+            'mediaRelaySetsId' => self::getMediaRelaySets() ? self::getMediaRelaySets()->getId() : null
         ];
     }
     // @codeCoverageIgnoreStart
@@ -349,6 +358,30 @@ abstract class DdiProviderAbstract
     public function getProxyTrunk()
     {
         return $this->proxyTrunk;
+    }
+
+    /**
+     * Set mediaRelaySets
+     *
+     * @param \Ivoz\Provider\Domain\Model\MediaRelaySet\MediaRelaySetInterface $mediaRelaySets | null
+     *
+     * @return static
+     */
+    protected function setMediaRelaySets(\Ivoz\Provider\Domain\Model\MediaRelaySet\MediaRelaySetInterface $mediaRelaySets = null)
+    {
+        $this->mediaRelaySets = $mediaRelaySets;
+
+        return $this;
+    }
+
+    /**
+     * Get mediaRelaySets
+     *
+     * @return \Ivoz\Provider\Domain\Model\MediaRelaySet\MediaRelaySetInterface | null
+     */
+    public function getMediaRelaySets()
+    {
+        return $this->mediaRelaySets;
     }
 
     // @codeCoverageIgnoreEnd

--- a/library/Ivoz/Provider/Domain/Model/DdiProvider/DdiProviderDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/DdiProvider/DdiProviderDtoAbstract.php
@@ -46,6 +46,11 @@ abstract class DdiProviderDtoAbstract implements DataTransferObjectInterface
     private $proxyTrunk;
 
     /**
+     * @var \Ivoz\Provider\Domain\Model\MediaRelaySet\MediaRelaySetDto | null
+     */
+    private $mediaRelaySets;
+
+    /**
      * @var \Ivoz\Provider\Domain\Model\DdiProviderRegistration\DdiProviderRegistrationDto[] | null
      */
     private $ddiProviderRegistrations = null;
@@ -79,7 +84,8 @@ abstract class DdiProviderDtoAbstract implements DataTransferObjectInterface
             'id' => 'id',
             'brandId' => 'brand',
             'transformationRuleSetId' => 'transformationRuleSet',
-            'proxyTrunkId' => 'proxyTrunk'
+            'proxyTrunkId' => 'proxyTrunk',
+            'mediaRelaySetsId' => 'mediaRelaySets'
         ];
     }
 
@@ -96,6 +102,7 @@ abstract class DdiProviderDtoAbstract implements DataTransferObjectInterface
             'brand' => $this->getBrand(),
             'transformationRuleSet' => $this->getTransformationRuleSet(),
             'proxyTrunk' => $this->getProxyTrunk(),
+            'mediaRelaySets' => $this->getMediaRelaySets(),
             'ddiProviderRegistrations' => $this->getDdiProviderRegistrations(),
             'ddiProviderAddresses' => $this->getDdiProviderAddresses()
         ];
@@ -326,6 +333,52 @@ abstract class DdiProviderDtoAbstract implements DataTransferObjectInterface
     public function getProxyTrunkId()
     {
         if ($dto = $this->getProxyTrunk()) {
+            return $dto->getId();
+        }
+
+        return null;
+    }
+
+    /**
+     * @param \Ivoz\Provider\Domain\Model\MediaRelaySet\MediaRelaySetDto $mediaRelaySets
+     *
+     * @return static
+     */
+    public function setMediaRelaySets(\Ivoz\Provider\Domain\Model\MediaRelaySet\MediaRelaySetDto $mediaRelaySets = null)
+    {
+        $this->mediaRelaySets = $mediaRelaySets;
+
+        return $this;
+    }
+
+    /**
+     * @return \Ivoz\Provider\Domain\Model\MediaRelaySet\MediaRelaySetDto | null
+     */
+    public function getMediaRelaySets()
+    {
+        return $this->mediaRelaySets;
+    }
+
+    /**
+     * @param mixed | null $id
+     *
+     * @return static
+     */
+    public function setMediaRelaySetsId($id)
+    {
+        $value = !is_null($id)
+            ? new \Ivoz\Provider\Domain\Model\MediaRelaySet\MediaRelaySetDto($id)
+            : null;
+
+        return $this->setMediaRelaySets($value);
+    }
+
+    /**
+     * @return mixed | null
+     */
+    public function getMediaRelaySetsId()
+    {
+        if ($dto = $this->getMediaRelaySets()) {
             return $dto->getId();
         }
 

--- a/library/Ivoz/Provider/Domain/Model/DdiProvider/DdiProviderInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/DdiProvider/DdiProviderInterface.php
@@ -57,6 +57,13 @@ interface DdiProviderInterface extends LoggableEntityInterface
     public function getProxyTrunk();
 
     /**
+     * Get mediaRelaySets
+     *
+     * @return \Ivoz\Provider\Domain\Model\MediaRelaySet\MediaRelaySetInterface | null
+     */
+    public function getMediaRelaySets();
+
+    /**
      * @return bool
      */
     public function isInitialized(): bool;

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/Carrier.CarrierAbstract.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/Carrier.CarrierAbstract.orm.yml
@@ -86,3 +86,15 @@ Ivoz\Provider\Domain\Model\Carrier\CarrierAbstract:
           referencedColumnName: id
           onDelete: set null
       orphanRemoval: false
+    mediaRelaySets:
+      targetEntity: \Ivoz\Provider\Domain\Model\MediaRelaySet\MediaRelaySetInterface
+      cascade: {  }
+      fetch: LAZY
+      mappedBy: null
+      inversedBy: null
+      joinColumns:
+        mediaRelaySetsId:
+          referencedColumnName: id
+          onDelete: set null
+          onUpdate: cascade
+      orphanRemoval: false

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/DdiProvider.DdiProviderAbstract.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/DdiProvider.DdiProviderAbstract.orm.yml
@@ -61,3 +61,15 @@ Ivoz\Provider\Domain\Model\DdiProvider\DdiProviderAbstract:
           referencedColumnName: id
           onDelete: set null
       orphanRemoval: false
+    mediaRelaySets:
+      targetEntity: \Ivoz\Provider\Domain\Model\MediaRelaySet\MediaRelaySetInterface
+      cascade: {  }
+      fetch: LAZY
+      mappedBy: null
+      inversedBy: null
+      joinColumns:
+        mediaRelaySetsId:
+          referencedColumnName: id
+          onDelete: set null
+          onUpdate: cascade
+      orphanRemoval: false

--- a/schema/DoctrineMigrations/Version20210607104602.php
+++ b/schema/DoctrineMigrations/Version20210607104602.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Application\Migrations;
+
+use Ivoz\Core\Infrastructure\Persistence\Doctrine\LoggableMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20210607104602 extends LoggableMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE DDIProviders ADD mediaRelaySetsId INT UNSIGNED DEFAULT NULL');
+        $this->addSql('ALTER TABLE DDIProviders ADD CONSTRAINT FK_CA534EFDC8555117 FOREIGN KEY (mediaRelaySetsId) REFERENCES MediaRelaySets (id) ON DELETE SET NULL');
+        $this->addSql('CREATE INDEX IDX_CA534EFDC8555117 ON DDIProviders (mediaRelaySetsId)');
+
+        $this->addSql('ALTER TABLE Carriers ADD mediaRelaySetsId INT UNSIGNED DEFAULT NULL');
+        $this->addSql('ALTER TABLE Carriers ADD CONSTRAINT FK_F63EC8E3C8555117 FOREIGN KEY (mediaRelaySetsId) REFERENCES MediaRelaySets (id) ON DELETE SET NULL');
+        $this->addSql('CREATE INDEX IDX_F63EC8E3C8555117 ON Carriers (mediaRelaySetsId)');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE Carriers DROP FOREIGN KEY FK_F63EC8E3C8555117');
+        $this->addSql('DROP INDEX IDX_F63EC8E3C8555117 ON Carriers');
+        $this->addSql('ALTER TABLE Carriers DROP mediaRelaySetsId');
+
+        $this->addSql('ALTER TABLE DDIProviders DROP FOREIGN KEY FK_CA534EFDC8555117');
+        $this->addSql('DROP INDEX IDX_CA534EFDC8555117 ON DDIProviders');
+        $this->addSql('ALTER TABLE DDIProviders DROP mediaRelaySetsId');
+    }
+}

--- a/web/admin/application/configs/klear/CarriersList.yaml
+++ b/web/admin/application/configs/klear/CarriersList.yaml
@@ -46,6 +46,7 @@ production:
           proxyTrunks: true
           balance: true
           proxyTrunk: true
+          mediaRelaySets: true
           statusIcon: true
         blacklist:
           externallyRated: true
@@ -55,6 +56,7 @@ production:
           balance: ${auth.brandFeatures.billing.disabled}
           acd: true
           asr: true
+          mediaRelaySets: ${auth.isNotMainOperator}
       options:
         title: _("Options")
         screens:
@@ -88,14 +90,16 @@ production:
           acd: true
           asr: true
           statusIcon: true
+          mediaRelaySets: ${auth.isNotMainOperator}
       fixedPositions: &carriersNew_fixedPositionsLink
         group0:
           label: _("Basic Configuration")
           colsPerRow: 12
           fields:
-            name: 6
-            proxyTrunks: 6
-            description: 12
+            name: 5
+            description: 7
+            proxyTrunk: 6
+            mediaRelaySets: 6
         group1:
           label: _("Extra Configuration")
           colsPerRow: 6
@@ -130,6 +134,7 @@ production:
           acd: true
           asr: true
           statusIcon: true
+          mediaRelaySets: ${auth.isNotMainOperator}
       fixedPositions:
         <<: *carriersNew_fixedPositionsLink
 

--- a/web/admin/application/configs/klear/DdiProvidersList.yaml
+++ b/web/admin/application/configs/klear/DdiProvidersList.yaml
@@ -41,6 +41,7 @@ production:
           description: true
         blacklist:
           externallyRated: true
+          mediaRelaySets: ${auth.isNotMainOperator}
       options:
         title: _("Options")
         screens:
@@ -63,14 +64,16 @@ production:
           <<: *PeerContractsOrder_Link
         blacklist:
           externallyRated: ${auth.brandFeatures.billing.disabled}
+          mediaRelaySets: ${auth.isNotMainOperator}
       fixedPositions: &ddiProvidersNew_fixedPositionsLink
         group0:
           label: _("Basic Configuration")
           colsPerRow: 12
           fields:
-            name: 6
-            proxyTrunks: 6
-            description: 12
+            name: 5
+            description: 7
+            proxyTrunk: 6
+            mediaRelaySets: 6
         group1:
           label: _("Extra Configuration")
           colsPerRow: 6
@@ -91,6 +94,7 @@ production:
           <<: *PeerContractsOrder_Link
         blacklist:
           externallyRated: ${auth.brandFeatures.billing.disabled}
+          mediaRelaySets: ${auth.isNotMainOperator}
       fixedPositions:
         <<: *ddiProvidersNew_fixedPositionsLink
 

--- a/web/admin/application/configs/klear/model/Carriers.yaml
+++ b/web/admin/application/configs/klear/model/Carriers.yaml
@@ -149,6 +149,21 @@ production:
       source:
         class: IvozProvider_Klear_Ghost_CarrierServerStatus
         method: getCarrierStatusIcon
+    mediaRelaySets:
+      title: _('Media relay Set')
+      type: select
+      defaultValue: 'null'
+      source:
+        data: mapper
+        config:
+          entity: \Ivoz\Provider\Domain\Model\MediaRelaySet\MediaRelaySet
+          fieldName:
+            fields:
+            - name
+            template: '%name%'
+          order:
+            MediaRelaySet.name: asc
+        'null': _("Client's default")
 staging:
   _extends: production
 testing:

--- a/web/admin/application/configs/klear/model/DdiProviders.yaml
+++ b/web/admin/application/configs/klear/model/DdiProviders.yaml
@@ -62,6 +62,21 @@ production:
         icon: help
         text: _("Local address used in SIP signalling with this DDI Provider.")
         label: _("Need help?")
+    mediaRelaySets:
+      title: _('Media relay Set')
+      type: select
+      defaultValue: 'null'
+      source:
+        data: mapper
+        config:
+          entity: \Ivoz\Provider\Domain\Model\MediaRelaySet\MediaRelaySet
+          fieldName:
+            fields:
+            - name
+            template: '%name%'
+          order:
+            MediaRelaySet.name: asc
+        'null': _("Client's default")
 staging:
   _extends: production
 testing:


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

Media-relays can be grouped into sets and assigned to clients. It was not possible to choose one set when talking to a specific carrier/ddiprovider because in some scenarios kamusers/kamtrunks media-relay was skipped.

This skip logic is gone, so it is possible to choose one media-relay set per client (in kamUsers) and another media-relay set per carrier/ddiprovider (in KamTrunks).

This PR adds missing pieces to achieve this.

#### Additional information

To make this change backward compatible, carriers/ddiprovider may use (and would use by default) client's mediarelay set.