### PR TITLE
Set default country value in edit screens

### DIFF
--- a/web/admin/application/configs/klear/CallForwardSettingsList.yaml
+++ b/web/admin/application/configs/klear/CallForwardSettingsList.yaml
@@ -90,6 +90,8 @@ production:
       class: ui-silk-pencil
       label: false
       title: _("Edit %s %2s", ngettext('Call forward setting', 'Call forward settings', 1), "[format| (%item%)]")
+      defaultValues:
+        numberCountry: ${auth.companyCountryId}
       fields: &callForwardSettingsEditFields_Link
         blacklist: &callForwardSettingsEditBlacklist_Link
           targetTypeValue: true

--- a/web/admin/application/configs/klear/ConditionalRoutesConditionsList.yaml
+++ b/web/admin/application/configs/klear/ConditionalRoutesConditionsList.yaml
@@ -111,6 +111,8 @@ production:
       label: false
       labelOnPostAction: _("Edit %s %2s", ngettext('Condition', 'Conditions', 1), "[format| (%item%)]")
       title: _("Edit %s %2s", ngettext('Condition', 'Conditions', 1), "[format| (%item%)]")
+      defaultValues:
+        numberCountry: ${auth.companyCountryId}
       fields:
         blacklist:
           <<: *conditionalRoutesConditionsBlacklist_link

--- a/web/admin/application/configs/klear/ConditionalRoutesList.yaml
+++ b/web/admin/application/configs/klear/ConditionalRoutesList.yaml
@@ -101,6 +101,8 @@ production:
       title: _("Edit %s %2s", ngettext('Conditional Route', 'Conditional Routes', 1), "[format| (%item%)]")
       forcedValues:
         <<: *forcedCompany
+      defaultValues:
+        numberCountry: ${auth.companyCountryId}
       fields:
         blacklist:
           <<: *conditionalRoutesBlacklist_link

--- a/web/admin/application/configs/klear/DdisList.yaml
+++ b/web/admin/application/configs/klear/DdisList.yaml
@@ -131,6 +131,8 @@ production:
         <<: *forcedBrand
         <<: *forcedCompany
       title: _("Edit %s %2s", ngettext('DDI', 'DDIs', 1), "[format| (%item%)]")
+      defaultValues:
+        country: ${auth.companyCountryId}
       fields:
         order:
           <<: *ddisFieldsOder_Link

--- a/web/admin/application/configs/klear/ExtensionsList.yaml
+++ b/web/admin/application/configs/klear/ExtensionsList.yaml
@@ -94,6 +94,8 @@ production:
       forcedValues:
         <<: *forcedCompany
       title: _("Edit %s %2s", ngettext('Extension', 'Extensions', 1), "[format| (%item%)]")
+      defaultValues:
+        numberCountry: ${auth.companyCountryId}
       fields:
         blacklist:
           target: true

--- a/web/admin/application/configs/klear/ExternalCallFiltersList.yaml
+++ b/web/admin/application/configs/klear/ExternalCallFiltersList.yaml
@@ -138,6 +138,9 @@ production:
       title: _("Edit %s %2s", ngettext('External call filter', 'External call filters', 1), "[format| (%item%)]")
       forcedValues:
         <<: *forcedCompany
+      defaultValues:
+        holidayNumberCountry: ${auth.companyCountryId}
+        outOfScheduleNumberCountry: ${auth.companyCountryId}
       fields:
         order:
           <<: *externalCallFilters_orderLink

--- a/web/admin/application/configs/klear/FaxesList.yaml
+++ b/web/admin/application/configs/klear/FaxesList.yaml
@@ -183,6 +183,8 @@ production:
       filterField: Fax
       forcedValues:
         "self::type": 'Out'
+      defaultValues:
+        dstCountry: ${auth.companyCountryId}
       fields:
         blacklist:
           calldate: true

--- a/web/admin/application/configs/klear/HuntGroupsList.yaml
+++ b/web/admin/application/configs/klear/HuntGroupsList.yaml
@@ -90,6 +90,8 @@ production:
       title: _("Edit %s %2s", ngettext('Hunt Group', 'Hunt Groups', 1), "[format| (%item%)]")
       forcedValues:
         <<: *forcedCompany
