### PR TITLE
Friend inter company

### DIFF
--- a/web/admin/application/configs/klear/FriendsList.yaml
+++ b/web/admin/application/configs/klear/FriendsList.yaml
@@ -86,9 +86,8 @@ production:
         <<: *forcedCompany
         ddiIn: "yes"
       fields:
-        readOnly:
-          interCompany: ${auth.isCompanyOperator}
         blacklist: &friends_blacklistLink
+          interCompany: ${auth.isCompanyOperator}
           domain: true
           directMediaMethod: true
           updateCallerid: true
@@ -182,9 +181,8 @@ production:
       fields:
         order:
           <<: *friends_orderLink
-        readOnly:
-          interCompany: ${auth.isCompanyOperator}
         blacklist:
+          interCompany: ${auth.isCompanyOperator}
           domain: true
           directMediaMethod: true
           updateCallerid: true

--- a/web/rest/brand/config/api/raw/provider.yml
+++ b/web/rest/brand/config/api/raw/provider.yml
@@ -519,12 +519,13 @@ Ivoz\Provider\Domain\Model\Friend\Friend:
       ROLE_BRAND_ADMIN:
         company:
           in: "companyRepository.getSupervisedCompanyIdsByAdmin(user)"
-    write_access_control:
-      ROLE_BRAND_ADMIN:
-        raw: 'FALSE'
-  itemOperations: []
+  itemOperations:
+    get: ~
+    put: ~
+    delete: ~
   collectionOperations:
     get: ~
+    post: ~
     get_status_collection:
       method: 'GET'
       path: 'friends/status'

--- a/web/rest/brand/features/provider/friend/postFriend.feature
+++ b/web/rest/brand/features/provider/friend/postFriend.feature
@@ -1,0 +1,92 @@
+Feature: Create friends
+  In order to manage friends
+  As a brand admin
+  I need to be able to create them through the API.
+
+  @createSchema
+  Scenario: Create a friend
+    Given I add Brand Authorization header
+     When I add "Content-Type" header equal to "application/json"
+      And I add "Accept" header equal to "application/json"
+      And I send a "POST" request to "/friends" with body:
+    """
+      {
+          "name": "beWatterMyFriend",
+          "description": "something",
+          "transport": "tls",
+          "ip": "129.1.2.3",
+          "port": 5060,
+          "password": "ZEF7t5n+b4",
+          "priority": 2,
+          "allow": "alaw",
+          "fromDomain": "",
+          "directConnectivity": "yes",
+          "ddiIn": "yes",
+          "t38Passthrough": "no",
+          "id": 2,
+          "transformationRuleSet": null,
+          "callAcl": null,
+          "outgoingDdi": null,
+          "language": null,
+          "company": 1
+      }
+    """
+    Then the response status code should be 201
+     And the response should be in JSON
+     And the header "Content-Type" should be equal to "application/json; charset=utf-8"
+     And the JSON should be equal to:
+    """
+      {
+          "name": "beWatterMyFriend",
+          "description": "something",
+          "transport": "tls",
+          "ip": "129.1.2.3",
+          "port": 5060,
+          "password": "ZEF7t5n+b4",
+          "priority": 2,
+          "allow": "alaw",
+          "fromUser": null,
+          "fromDomain": "",
+          "directConnectivity": "yes",
+          "ddiIn": "yes",
+          "t38Passthrough": "no",
+          "id": 2,
+          "company": 1,
+          "transformationRuleSet": null,
+          "outgoingDdi": null,
+          "language": null,
+          "interCompany": null
+      }
+    """
+
+  Scenario: Retrieve created friends
+    Given I add Brand Authorization header
+     When I add "Accept" header equal to "application/json"
+      And I send a "GET" request to "friends/2"
+     Then the response status code should be 200
+      And the response should be in JSON
+      And the header "Content-Type" should be equal to "application/json; charset=utf-8"
+      And the JSON should be like:
+    """
+      {
+          "name": "beWatterMyFriend",
+          "description": "something",
+          "transport": "tls",
+          "ip": "129.1.2.3",
+          "port": 5060,
+          "password": "ZEF7t5n+b4",
+          "priority": 2,
+          "allow": "alaw",
+          "fromUser": null,
+          "fromDomain": "",
+          "directConnectivity": "yes",
+          "ddiIn": "yes",
+          "t38Passthrough": "no",
+          "id": 2,
+          "company": "~",
+          "transformationRuleSet": null,
+          "outgoingDdi": null,
+          "language": null,
+          "interCompany": null
+      }
+    """

