### PR TITLE
Add retail to retail call-forward

### DIFF
--- a/asterisk/agi/config/services.yml
+++ b/asterisk/agi/config/services.yml
@@ -172,6 +172,10 @@ services:
     lazy: true
     arguments: ~
 
+  Agi\Action\RetailCallAction:
+    lazy: true
+    arguments: ~
+
   Agi\Action\ResidentialStatusAction:
     lazy: true
     arguments: ~

--- a/asterisk/agi/src/Agi/Action/RetailCallAction.php
+++ b/asterisk/agi/src/Agi/Action/RetailCallAction.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Agi\Action;
+
+use Agi\Wrapper;
+use Ivoz\Core\Infrastructure\Persistence\Doctrine\Model\Helper\CriteriaHelper;
+use Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface;
+
+class RetailCallAction
+{
+    /**
+     * @var Wrapper
+     */
+    protected $agi;
+
+    /**
+     * @var RetailAccountInterface|null
+     */
+    protected $retailAccount;
+
+    /**
+     * RetailCallAction constructor.
+     * @param Wrapper $agi
+     */
+    public function __construct(
+        Wrapper $agi
+    ) {
+        $this->agi = $agi;
+    }
+
+    /**
+     * @param RetailAccountInterface|null $retailAccount
+     * @return $this
+     */
+    public function setRetailAccount(RetailAccountInterface $retailAccount = null)
+    {
+        $this->retailAccount = $retailAccount;
+        return $this;
+    }
+
+    public function process()
+    {
+        // Local variables to improve readability
+        $retailAccount = $this->retailAccount;
+
+        if (is_null($retailAccount)) {
+            $this->agi->error("Retail Account is not properly defined. Check configuration.");
+            return;
+        }
+
+        // Get dialed number (DDI called to cause this call-forward)
+        $number =  $this->agi->getExtension();
+
+        // Get device endpoint
+        $endpointName = $retailAccount->getSorcery();
+
+        // Some verbose dolan pls
+        $this->agi->notice("Preparing call to %s", $endpointName);
+
+        // Configure Dial options
+        $timeout = "10800";
+        $options = "g";
+
+        // Call the PSJIP endpoint
+        $this->agi->setVariable("DIAL_DST", "PJSIP/$endpointName");
+        $this->agi->setVariable("__DIAL_ENDPOINT", $endpointName);
+        $this->agi->setVariable("DIAL_TIMEOUT", $timeout);
+        $this->agi->setVariable("DIAL_OPTS", $options);
+
+        // Redirect to the calling dialplan context
+        $this->agi->redirect('call-retail', $number);
+    }
+}

--- a/asterisk/agi/src/Agi/Action/RouterAction.php
+++ b/asterisk/agi/src/Agi/Action/RouterAction.php
@@ -18,6 +18,7 @@ use Ivoz\Provider\Domain\Model\Friend\FriendInterface;
 use Ivoz\Provider\Domain\Model\HuntGroup\HuntGroupInterface;
 use Ivoz\Provider\Domain\Model\Ivr\IvrInterface;
 use Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDeviceInterface;
+use Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface;
 use Ivoz\Provider\Domain\Model\User\UserInterface;
 
 class RouterAction
@@ -37,6 +38,7 @@ class RouterAction
     const ConferenceRoom = 'conferenceRoom';
     const Queue          = 'queue';
     const Residential    = 'residential';
+    const Retail         = 'retail';
     const Conditional    = 'conditional';
 
     /**
@@ -120,6 +122,11 @@ class RouterAction
     protected $routeResidential;
 
     /**
+     * @var RetailAccountInterface
+     */
+    protected $routeRetail;
+
+    /**
      * @var ConditionalRouteInterface
      */
     protected $routeConditional;
@@ -185,6 +192,11 @@ class RouterAction
     protected $residentialCallAction;
 
     /**
+     * @var RetailCallAction
+     */
+    protected $retailCallAction;
+
+    /**
      * @var ServiceAction
      */
     protected $serviceAction;
@@ -208,6 +220,7 @@ class RouterAction
         IvrAction $ivrAction,
         QueueAction $queueAction,
         ResidentialCallAction $residentialCallAction,
+        RetailCallAction $retailCallAction,
         ServiceAction $serviceAction,
         VoiceMailAction $voiceMailAction
     ) {
@@ -224,6 +237,7 @@ class RouterAction
         $this->ivrAction = $ivrAction;
         $this->queueAction = $queueAction;
         $this->residentialCallAction = $residentialCallAction;
+        $this->retailCallAction = $retailCallAction;
         $this->serviceAction = $serviceAction;
         $this->voiceMailAction = $voiceMailAction;
     }
