### PR TITLE
kamtrunks: fix ddiProvider detection logic

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -457,7 +457,8 @@ request_route {
 
     # Transformate numbers for calls from ddiProviders
     if (!$var(is_from_inside)) {
-        route(GET_TRANSFORMATIONS_IN);
+        route(MATCH_DDI);
+        route(GET_INFO_FROM_DDIPROVIDER);
         route(TRANSFORMATE_IN);
     }
 
@@ -1134,52 +1135,58 @@ route[TRANSFORMATE_WITHINDLG] {
     }
 }
 
-# Get incoming tranformations (sets tr_* dlg_vars)
-route[GET_TRANSFORMATIONS_IN] {
-    # Get DDI Providers by DDI and their transformation rules
-    sql_query("cb", "SELECT brandId, CONCAT(DP.transformationRuleSetId, 1) AS callee_in, CONCAT(DP.transformationRuleSetId, 0) AS caller_in, CONCAT(DP.transformationRuleSetId, 2) AS caller_out, CONCAT(DP.transformationRuleSetId, 3) AS callee_out, DP.id AS ddiProviderId FROM DDIProviderAddresses DPA INNER JOIN DDIProviders DP ON DPA.ddiProviderId=DP.id JOIN ProxyTrunks PT ON PT.id=DP.proxyTrunkId WHERE DPA.ip='$si' AND PT.ip='$Ri' ORDER BY DP.id ASC", "ra");
+# Sets $dlg_var(ddiId), $dlg_var(companyId), $dlg_var(brandId), $dlg_var(ddiProviderId)
+#
+# Winner DDIProvider must match in terms of:
+# - Request source IP
+# - Request received socket
+# - callee_in transformation should produce a DDIE164 existing in a client of the same brand
+#
+# In case of multiple valid DDIProviders, the one linked to DDI will be chosen (as long as it is valid).
+# Otherwise, valid DDIProvider with lowest id will be chosen.
+route[MATCH_DDI] {
+    # Get DDIProviders matching request source IP and received socket
+    sql_query("cb", "SELECT DP.id AS ddiProviderId, brandId, CONCAT(DP.transformationRuleSetId, 1) AS callee_in FROM DDIProviderAddresses DPA INNER JOIN DDIProviders DP ON DPA.ddiProviderId=DP.id JOIN ProxyTrunks PT ON PT.id=DP.proxyTrunkId WHERE DPA.ip='$si' AND PT.ip='$Ri' ORDER BY DP.id ASC", "ra");
 
-    # Found?
+    # Do we have any DDIProvider candidates?
     if ($dbr(ra=>rows) == 0) {
-        xwarn("[$dlg_var(cidhash)] GET-TRANSFORMATIONS-IN: $si not recognized as a valid DDI Provider, 403 Forbidden\n");
+        xwarn("[$dlg_var(cidhash)] MATCH-DDI: $si not recognized as a valid DDI Provider, 403 Forbidden\n");
         send_reply("403", "Forbidden");
         exit;
     }
 
-    # Iterate through all matching DDI Providers
+    # Iterate through all DDIProvider candidates
     $var(i) = 0;
-    $var(found) = 0;
+    $var(number) = $rU;
+
     while ($var(i)<$dbr(ra=>rows)) {
-        # Save transformations for further application
-        $dlg_var(tr_callee_in) = $dbr(ra=>[$var(i), 1]);
-        $dlg_var(tr_caller_in) = $dbr(ra=>[$var(i), 2]);
-        $dlg_var(tr_caller_out) = $dbr(ra=>[$var(i), 3]);
-        $dlg_var(tr_callee_out) = $dbr(ra=>[$var(i), 4]);
-        $dlg_var(ddiProviderId) = $dbr(ra=>[$var(i), 5]);
 
-        # Apply transformations to $rU
-        $var(transformation) = $dlg_var(tr_callee_in);
-        $var(number) = $rU;
-        route(APPLY_TRANSFORMATION); # Apply $var(transformation) to $var(number)
+        $var(ddiProviderCandidate) = $dbr(ra=>[$var(i), 0]);
+        $dlg_var(brandId) = $dbr(ra=>[$var(i), 1]);
+        $var(transformation) = $dbr(ra=>[$var(i), 2]);
 
-        # Search for DDI in brand
-        sql_query("cb", "SELECT companyId, id, ddiProviderId FROM DDIs WHERE DDIE164='$var(transformated)' AND brandId='$dbr(ra=>[$var(i), 0])'", "rb");
+        # Apply DDIProvider callee_in transformation ($var(transformation)) to $rU ($var(number))
+        route(APPLY_TRANSFORMATION);
 
-        # Found?
+        # Resulting DDI exists in brand?
+        sql_query("cb", "SELECT companyId, id, ddiProviderId FROM DDIs WHERE DDIE164='$var(transformated)' AND brandId='$dlg_var(brandId)'", "rb");
+
         if ($dbr(rb=>rows) > 0) {
-            xinfo("[$dlg_var(cidhash)] GET-TRANSFORMATIONS-IN: DDI $rU recognized as $var(transformated) (b$dbr(ra=>[$var(i), 0])c$dbr(rb=>[0, 0])dp$dlg_var(ddiProviderId)), proceed\n");
-            $var(found) = 1;
+            # It exists, we have found matching DDI!
+            $dlg_var(companyId) = $dbr(rb=>[0, 0]);
             $dlg_var(ddiId) = $dbr(rb=>[0, 1]);
-            if ($dbr(rb=>[0, 2]) != $null && $dbr(rb=>[0, 2]) != $dlg_var(ddiProviderId)) {
-                # Matched DDI is linked to a ddiProvider different from the one that matched, override $dlg_var(ddiProviderId) only if source address matches
-                $xavp(rc) = $null;
-                sql_xquery("cb", "SELECT COUNT(*) AS matchesSrcAddr FROM DDIProviders DP JOIN DDIProviderAddresses DPA ON DPA.ddiProviderId=DP.id WHERE DP.id=$dbr(rb=>[0, 2]) AND DPA.ip='$si'", "rc");
-                if ($xavp(rc=>matchesSrcAddr) > 0) {
-                    $dlg_var(ddiProviderId) = $dbr(rb=>[0, 2]);
-                    xinfo("[$dlg_var(cidhash)] GET-TRANSFORMATIONS-IN: DDI is linked to a ddiProvider that matches source address, update ddiProviderId to $dlg_var(ddiProviderId)\n");
-                }
+            $var(ddiProviderLinkedToDdi) = $dbr(rb=>[0, 2]);
+
+            # If matching DDI is not linked to any DDIProvider (of if it is linked to current DDIProvider, we are done)
+            if ($var(ddiProviderLinkedToDdi) == 0 || $var(ddiProviderLinkedToDdi) == $var(ddiProviderCandidate)) {
+                $dlg_var(ddiProviderId) = $var(ddiProviderCandidate);
+                break; # final ddiProvider found, leave while loop
             }
-            break;
+
+            # Save first match and continue loop to check whether linked DDIProvider also matches
+            if ($dlg_var(ddiProviderId) == $null) {
+                $dlg_var(ddiProviderId) = $var(ddiProviderCandidate);
+            }
         }
 
         # Try next DDI Provider
@@ -1189,16 +1196,25 @@ route[GET_TRANSFORMATIONS_IN] {
     sql_result_free("ra");
     sql_result_free("rb");
 
-    if ($var(found) == 0) {
+    if ($dlg_var(ddiProviderId) == $null) {
         # No candidate succeeded after applying transformations
-        xwarn("[$dlg_var(cidhash)] GET-TRANSFORMATIONS-IN: DDI '$rU' not recognized, 404 Not Found");
+        xwarn("[$dlg_var(cidhash)] MATCH-DDI: DDI '$rU' not recognized, 404 Not Found");
         send_reply("404", "Not Here");
         exit;
     }
 
-    # Get mediaRelaySetsId from selected DDIProvider
-    sql_xquery("cb", "SELECT mediaRelaySetsId FROM DDIProviders WHERE id='$dlg_var(ddiProviderId)'", "dp");
-    $dlg_var(ddiProviderMediaRelaySetsId) = $xavp(dp=>mediaRelaySetsId);
+    xnotice("[$dlg_var(cidhash)] MATCH-DDI: $rU recognized as $var(transformated) (b$dlg_var(brandId)c$dlg_var(companyId)ddi$dlg_var(ddiId)dp$dlg_var(ddiProviderId))\n");
+}
+
+# Sets tr_* and ddiProviderMediaRelaySetsId of final matched DDIProvider
+route[GET_INFO_FROM_DDIPROVIDER] {
+    sql_query("cb", "SELECT CONCAT(transformationRuleSetId, 1) AS callee_in, CONCAT(transformationRuleSetId, 0) AS caller_in, CONCAT(transformationRuleSetId, 2) AS caller_out, CONCAT(transformationRuleSetId, 3) AS callee_out, mediaRelaySetsId FROM DDIProviders WHERE id='$dlg_var(ddiProviderId)'", "rc");
+    $dlg_var(tr_callee_in) = $dbr(rc=>[0, 0]);
+    $dlg_var(tr_caller_in) = $dbr(rc=>[0, 1]);
+    $dlg_var(tr_caller_out) = $dbr(rc=>[0, 2]);
+    $dlg_var(tr_callee_out) = $dbr(rc=>[0, 3]);
+    $dlg_var(ddiProviderMediaRelaySetsId) = $dbr(rc=>[0, 4]);
+    sql_result_free("rc");
 }
 
 # This route apply transformations to rU, PAI and Diversion to E.164


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

Before overriding lowest-id-first-matching ddiProvider with ddiProvider linked
to matching DDI, make sure this ddiProvider matches source IP, local socket and
callee_in transformation too.

If so, override $dlg_var(ddiProviderId) and related dlg_vars (tr_* and mediaRelaySetsId).