+      defaultValues:
+        noAnswerNumberCountry: ${auth.companyCountryId}
       fields:
         blacklist:
           <<: *huntGroupsBlacklist_Link

--- a/web/admin/application/configs/klear/HuntGroupsRelUsersList.yaml
+++ b/web/admin/application/configs/klear/HuntGroupsRelUsersList.yaml
@@ -71,6 +71,8 @@ production:
       class: ui-silk-pencil
       label: false
       title: _("Edit %s %2s", ngettext('Hunt Group', 'Hunt Groups', 1), "[format| (%parent%)]")
+      defaultValues:
+        numberCountry: ${auth.companyCountryId}
       fields:
         blacklist:
           user: true

--- a/web/admin/application/configs/klear/IvrEntriesList.yaml
+++ b/web/admin/application/configs/klear/IvrEntriesList.yaml
@@ -77,6 +77,8 @@ production:
       class: ui-silk-pencil
       label: false
       title: _("Edit %s %2s", ngettext('IVR entry', 'IVR entries', 1), "[format| (%item%)]")
+      defaultValues:
+        numberCountry: ${auth.companyCountryId}
       fields:
         blacklist:
           target: true

--- a/web/admin/application/configs/klear/IvrList.yaml
+++ b/web/admin/application/configs/klear/IvrList.yaml
@@ -127,6 +127,9 @@ production:
       title: _("Edit %s %2s", ngettext('IVR', 'IVRs', 1), "[format| (%item%)]")
       forcedValues:
         <<: *forcedCompany
+      defaultValues:
+        noInputNumberCountry: ${auth.companyCountryId}
+        errorNumberCountry: ${auth.companyCountryId}
       fields:
         order:
           name: true

--- a/web/admin/application/configs/klear/MatchListPatternsList.yaml
+++ b/web/admin/application/configs/klear/MatchListPatternsList.yaml
@@ -70,6 +70,8 @@ production:
       label: false
       labelOnPostAction: _("Edit %s %2s", ngettext('Match List Pattern', 'Match List Patterns', 1), "[format| (%item%)]")
       title: _("Edit %s %2s", ngettext('Match List Pattern', 'Match List Patterns', 1), "[format| (%item%)]")
+      defaultValues:
+        numberCountry: ${auth.companyCountryId}
       fields:
         blacklist:
           matchValue: true

--- a/web/admin/application/configs/klear/QueuesList.yaml
+++ b/web/admin/application/configs/klear/QueuesList.yaml
@@ -131,6 +131,9 @@ production:
       title: _("Edit %s %2s", ngettext('Queue', 'Queues', 1), "[format| (%item%)]")
       forcedValues:
         <<: *forcedCompany
+      defaultValues:
+        timeoutNumberCountry: ${auth.companyCountryId}
+        fullNumberCountry: ${auth.companyCountryId}
       fields:
         order:
           <<: *Queues_orderLink

--- a/web/admin/application/configs/klear/RetailDdisList.yaml
+++ b/web/admin/application/configs/klear/RetailDdisList.yaml
@@ -137,6 +137,8 @@ production:
         <<: *forcedCompany
         routeType: 'retail'
       title: _("Edit %s %2s", ngettext('DDI', 'DDIs', 1), "[format| (%item%)]")
+      defaultValues:
+        country: ${auth.companyCountryId}
       fields:
         order:
           <<: *ddisFieldsOder_Link
@@ -154,6 +156,8 @@ production:
         <<: *forcedCompany
         routeType: 'retail'
       title: _("Edit %s %2s", ngettext('DDI', 'DDIs', 1), "[format| (%item%)]")
+      defaultValues:
+        country: ${auth.companyCountryId}
       fields:
         order:
           <<: *ddisFieldsOder_Link


### PR DESCRIPTION
#### Description

Replace afganistan by client country as default country number value in edit screen

requires: https://github.com/irontec/klearMatrix/commit/e35a093e242fbdda34b8d7dabf3fe06904144cb8

<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

