### PR TITLE
Dto default empty strings

### DIFF
--- a/library/Ivoz/Ast/Domain/Model/PsEndpoint/PsEndpointDtoAbstract.php
+++ b/library/Ivoz/Ast/Domain/Model/PsEndpoint/PsEndpointDtoAbstract.php
@@ -20,7 +20,7 @@ abstract class PsEndpointDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $sorceryId = '';
+    private $sorceryId;
 
     /**
      * @var string|null

--- a/library/Ivoz/Ast/Domain/Model/PsIdentify/PsIdentifyDtoAbstract.php
+++ b/library/Ivoz/Ast/Domain/Model/PsIdentify/PsIdentifyDtoAbstract.php
@@ -20,7 +20,7 @@ abstract class PsIdentifyDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $sorceryId = '';
+    private $sorceryId;
 
     /**
      * @var string|null

--- a/library/Ivoz/Ast/Domain/Model/Queue/QueueDtoAbstract.php
+++ b/library/Ivoz/Ast/Domain/Model/Queue/QueueDtoAbstract.php
@@ -17,7 +17,7 @@ abstract class QueueDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $name = '';
+    private $name;
 
     /**
      * @var string|null

--- a/library/Ivoz/Ast/Domain/Model/Voicemail/VoicemailDtoAbstract.php
+++ b/library/Ivoz/Ast/Domain/Model/Voicemail/VoicemailDtoAbstract.php
@@ -18,12 +18,12 @@ abstract class VoicemailDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $context = '';
+    private $context;
 
     /**
      * @var string
      */
-    private $mailbox = '';
+    private $mailbox;
 
     /**
      * @var string|null

--- a/library/Ivoz/Cgr/Domain/Model/TpAccountAction/TpAccountActionDtoAbstract.php
+++ b/library/Ivoz/Cgr/Domain/Model/TpAccountAction/TpAccountActionDtoAbstract.php
@@ -28,12 +28,12 @@ abstract class TpAccountActionDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $tenant = '';
+    private $tenant;
 
     /**
      * @var string
      */
-    private $account = '';
+    private $account;
 
     /**
      * @var string|null

--- a/library/Ivoz/Cgr/Domain/Model/TpCdr/TpCdrDtoAbstract.php
+++ b/library/Ivoz/Cgr/Domain/Model/TpCdr/TpCdrDtoAbstract.php
@@ -16,62 +16,62 @@ abstract class TpCdrDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $cgrid = '';
+    private $cgrid;
 
     /**
      * @var string
      */
-    private $runId = '';
+    private $runId;
 
     /**
      * @var string
      */
-    private $originHost = '';
+    private $originHost;
 
     /**
      * @var string
      */
-    private $source = '';
+    private $source;
 
     /**
      * @var string
      */
-    private $originId = '';
+    private $originId;
 
     /**
      * @var string
      */
-    private $tor = '';
+    private $tor;
 
     /**
      * @var string
      */
-    private $requestType = '';
+    private $requestType;
 
     /**
      * @var string
      */
-    private $tenant = '';
+    private $tenant;
 
     /**
      * @var string
      */
-    private $category = '';
+    private $category;
 
     /**
      * @var string
      */
-    private $account = '';
+    private $account;
 
     /**
      * @var string
      */
-    private $subject = '';
+    private $subject;
 
     /**
      * @var string
      */
-    private $destination = '';
+    private $destination;
 
     /**
      * @var \DateTime|string
@@ -91,12 +91,12 @@ abstract class TpCdrDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $extraFields = '';
+    private $extraFields;
 
     /**
      * @var string
      */
-    private $costSource = '';
+    private $costSource;
 
     /**
      * @var float
@@ -111,7 +111,7 @@ abstract class TpCdrDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $extraInfo = '';
+    private $extraInfo;
 
     /**
      * @var \DateTime|string|null

--- a/library/Ivoz/Cgr/Domain/Model/TpCdrStat/TpCdrStatDtoAbstract.php
+++ b/library/Ivoz/Cgr/Domain/Model/TpCdrStat/TpCdrStatDtoAbstract.php
@@ -22,7 +22,7 @@ abstract class TpCdrStatDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $tag = '';
+    private $tag;
 
     /**
      * @var int
@@ -42,7 +42,7 @@ abstract class TpCdrStatDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $metrics = '';
+    private $metrics;
 
     /**
      * @var string

--- a/library/Ivoz/Cgr/Domain/Model/TpDerivedCharger/TpDerivedChargerDtoAbstract.php
+++ b/library/Ivoz/Cgr/Domain/Model/TpDerivedCharger/TpDerivedChargerDtoAbstract.php
@@ -32,7 +32,7 @@ abstract class TpDerivedChargerDtoAbstract implements DataTransferObjectInterfac
     /**
      * @var string
      */
-    private $tenant = '';
+    private $tenant;
 
     /**
      * @var string

--- a/library/Ivoz/Cgr/Domain/Model/TpDestination/TpDestinationDtoAbstract.php
+++ b/library/Ivoz/Cgr/Domain/Model/TpDestination/TpDestinationDtoAbstract.php
@@ -27,7 +27,7 @@ abstract class TpDestinationDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $prefix = '';
+    private $prefix;
 
     /**
      * @var \DateTime|string

--- a/library/Ivoz/Cgr/Domain/Model/TpLcrRule/TpLcrRuleDtoAbstract.php
+++ b/library/Ivoz/Cgr/Domain/Model/TpLcrRule/TpLcrRuleDtoAbstract.php
@@ -27,12 +27,12 @@ abstract class TpLcrRuleDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $tenant = '';
+    private $tenant;
 
     /**
      * @var string
      */
