### PR TITLE
Invoice decimal precision

### DIFF
--- a/library/Ivoz/Provider/Domain/Service/Invoice/Generator.php
+++ b/library/Ivoz/Provider/Domain/Service/Invoice/Generator.php
@@ -25,7 +25,6 @@ class Generator
     protected $fixedCostTotal = 0;
     protected $fixedCosts = array();
     protected $totals = array();
-    protected $pricingPlanCache = [];
 
     /**
      * @var InvoiceRepository
@@ -300,8 +299,8 @@ class Generator
         $total = $callSumaryTotals['totalPrice'] + $this->fixedCostTotal;
         $total = ceil($total*100) / 100;
 
-        $totalTaxex = ceil(($total*$invoice->getTaxRate()/100)*10000)/10000;
-        $totalWithTaxex = ceil(($totalTaxex + $total)*100)/100;
+        $totalTaxex = ceil(($total*$invoice->getTaxRate()/100)*100)/100;
+        $totalWithTaxex = $totalTaxex + $total;
 
         $this->totals = array(
             'totalPrice' => $total,

--- a/schema/DoctrineMigrations/Version20191226104551.php
+++ b/schema/DoctrineMigrations/Version20191226104551.php
@@ -325,10 +325,6 @@ class Version20191226104551 extends LoggableMigration
                     </div>
                 </div>
                 {{/if}}
-                <div class="tr bold center">
-                    <div class="th">Llamadas</div>
-                    <div class="td bold">{{callData.callSumaryTotals.totalPrice}} {{invoice.currency}}</div>
-                </div>
                 <div class="tr bold">
                     <div class="th">Total:</div>
                     <div class="td bold">{{totals.totalPrice}} {{invoice.currency}}</div>
@@ -621,10 +617,6 @@ class Version20191226104551 extends LoggableMigration
                     </div>
                 </div>
                 {{/if}}
-                <div class="tr bold center">
-                    <div class="th">Llamadas</div>
-                    <div class="td bold">{{callData.callSumaryTotals.totalPrice}} {{invoice.currency}}</div>
-                </div>
                 <div class="tr bold">
                     <div class="th">Total:</div>
                     <div class="td bold">{{totals.totalPrice}} {{invoice.currency}}</div>

--- a/web/admin/templates/basic.txt
+++ b/web/admin/templates/basic.txt
@@ -200,10 +200,6 @@
                     </div>
                 </div>
                 {{/if}}
-                <div class="tr bold center">
-                    <div class="th">Llamadas</div>
-                    <div class="td bold">{{callData.callSumaryTotals.totalPrice}} {{invoice.currency}}</div>
-                </div>
                 <div class="tr bold">
                     <div class="th">Total:</div>
                     <div class="td bold">{{totals.totalPrice}} {{invoice.currency}}</div>

--- a/web/admin/templates/detailed.txt
+++ b/web/admin/templates/detailed.txt
@@ -200,10 +200,6 @@
                     </div>
                 </div>
                 {{/if}}
-                <div class="tr bold center">
-                    <div class="th">Llamadas</div>
-                    <div class="td bold">{{callData.callSumaryTotals.totalPrice}} {{invoice.currency}}</div>
-                </div>
                 <div class="tr bold">
                     <div class="th">Total:</div>
                     <div class="td bold">{{totals.totalPrice}} {{invoice.currency}}</div>


### PR DESCRIPTION
Use two decimals instead of four in invoice tax amount and simplify default template resume table

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
