### PR TITLE
agi: add support to residential cfw to voicemail

### DIFF
--- a/asterisk/agi/src/Agi/Action/ServiceAction.php
+++ b/asterisk/agi/src/Agi/Action/ServiceAction.php
@@ -472,6 +472,11 @@ class ServiceAction
             return;
         }
 
+        // Determine forward type based on dialed number
+        $targetType = $destination == "*"
+            ? CallForwardSettingInterface::TARGETTYPE_VOICEMAIL
+            : CallForwardSettingInterface::TARGETTYPE_NUMBER;
+
         // Create a new callForwardSetting if none found
         /** @var CallForwardSettingDto $callForwardSettingDto */
         $callForwardSettingDto = $callForwardSetting
@@ -483,10 +488,14 @@ class ServiceAction
             ->setResidentialDeviceId($caller->getId())
             ->setCallTypeFilter(CallForwardSettingInterface::CALLTYPEFILTER_BOTH)
             ->setCallForwardType($callForwardType)
-            ->setTargetType(CallForwardSettingInterface::TARGETTYPE_NUMBER)
-            ->setNumberCountryId($companyCountry->getId())
-            ->setNumberValue($destination)
+            ->setTargetType($targetType)
             ->setNoAnswerTimeout(10);
+
+        if ($targetType == CallForwardSettingInterface::TARGETTYPE_NUMBER) {
+            $callForwardSettingDto
+                ->setNumberCountryId($companyCountry->getId())
+                ->setNumberValue($destination);
+        }
 
         try {
             $this->entityTools

--- a/doc/sphinx/administration_portal/brand/settings/generic_services.rst
+++ b/doc/sphinx/administration_portal/brand/settings/generic_services.rst
@@ -15,11 +15,11 @@ Call forward services
 =====================
 
 Call forward services (unconditional, no answer, busy and unreachable) are **only available for residential clients**
-and allow adding **call forward to national phone numbers**.
+and allow adding **call forward to national phone numbers and to voicemail**.
 
 All residential **clients within a brand use the same codes** to access to this feature, those defined in this section.
 
-.. note:: Call forward to voicemail or to numbers outside company's country is not supported using services codes.
+.. note:: Call forward to numbers outside company's country is not supported using services codes.
              Use web portal instead.
 
 .. rubric:: Enabling a call forward setting
@@ -27,6 +27,10 @@ All residential **clients within a brand use the same codes** to access to this 
 To enable a call forward of a given type to forward calls to a national number, residential device must call to defined
 service code followed by destination number. This will create and enable (or modify if already exists one) a call
 forward of given type to that national number.
+
+To enable a call forward of a given type to forward calls to voicemail, residential device must call to defined
+service code followed by '*'. This will create and enable (or modify if already exists one) a call
+forward of given type to voicemail.
 
 .. rubric:: Disabling a call forward setting
 


### PR DESCRIPTION
Residential devices can add and remove call forward settings
using services codes.

When adding a new call forward setting to destination '*'
the created cfw target will be voicemail instead of number.

<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
<!-- Describe your changes in detail -->

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