-    private $category = '';
+    private $category;
 
     /**
      * @var string
@@ -52,7 +52,7 @@ abstract class TpLcrRuleDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $rpCategory = '';
+    private $rpCategory;
 
     /**
      * @var string

--- a/library/Ivoz/Cgr/Domain/Model/TpRate/TpRateDtoAbstract.php
+++ b/library/Ivoz/Cgr/Domain/Model/TpRate/TpRateDtoAbstract.php
@@ -42,7 +42,7 @@ abstract class TpRateDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $rateIncrement = '';
+    private $rateIncrement;
 
     /**
      * @var string

--- a/library/Ivoz/Cgr/Domain/Model/TpTiming/TpTimingDtoAbstract.php
+++ b/library/Ivoz/Cgr/Domain/Model/TpTiming/TpTimingDtoAbstract.php
@@ -27,22 +27,22 @@ abstract class TpTimingDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $years = '';
+    private $years;
 
     /**
      * @var string
      */
-    private $months = '';
+    private $months;
 
     /**
      * @var string
      */
-    private $monthDays = '';
+    private $monthDays;
 
     /**
      * @var string
      */
-    private $weekDays = '';
+    private $weekDays;
 
     /**
      * @var string

--- a/library/Ivoz/Kam/Domain/Model/Rtpengine/RtpengineDtoAbstract.php
+++ b/library/Ivoz/Kam/Domain/Model/Rtpengine/RtpengineDtoAbstract.php
@@ -22,7 +22,7 @@ abstract class RtpengineDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $url = '';
+    private $url;
 
     /**
      * @var int

--- a/library/Ivoz/Kam/Domain/Model/TrunksDomainAttr/TrunksDomainAttrDtoAbstract.php
+++ b/library/Ivoz/Kam/Domain/Model/TrunksDomainAttr/TrunksDomainAttrDtoAbstract.php
@@ -16,12 +16,12 @@ abstract class TrunksDomainAttrDtoAbstract implements DataTransferObjectInterfac
     /**
      * @var string
      */
-    private $did = '';
+    private $did;
 
     /**
      * @var string
      */
-    private $name = '';
+    private $name;
 
     /**
      * @var int
@@ -31,7 +31,7 @@ abstract class TrunksDomainAttrDtoAbstract implements DataTransferObjectInterfac
     /**
      * @var string
      */
-    private $value = '';
+    private $value;
 
     /**
      * @var \DateTime|string

--- a/library/Ivoz/Kam/Domain/Model/TrunksLcrGateway/TrunksLcrGatewayDtoAbstract.php
+++ b/library/Ivoz/Kam/Domain/Model/TrunksLcrGateway/TrunksLcrGatewayDtoAbstract.php
@@ -22,7 +22,7 @@ abstract class TrunksLcrGatewayDtoAbstract implements DataTransferObjectInterfac
     /**
      * @var string
      */
-    private $gwName = '';
+    private $gwName;
 
     /**
      * @var string|null

--- a/library/Ivoz/Kam/Domain/Model/UsersActiveWatcher/UsersActiveWatcherDtoAbstract.php
+++ b/library/Ivoz/Kam/Domain/Model/UsersActiveWatcher/UsersActiveWatcherDtoAbstract.php
@@ -16,27 +16,27 @@ abstract class UsersActiveWatcherDtoAbstract implements DataTransferObjectInterf
     /**
      * @var string
      */
-    private $presentityUri = '';
+    private $presentityUri;
 
     /**
      * @var string
      */
-    private $watcherUsername = '';
+    private $watcherUsername;
 
     /**
      * @var string
      */
-    private $watcherDomain = '';
+    private $watcherDomain;
 
     /**
      * @var string
      */
-    private $toUser = '';
+    private $toUser;
 
     /**
      * @var string
      */
-    private $toDomain = '';
+    private $toDomain;
 
     /**
      * @var string
@@ -51,17 +51,17 @@ abstract class UsersActiveWatcherDtoAbstract implements DataTransferObjectInterf
     /**
      * @var string
      */
-    private $toTag = '';
+    private $toTag;
 
     /**
      * @var string
      */
-    private $fromTag = '';
+    private $fromTag;
 
     /**
      * @var string
      */
-    private $callid = '';
+    private $callid;
 
     /**
      * @var int
@@ -76,7 +76,7 @@ abstract class UsersActiveWatcherDtoAbstract implements DataTransferObjectInterf
     /**
      * @var string
      */
-    private $contact = '';
+    private $contact;
 
     /**
      * @var string|null
@@ -106,22 +106,22 @@ abstract class UsersActiveWatcherDtoAbstract implements DataTransferObjectInterf
     /**
      * @var string
      */
-    private $socketInfo = '';
+    private $socketInfo;
 
     /**
      * @var string
      */
-    private $localContact = '';
+    private $localContact;
 
     /**
      * @var string
      */
-    private $fromUser = '';
+    private $fromUser;
 
     /**
      * @var string
      */
-    private $fromDomain = '';
+    private $fromDomain;
 
     /**
      * @var int

--- a/library/Ivoz/Kam/Domain/Model/UsersAddress/UsersAddressDtoAbstract.php
+++ b/library/Ivoz/Kam/Domain/Model/UsersAddress/UsersAddressDtoAbstract.php
@@ -17,7 +17,7 @@ abstract class UsersAddressDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $sourceAddress = '';
+    private $sourceAddress;
 
     /**
      * @var string|null

--- a/library/Ivoz/Kam/Domain/Model/UsersPresentity/UsersPresentityDtoAbstract.php
+++ b/library/Ivoz/Kam/Domain/Model/UsersPresentity/UsersPresentityDtoAbstract.php
@@ -16,22 +16,22 @@ abstract class UsersPresentityDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $username = '';
+    private $username;
 
     /**
      * @var string
      */
