### PR TITLE
ci: new Docker image for debian packaging testing

### DIFF
--- a/tests/packaging/Dockerfile
+++ b/tests/packaging/Dockerfile
@@ -1,0 +1,52 @@
+# See https://github.com/docker-library/php/blob/4677ca134fe48d20c820a19becb99198824d78e3/7.0/fpm/Dockerfile
+FROM debian:bullseye
+
+MAINTAINER Mikel Madariaga <mikel@irontec.com>
+MAINTAINER Ivan Alonso <kaian@irontec.com>
+
+RUN apt-get update && apt-get -y install gnupg wget
+
+RUN echo deb http://packages.irontec.com/debian halliday main extra >> \
+    /etc/apt/sources.list
+
+RUN wget http://packages.irontec.com/public.key -q -O - | apt-key add -
+
+RUN apt-get update && apt-get install -y \
+    dpkg-dev \
+    debhelper \
+    nodejs \
+    npm \
+    ruby-dev \
+    git \
+    openssh-client \
+    curl \
+    php8.0 \
+    python \
+    make \
+    gettext \
+    yarnpkg \
+    sphinx-common \
+    python3-sphinx-rtd-theme \
+    libjs-sphinxdoc \
+    libjs-jquery \
+    composer \
+    php8.0-mbstring \
+    php8.0-xml \
+    php8.0-zip \
+    php8.0-mailparse \
+    php8.0-gearman
+
+
+# Create jenkins user (configurable)
+ARG UNAME=jenkins
+ARG UID=108
+ARG GID=117
+RUN groupadd -g $GID $UNAME
+RUN useradd -m -u $UID -g $GID -s /bin/bash $UNAME
+RUN chown jenkins.jenkins /opt/
+
+# Base project
+USER $UNAME
+RUN mkdir -p /opt/irontec/ivozprovider
+
+WORKDIR /opt/irontec/ivozprovider/


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [ ] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [ ] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
New Dockerfile with all required dependencies for running/testing `dpkg-buildpackage -b` command

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
