### PR TITLE
kamtrunks: close xmlrpc conns after replying

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -2109,6 +2109,9 @@ onsend_route {
 }
 
 route[XMLRPC]{
+    set_reply_close();
+    set_reply_no_connect();
+
     if ($Rp != XMLRPC_PORT) {
         xwarn("XMLRPC: request received on $Rp, forbidden\n");
         xmlrpc_reply("400", "Unauthorized");
@@ -2133,11 +2136,6 @@ route[XMLRPC]{
 
 route[GENERIC_XMLRPC_COMMAND] {
     xinfo("GENERIC_XMLRPC_COMMAND: XMLRPC generic command from allowed IP ($si), dispatch!\n");
-
-    # close connection only for xmlrpclib user agents
-    if search("^User-Agent:.*xmlrpclib")
-        set_reply_close();
-    set_reply_no_connect(); # optional
     dispatch_rpc();
 }
 


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

Close XMLRPC connections after generating a response.