-    private $domain = '';
+    private $domain;
 
     /**
      * @var string
      */
-    private $event = '';
+    private $event;
 
     /**
      * @var string
      */
-    private $etag = '';
+    private $etag;
 
     /**
      * @var int
@@ -46,12 +46,12 @@ abstract class UsersPresentityDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $body = '';
+    private $body;
 
     /**
      * @var string
      */
-    private $sender = '';
+    private $sender;
 
     /**
      * @var int

--- a/library/Ivoz/Kam/Domain/Model/UsersPua/UsersPuaDtoAbstract.php
+++ b/library/Ivoz/Kam/Domain/Model/UsersPua/UsersPuaDtoAbstract.php
@@ -16,12 +16,12 @@ abstract class UsersPuaDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $presUri = '';
+    private $presUri;
 
     /**
      * @var string
      */
-    private $presId = '';
+    private $presId;
 
     /**
      * @var int
@@ -46,7 +46,7 @@ abstract class UsersPuaDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $etag = '';
+    private $etag;
 
     /**
      * @var string|null
@@ -56,22 +56,22 @@ abstract class UsersPuaDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $watcherUri = '';
+    private $watcherUri;
 
     /**
      * @var string
      */
-    private $callId = '';
+    private $callId;
 
     /**
      * @var string
      */
-    private $toTag = '';
+    private $toTag;
 
     /**
      * @var string
      */
-    private $fromTag = '';
+    private $fromTag;
 
     /**
      * @var int
@@ -86,12 +86,12 @@ abstract class UsersPuaDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $contact = '';
+    private $contact;
 
     /**
      * @var string
      */
-    private $remoteContact = '';
+    private $remoteContact;
 
     /**
      * @var int
@@ -101,7 +101,7 @@ abstract class UsersPuaDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $extraHeaders = '';
+    private $extraHeaders;
 
     /**
      * @var int

--- a/library/Ivoz/Kam/Domain/Model/UsersWatcher/UsersWatcherDtoAbstract.php
+++ b/library/Ivoz/Kam/Domain/Model/UsersWatcher/UsersWatcherDtoAbstract.php
@@ -16,17 +16,17 @@ abstract class UsersWatcherDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $presentityUri = '';
+    private $presentityUri;
 
     /**
      * @var string
      */
-    private $watcherUsername = '';
+    private $watcherUsername;
 
     /**
      * @var string
      */
-    private $watcherDomain = '';
+    private $watcherDomain;
 
     /**
      * @var string

--- a/library/Ivoz/Kam/Domain/Model/UsersXcap/UsersXcapDtoAbstract.php
+++ b/library/Ivoz/Kam/Domain/Model/UsersXcap/UsersXcapDtoAbstract.php
@@ -16,17 +16,17 @@ abstract class UsersXcapDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $username = '';
+    private $username;
 
     /**
      * @var string
      */
-    private $domain = '';
+    private $domain;
 
     /**
      * @var string
      */
-    private $doc = '';
+    private $doc;
 
     /**
      * @var int
@@ -36,7 +36,7 @@ abstract class UsersXcapDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $etag = '';
+    private $etag;
 
     /**
      * @var int
@@ -46,7 +46,7 @@ abstract class UsersXcapDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $docUri = '';
+    private $docUri;
 
     /**
      * @var int

--- a/library/Ivoz/Provider/Domain/Model/Administrator/AdministratorDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Administrator/AdministratorDtoAbstract.php
@@ -20,12 +20,12 @@ abstract class AdministratorDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $username = '';
+    private $username;
 
     /**
      * @var string
      */
-    private $pass = '';
+    private $pass;
 
     /**
      * @var string

--- a/library/Ivoz/Provider/Domain/Model/ApplicationServer/ApplicationServerDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/ApplicationServer/ApplicationServerDtoAbstract.php
@@ -16,7 +16,7 @@ abstract class ApplicationServerDtoAbstract implements DataTransferObjectInterfa
     /**
      * @var string
      */
-    private $ip = '';
+    private $ip;
 
     /**
      * @var string|null

--- a/library/Ivoz/Provider/Domain/Model/Brand/BrandDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Brand/BrandDtoAbstract.php
@@ -30,7 +30,7 @@ abstract class BrandDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $name = '';
+    private $name;
 
     /**
      * @var string|null
@@ -75,32 +75,32 @@ abstract class BrandDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $invoiceNif = '';
+    private $invoiceNif;
 
     /**
      * @var string
      */
-    private $invoicePostalAddress = '';
+    private $invoicePostalAddress;
 
     /**
      * @var string
      */
-    private $invoicePostalCode = '';
+    private $invoicePostalCode;
 
     /**
      * @var string
      */
-    private $invoiceTown = '';
+    private $invoiceTown;
 
     /**
      * @var string
      */
-    private $invoiceProvince = '';
+    private $invoiceProvince;
 
     /**
      * @var string
      */
-    private $invoiceCountry = '';
+    private $invoiceCountry;
 
     /**
      * @var string|null

--- a/library/Ivoz/Provider/Domain/Model/BrandService/BrandServiceDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/BrandService/BrandServiceDtoAbstract.php
@@ -18,7 +18,7 @@ abstract class BrandServiceDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $code = '';
+    private $code;
 
     /**
      * @var int

--- a/library/Ivoz/Provider/Domain/Model/Calendar/CalendarDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Calendar/CalendarDtoAbstract.php
@@ -19,7 +19,7 @@ abstract class CalendarDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $name = '';
+    private $name;
 
     /**
      * @var int

--- a/library/Ivoz/Provider/Domain/Model/CallAcl/CallAclDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/CallAcl/CallAclDtoAbstract.php
@@ -18,12 +18,12 @@ abstract class CallAclDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $name = '';
+    private $name;
 
     /**
      * @var string
      */
