### PR TITLE
kamusers: fix direction rtpengine param for multisocket + parallel-fo…

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -51,6 +51,9 @@
 # Marked for branches involving wss
 #!define FLB_WEBSOCKETS 8
 
+# Marked for branches calling to UAC using non-main address
+#!define FLB_EXTRASOCKET 9
+
 # - options
 #!define WITH_ANTIFLOOD
 #!define WITH_REALTIME
@@ -555,13 +558,6 @@ request_route {
         route(ADAPT_RURI_IN);
         route(ADAPT_DIVERSION);
         route(ADAPT_CALLER);
-        #!ifdef WITH_MULTISOCKET
-        if ($Ri != $sel(cfg_get.address.main)) {
-            # force_send_socket to main address (UAC talking to non-main address $dlg_var(extra_socket)
-            $fs = "udp:" + $sel(cfg_get.address.main) + ":5060";
-            $dlg_var(extra_socket) = $Ri;
-        }
-        #!endif
         if ($dlg_var(type) == 'wholesale' || $dlg_var(type) == 'retail') {
             route(DISPATCH_TO_TRUNKS);
         } else {
@@ -2074,6 +2070,12 @@ route[REGISTER] {
     # Store in kam_users_location_attrs used transport to retrieve it in lookup
     $xavp(ulattrs=>transport) = $proto;
 
+    #!ifdef WITH_MULTISOCKET
+    if ($Ri != $sel(cfg_get.address.main)) {
+        $xavp(ulattrs[0]=>extrasocket) = $Ri;
+    }
+    #!endif
+
     if (is_present_hf("Contact")) {
         $var(contact_uri) = @contact.uri;
     }
@@ -2578,13 +2580,6 @@ branch_route[MANAGE_BRANCH] {
         }
     }
 
-    #!ifdef WITH_MULTISOCKET
-    if ($fs != $null && $fs != "udp:" + $sel(cfg_get.address.main) + ":5060") {
-        $dlg_var(extra_socket) = $(fs{s.select,1,:});
-        xinfo("[$dlg_var(cidhash)] MANAGE_BRANCH: Calling to a UAC through $dlg_var(extra_socket)\n");
-    }
-    #!endif
-
     route(IS_FROM_INSIDE);
 
     # Prepare call
@@ -2595,6 +2590,13 @@ branch_route[MANAGE_BRANCH] {
     }
 
     route(TRANSPORT_DETECT);
+
+    #!ifdef WITH_MULTISOCKET
+    if (is_request() && !has_totag() && is_method("INVITE")) {
+        route(SOCKET_DETECT);
+    }
+    #!endif
+
     route(NATMANAGE);
 }
 
@@ -2604,6 +2606,12 @@ event_route[dialog:start] {
         xnotice("[$dlg_var(cidhash)] Dialog involving WSS started\n");
         $dlg_var(ws) = 'yes';
     }
+
+    #!ifdef WITH_MULTISOCKET
+    if(isbflagset(FLB_EXTRASOCKET)) {
+        $dlg_var(extra_socket) = $Ri;
+    }
+    #!endif
 
     #!ifdef WITH_REALTIME
     $var(rtEvent) = "Confirmed";
@@ -2658,6 +2666,26 @@ route[TRANSPORT_DETECT] {
         }
     }
 }
+
+#!ifdef WITH_MULTISOCKET
+route[SOCKET_DETECT] {
+    $var(extra_socket) = 0;
+    if ($var(is_from_inside)) {
+        # To UAC
+        if ($xavp(ulattrs[$T_branch_idx]=>extrasocket) != $null) {
+            setbflag(FLB_EXTRASOCKET);
+            $var(extra_socket) = $xavp(ulattrs[$T_branch_idx]=>extrasocket);
+        }
+    } else {
+        # From UAC
+        if ($Ri != $sel(cfg_get.address.main)) {
+            # force_send_socket to main address (UAC talking to non-main address)
+            $fs = "udp:" + $sel(cfg_get.address.main) + ":5060";
+            $dlg_var(extra_socket) = $Ri;
+        }
+    }
+}
+#!endif
 
 route[GET_CODEC_INFO] {
     $dlg_var(codecs) = "";
@@ -2714,8 +2742,15 @@ route[RTPENGINE] {
 
     $var(interfaces) = "";
     #!ifdef WITH_MULTISOCKET
-    if ($Ri == $sel(cfg_get.address.main) && $dlg_var(extra_socket) != $null) {
+    $var(interfaces) = "direction=" + $sel(cfg_get.address.main) + " direction=" + $sel(cfg_get.address.main);
+
+    if ($var(is_from_inside) && $dlg_var(extra_socket) != $null) {
         $var(interfaces) = "direction=" + $sel(cfg_get.address.main) + " direction=" + $dlg_var(extra_socket);
+    }
+
+    if ($var(is_from_inside) && $var(extra_socket) != 0) {
+        $var(interfaces) = "direction=" + $sel(cfg_get.address.main) + " direction=" + $var(extra_socket);
+        $var(extra_socket) = 0; # Avoid unwanted re-usages
     }
     #!endif
 


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

When WITH_MULTISOCKET is enabled and UAC registers to 2 different addresses SDP are not mangled correctly (as soon as additional address branch is mangled, remaining SDPs are wrong).
    
This PR tries to fix this.

#### Additional information

Environments without WITH_MULTISOCKET are not affected at all.