@@ -335,6 +349,12 @@ class RouterAction
         return $this;
     }
 
+    public function setRouteRetail(RetailAccountInterface $routeRetail = null)
+    {
+        $this->routeRetail = $routeRetail;
+        return $this;
+    }
+
     public function setRouteFax(FaxInterface $routeFax = null)
     {
         $this->routeFax = $routeFax;
@@ -377,6 +397,9 @@ class RouterAction
                 break;
             case RouterAction::Residential:
                 $this->routeToResidentialDevice();
+                break;
+            case RouterAction::Retail:
+                $this->routeToRetailAccount();
                 break;
             case RouterAction::Conditional:
                 $this->routeToConditionalRoute();
@@ -480,6 +503,13 @@ class RouterAction
     {
         $this->residentialCallAction
             ->setResidentialDevice($this->routeResidential)
+            ->process();
+    }
+
+    protected function routeToRetailAccount()
+    {
+        $this->retailCallAction
+            ->setRetailAccount($this->routeRetail)
             ->process();
     }
 

--- a/asterisk/config/dialplan/default.conf
+++ b/asterisk/config/dialplan/default.conf
@@ -106,6 +106,11 @@ exten => _[+*0-9]!,1,NoOp(Calling ${EXTEN} through ${DIAL_ENDPOINT})
     same => n,Dial(${DIAL_DST},${DIAL_TIMEOUT},${DIAL_OPTS}b(add-headers^${EXTEN}^1))
     same => n,AGI(agi://127.0.0.1:4573/fastagi-runner.php?command=dialplan/residentialstatus)
 
+;; Context for calling to a retail account
+[call-retail]
+exten => _[+*0-9]!,1,NoOp(Calling ${DIAL_ENDPOINT})
+    same => n,Dial(${DIAL_DST},${DIAL_TIMEOUT},${DIAL_OPTS}b(add-headers^${EXTEN}^1))
+
 ;;---------------------------------------------------------------------------------------------------
 ;;------------------------------------[      Subroutines      ]--------------------------------------
 ;;---------------------------------------------------------------------------------------------------

--- a/doc/sphinx/administration_portal/client/retail/retail_accounts.rst
+++ b/doc/sphinx/administration_portal/client/retail/retail_accounts.rst
@@ -103,13 +103,19 @@ There is no voicemail service for retail clients.
 Call forwarding settings
 ========================
 
-There are 2 types of call forward settings for retail accounts, both pointing to an external number:
+There are 2 types of call forward settings for retail accounts:
 
 - Unconditional call forward.
 
 - Unreachable call forward.
 
-The last one will be called whenever the retail account cannot be reached:
+You can point both types to 2 different destination:
+
+- An external number.
+
+- Another retail account within the same retail client.
+
+Unreachable call forward will be executed whenever the retail account cannot be reached:
 
 - Direct connectivity accounts: when no answer is received from defined address.
 

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -1211,8 +1211,8 @@ route[DISPATCH_TO_AS] {
 }
 
 route[LOOKUP] {
-    if ($dlg_var(retail_callfwd) == 'inconditional') {
-        route(PREPARE_RETAIL_CFW);
+    if ($dlg_var(retail_callfwdType) == 'inconditional') {
+        route(APPLY_RETAIL_CFW);
         return;
     }
 
@@ -1223,8 +1223,8 @@ route[LOOKUP] {
     switch ($?) {
         case -1:
             xwarn("[$dlg_var(cidhash)] LOOKUP: Contact not found for $ru, 404\n");
-            if ($dlg_var(retail_callfwd) == 'userNotRegistered') {
-                route(PREPARE_RETAIL_CFW);
+            if ($dlg_var(retail_callfwdType) == 'userNotRegistered') {
+                route(APPLY_RETAIL_CFW);
                 return;
             }
             send_reply("404", "Not Found");
@@ -1254,14 +1254,11 @@ route[LOOKUP] {
     }
 }
 
-route[PREPARE_RETAIL_CFW] {
-    xinfo("[$dlg_var(cidhash)] PREPARE-RETAIL-CFW: Calling to retail account with $dlg_var(retail_callfwd) call-forward configured");
-    $avp(apply_cfwd) = 'yes';
-    $dlg_var(skipRealtime) = 'yes';
-    route(DISPATCH_TO_AS);
-}
-
 route[APPLY_RETAIL_CFW] {
+    xnotice("[$dlg_var(cidhash)] APPLY-RETAIL-CFW: $dlg_var(retail_callfwdType) call-forward to $dlg_var(retail_callfwdTarget) $ru\n");
+    $avp(retail_cfwd) = 'yes';
+    $dlg_var(skipRealtime) = 'yes';
+
     # Save From user in PAI if PAI not present
     if (!is_present_hf("P-Asserted-Identity")) {
         append_hf("P-Asserted-Identity: <$dlg_var(rcfw_newpaiuri)>\r\n");
@@ -1279,7 +1276,11 @@ route[APPLY_RETAIL_CFW] {
     # Modify R-URI with call forward target
     $ru = $dlg_var(rcfw_newruri);
 
-    xinfo("[$dlg_var(cidhash)] APPLY-RETAIL-CFW: Call forward to $rU\n");
+    if ($dlg_var(retail_callfwdTarget) == 'retail') {
+        append_hf("X-Info-Cfw-Destination: $dlg_var(cfw_destination)\r\n");
+    }
+
+    route(DISPATCH_TO_AS);
 }
 
 route[STATIC_LOCATION] {
@@ -1365,7 +1366,7 @@ route[GET_CALL_INFO] {
 
         # Get retail call-forward settings
         if ($dlg_var(type) == 'retail') {
-            route(GET_RETAIL_CFW_SETTINGS);
+            route(GET_RETAIL_CFW);
         }
 
         # Set AoR for maxcallsUser counting
@@ -1380,28 +1381,34 @@ route[GET_CALL_INFO] {
     }
 }
 
-route[GET_RETAIL_CFW_SETTINGS] {
-    # Check for unconditional call forward settings
+route[GET_RETAIL_CFW] {
+    # Check for retail call forward settings
     $xavp(ra) = $null;
-    sql_xquery("cb", "SELECT RA.name, D.domain, CONCAT(C.countryCode, CFS.numberValue) AS CfwTarget, RA.t38passthrough, CFS.callForwardType FROM RetailAccounts RA INNER JOIN Domains D ON RA.domainId=D.id INNER JOIN CallForwardSettings CFS ON CFS.retailAccountId=RA.id INNER JOIN Countries C ON C.id=CFS.numberCountryId WHERE CFS.enabled=1 AND CFS.callForwardType='inconditional' AND RA.t38passthrough='no' AND RA.id='$dlg_var(retailAccountId)'", "ra");
-
-    if ($xavp(ra=>CfwTarget) == $null) {
-        # Check for unreachable call forward settings
-        $xavp(ra) = $null;
-        sql_xquery("cb", "SELECT RA.name, D.domain, CONCAT(C.countryCode, CFS.numberValue) AS CfwTarget, RA.t38passthrough, CFS.callForwardType FROM RetailAccounts RA INNER JOIN Domains D ON RA.domainId=D.id INNER JOIN CallForwardSettings CFS ON CFS.retailAccountId=RA.id INNER JOIN Countries C ON C.id=CFS.numberCountryId WHERE CFS.enabled=1 AND CFS.callForwardType='userNotRegistered' AND RA.t38passthrough='no' AND RA.id='$dlg_var(retailAccountId)'", "ra");
-    }
+    sql_xquery("cb", "SELECT RA.name, D.domain, CFS.targetType, CFS.cfwToRetailAccountId, CONCAT(C.countryCode, CFS.numberValue) AS number, CFS.callForwardType FROM RetailAccounts RA JOIN Domains D ON RA.domainId=D.id JOIN CallForwardSettings CFS ON CFS.retailAccountId=RA.id LEFT JOIN Countries C ON C.id=CFS.numberCountryId WHERE CFS.enabled=1 AND RA.t38passthrough='no' AND RA.id='$dlg_var(retailAccountId)'", "ra");
 
     # Leave if no call forward configured
-    if ($xavp(ra=>CfwTarget) == $null) return;
+    if ($xavp(ra=>name) == $null) return;
 
+    $dlg_var(retail_callfwdType) = $xavp(ra=>callForwardType);
+    $dlg_var(retail_callfwdTarget) = $xavp(ra=>targetType);
     $dlg_var(rcfw_newfromuri) =  "sip:" + $xavp(ra=>name) + '@' + $xavp(ra=>domain);
     $dlg_var(rcfw_newpaiuri) = "sip:" + $fU + '@' + $xavp(ra=>domain);
     $dlg_var(rcfw_newpaiuser) = $fU;
     $dlg_var(rcfw_newdiversionuri) = 'sip:' + $hdr(X-Info-Callee) + '@' + $xavp(ra=>domain);
-    $dlg_var(rcfw_newruri) = "sip:" + $xavp(ra=>CfwTarget) + '@' + $xavp(ra=>domain);
-    $dlg_var(retail_callfwd) = $xavp(ra=>callForwardType);
 
-    if ($dlg_var(retail_callfwd) == "userNotRegistered") {
+    if ($dlg_var(retail_callfwdTarget) == 'number') {
+        $dlg_var(rcfw_newruri) = "sip:" + $xavp(ra=>number) + '@' + $xavp(ra=>domain);
+    } else if ($dlg_var(retail_callfwdTarget) == 'retail') {
+        $xavp(rb) = $null;
+        sql_xquery("cb", "SELECT name FROM RetailAccounts WHERE id='$xavp(ra=>cfwToRetailAccountId)'", "rb");
+        $dlg_var(rcfw_newruri) = "sip:" + $hdr(X-Info-Callee) + '@' + $xavp(ra=>domain);
+        $dlg_var(cfw_destination) = 'b' + $dlg_var(brandId) + 'c' + $dlg_var(companyId) + "rt" + $xavp(ra=>cfwToRetailAccountId) +"_" + $xavp(rb=>name);
+    } else {
+        send_reply("500", "Internal Server Error [GRC]");
+        exit;
+    }
+
+    if ($dlg_var(retail_callfwdType) == "userNotRegistered") {
         t_on_failure("MANAGE_FAILURE_RETAIL");
     }
 }
@@ -2513,7 +2520,7 @@ failure_route[MANAGE_FAILURE_RETAIL] {
         $var(rtEvent) = 'Terminated';
         route(REALTIME);
         #!endif
-        route(PREPARE_RETAIL_CFW);
+        route(APPLY_RETAIL_CFW);
         route(RELAY);
     }
 }
@@ -2571,14 +2578,10 @@ branch_route[MANAGE_BRANCH] {
     route(IS_FROM_INSIDE);
 
     # Prepare call
-    if ($var(is_from_inside) && !has_totag() && is_method("INVITE")) {
-        if ($avp(apply_cfwd) == 'yes') {
-            route(APPLY_RETAIL_CFW);
-        } else {
-            route(ADAPT_CALLER);
-            route(ADAPT_DIVERSION);
-            route(ADAPT_RURI_OUT);
-        }
+    if ($var(is_from_inside) && !has_totag() && is_method("INVITE") && $avp(retail_cfwd) != 'yes') {
+        route(ADAPT_CALLER);
+        route(ADAPT_DIVERSION);
+        route(ADAPT_RURI_OUT);
     }
 
     route(TRANSPORT_DETECT);

--- a/library/Ivoz/Ast/Domain/Service/PsEndpoint/UpdateByRetailAccount.php
+++ b/library/Ivoz/Ast/Domain/Service/PsEndpoint/UpdateByRetailAccount.php
@@ -76,14 +76,7 @@ class UpdateByRetailAccount implements RetailAccountLifecycleEventHandlerInterfa
             ->setTrustIdInbound('yes')
             ->setOutboundProxy('sip:users.ivozprovider.local^3Blr')
             ->setT38Udptl($entity->getT38Passthrough())
-            ->setDirectMediaMethod('invite');
-
-        // Disable direct media for T.38 capable devices
-        if ($entity->getT38Passthrough() === RetailAccountInterface::T38PASSTHROUGH_YES) {
-            $endpointDto->setDirectMedia('no');
-        } else {
-            $endpointDto->setDirectMedia('yes');
-        }
+            ->setDirectMedia('no');
 
         $this->entityTools->persistDto($endpointDto, $endpoint);
     }

--- a/library/Ivoz/Provider/Domain/Model/CallForwardSetting/CallForwardSetting.php
+++ b/library/Ivoz/Provider/Domain/Model/CallForwardSetting/CallForwardSetting.php
@@ -149,4 +149,13 @@ class CallForwardSetting extends CallForwardSettingAbstract implements CallForwa
     {
         return $this->getTargetType();
     }
+
+    public function getCallForwardTarget()
+    {
+        if ($this->getRouteType() == CallForwardSettingInterface::TARGETTYPE_RETAIL) {
+            return $this->getCfwToRetailAccount()->getName();
+        }
+
+        return $this->getTarget();
+    }
 }

--- a/library/Ivoz/Provider/Domain/Model/CallForwardSetting/CallForwardSettingAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/CallForwardSetting/CallForwardSettingAbstract.php
@@ -26,7 +26,7 @@ abstract class CallForwardSettingAbstract
     protected $callForwardType;
 
     /**
-     * comment: enum:number|extension|voicemail
+     * comment: enum:number|extension|voicemail|retail
      * @var string | null
      */
     protected $targetType;
@@ -75,6 +75,11 @@ abstract class CallForwardSettingAbstract
      * @var \Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface | null
      */
     protected $retailAccount;
+
+    /**
+     * @var \Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface | null
+     */
+    protected $cfwToRetailAccount;
 
 
     use ChangelogTrait;
@@ -178,6 +183,7 @@ abstract class CallForwardSettingAbstract
             ->setNumberCountry($fkTransformer->transform($dto->getNumberCountry()))
             ->setResidentialDevice($fkTransformer->transform($dto->getResidentialDevice()))
             ->setRetailAccount($fkTransformer->transform($dto->getRetailAccount()))
+            ->setCfwToRetailAccount($fkTransformer->transform($dto->getCfwToRetailAccount()))
         ;
 
         $self->initChangelog();
@@ -208,7 +214,8 @@ abstract class CallForwardSettingAbstract
             ->setVoiceMailUser($fkTransformer->transform($dto->getVoiceMailUser()))
             ->setNumberCountry($fkTransformer->transform($dto->getNumberCountry()))
             ->setResidentialDevice($fkTransformer->transform($dto->getResidentialDevice()))
-            ->setRetailAccount($fkTransformer->transform($dto->getRetailAccount()));
+            ->setRetailAccount($fkTransformer->transform($dto->getRetailAccount()))
+            ->setCfwToRetailAccount($fkTransformer->transform($dto->getCfwToRetailAccount()));
 
 
 
@@ -234,7 +241,8 @@ abstract class CallForwardSettingAbstract
             ->setVoiceMailUser(\Ivoz\Provider\Domain\Model\User\User::entityToDto(self::getVoiceMailUser(), $depth))
             ->setNumberCountry(\Ivoz\Provider\Domain\Model\Country\Country::entityToDto(self::getNumberCountry(), $depth))
             ->setResidentialDevice(\Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDevice::entityToDto(self::getResidentialDevice(), $depth))
-            ->setRetailAccount(\Ivoz\Provider\Domain\Model\RetailAccount\RetailAccount::entityToDto(self::getRetailAccount(), $depth));
+            ->setRetailAccount(\Ivoz\Provider\Domain\Model\RetailAccount\RetailAccount::entityToDto(self::getRetailAccount(), $depth))
+            ->setCfwToRetailAccount(\Ivoz\Provider\Domain\Model\RetailAccount\RetailAccount::entityToDto(self::getCfwToRetailAccount(), $depth));
     }
 
     /**
@@ -254,7 +262,8 @@ abstract class CallForwardSettingAbstract
             'voiceMailUserId' => self::getVoiceMailUser() ? self::getVoiceMailUser()->getId() : null,
             'numberCountryId' => self::getNumberCountry() ? self::getNumberCountry()->getId() : null,
             'residentialDeviceId' => self::getResidentialDevice() ? self::getResidentialDevice()->getId() : null,
-            'retailAccountId' => self::getRetailAccount() ? self::getRetailAccount()->getId() : null
+            'retailAccountId' => self::getRetailAccount() ? self::getRetailAccount()->getId() : null,
+            'cfwToRetailAccountId' => self::getCfwToRetailAccount() ? self::getCfwToRetailAccount()->getId() : null
         ];
     }
     // @codeCoverageIgnoreStart
@@ -338,7 +347,8 @@ abstract class CallForwardSettingAbstract
             Assertion::choice($targetType, [
                 CallForwardSettingInterface::TARGETTYPE_NUMBER,
                 CallForwardSettingInterface::TARGETTYPE_EXTENSION,
-                CallForwardSettingInterface::TARGETTYPE_VOICEMAIL
+                CallForwardSettingInterface::TARGETTYPE_VOICEMAIL,
+                CallForwardSettingInterface::TARGETTYPE_RETAIL
             ], 'targetTypevalue "%s" is not an element of the valid values: %s');
         }
 
@@ -582,6 +592,30 @@ abstract class CallForwardSettingAbstract
     public function getRetailAccount()
     {
         return $this->retailAccount;
+    }
+
+    /**
+     * Set cfwToRetailAccount
+     *
+     * @param \Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface $cfwToRetailAccount | null
+     *
+     * @return static
+     */
+    protected function setCfwToRetailAccount(\Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface $cfwToRetailAccount = null)
+    {
+        $this->cfwToRetailAccount = $cfwToRetailAccount;
+
+        return $this;
+    }
+
+    /**
+     * Get cfwToRetailAccount
+     *
+     * @return \Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface | null
+     */
+    public function getCfwToRetailAccount()
+    {
+        return $this->cfwToRetailAccount;
     }
 
     // @codeCoverageIgnoreEnd

--- a/library/Ivoz/Provider/Domain/Model/CallForwardSetting/CallForwardSettingDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/CallForwardSetting/CallForwardSettingDtoAbstract.php
@@ -75,6 +75,11 @@ abstract class CallForwardSettingDtoAbstract implements DataTransferObjectInterf
      */
     private $retailAccount;
 
+    /**
+     * @var \Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountDto | null
+     */
+    private $cfwToRetailAccount;
+
 
     use DtoNormalizer;
 
@@ -105,7 +110,8 @@ abstract class CallForwardSettingDtoAbstract implements DataTransferObjectInterf
             'voiceMailUserId' => 'voiceMailUser',
             'numberCountryId' => 'numberCountry',
             'residentialDeviceId' => 'residentialDevice',
-            'retailAccountId' => 'retailAccount'
+            'retailAccountId' => 'retailAccount',
+            'cfwToRetailAccountId' => 'cfwToRetailAccount'
         ];
     }
 
@@ -127,7 +133,8 @@ abstract class CallForwardSettingDtoAbstract implements DataTransferObjectInterf
             'voiceMailUser' => $this->getVoiceMailUser(),
             'numberCountry' => $this->getNumberCountry(),
             'residentialDevice' => $this->getResidentialDevice(),
-            'retailAccount' => $this->getRetailAccount()
+            'retailAccount' => $this->getRetailAccount(),
+            'cfwToRetailAccount' => $this->getCfwToRetailAccount()
         ];
 
         if (!$hideSensitiveData) {
@@ -554,6 +561,52 @@ abstract class CallForwardSettingDtoAbstract implements DataTransferObjectInterf
     public function getRetailAccountId()
     {
         if ($dto = $this->getRetailAccount()) {
+            return $dto->getId();
+        }
+
+        return null;
+    }
+
+    /**
+     * @param \Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountDto $cfwToRetailAccount
+     *
+     * @return static
+     */
+    public function setCfwToRetailAccount(\Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountDto $cfwToRetailAccount = null)
+    {
+        $this->cfwToRetailAccount = $cfwToRetailAccount;
+
+        return $this;
+    }
+
+    /**
+     * @return \Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountDto | null
+     */
+    public function getCfwToRetailAccount()
+    {
+        return $this->cfwToRetailAccount;
+    }
+
+    /**
+     * @param mixed | null $id
+     *
+     * @return static
+     */
+    public function setCfwToRetailAccountId($id)
+    {
+        $value = !is_null($id)
+            ? new \Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountDto($id)
+            : null;
+
+        return $this->setCfwToRetailAccount($value);
+    }
+
+    /**
+     * @return mixed | null
+     */
+    public function getCfwToRetailAccountId()
+    {
+        if ($dto = $this->getCfwToRetailAccount()) {
             return $dto->getId();
         }
 

--- a/library/Ivoz/Provider/Domain/Model/CallForwardSetting/CallForwardSettingInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/CallForwardSetting/CallForwardSettingInterface.php
@@ -20,6 +20,7 @@ interface CallForwardSettingInterface extends LoggableEntityInterface
     const TARGETTYPE_NUMBER = 'number';
     const TARGETTYPE_EXTENSION = 'extension';
     const TARGETTYPE_VOICEMAIL = 'voicemail';
+    const TARGETTYPE_RETAIL = 'retail';
 
 
     /**
@@ -161,6 +162,13 @@ interface CallForwardSettingInterface extends LoggableEntityInterface
      * @return \Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface | null
      */
     public function getRetailAccount();
+
+    /**
+     * Get cfwToRetailAccount
+     *
+     * @return \Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface | null
+     */
+    public function getCfwToRetailAccount();
 
     /**
      * @return bool

--- a/library/Ivoz/Provider/Domain/Model/CallForwardSetting/CallForwardSettingInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/CallForwardSetting/CallForwardSettingInterface.php
@@ -52,6 +52,8 @@ interface CallForwardSettingInterface extends LoggableEntityInterface
      */
     public function getRouteType();
 
+    public function getCallForwardTarget();
+
     /**
      * Get callTypeFilter
      *

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/CallForwardSetting.CallForwardSettingAbstract.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/CallForwardSetting.CallForwardSettingAbstract.orm.yml
@@ -23,7 +23,7 @@ Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSettingAbstract:
       length: 25
       options:
         fixed: false
-        comment: '[enum:number|extension|voicemail]'
+        comment: '[enum:number|extension|voicemail|retail]'
       column: targetType
     numberValue:
       type: string
@@ -113,6 +113,18 @@ Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSettingAbstract:
       inversedBy: callForwardSettings
       joinColumns:
         retailAccountId:
+          referencedColumnName: id
+          nullable: true
+          onDelete: cascade
+      orphanRemoval: false
+    cfwToRetailAccount:
+      targetEntity: \Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface
+      cascade: {  }
+      fetch: LAZY
+      mappedBy: null
+      inversedBy: null
+      joinColumns:
+        cfwToRetailAccountId:
           referencedColumnName: id
           nullable: true
           onDelete: cascade

--- a/schema/DoctrineMigrations/Version20210708134307.php
+++ b/schema/DoctrineMigrations/Version20210708134307.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Application\Migrations;
+
+use Ivoz\Core\Infrastructure\Persistence\Doctrine\LoggableMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20210708134307 extends LoggableMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE CallForwardSettings CHANGE targetType targetType VARCHAR(25) DEFAULT NULL COMMENT \'[enum:number|extension|voicemail|retail]\'');
+
+        $this->addSql('ALTER TABLE CallForwardSettings ADD cfwToRetailAccountId INT UNSIGNED DEFAULT NULL');
+        $this->addSql('ALTER TABLE CallForwardSettings ADD CONSTRAINT FK_E71B58A4DE65F396 FOREIGN KEY (cfwToRetailAccountId) REFERENCES RetailAccounts (id) ON DELETE CASCADE');
+        $this->addSql('CREATE INDEX IDX_E71B58A4DE65F396 ON CallForwardSettings (cfwToRetailAccountId)');
+
+        # Disable directmedia for all retail accounts
+        $this->addSql("UPDATE ast_ps_endpoints SET direct_media='no' WHERE retailAccountId IS NOT NULL");
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE CallForwardSettings CHANGE targetType targetType VARCHAR(25) DEFAULT NULL COLLATE utf8_general_ci COMMENT \'[enum:number|extension|voicemail]\'');
+
+        $this->addSql('ALTER TABLE CallForwardSettings DROP FOREIGN KEY FK_E71B58A4DE65F396');
+        $this->addSql('DROP INDEX IDX_E71B58A4DE65F396 ON CallForwardSettings');
+        $this->addSql('ALTER TABLE CallForwardSettings DROP cfwToRetailAccountId');
+    }
+}

--- a/web/admin/application/configs/klear/CallForwardSettingsList.yaml
+++ b/web/admin/application/configs/klear/CallForwardSettingsList.yaml
@@ -35,6 +35,7 @@ production:
           noAnswerTimeout: true
           user: true
           residentialDevice: true
+          cfwToretailAccount: true
       options:
         title: _("Options")
         screens:
@@ -77,6 +78,7 @@ production:
             numberValue: 2
             extension: 3
             voiceMailUser: 3
+            cfwToretailAccount: 3
 
     callForwardSettingsEdit_screen: &callForwardSettingsEdit_screenLink 
       <<: *CallForwardSettings

--- a/web/admin/application/configs/klear/model/CallForwardSettings.yaml
+++ b/web/admin/application/configs/klear/model/CallForwardSettings.yaml
@@ -31,6 +31,22 @@ production:
           order:
             ResidentialDevice.name: asc
       default: true
+    cfwToretailAccount:
+      title:  ngettext('Retail Account', 'Retail Accounts', 1)
+      type: select
+      required: true
+      source:
+        data: mapper
+        config:
+          entity: \Ivoz\Provider\Domain\Model\RetailAccount\RetailAccount
+          filterClass: IvozProvider_Klear_Filter_RetailAccounts
+          fieldName:
+            fields:
+            - name
+            template: '%name%'
+          order:
+            RetailAccount.name: asc
+        'null': _("Unassigned")
     callTypeFilter:
       title: _('Call type')
       type: select
@@ -77,22 +93,27 @@ production:
             title: _('Unassigned')
             visualFilter:
               show: [ ]
-              hide: [ extension, voiceMailUser, numberCountry, numberValue ]
+              hide: [ extension, voiceMailUser, numberCountry, numberValue, cfwToretailAccount ]
           'number':
             title: _('Number')
             visualFilter:
               show: [ numberCountry, numberValue ]
-              hide: [ extension, voiceMailUser ]
+              hide: [ extension, voiceMailUser, cfwToretailAccount ]
           'extension':
             title: ngettext('Extension', 'Extensions', 1)
             visualFilter:
               show: [ extension ]
-              hide: [ numberCountry, numberValue, voiceMailUser ]
+              hide: [ numberCountry, numberValue, voiceMailUser, cfwToretailAccount ]
           'voicemail':
             title: ngettext('Voicemail', 'Voicemails', 1)
             visualFilter:
               show: [ voiceMailUser ]
-              hide: [ extension, numberCountry, numberValue ]
+              hide: [ extension, numberCountry, numberValue, cfwToretailAccount ]
+          'retail':
+            title: ngettext('Retail Account', 'Retail Accounts', 1)
+            visualFilter:
+              show: [ cfwToretailAccount ]
+              hide: [ extension, numberCountry, numberValue, voiceMailUser ]
     numberCountry:
       title: _('Country')
       type: select
@@ -159,7 +180,7 @@ production:
       type: ghost
       source:
         class: IvozProvider_Klear_Ghost_RouteTarget
-        method: getTarget
+        method: getCallForwardTarget
     enabled:
       title: _('Enabled')
       type: select

--- a/web/admin/application/library/IvozProvider/Klear/Filter/RetailAccounts.php
+++ b/web/admin/application/library/IvozProvider/Klear/Filter/RetailAccounts.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Class IvozProvider_Klear_Filter_RetailAccounts
+ *
+ * Filter company's retail accounts to exclude current edited retail account
+ */
+class IvozProvider_Klear_Filter_RetailAccounts extends IvozProvider_Klear_Filter_Company
+{
+    protected $_condition = array();
+
+    public function setRouteDispatcher(KlearMatrix_Model_RouteDispatcher $routeDispatcher)
+    {
+        // Add parent filters
+        parent::setRouteDispatcher($routeDispatcher);
+
+        $pk = $routeDispatcher->getParam("parentId", false);
+
+        if (!is_array($pk)) {
+            $this->_condition[] = "self::id != $pk";
+        }
+
+        return true;
+    }
+}

--- a/web/admin/application/library/IvozProvider/Klear/Filter/TargetTypes.php
+++ b/web/admin/application/library/IvozProvider/Klear/Filter/TargetTypes.php
@@ -47,6 +47,10 @@ class IvozProvider_Klear_Filter_TargetTypes implements KlearMatrix_Model_Field_S
             $excludedRoutes[] = "extension";
         }
 
+        if ($companyDto->getType() !== CompanyInterface::TYPE_RETAIL) {
+            $excludedRoutes[] = "retail";
+        }
+
         if ($companyDto->getType() === CompanyInterface::TYPE_RETAIL) {
             $excludedRoutes[] = "voicemail";
         }

--- a/web/admin/application/library/IvozProvider/Klear/Ghost/RouteTarget.php
+++ b/web/admin/application/library/IvozProvider/Klear/Ghost/RouteTarget.php
@@ -70,4 +70,9 @@ class IvozProvider_Klear_Ghost_RouteTarget extends KlearMatrix_Model_Field_Ghost
             []
         );
     }
+
+    public function getCallForwardTarget(DataTransferObjectInterface $model)
+    {
+        return $this->getTarget($model, 'getCallForwardTarget');
+    }
 }

--- a/web/rest/client/features/provider/callForwardSetting/postCallForwardSetting.feature
+++ b/web/rest/client/features/provider/callForwardSetting/postCallForwardSetting.feature
@@ -41,7 +41,8 @@ Feature: Create call forward setting
           "voiceMailUser": null,
           "numberCountry": 68,
           "residentialDevice": null,
-          "retailAccount": null
+          "retailAccount": null,
+          "cfwToRetailAccount": null
       }
     """
 

--- a/web/rest/client/features/provider/callForwardSetting/putCallForwardSetting.feature
+++ b/web/rest/client/features/provider/callForwardSetting/putCallForwardSetting.feature
@@ -41,6 +41,7 @@ Feature: Update call forward settings
           "voiceMailUser": null,
           "numberCountry": 1,
           "residentialDevice": null,
-          "retailAccount": null
+          "retailAccount": null,
+          "cfwToRetailAccount": null
       }
     """


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
Retail account call-forward can only be routed to external numbers.

This PR makes it possible to call-forward to another retail account in the same retail client.