-    private $defaultPolicy = '';
+    private $defaultPolicy;
 
     /**
      * @var int

--- a/library/Ivoz/Provider/Domain/Model/CallAclRelMatchList/CallAclRelMatchListDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/CallAclRelMatchList/CallAclRelMatchListDtoAbstract.php
@@ -23,7 +23,7 @@ abstract class CallAclRelMatchListDtoAbstract implements DataTransferObjectInter
     /**
      * @var string
      */
-    private $policy = '';
+    private $policy;
 
     /**
      * @var int

--- a/library/Ivoz/Provider/Domain/Model/CallCsvScheduler/CallCsvSchedulerDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/CallCsvScheduler/CallCsvSchedulerDtoAbstract.php
@@ -27,7 +27,7 @@ abstract class CallCsvSchedulerDtoAbstract implements DataTransferObjectInterfac
     /**
      * @var string
      */
-    private $name = '';
+    private $name;
 
     /**
      * @var string
@@ -47,7 +47,7 @@ abstract class CallCsvSchedulerDtoAbstract implements DataTransferObjectInterfac
     /**
      * @var string
      */
-    private $email = '';
+    private $email;
 
     /**
      * @var \DateTime|string|null

--- a/library/Ivoz/Provider/Domain/Model/CallForwardSetting/CallForwardSettingDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/CallForwardSetting/CallForwardSettingDtoAbstract.php
@@ -21,12 +21,12 @@ abstract class CallForwardSettingDtoAbstract implements DataTransferObjectInterf
     /**
      * @var string
      */
-    private $callTypeFilter = '';
+    private $callTypeFilter;
 
     /**
      * @var string
      */
-    private $callForwardType = '';
+    private $callForwardType;
 
     /**
      * @var string|null

--- a/library/Ivoz/Provider/Domain/Model/Carrier/CarrierDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Carrier/CarrierDtoAbstract.php
@@ -31,7 +31,7 @@ abstract class CarrierDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $name = '';
+    private $name;
 
     /**
      * @var bool|null

--- a/library/Ivoz/Provider/Domain/Model/Changelog/ChangelogDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Changelog/ChangelogDtoAbstract.php
@@ -17,12 +17,12 @@ abstract class ChangelogDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $entity = '';
+    private $entity;
 
     /**
      * @var string
      */
-    private $entityId = '';
+    private $entityId;
 
     /**
      * @var array|null

--- a/library/Ivoz/Provider/Domain/Model/Codec/CodecDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Codec/CodecDtoAbstract.php
@@ -21,12 +21,12 @@ abstract class CodecDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $iden = '';
+    private $iden;
 
     /**
      * @var string
      */
-    private $name = '';
+    private $name;
 
     /**
      * @var int

--- a/library/Ivoz/Provider/Domain/Model/Commandlog/CommandlogDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Commandlog/CommandlogDtoAbstract.php
@@ -16,12 +16,12 @@ abstract class CommandlogDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $requestId = '';
+    private $requestId;
 
     /**
      * @var string
      */
-    private $class = '';
+    private $class;
 
     /**
      * @var string|null

--- a/library/Ivoz/Provider/Domain/Model/Company/CompanyDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Company/CompanyDtoAbstract.php
@@ -44,7 +44,7 @@ abstract class CompanyDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $name = '';
+    private $name;
 
     /**
      * @var string|null
@@ -54,7 +54,7 @@ abstract class CompanyDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $nif = '';
+    private $nif;
 
     /**
      * @var string
@@ -84,27 +84,27 @@ abstract class CompanyDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $postalAddress = '';
+    private $postalAddress;
 
     /**
      * @var string
      */
-    private $postalCode = '';
+    private $postalCode;
 
     /**
      * @var string
      */
-    private $town = '';
+    private $town;
 
     /**
      * @var string
      */
-    private $province = '';
+    private $province;
 
     /**
      * @var string
      */
-    private $countryName = '';
+    private $countryName;
 
     /**
      * @var bool|null

--- a/library/Ivoz/Provider/Domain/Model/CompanyService/CompanyServiceDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/CompanyService/CompanyServiceDtoAbstract.php
@@ -18,7 +18,7 @@ abstract class CompanyServiceDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $code = '';
+    private $code;
 
     /**
      * @var int

--- a/library/Ivoz/Provider/Domain/Model/ConditionalRoute/ConditionalRouteDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/ConditionalRoute/ConditionalRouteDtoAbstract.php
@@ -26,7 +26,7 @@ abstract class ConditionalRouteDtoAbstract implements DataTransferObjectInterfac
     /**
      * @var string
      */
-    private $name = '';
+    private $name;
 
     /**
      * @var string|null

--- a/library/Ivoz/Provider/Domain/Model/ConferenceRoom/ConferenceRoomDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/ConferenceRoom/ConferenceRoomDtoAbstract.php
@@ -17,7 +17,7 @@ abstract class ConferenceRoomDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $name = '';
+    private $name;
 
     /**
      * @var bool

--- a/library/Ivoz/Provider/Domain/Model/Currency/CurrencyDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Currency/CurrencyDtoAbstract.php
@@ -16,12 +16,12 @@ abstract class CurrencyDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $iden = '';
+    private $iden;
 
     /**
      * @var string
      */
