### PR TITLE
core: fixed CFW creation issues

### DIFF
--- a/library/Ivoz/Provider/Domain/Service/CallForwardSetting/CheckUniqueness.php
+++ b/library/Ivoz/Provider/Domain/Service/CallForwardSetting/CheckUniqueness.php
@@ -225,7 +225,7 @@ class CheckUniqueness implements CallForwardSettingLifecycleEventHandlerInterfac
         $ddi = $entity->getDdi();
 
         if ($ddi) {
-            $criteria[] = ['ddi', 'eq', $ddi->getId()];
+            $criteria[] = ['ddi', 'eq', $ddi];
         }
 
         return CriteriaHelper::fromArray($criteria);

--- a/library/spec/Ivoz/Provider/Domain/Service/CallForwardSetting/CheckUniquenessSpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Service/CallForwardSetting/CheckUniquenessSpec.php
@@ -3,6 +3,7 @@
 namespace spec\Ivoz\Provider\Domain\Service\CallForwardSetting;
 
 use Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSetting;
+use Ivoz\Provider\Domain\Model\Ddi\Ddi;
 use Ivoz\Provider\Domain\Model\User\User;
 use Ivoz\Provider\Infrastructure\Persistence\Doctrine\CallForwardSettingDoctrineRepository;
 use Ivoz\Provider\Domain\Service\CallForwardSetting\CheckUniqueness;
@@ -10,7 +11,6 @@ use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use spec\HelperTrait;
-use Ivoz\Provider\Domain\Model\Ddi\DdiInterface;
 
 class CheckUniquenessSpec extends ObjectBehavior
 {
@@ -187,18 +187,8 @@ class CheckUniquenessSpec extends ObjectBehavior
     {
         $this->prepareExecution();
 
-        $ddi = $this->getTestDouble(
-            DdiInterface::class,
-            false
-        );
-
-        $ddiId = 10;
-        $this->getterProphecy(
-            $ddi,
-            [
-                'getId' => $ddiId,
-            ],
-            true
+        $ddi = $this->getInstance(
+            Ddi::class
         );
 
         $this->getterProphecy(
@@ -212,7 +202,7 @@ class CheckUniquenessSpec extends ObjectBehavior
 
         $criteria = $this->getCriteriaArgument(
             'inconditional',
-            $ddiId
+            $ddi
         );
 
         $this


### PR DESCRIPTION
Doctrine was throwing an error when a ddi was selected:
"Cannot match on Ivoz\Provider\Domain\Model\CallForwardSetting\CallForwardSetting::ddi with a non-object value. Matching objects by id is not compatible with matching on an in-memory collection, which compares objects by reference. (0) # /opt/irontec/ivozprovider/library/vendor/doctrine/orm/lib/Doctrine/ORM/Persisters/PersisterException.php"

<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
<!-- Describe your changes in detail -->

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
