### PR TITLE
kam: new maintenance mode

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -36,6 +36,26 @@
 # Maximum call duration: 3 hours
 #!define MAX_DIALOG_TIMEOUT 10800
 
+# Maintenance mode:
+#
+# (0) Normal operation mode
+# (1) Exit server when no active calls
+# (2) Reject new dialogs and exit server when no active calls
+# (3) Reject new dialogs, end active calls and exit server
+#
+# To enable maintenance mode:
+# kamcmd-proxytrunks cfg.set config maintenance_mode 1
+# kamcmd-proxytrunks cfg.set config maintenance_mode 2
+# kamcmd-proxytrunks cfg.set config maintenance_mode 3
+#
+# To disable maintenance mode:
+# kamcmd-proxytrunks cfg.set config maintenance_mode 0
+#
+# To see current value:
+# kamcmd-proxytrunks cfg.get config maintenance_mode
+
+config.maintenance_mode = 0
+
 # CGRateS mode:
 #
 # (0) Ask CGRateS for acceptance for all calls. If CGRateS is down, allow only
@@ -168,6 +188,7 @@ loadmodule    "xhttp.so"
 loadmodule    "jsonrpcs.so"
 loadmodule    "http_client.so"
 loadmodule    "ipops.so"
+loadmodule    "timer.so"
 
 #!ifdef WITH_REALTIME
 loadmodule    "ndb_redis.so"
@@ -376,6 +397,10 @@ modparam("permissions", "trusted_table", "kam_trusted") # Not used but necessary
 # JSONRPCS
 modparam("jsonrpcs", "transport", 1)
 