-    private $symbol = '';
+    private $symbol;
 
     /**
      * @var int

--- a/library/Ivoz/Provider/Domain/Model/Ddi/DdiDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Ddi/DdiDtoAbstract.php
@@ -31,7 +31,7 @@ abstract class DdiDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $ddi = '';
+    private $ddi;
 
     /**
      * @var string|null

--- a/library/Ivoz/Provider/Domain/Model/DdiProvider/DdiProviderDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/DdiProvider/DdiProviderDtoAbstract.php
@@ -27,7 +27,7 @@ abstract class DdiProviderDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $name = '';
+    private $name;
 
     /**
      * @var bool|null

--- a/library/Ivoz/Provider/Domain/Model/Destination/DestinationDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Destination/DestinationDtoAbstract.php
@@ -19,7 +19,7 @@ abstract class DestinationDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $prefix = '';
+    private $prefix;
 
     /**
      * @var int

--- a/library/Ivoz/Provider/Domain/Model/DestinationRate/DestinationRateDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/DestinationRate/DestinationRateDtoAbstract.php
@@ -30,7 +30,7 @@ abstract class DestinationRateDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $rateIncrement = '';
+    private $rateIncrement;
 
     /**
      * @var string

--- a/library/Ivoz/Provider/Domain/Model/DestinationRateGroup/DestinationRateGroupDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/DestinationRateGroup/DestinationRateGroupDtoAbstract.php
@@ -39,42 +39,42 @@ abstract class DestinationRateGroupDtoAbstract implements DataTransferObjectInte
     /**
      * @var string
      */
-    private $nameEn = '';
+    private $nameEn;
 
     /**
      * @var string
      */
-    private $nameEs = '';
+    private $nameEs;
 
     /**
      * @var string
      */
-    private $nameCa = '';
+    private $nameCa;
 
     /**
      * @var string
      */
-    private $nameIt = '';
+    private $nameIt;
 
     /**
      * @var string
      */
-    private $descriptionEn = '';
+    private $descriptionEn;
 
     /**
      * @var string
      */
-    private $descriptionEs = '';
+    private $descriptionEs;
 
     /**
      * @var string
      */
-    private $descriptionCa = '';
+    private $descriptionCa;
 
     /**
      * @var string
      */
-    private $descriptionIt = '';
+    private $descriptionIt;
 
     /**
      * @var int|null

--- a/library/Ivoz/Provider/Domain/Model/Domain/DomainDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Domain/DomainDtoAbstract.php
@@ -19,7 +19,7 @@ abstract class DomainDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $domain = '';
+    private $domain;
 
     /**
      * @var string

--- a/library/Ivoz/Provider/Domain/Model/Extension/ExtensionDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Extension/ExtensionDtoAbstract.php
@@ -24,7 +24,7 @@ abstract class ExtensionDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $number = '';
+    private $number;
 
     /**
      * @var string|null

--- a/library/Ivoz/Provider/Domain/Model/ExternalCallFilter/ExternalCallFilterDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/ExternalCallFilter/ExternalCallFilterDtoAbstract.php
@@ -25,7 +25,7 @@ abstract class ExternalCallFilterDtoAbstract implements DataTransferObjectInterf
     /**
      * @var string
      */
-    private $name = '';
+    private $name;
 
     /**
      * @var string|null

--- a/library/Ivoz/Provider/Domain/Model/Fax/FaxDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Fax/FaxDtoAbstract.php
@@ -18,7 +18,7 @@ abstract class FaxDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $name = '';
+    private $name;
 
     /**
      * @var string|null

--- a/library/Ivoz/Provider/Domain/Model/Feature/FeatureDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Feature/FeatureDtoAbstract.php
@@ -16,7 +16,7 @@ abstract class FeatureDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $iden = '';
+    private $iden;
 
     /**
      * @var int

--- a/library/Ivoz/Provider/Domain/Model/FixedCost/FixedCostDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/FixedCost/FixedCostDtoAbstract.php
@@ -17,7 +17,7 @@ abstract class FixedCostDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $name = '';
+    private $name;
 
     /**
      * @var string|null

--- a/library/Ivoz/Provider/Domain/Model/Friend/FriendDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Friend/FriendDtoAbstract.php
@@ -25,7 +25,7 @@ abstract class FriendDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $name = '';
+    private $name;
 
     /**
      * @var string

--- a/library/Ivoz/Provider/Domain/Model/FriendsPattern/FriendsPatternDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/FriendsPattern/FriendsPatternDtoAbstract.php
@@ -17,12 +17,12 @@ abstract class FriendsPatternDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $name = '';
+    private $name;
 
     /**
      * @var string
      */
-    private $regExp = '';
+    private $regExp;
 
     /**
      * @var int

--- a/library/Ivoz/Provider/Domain/Model/HolidayDate/HolidayDateDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/HolidayDate/HolidayDateDtoAbstract.php
@@ -21,7 +21,7 @@ abstract class HolidayDateDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $name = '';
+    private $name;
 
     /**
      * @var \DateTime|string

--- a/library/Ivoz/Provider/Domain/Model/HuntGroup/HuntGroupDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/HuntGroup/HuntGroupDtoAbstract.php
@@ -32,7 +32,7 @@ abstract class HuntGroupDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $strategy = '';
+    private $strategy;
 
     /**
      * @var int|null

--- a/library/Ivoz/Provider/Domain/Model/HuntGroupsRelUser/HuntGroupsRelUserDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/HuntGroupsRelUser/HuntGroupsRelUserDtoAbstract.php
@@ -29,7 +29,7 @@ abstract class HuntGroupsRelUserDtoAbstract implements DataTransferObjectInterfa
     /**
      * @var string
      */
