### PR TITLE
kamtrunks: fix realtime for GW failover

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -1764,7 +1764,8 @@ route[REALTIME] {
     if ($dlg_var(lastCallState) != $null) {
         switch ($var(rtEvent)) {
             case "Trying":
-                return;
+                if ($(dlg_var(lastCallState){s.int}) != 4) return; # Allow going back from Terminated to Trying (for GW failover)
+                break;
             case "Proceeding":
                 if ($(dlg_var(lastCallState){s.int}) >= 1) return;
                 $dlg_var(lastCallState) = "1";


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

Once Terminated state was reached, logic avoided going back to Trying for next selected gateway. This PR fixes realtime in gateway failover scenarios.

#### Additional information

Prior to this PR, only first attempt was listed in god/brand realtime section. If it failed, call disappeared nevertheless it was routing through other gateway.