--- a/web/rest/brand/features/provider/friend/putFriend.feature
+++ b/web/rest/brand/features/provider/friend/putFriend.feature
@@ -1,0 +1,61 @@
+Feature: Update friends
+  In order to manage friends
+  As a brand admin
+  I need to be able to update them through the API.
+
+  @createSchema
+  Scenario: Update a friend
+    Given I add Brand Authorization header
+     When I add "Content-Type" header equal to "application/json"
+      And I add "Accept" header equal to "application/json"
+      And I send a "PUT" request to "/friends/1" with body:
+    """
+      {
+          "name": "updatedTestFriend",
+          "description": "",
+          "transport": "udp",
+          "ip": "1.2.3.4",
+          "port": 5061,
+          "password": "ZEF7t5n+b4",
+          "priority": 1,
+          "disallow": "all",
+          "allow": "alaw",
+          "directMediaMethod": "update",
+          "calleridUpdateHeader": "pai",
+          "updateCallerid": "yes",
+          "fromDomain": "",
+          "directConnectivity": "yes",
+          "id": 1,
+          "company": 1,
+          "callAcl": null,
+          "outgoingDdi": null,
+          "language": null
+      }
+    """
+    Then the response status code should be 200
+     And the response should be in JSON
+     And the header "Content-Type" should be equal to "application/json; charset=utf-8"
+     And the JSON should be like:
+    """
+      {
+          "name": "updatedTestFriend",
+          "description": "",
+          "transport": "udp",
+          "ip": "1.2.3.4",
+          "port": 5061,
+          "password": "ZEF7t5n+b4",
+          "priority": 1,
+          "allow": "alaw",
+          "fromUser": null,
+          "fromDomain": "",
+          "directConnectivity": "yes",
+          "ddiIn": "yes",
+          "t38Passthrough": "no",
+          "id": 1,
+          "company": 1,
+          "transformationRuleSet": null,
+          "outgoingDdi": null,
+          "language": null,
+          "interCompany": null
+      }
+    """

--- a/web/rest/brand/features/provider/friend/removeFriend.feature
+++ b/web/rest/brand/features/provider/friend/removeFriend.feature
@@ -1,0 +1,12 @@
+Feature: Manage friends
+  In order to manage friends
+  As a brand admin
+  I need to be able to delete them through the API.
+
+  @createSchema
+  Scenario: Remove a friends
+    Given I add Brand Authorization header
+     When I add "Content-Type" header equal to "application/json"
+      And I add "Accept" header equal to "application/json"
+      And I send a "DELETE" request to "/friends/1"
+     Then the response status code should be 204

--- a/web/rest/brand/tests/DataAccessControl/Provider/FriendTest.php
+++ b/web/rest/brand/tests/DataAccessControl/Provider/FriendTest.php
@@ -57,7 +57,11 @@ class FriendTest extends KernelTestCase
         $this->assertEquals(
             $accessControl,
             [
-                'FALSE',
+                [
+                    'company',
+                    'in',
+                    'companyRepository.getSupervisedCompanyIdsByAdmin(user)',
+                ]
             ]
         );
     }


### PR DESCRIPTION
Allow brand admins to managed friends from API
Remove inter company field from clients admin page (read only field until now)

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