-    private $routeType = '';
+    private $routeType;
 
     /**
      * @var string|null

--- a/library/Ivoz/Provider/Domain/Model/InvoiceNumberSequence/InvoiceNumberSequenceDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/InvoiceNumberSequence/InvoiceNumberSequenceDtoAbstract.php
@@ -17,7 +17,7 @@ abstract class InvoiceNumberSequenceDtoAbstract implements DataTransferObjectInt
     /**
      * @var string
      */
-    private $name = '';
+    private $name;
 
     /**
      * @var string

--- a/library/Ivoz/Provider/Domain/Model/InvoiceScheduler/InvoiceSchedulerDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/InvoiceScheduler/InvoiceSchedulerDtoAbstract.php
@@ -21,7 +21,7 @@ abstract class InvoiceSchedulerDtoAbstract implements DataTransferObjectInterfac
     /**
      * @var string
      */
-    private $name = '';
+    private $name;
 
     /**
      * @var string
@@ -36,7 +36,7 @@ abstract class InvoiceSchedulerDtoAbstract implements DataTransferObjectInterfac
     /**
      * @var string
      */
-    private $email = '';
+    private $email;
 
     /**
      * @var \DateTime|string|null

--- a/library/Ivoz/Provider/Domain/Model/InvoiceTemplate/InvoiceTemplateDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/InvoiceTemplate/InvoiceTemplateDtoAbstract.php
@@ -17,7 +17,7 @@ abstract class InvoiceTemplateDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $name = '';
+    private $name;
 
     /**
      * @var string|null
@@ -27,7 +27,7 @@ abstract class InvoiceTemplateDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $template = '';
+    private $template;
 
     /**
      * @var string|null

--- a/library/Ivoz/Provider/Domain/Model/Ivr/IvrDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Ivr/IvrDtoAbstract.php
@@ -23,7 +23,7 @@ abstract class IvrDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $name = '';
+    private $name;
 
     /**
      * @var int

--- a/library/Ivoz/Provider/Domain/Model/IvrEntry/IvrEntryDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/IvrEntry/IvrEntryDtoAbstract.php
@@ -22,12 +22,12 @@ abstract class IvrEntryDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $entry = '';
+    private $entry;
 
     /**
      * @var string
      */
-    private $routeType = '';
+    private $routeType;
 
     /**
      * @var string|null

--- a/library/Ivoz/Provider/Domain/Model/Language/LanguageDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Language/LanguageDtoAbstract.php
@@ -16,7 +16,7 @@ abstract class LanguageDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $iden = '';
+    private $iden;
 
     /**
      * @var int

--- a/library/Ivoz/Provider/Domain/Model/Locution/LocutionDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Locution/LocutionDtoAbstract.php
@@ -17,7 +17,7 @@ abstract class LocutionDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $name = '';
+    private $name;
 
     /**
      * @var string|null

--- a/library/Ivoz/Provider/Domain/Model/MatchList/MatchListDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/MatchList/MatchListDtoAbstract.php
@@ -19,7 +19,7 @@ abstract class MatchListDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $name = '';
+    private $name;
 
     /**
      * @var int

--- a/library/Ivoz/Provider/Domain/Model/MatchListPattern/MatchListPatternDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/MatchListPattern/MatchListPatternDtoAbstract.php
@@ -23,7 +23,7 @@ abstract class MatchListPatternDtoAbstract implements DataTransferObjectInterfac
     /**
      * @var string
      */
-    private $type = '';
+    private $type;
 
     /**
      * @var string|null

--- a/library/Ivoz/Provider/Domain/Model/MusicOnHold/MusicOnHoldDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/MusicOnHold/MusicOnHoldDtoAbstract.php
@@ -18,7 +18,7 @@ abstract class MusicOnHoldDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $name = '';
+    private $name;
 
     /**
      * @var string|null

--- a/library/Ivoz/Provider/Domain/Model/NotificationTemplate/NotificationTemplateDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/NotificationTemplate/NotificationTemplateDtoAbstract.php
@@ -18,12 +18,12 @@ abstract class NotificationTemplateDtoAbstract implements DataTransferObjectInte
     /**
      * @var string
      */
-    private $name = '';
+    private $name;
 
     /**
      * @var string
      */
-    private $type = '';
+    private $type;
 
     /**
      * @var int

--- a/library/Ivoz/Provider/Domain/Model/NotificationTemplateContent/NotificationTemplateContentDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/NotificationTemplateContent/NotificationTemplateContentDtoAbstract.php
@@ -28,12 +28,12 @@ abstract class NotificationTemplateContentDtoAbstract implements DataTransferObj
     /**
      * @var string
      */
-    private $subject = '';
+    private $subject;
 
     /**
      * @var string
      */
-    private $body = '';
+    private $body;
 
     /**
      * @var string

--- a/library/Ivoz/Provider/Domain/Model/OutgoingDdiRule/OutgoingDdiRuleDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/OutgoingDdiRule/OutgoingDdiRuleDtoAbstract.php
@@ -19,12 +19,12 @@ abstract class OutgoingDdiRuleDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $name = '';
+    private $name;
 
     /**
      * @var string
      */
-    private $defaultAction = '';
+    private $defaultAction;
 
     /**
      * @var int

--- a/library/Ivoz/Provider/Domain/Model/OutgoingDdiRulesPattern/OutgoingDdiRulesPatternDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/OutgoingDdiRulesPattern/OutgoingDdiRulesPatternDtoAbstract.php
@@ -19,7 +19,7 @@ abstract class OutgoingDdiRulesPatternDtoAbstract implements DataTransferObjectI
     /**
      * @var string
      */
-    private $type = '';
+    private $type;
 
     /**
      * @var string|null
@@ -29,7 +29,7 @@ abstract class OutgoingDdiRulesPatternDtoAbstract implements DataTransferObjectI
     /**
      * @var string
      */
