### PR TITLE
[wip] New bouncer proxy

### DIFF
--- a/asterisk/agi/src/Dialplan/Trunks.php
+++ b/asterisk/agi/src/Dialplan/Trunks.php
@@ -66,8 +66,15 @@ class Trunks extends RouteHandlerAbstract
         /** @var \Ivoz\Provider\Domain\Model\Ddi\DdiRepository $ddiRepository */
         $ddiRepository = $this->em->getRepository(Ddi::class);
 
+        $brandId = $this->agi->getSIPHeader('X-Info-BrandId');
+        if (!$brandId) {
+            $this->agi->error("Missing X-Info-BrandId header, drop call");
+            $this->agi->decline();
+            return;
+        }
+
         /** @var \Ivoz\Provider\Domain\Model\Ddi\DdiInterface $ddi */
-        $ddi = $ddiRepository->findOneByDdiE164($exten);
+        $ddi = $ddiRepository->findOneByDdiE164AndBrand($exten, $brandId);
 
         // Check if incoming DDI is for us
         Assertion::notNull(

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -1150,8 +1150,13 @@ route[TRANSFORMATE_WITHINDLG] {
 # In case of multiple valid DDIProviders, the one linked to DDI will be chosen (as long as it is valid).
 # Otherwise, valid DDIProvider with lowest id will be chosen.
 route[MATCH_DDI] {
+    $var(srcIp) = $si;
+    if ($si == $var(bouncerAddress)) {
+        xinfo("[$dlg_var(cidhash)] MATCH-DDI: Using users address $var(usersAddress) as request source address instead of bouncer address $var(bouncerAddress)\n");
+        $var(srcIp) = $var(usersAddress);
+    }
     # Get DDIProviders matching request source IP and received socket
-    sql_query("cb", "SELECT DP.id AS ddiProviderId, brandId, CONCAT(DP.transformationRuleSetId, 1) AS callee_in FROM DDIProviderAddresses DPA INNER JOIN DDIProviders DP ON DPA.ddiProviderId=DP.id JOIN ProxyTrunks PT ON PT.id=DP.proxyTrunkId WHERE DPA.ip='$si' AND PT.ip='$Ri' ORDER BY DP.id ASC", "ra");
+    sql_query("cb", "SELECT DP.id AS ddiProviderId, brandId, CONCAT(DP.transformationRuleSetId, 1) AS callee_in FROM DDIProviderAddresses DPA INNER JOIN DDIProviders DP ON DPA.ddiProviderId=DP.id JOIN ProxyTrunks PT ON PT.id=DP.proxyTrunkId WHERE DPA.ip='$var(srcIp)' AND PT.ip='$Ri' ORDER BY DP.id ASC", "ra");
 
     # Do we have any DDIProvider candidates?
     if ($dbr(ra=>rows) == 0) {

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -930,6 +930,10 @@ route[SELECT_NEXT_GW] {
             route(SELECT_NEXT_GW);
         } else {
             xinfo("[$dlg_var(cidhash)] SELECT-NEXT-GW: Resolvable domain '$nh(d)' ($dns(nextgwaddr=>addr)) in GW, proceed");
+            if ($dns(nextgwaddr=>addr) == $var(usersAddress)) {
+                xnotice("[$dlg_var(cidhash)] SELECT-NEXT-GW: carrier pointing to users.ivozprovider.local, forward to bouncer");
+                $du = "sip:" + $var(bouncerAddress) + ":5060;transport=udp";
+            }
         }
     }
 

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -562,9 +562,10 @@ route[CHECK_BOUNCE] {
     #!endif
 
     $xavp(ra) = $null;
-    sql_xquery("cb", "SELECT C.type FROM DDIs D INNER JOIN Companies C ON C.id=D.companyId WHERE D.DDIE164='$rU'", "ra");
-    if ($xavp(ra=>type) != $null) {
+    sql_xquery("cb", "SELECT C.brandId FROM DDIs D INNER JOIN Companies C ON C.id=D.companyId WHERE D.DDIE164='$rU' ORDER BY D.id ASC LIMIT 1", "ra");
+    if ($xavp(ra=>brandId) != $null) {
         xnotice("[$dlg_var(cidhash)] CHECK-BOUNCE: Call is to one of my DDIs\n");
+        append_hf("X-Info-BrandId: $xavp(ra=>brandId)\r\n");
         $dlg_var(bounced) = '1';
     }
 
@@ -1672,6 +1673,13 @@ route[CLASSIFY] {
         set_dlg_profile("outboundCallsCompany", "$dlg_var(companyId)");
         set_dlg_profile("outboundCallsBrand", "$dlg_var(brandId)");
     } else {
+        if ($dlg_var(brandId) == $null) {
+            # This should only happen for local bounced calls (they must have X-Info-BrandId header)
+            $var(header) = 'X-Info-BrandId';
+            route(PARSE_MANDATORY_X_HEADER);
+            $dlg_var(brandId) = $var(header-value);
+        }
+
         sql_xquery("cb", "SELECT C.id AS companyId, C.type FROM DDIs D JOIN Companies C ON D.companyId=C.id WHERE DDIE164='$rU' AND C.brandId='$dlg_var(brandId)'", "rp");
         $dlg_var(companyId) = $xavp(rp=>companyId);
         $dlg_var(type) = $xavp(rp=>type);

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -401,7 +401,7 @@ request_route {
 
     xnotice("[$dlg_var(cidhash)] Request: $rm $ru from $fu ($cs $rm - $proto:$si:$sp) [$ci]\n");
 
-    if (!$var(is_from_inside) && !has_totag() && !allow_source_address_group()) {
+    if (!has_totag() && !$var(is_from_inside) && $si != $var(bouncerAddress) && !allow_source_address_group()) {
         xwarn("[$dlg_var(cidhash)] Inbound initial request from $si, not recognized as a valid DDI Provider, 403 Forbidden\n");
         send_reply("403", "Forbidden");
         exit;

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -1415,7 +1415,7 @@ route[APPLY_TRANSFORMATION] {
 }
 
 route[GET_INFO_FROM_MATCHED_DDI] {
-    sql_xquery("cb", "SELECT c.mediaRelaySetsId, c.maxCalls AS maxCallsCompany, b.maxCalls AS maxCallsBrand, d.recordCalls, c.distributeMethod, AppS.ip AS asAddress, d.routeType, d.residentialDeviceId, d.retailAccountId, d.faxId FROM DDIs d JOIN Companies c ON d.companyId=c.id LEFT JOIN ApplicationServers AppS ON AppS.id=c.applicationServerId JOIN Brands b ON c.brandId=b.id WHERE d.DDIE164='$rU'", "ra");
+    sql_xquery("cb", "SELECT c.mediaRelaySetsId, c.maxCalls AS maxCallsCompany, b.maxCalls AS maxCallsBrand, d.recordCalls, c.distributeMethod, AppS.ip AS asAddress, d.routeType, d.residentialDeviceId, d.retailAccountId, d.faxId FROM DDIs d JOIN Companies c ON d.companyId=c.id LEFT JOIN ApplicationServers AppS ON AppS.id=c.applicationServerId JOIN Brands b ON c.brandId=b.id WHERE d.DDIE164='$rU' AND c.brandId='$dlg_var(brandId)'", "ra");
 
     # Matched DDI
     $dlg_var(maxCallsCompany) = $xavp(ra=>maxCallsCompany);
@@ -1570,7 +1570,7 @@ route[SETUP_KAMUSERS_CALL] {
 
     # Check DDI is routed to a retail account
     $xavp(ra) = $null;
-    sql_xquery("cb", "SELECT RA.name AS username, DS.domain AS domain FROM DDIs D INNER JOIN RetailAccounts RA ON D.retailAccountId=RA.id INNER JOIN Domains DS ON RA.domainId=DS.id WHERE DDIE164='$rU'", "ra");
+    sql_xquery("cb", "SELECT RA.name AS username, DS.domain AS domain FROM DDIs D INNER JOIN RetailAccounts RA ON D.retailAccountId=RA.id INNER JOIN Domains DS ON RA.domainId=DS.id WHERE DDIE164='$rU' AND RA.companyId='$dlg_var(companyId)'", "ra");
 
     # Update $ru using retail account username@domain
     $ru = "sip:" + $xavp(ra=>username) + '@' + $xavp(ra=>domain);
@@ -1672,8 +1672,7 @@ route[CLASSIFY] {
         set_dlg_profile("outboundCallsCompany", "$dlg_var(companyId)");
         set_dlg_profile("outboundCallsBrand", "$dlg_var(brandId)");
     } else {
-        sql_xquery("cb", "SELECT C.brandId, C.id AS companyId, C.type FROM DDIs D JOIN Companies C ON D.companyId=C.id WHERE DDIE164='$rU'", "rp");
-        $dlg_var(brandId) = $xavp(rp=>brandId);
+        sql_xquery("cb", "SELECT C.id AS companyId, C.type FROM DDIs D JOIN Companies C ON D.companyId=C.id WHERE DDIE164='$rU' AND C.brandId='$dlg_var(brandId)'", "rp");
         $dlg_var(companyId) = $xavp(rp=>companyId);
         $dlg_var(type) = $xavp(rp=>type);
 

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -2084,6 +2084,12 @@ event_route[tm:local-request] {
 
     # UACREG sends REGISTER requests whose Contact domain must be adapted
     if (is_method("REGISTER")) {
+        if(!is_ip("$rd") && dns_query("$rd", "nextgwaddr") && $dns(nextgwaddr=>addr) == $var(usersAddress)) {
+            xinfo("[$dlg_var(cidhash)] Local register pointing to users.ivozprovider.local, add Path header");
+            $var(path) = "<sip:" + $var(bouncerAddress) + ":5060;lr>";
+            append_hf("Supported: path\r\n");
+            append_hf("Path: $var(path)\r\n");
+        }
         #!ifdef WITH_MULTISOCKET
         $var(tmp1) = $(ct{s.rm,<}); # Remove initial < from Contact header
         $var(tmp2) = $(var(tmp1){s.rm,>}); # Remove final > from Contact header

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -1526,7 +1526,7 @@ route[DISPATCH] {
         return;
     }
 
-    # Insert header with LogTag
+    insert_hf("X-Info-BrandId: $dlg_var(brandId)\r\n");
     insert_hf("X-Info-Logtag: b$dlg_var(brandId)\r\n");
 
     # Static routing to specific AS?

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -2480,6 +2480,13 @@ event_route[htable:mod-init] {
         xerr("Problems resolving users.ivozprovider.local, aborting\n");
         abort();
     }
+    if (dns_query("bouncer.ivozprovider.local", "bouncer")) {
+        $var(bouncerAddress) = $dns(bouncer=>addr);
+        xnotice("bouncer.ivozprovider.local: $var(bouncerAddress)\n");
+    } else {
+        xerr("Problems resolving bouncer.ivozprovider.local, aborting\n");
+        abort();
+    }
 
     #!ifdef WITH_MULTISOCKET
         xnotice("Multi-socket ENABLED");

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -1163,7 +1163,7 @@ route[DISPATCH_TO_TRUNKS] {
         insert_hf("X-Info-RetailAccountId: $dlg_var(retailAccountId)\r\n");
 
         # Check if recordings are enabled for DDI
-        sql_xquery("cb", "SELECT recordCalls FROM DDIs WHERE DDIE164='$dlg_var(caller)'", "ra");
+        sql_xquery("cb", "SELECT recordCalls FROM DDIs WHERE DDIE164='$dlg_var(caller)' AND brandId='$dlg_var(brandId)'", "ra");
         if ($xavp(ra=>recordCalls) == 'all' || $xavp(ra=>recordCalls) == 'outbound') {
             xinfo("[$dlg_var(cidhash)] DISPATCH-TO-TRUNKS: Set X-Info-Record for $dlg_var(caller)\n");
             insert_hf("X-Info-Record: yes\r\n");

--- a/library/Ivoz/Provider/Domain/Model/Ddi/DdiRepository.php
+++ b/library/Ivoz/Provider/Domain/Model/Ddi/DdiRepository.php
@@ -8,13 +8,12 @@ use Doctrine\Common\Persistence\ObjectRepository;
 interface DdiRepository extends ObjectRepository, Selectable
 {
     /**
-     * @param string $ddiE164
-     * @return DdiInterface | null
+     * @return \Ivoz\Provider\Domain\Model\Ddi\DdiInterface | null
      */
-    public function findOneByDdiE164($ddiE164);
+    public function findOneByDdiAndCountryAndBrand(string $ddi, int $countryId, int $brandId);
 
     /**
      * @return \Ivoz\Provider\Domain\Model\Ddi\DdiInterface | null
      */
-    public function findOneByDdiAndCountry(string $ddi, int $countryId);
+    public function findOneByDdiE164AndBrand(string $ddiE164, int $brandId);
 }

--- a/library/Ivoz/Provider/Domain/Service/Ddi/DdiFactory.php
+++ b/library/Ivoz/Provider/Domain/Service/Ddi/DdiFactory.php
@@ -73,9 +73,10 @@ class DdiFactory
 
         $ddi = $this
             ->ddiRepository
-            ->findOneByDdiAndCountry(
+            ->findOneByDdiAndCountryAndBrand(
                 $ddiNumber,
-                $country->getId()
+                $country->getId(),
+                $company->getBrand()->getId()
             );
 
         if ($ddi) {

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/DdiDoctrineRepository.php
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/DdiDoctrineRepository.php
@@ -22,14 +22,14 @@ class DdiDoctrineRepository extends ServiceEntityRepository implements DdiReposi
     }
 
     /**
-     * @param string $ddiE164
      * @return \Ivoz\Provider\Domain\Model\Ddi\DdiInterface | null
      */
-    public function findOneByDdiE164($ddiE164)
+    public function findOneByDdiE164AndBrand(string $ddiE164, int $brandId)
     {
         /** @var DdiInterface $response */
         $response = $this->findOneBy([
-            "ddie164" => $ddiE164
+            "ddie164" => $ddiE164,
+            "brand" => $brandId
         ]);
 
         return $response;
@@ -38,12 +38,13 @@ class DdiDoctrineRepository extends ServiceEntityRepository implements DdiReposi
     /**
      * @return \Ivoz\Provider\Domain\Model\Ddi\DdiInterface | null
      */
-    public function findOneByDdiAndCountry(string $ddi, int $countryId)
+    public function findOneByDdiAndCountryAndBrand(string $ddi, int $countryId, int $brandId)
     {
         /** @var DdiInterface $response */
         $response = $this->findOneBy([
             'ddi' => $ddi,
-            'country' => $countryId
+            'country' => $countryId,
+            'brand' => $brandId
         ]);
 
         return $response;

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/Ddi.DdiAbstract.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/Ddi.DdiAbstract.orm.yml
@@ -5,9 +5,10 @@ Ivoz\Provider\Domain\Model\Ddi\DdiAbstract:
       columns:
         - DdiE164
   uniqueConstraints:
-    Ddicountry:
+    Ddicountrybrand:
       columns:
         - Ddi
+        - brandId
         - countryId
   fields:
     ddi:

--- a/library/spec/Ivoz/Provider/Domain/Service/Ddi/DdiFactorySpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Service/Ddi/DdiFactorySpec.php
@@ -103,8 +103,9 @@ class DdiFactorySpec extends ObjectBehavior
 
         $this
             ->ddiRepository
-            ->findOneByDdiAndCountry(
+            ->findOneByDdiAndCountryAndBrand(
                 Argument::type('string'),
+                Argument::type('int'),
                 Argument::type('int')
             )
             ->shouldBeCalled()
@@ -121,8 +122,9 @@ class DdiFactorySpec extends ObjectBehavior
 
         $this
             ->ddiRepository
-            ->findOneByDdiAndCountry(
+            ->findOneByDdiAndCountryAndBrand(
                 Argument::type('string'),
+                Argument::type('int'),
                 Argument::type('int')
             )
             ->shouldBeCalled()

--- a/microservices/recordings/src/Recording/Encoder.php
+++ b/microservices/recordings/src/Recording/Encoder.php
@@ -173,6 +173,9 @@ class Encoder
                     $type = 'ddi';
                     $direction = $kamAccCdr->getDirection();
 
+                    /* @var \Ivoz\Provider\Domain\Model\Brand\BrandInterface $brand */
+                    $brand = $kamAccCdr->getBrand();
+
                     if ($direction == 'outbound') {
                         // If call first leg, caller is who activated the recording
                         $recorder = $kamAccCdr->getCaller();

--- a/microservices/recordings/src/Recording/Encoder.php
+++ b/microservices/recordings/src/Recording/Encoder.php
@@ -172,6 +172,7 @@ class Encoder
                 if ($kamAccCdr instanceof TrunksCdrInterface) {
                     $type = 'ddi';
                     $direction = $kamAccCdr->getDirection();
+                    $brand = $kamAccCdr->getBrand();
 
                     /* @var \Ivoz\Provider\Domain\Model\Brand\BrandInterface $brand */
                     $brand = $kamAccCdr->getBrand();
@@ -185,7 +186,7 @@ class Encoder
                     }
 
                     // Check this ddi has recording enabled
-                    $ddi = $this->ddiRepository->findOneByDdiE164($recorder);
+                    $ddi = $this->ddiRepository->findOneByDdiE164AndBrand($recorder, $brand->getId());
                     if (!$ddi) {
                         $stats['error']++;
                         $this->logger->error(

--- a/schema/DoctrineMigrations/Version20210615095630.php
+++ b/schema/DoctrineMigrations/Version20210615095630.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Application\Migrations;
+
+use Ivoz\Core\Infrastructure\Persistence\Doctrine\LoggableMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20210615095630 extends LoggableMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP INDEX DDIcountry ON DDIs');
+        $this->addSql('CREATE UNIQUE INDEX Ddicountrybrand ON DDIs (Ddi, brandId, countryId)');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP INDEX Ddicountrybrand ON DDIs');
+        $this->addSql('CREATE UNIQUE INDEX DDIcountry ON DDIs (DDI, countryId)');
+    }
+}

--- a/schema/tests/Provider/Ddi/DdiRepositoryTest.php
+++ b/schema/tests/Provider/Ddi/DdiRepositoryTest.php
@@ -17,7 +17,7 @@ class DdiRepositoryTest extends KernelTestCase
     public function test_runner()
     {
         $this->its_instantiable();
-        $this->it_finds_one_by_ddi_e164();
+        $this->it_finds_one_by_ddi_e164_n_brand();
     }
 
     public function its_instantiable()
@@ -33,14 +33,14 @@ class DdiRepositoryTest extends KernelTestCase
         );
     }
 
-    public function it_finds_one_by_ddi_e164()
+    public function it_finds_one_by_ddi_e164_n_brand()
     {
         /** @var DdiRepository $repository */
         $repository = $this
             ->em
             ->getRepository(Ddi::class);
 
-        $ddi = $repository->findOneByDdiE164('+34123');
+        $ddi = $repository->findOneByDdiE164AndBrand('+34123', '1');
 
         $this->assertInstanceOf(
             Ddi::class,


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

Bouncing is the internal name of outgoing external calls to DDIs handled in the platform (a user calling to its company's DDI, or calling to a DDI of another client in the platform).

These bounced calls are special in many ways:

- They traverse routing and billing logic as if they were being routed a carrier.
- In the last moment, calls are bounced from KamTrunks to KamTrunks.
- Despite being one SIP dialog, they are treated as 2 dialogs: one outgoing external and one incoming external.
- 2 CDRs will be created.
- They are indistinguible from a normal outgoing external call from the perspective of the caller and one incoming external call from the perspective of the callee.

This PR is a POC of rewriting current logic adding one additional piece of software: bouncer proxy.

This proxy will act as a B2BUA decoupling SIP dialog into 2 different dialogs making bouncing logic in KamTrunks unnecessary.

#### Additional information

With this new approach, relationship among brands in same platform may change, making possible that one specific brand sells PSTN connection to another brand in the same platform.