### PR TITLE
kamtrunks: blocking route no prio 0

### DIFF
--- a/doc/sphinx/administration_portal/brand/routing/outgoing_routings.rst
+++ b/doc/sphinx/administration_portal/brand/routing/outgoing_routings.rst
@@ -124,8 +124,7 @@ Carrier election process can combine static and LCR routes:
 Blocking routes
 ===============
 
-Blocking routes are the only routes with **priority 0**. This enforcement makes them be **evaluated first**. They are
-*Stopper* routes as whenever they apply, call is dropped and no further route is evaluated.
+Blocking routes are *Stopper* routes as whenever they apply, call is dropped and no further route is evaluated.
 
 .. tip:: Using these routes, it is easy to make a group with unwanted call prefixes and reject all calls to those
          destinations for every client (or for one particular client).

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -637,6 +637,7 @@ route[REQINIT] {
 }
 
 route[LOAD_GWS] {
+    # Load fax specific gateways (if current call is a fax)
     $var(filter) = 'b' + $dlg_var(brandId) + 'c' + $dlg_var(companyId);
     if ($avp(fax)) {
         load_gws(1, 'fax', $var(filter));
@@ -645,11 +646,13 @@ route[LOAD_GWS] {
         }
     }
 
+    # Load non-fax gateways for non-faxes or faxes with no specific routes
     if ($avp(gw_uri_avp) == $null) {
         $var(prefix) = $dlg_var(routingTag) + $rU;
         load_gws(1, $var(prefix), $var(filter));
     }
 
+    # No gateways
     if ($avp(gw_uri_avp) == $null) {
         xwarn("[$dlg_var(cidhash)] LOAD-GWS: No valid gateway for '$rU' for company '$dlg_var(companyId)'\n");
         send_reply("500", "Server Internal Error - No gateways");
@@ -663,35 +666,37 @@ route[LOAD_GWS] {
     $var(step) = "initial";
     route(PRINT_GWS);
 
-    # Lookup for dummy GWs and replace them with CGRateS LCR gateways
+    # Lookup for dummy GWs and replace them with CGRateS LCR gateways or blocking gateways
     $var(i) = 0;
-    $var(lastPrio) = 0;
+    $var(lastPrio) = -1;
     while(is_avp_set("$(avp(gw_uri_avp)[$var(i)])")) {
         $var(rule_id) = $(avp(gw_uri_avp)[$var(i)]{s.select,-1,|});
-        $var(gw_hostname) = $(avp(gw_uri_avp)[$var(i)]{s.select,6,|});
 
+        $xavp(rr) = $null;
         sql_xquery("cb", "SELECT O.routingMode, O.stopper, O.priority FROM kam_trunks_lcr_rules K JOIN OutgoingRouting O ON O.id=K.outgoingRoutingId WHERE K.id=$var(rule_id)", "rr");
 
-        if ($var(lastPrio) == 0 && $xavp(rr=>stopper)) {
-            # First stopper rule found
-            if ($xavp(rr=>stopper)) {
-                 $var(lastPrio) = $xavp(rr=>priority);
-                 xnotice("[$dlg_var(cidhash)] LOAD-GWS: Stopper rule [$var(i)] found, skip rules with priority higher than $var(lastPrio)");
-            }
-        } else if ($var(lastPrio) > 0){
+        if ($var(lastPrio) != -1) {
+            # Stopper rule found in previous iteration
             if ($xavp(rr=>priority) > $var(lastPrio)) {
                 xinfo("[$dlg_var(cidhash)] LOAD-GWS: Skip route [$var(i)] and remaining ones as higher priority found");
                 break;
             } else {
                 xinfo("[$dlg_var(cidhash)] LOAD-GWS: Adding route [$var(i)] as has same prio than stopper rule");
             }
+        } else if ($xavp(rr=>stopper)) {
+            # First stopper rule found
+            $var(lastPrio) = $xavp(rr=>priority);
+            xinfo("[$dlg_var(cidhash)] LOAD-GWS: Stopper rule [$var(i)] found, skip rules with priority higher than $var(lastPrio)");
+        } else {
+            # Stopper rule not found yet
+            xinfo("[$dlg_var(cidhash)] LOAD-GWS: Stopper rule not found yet, continue");
         }
 
+        $var(gw_hostname) = $(avp(gw_uri_avp)[$var(i)]{s.select,6,|});
         if ($var(gw_hostname) == "dummy.ivozprovider.local") {
             if ($xavp(rr=>routingMode) == 'block') {
-                xnotice("[$dlg_var(cidhash)] LOAD-GWS: Blocking route [$var(i)] found, drop call");
-                send_reply("403","Forbidden");
-                exit;
+                avp_printf("$avp(avp_new_entry)", "0|sip:|0||||block.ivozprovider.local|5060||;transport=udp|0|$var(rule_id)");
+                $avp(new_gw_uri_avp) = $avp(avp_new_entry);
             } else if ($xavp(rr=>routingMode) == 'lcr') {
                 xinfo("[$dlg_var(cidhash)] LOAD-GWS: LCR route [$var(i)] found, replace it with LCR gateways");
                 route(ADD_LCR_CARRIERS);
@@ -707,7 +712,7 @@ route[LOAD_GWS] {
     $(avp(gw_uri_avp)[*]) = $null;
     avp_copy("$avp(new_gw_uri_avp)", "$avp(gw_uri_avp)/gd");
 
-    # Print final GWs (static + dynamic)
+    # Print final GWs (static + lcr + blocking)
     xinfo("[$dlg_var(cidhash)] LOAD-GWS: Final carriers (static + dynamic rules)\n");
     $var(step) = "final";
     route(PRINT_GWS);
@@ -919,6 +924,13 @@ route[SELECT_NEXT_GW] {
 
     # GW selection may modify both $ru and $du
     xinfo("[$dlg_var(cidhash)] SELECT-NEXT-GW: New dest-URI $du - New RURI $ru\n");
+
+    # Blocking route found, drop call
+    if ($rd == "block.ivozprovider.local") {
+        xwarn("[$dlg_var(cidhash)] SELECT-NEXT-GW: Blocking route found, drop call");
+        send_reply("403","Forbidden");
+        exit;
+    }
 
     # Skip GW if has an unresolvable domain
     if(!is_ip("$nh(d)")) {

--- a/library/Ivoz/Provider/Domain/Model/OutgoingRouting/OutgoingRouting.php
+++ b/library/Ivoz/Provider/Domain/Model/OutgoingRouting/OutgoingRouting.php
@@ -78,7 +78,6 @@ class OutgoingRouting extends OutgoingRoutingAbstract implements OutgoingRouting
                 break;
             case self::ROUTINGMODE_BLOCK:
                 $this->setCarrier(null);
-                $this->setPriority(0);
                 $this->setStopper(true);
                 break;
             default:

--- a/library/Ivoz/Provider/Domain/Model/OutgoingRouting/OutgoingRoutingDto.php
+++ b/library/Ivoz/Provider/Domain/Model/OutgoingRouting/OutgoingRoutingDto.php
@@ -94,13 +94,4 @@ class OutgoingRoutingDto extends OutgoingRoutingDtoAbstract
 
         $this->setRelCarriers($relCarriers);
     }
-
-    public function setRoutingMode($routingMode = null)
-    {
-        if ($routingMode === OutgoingRoutingInterface::ROUTINGMODE_BLOCK) {
-            // klear visual filter fix
-            $this->setPriority(0);
-        }
-        return parent::setRoutingMode($routingMode);
-    }
 }

--- a/web/admin/application/configs/klear/model/OutgoingRouting.yaml
+++ b/web/admin/application/configs/klear/model/OutgoingRouting.yaml
@@ -116,7 +116,7 @@ production:
       required: true
       source:
         control: Spinner
-        min: 1
+        min: 0
         max: 254
     weight:
       title: _('Weight')
@@ -147,8 +147,8 @@ production:
           'block':
             title: _("Block")
             visualFilter:
-              show: [ ]
-              hide: [ carrier, prefix, forceClid, clidCountry, clid, relCarriers, weight, priority, stopper]
+              show: [ priority ]
+              hide: [ carrier, prefix, forceClid, clidCountry, clid, relCarriers, weight, stopper]
     company:
       title: ngettext('Client', 'Clients', 1)
       type: select


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

Until this PR, blocking OutgoingRoutes had a forced 0 priority value. This made impossible setups like these:

- Allow All clients to call Emergency numbers (prio 1).
- Block remaining call for specific client X (blocking prio 2).

This PR tries to make it possible.