-    private $action = '';
+    private $action;
 
     /**
      * @var int

--- a/library/Ivoz/Provider/Domain/Model/PickUpGroup/PickUpGroupDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/PickUpGroup/PickUpGroupDtoAbstract.php
@@ -18,7 +18,7 @@ abstract class PickUpGroupDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $name = '';
+    private $name;
 
     /**
      * @var int

--- a/library/Ivoz/Provider/Domain/Model/ProxyTrunk/ProxyTrunkDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/ProxyTrunk/ProxyTrunkDtoAbstract.php
@@ -21,7 +21,7 @@ abstract class ProxyTrunkDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $ip = '';
+    private $ip;
 
     /**
      * @var int

--- a/library/Ivoz/Provider/Domain/Model/PublicEntity/PublicEntityDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/PublicEntity/PublicEntityDtoAbstract.php
@@ -16,7 +16,7 @@ abstract class PublicEntityDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $iden = '';
+    private $iden;
 
     /**
      * @var string|null

--- a/library/Ivoz/Provider/Domain/Model/RatingPlanGroup/RatingPlanGroupDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/RatingPlanGroup/RatingPlanGroupDtoAbstract.php
@@ -24,42 +24,42 @@ abstract class RatingPlanGroupDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $nameEn = '';
+    private $nameEn;
 
     /**
      * @var string
      */
-    private $nameEs = '';
+    private $nameEs;
 
     /**
      * @var string
      */
-    private $nameCa = '';
+    private $nameCa;
 
     /**
      * @var string
      */
-    private $nameIt = '';
+    private $nameIt;
 
     /**
      * @var string
      */
-    private $descriptionEn = '';
+    private $descriptionEn;
 
     /**
      * @var string
      */
-    private $descriptionEs = '';
+    private $descriptionEs;
 
     /**
      * @var string
      */
-    private $descriptionCa = '';
+    private $descriptionCa;
 
     /**
      * @var string
      */
-    private $descriptionIt = '';
+    private $descriptionIt;
 
     /**
      * @var BrandDto | null

--- a/library/Ivoz/Provider/Domain/Model/ResidentialDevice/ResidentialDeviceDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/ResidentialDevice/ResidentialDeviceDtoAbstract.php
@@ -25,7 +25,7 @@ abstract class ResidentialDeviceDtoAbstract implements DataTransferObjectInterfa
     /**
      * @var string
      */
-    private $name = '';
+    private $name;
 
     /**
      * @var string

--- a/library/Ivoz/Provider/Domain/Model/RetailAccount/RetailAccountDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/RetailAccount/RetailAccountDtoAbstract.php
@@ -24,7 +24,7 @@ abstract class RetailAccountDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $name = '';
+    private $name;
 
     /**
      * @var string

--- a/library/Ivoz/Provider/Domain/Model/RouteLock/RouteLockDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/RouteLock/RouteLockDtoAbstract.php
@@ -17,7 +17,7 @@ abstract class RouteLockDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $name = '';
+    private $name;
 
     /**
      * @var string

--- a/library/Ivoz/Provider/Domain/Model/RoutingPattern/RoutingPatternDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/RoutingPattern/RoutingPatternDtoAbstract.php
@@ -20,7 +20,7 @@ abstract class RoutingPatternDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $prefix = '';
+    private $prefix;
 
     /**
      * @var int
@@ -30,22 +30,22 @@ abstract class RoutingPatternDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $nameEn = '';
+    private $nameEn;
 
     /**
      * @var string
      */
-    private $nameEs = '';
+    private $nameEs;
 
     /**
      * @var string
      */
-    private $nameCa = '';
+    private $nameCa;
 
     /**
      * @var string
      */
-    private $nameIt = '';
+    private $nameIt;
 
     /**
      * @var string|null

--- a/library/Ivoz/Provider/Domain/Model/RoutingPatternGroup/RoutingPatternGroupDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/RoutingPatternGroup/RoutingPatternGroupDtoAbstract.php
@@ -19,7 +19,7 @@ abstract class RoutingPatternGroupDtoAbstract implements DataTransferObjectInter
     /**
      * @var string
      */
-    private $name = '';
+    private $name;
 
     /**
      * @var string|null

--- a/library/Ivoz/Provider/Domain/Model/RoutingTag/RoutingTagDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/RoutingTag/RoutingTagDtoAbstract.php
@@ -19,12 +19,12 @@ abstract class RoutingTagDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $name = '';
+    private $name;
 
     /**
      * @var string
      */
-    private $tag = '';
+    private $tag;
 
     /**
      * @var int

--- a/library/Ivoz/Provider/Domain/Model/Schedule/ScheduleDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Schedule/ScheduleDtoAbstract.php
@@ -17,7 +17,7 @@ abstract class ScheduleDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $name = '';
+    private $name;
 
     /**
      * @var \DateTime|string

--- a/library/Ivoz/Provider/Domain/Model/Service/ServiceDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Service/ServiceDtoAbstract.php
@@ -21,7 +21,7 @@ abstract class ServiceDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $defaultCode = '';
+    private $defaultCode;
 
     /**
      * @var bool

--- a/library/Ivoz/Provider/Domain/Model/SpecialNumber/SpecialNumberDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/SpecialNumber/SpecialNumberDtoAbstract.php
@@ -18,7 +18,7 @@ abstract class SpecialNumberDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $number = '';
+    private $number;
 
     /**
      * @var string|null

--- a/library/Ivoz/Provider/Domain/Model/Terminal/TerminalDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Terminal/TerminalDtoAbstract.php
@@ -22,7 +22,7 @@ abstract class TerminalDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $name = '';
+    private $name;
 
     /**
      * @var string

--- a/library/Ivoz/Provider/Domain/Model/TerminalManufacturer/TerminalManufacturerDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/TerminalManufacturer/TerminalManufacturerDtoAbstract.php
@@ -16,7 +16,7 @@ abstract class TerminalManufacturerDtoAbstract implements DataTransferObjectInte
     /**
      * @var string
      */