+# TIMER
+modparam("timer", "declare_timer", "EXIT_NOW=EXIT_NOW,3000,slow,enable");
+modparam("timer", "declare_timer", "EXIT_WHEN_NO_CALLS=EXIT_WHEN_NO_CALLS,3000,slow,enable");
+
 ####### Routing Logic ########
 
 request_route {
@@ -436,6 +461,12 @@ request_route {
     }
 
     ### only initial requests (no To tag)
+
+    if ($sel(cfg_get.config.maintenance_mode) >= 2) {
+        xwarn("[$dlg_var(cidhash)] Reject $rm, maintenance mode ON (disable maintenance_mode: kamcmd-proxytrunks cfg.set config maintenance_mode 0)");
+        send_reply("500", "Service Unavailable [MM]");
+        exit;
+    }
 
     # Only INVITE can start a dialog
     if (!is_method("INVITE")) {
@@ -2369,6 +2400,34 @@ route[END_COMPANY_CALLS] {
 
     xhttp_reply("200", "OK", "text/html", "<html><body>Dialogs of company $var(companyId) ended</body></html>");
 }
+
+route[EXIT_NOW] {
+    if ($sel(cfg_get.config.maintenance_mode) != 3) {
+        # Only when maintenance mode 3 is enabled
+        return;
+    }
+
+    xwarn("EXIT-NOW: Ending all dialogs (maintenance mode 3)\n");
+    jsonrpc_exec('{"jsonrpc": "2.0", "method": "dlg.profile_end", "params": ["activeCallsCompany"], "id": 1}');
+
+    if ($jsonrpl(code) == "200") {
+        xnotice("EXIT-NOW: jsonrpc response code: $jsonrpl(code) - the body is: $jsonrpl(body), abort\n");
+        abort();
+    } else {
+        xerr("EXIT-NOW: jsonrpc response code: $jsonrpl(code) - the body is: $jsonrpl(body)\n");
+    }
+}
+
+route[EXIT_WHEN_NO_CALLS] {
+    if ($sel(cfg_get.config.maintenance_mode) == 0) return;
+    if ($sel(cfg_get.config.maintenance_mode) == 3) return;
+
+    if ($DLG_count > 0) return;
+
+    xwarn("No active calls and maintenance_mode 1/2, abort\n");
+    abort();
+}
+
 
 route[CGR_AUTH_REPLY] {
     json_get_field("$evapi(msg)", "TransactionIndex", "$var(TransactionIndex)");

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -68,6 +68,26 @@
 # Enable/disable debug logs
 dolog.websocket = 1 desc "If 1, debug WS connection upgrade"
 
+# Maintenance mode:
+#
+# (0) Normal operation mode
+# (1) Exit server when no active calls
+# (2) Reject new dialogs and exit server when no active calls
+# (3) Reject new dialogs, end active calls and exit server
+#
+# To enable maintenance mode:
+# kamcmd-proxyusers cfg.set config maintenance_mode 1
+# kamcmd-proxyusers cfg.set config maintenance_mode 2
+# kamcmd-proxyusers cfg.set config maintenance_mode 3
+#
+# To disable maintenance mode:
+# kamcmd-proxyusers cfg.set config maintenance_mode 0
+#
+# To see current value:
+# kamcmd-proxyusers cfg.get config maintenance_mode
+
+config.maintenance_mode = 0
+
 ####### Global Parameters #########
 
 listen=udp:IP:SIP_PORT
@@ -188,6 +208,7 @@ loadmodule    "dialplan.so"
 loadmodule    "diversion.so"
 loadmodule    "cfgutils.so"
 loadmodule    "uac.so"
+loadmodule    "timer.so"
 
 #!ifdef WITH_ANTIFLOOD
 loadmodule    "pike.so"
@@ -428,6 +449,10 @@ modparam("ndb_redis", "server", "name=realtime;sentinel_group=mymaster;sentinel_
 modparam("ndb_redis", "init_without_redis", 1)
 #!endif
 
+# TIMER
+modparam("timer", "declare_timer", "EXIT_NOW=EXIT_NOW,3000,slow,enable");
+modparam("timer", "declare_timer", "EXIT_WHEN_NO_CALLS=EXIT_WHEN_NO_CALLS,3000,slow,enable");
+
 ####### Routing Logic ########
 
 request_route {
@@ -483,6 +508,12 @@ request_route {
     }
 
     ### only initial requests (no To tag)
+
+    if ($sel(cfg_get.config.maintenance_mode) >= 2) {
+        xwarn("[$dlg_var(cidhash)] Reject $rm, maintenance mode ON (disable maintenance_mode: kamcmd-proxyusers cfg.set config maintenance_mode 0)");
+        send_reply("500", "Service Unavailable [MM]");
+        exit;
+    }
 
     # Wholesale request?
     if(allow_trusted($si, 'any') && $avp(wholesaleId) != $null) {
@@ -2858,6 +2889,33 @@ route[PRESENCE] {
         route(RELAY);
     }
     exit;
+}
+
+route[EXIT_NOW] {
+    if ($sel(cfg_get.config.maintenance_mode) != 3) {
+        # Only when maintenance mode 3 is enabled
+        return;
+    }
+
+    xwarn("EXIT-NOW: Ending all dialogs (maintenance mode ON)\n");
+    jsonrpc_exec('{"jsonrpc": "2.0", "method": "dlg.profile_end", "params": ["callsPerAor"], "id": 1}');
+
+    if ($jsonrpl(code) == "200") {
+        xnotice("EXIT-NOW: jsonrpc response code: $jsonrpl(code) - the body is: $jsonrpl(body), abort\n");
+        abort();
+    } else {
+        xerr("EXIT-NOW: jsonrpc response code: $jsonrpl(code) - the body is: $jsonrpl(body)\n");
+    }
+}
+
+route[EXIT_WHEN_NO_CALLS] {
+    if ($sel(cfg_get.config.maintenance_mode) == 0) return;
+    if ($sel(cfg_get.config.maintenance_mode) == 3) return;
+
+    if ($DLG_count > 0) return;
+
+    xwarn("No active calls and maintenance_mode 1/2, abort\n");
+    abort();
 }
 
 event_route[xhttp:request] {


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

kam: new maintenance mode                                                       
                                                                                
kamcmd-proxyusers cfg.set config maintenance_mode 1                             
kamcmd-proxytrunks cfg.set config maintenance_mode 1                            
                                                                                
- Exit Kamailio when no active calls                                            
                                                                                
kamcmd-proxyusers cfg.set config maintenance_mode 2                             
kamcmd-proxytrunks cfg.set config maintenance_mode 2                            
                                                                                
- Rejects any request not belonging to any existing dialog (reject new calls)   
- Wait until active calls end                                                   
- Exit Kamailio when no active calls                                            
                                                                                
kamcmd-proxyusers cfg.set config maintenance_mode 3                             
kamcmd-proxytrunks cfg.set config maintenance_mode 3                            
                                                                                
- Rejects any request not belonging to any existing dialog (reject new calls)   
- Ends all active calls (generating CDRs)                                       
- Exit Kamailio                                                                 
                                                                                
May be useful for graceful restarts.