-    private $iden = '';
+    private $iden;
 
     /**
      * @var string

--- a/library/Ivoz/Provider/Domain/Model/TerminalModel/TerminalModelDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/TerminalModel/TerminalModelDtoAbstract.php
@@ -17,7 +17,7 @@ abstract class TerminalModelDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $iden = '';
+    private $iden;
 
     /**
      * @var string

--- a/library/Ivoz/Provider/Domain/Model/Timezone/TimezoneDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Timezone/TimezoneDtoAbstract.php
@@ -17,7 +17,7 @@ abstract class TimezoneDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $tz = '';
+    private $tz;
 
     /**
      * @var string|null

--- a/library/Ivoz/Provider/Domain/Model/TransformationRule/TransformationRuleDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/TransformationRule/TransformationRuleDtoAbstract.php
@@ -17,7 +17,7 @@ abstract class TransformationRuleDtoAbstract implements DataTransferObjectInterf
     /**
      * @var string
      */
-    private $type = '';
+    private $type;
 
     /**
      * @var string

--- a/library/Ivoz/Provider/Domain/Model/TransformationRuleSet/TransformationRuleSetDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/TransformationRuleSet/TransformationRuleSetDtoAbstract.php
@@ -54,22 +54,22 @@ abstract class TransformationRuleSetDtoAbstract implements DataTransferObjectInt
     /**
      * @var string
      */
-    private $nameEn = '';
+    private $nameEn;
 
     /**
      * @var string
      */
-    private $nameEs = '';
+    private $nameEs;
 
     /**
      * @var string
      */
-    private $nameCa = '';
+    private $nameCa;
 
     /**
      * @var string
      */
-    private $nameIt = '';
+    private $nameIt;
 
     /**
      * @var BrandDto | null

--- a/library/Ivoz/Provider/Domain/Model/User/UserDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/User/UserDtoAbstract.php
@@ -30,12 +30,12 @@ abstract class UserDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $name = '';
+    private $name;
 
     /**
      * @var string
      */
-    private $lastname = '';
+    private $lastname;
 
     /**
      * @var string|null

--- a/library/Ivoz/Provider/Domain/Model/WebPortal/WebPortalDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/WebPortal/WebPortalDtoAbstract.php
@@ -17,7 +17,7 @@ abstract class WebPortalDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $url = '';
+    private $url;
 
     /**
      * @var string|null
@@ -27,7 +27,7 @@ abstract class WebPortalDtoAbstract implements DataTransferObjectInterface
     /**
      * @var string
      */
-    private $urlType = '';
+    private $urlType;
 
     /**
      * @var string|null

--- a/library/composer.lock
+++ b/library/composer.lock
@@ -2378,16 +2378,16 @@
         },
         {
             "name": "irontec/ivoz-dev-tools",
-            "version": "5.2.2",
+            "version": "5.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/irontec/ivoz-dev-tools.git",
-                "reference": "00be9ad336ccd5ad0586657e96cfcef5a131ad04"
+                "reference": "8b7d00333eb485632777a7e7e0fb23c795bb5902"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/irontec/ivoz-dev-tools/zipball/00be9ad336ccd5ad0586657e96cfcef5a131ad04",
-                "reference": "00be9ad336ccd5ad0586657e96cfcef5a131ad04",
+                "url": "https://api.github.com/repos/irontec/ivoz-dev-tools/zipball/8b7d00333eb485632777a7e7e0fb23c795bb5902",
+                "reference": "8b7d00333eb485632777a7e7e0fb23c795bb5902",
                 "shasum": ""
             },
             "require": {
@@ -2421,7 +2421,11 @@
                 }
             ],
             "description": "DevTools for ivozprovider",
-            "time": "2021-07-23T09:59:41+00:00"
+            "support": {
+                "issues": "https://github.com/irontec/ivoz-dev-tools/issues",
+                "source": "https://github.com/irontec/ivoz-dev-tools/tree/5.2.3"
+            },
+            "time": "2021-09-09T10:13:56+00:00"
         },
         {
             "name": "irontec/ivoz-provider-bundle",

--- a/schema/composer.lock
+++ b/schema/composer.lock
@@ -1858,11 +1858,11 @@
         },
         {
             "name": "irontec/ivoz-dev-tools",
-            "version": "5.2.2",
+            "version": "5.2.3",
             "dist": {
                 "type": "path",
                 "url": "../library/vendor/irontec/ivoz-dev-tools",
-                "reference": "00be9ad336ccd5ad0586657e96cfcef5a131ad04"
+                "reference": "8b7d00333eb485632777a7e7e0fb23c795bb5902"
             },
             "require": {
                 "doctrine/doctrine-bundle": "^2.0",

--- a/web/rest/client/features/provider/calendarPeriodsRelSchedule/postCalendarPeriodsRelSchedule.feature
+++ b/web/rest/client/features/provider/calendarPeriodsRelSchedule/postCalendarPeriodsRelSchedule.feature
@@ -35,7 +35,7 @@ Feature: Create calendar periods rel schedules
               "numberCountry": null
           },
           "schedule": {
-              "name": "",
+              "name": null,
               "timeIn": null,
               "timeout": null,
               "monday": false,


### PR DESCRIPTION
Not nullable string fields should not have a default empty string value

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
