### PR TITLE
kam: publish to redis BYEs of unknown dialogs

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -200,7 +200,7 @@ loadmodule    "pike.so"
 
 #!ifdef WITH_REALTIME
 # REDIS
-modparam("ndb_redis", "server", "name=realtime;sentinel_group=mymaster;sentinel_master=1;sentinel=data.ivozprovider.local:26379")
+modparam("ndb_redis", "server", "name=realtime;sentinel_group=mymaster;sentinel_master=1;sentinel=data.ivozprovider.local:26379;db=1")
 modparam("ndb_redis", "init_without_redis", 1)
 #!endif
 
@@ -1535,6 +1535,12 @@ route[WITHINDLG] {
         if (is_method("BYE")) {
             setflag(FLT_ACC);       # do accounting
             setflag(FLT_ACCFAILED); # even if the transaction fails
+            if (!is_known_dlg()) {
+                #!ifdef WITH_REALTIME
+                route(RT_UNKNOWN_BYE); # Try to stop realtime call
+                #!endif
+                route(RTPENGINE_UNKNOWN_BYE); # Try to free rtpengine session
+            }
         }
         route(RTPENGINE);
         route(RELAY);
@@ -1659,7 +1665,7 @@ route[ANTIFLOOD] {
     if ($var(is_from_inside)) return;
 
     # No antiflood for within dialog requests
-    if (has_totag()) return;
+    if (has_totag() && is_known_dlg()) return;
 
     # Allowed sources by DDI provider
     $var(group) = allow_source_address_group();
@@ -1877,6 +1883,40 @@ route[RT_NEWCALL] {
 
     # Calculate session-id
     $dlg_var(rtId) = $(dlg_var(rtChannel){s.md5}{s.substr,0,8});
+}
+
+route[RT_UNKNOWN_BYE] {
+    # BYE of unknown dialog (probably after Kamailio crash/restart)
+    $var(cidhash) = $(ci{s.md5}{s.substr,0,8});
+    xwarn("[$var(cidhash)] RT-UNKNOWN-BYE: BYE of unknown dialog (probably after Kamailio crash/restart)\n");
+
+    # Reset JSON value
+    $var(rtValue) = 0;
+
+    # Common fields
+    jansson_set("string", "Event", "Terminated", "$var(rtValue)");
+    jansson_set("integer", "Time", "$TS", "$var(rtValue)");
+    jansson_set("string", "Call-ID", "$ci", "$var(rtValue)");
+
+    if(!redis_cmd("realtime", "KEYS %s", "trunks:*:$ci", "r")) {
+        xwarn("[$var(cidhash)] RT-UNKNOWN-BYE: problems getting realtime keys\n");
+        return;
+    }
+
+    if ($redis(r=>size) == 0) {
+        xwarn("[$var(cidhash)] RT-UNKNOWN-BYE: realtime key not found\n");
+        return;
+    }
+
+    $var(rtChannel) = $redis(r=>value[0]);
+    $var(rtId) = $(var(rtChannel){s.md5}{s.substr,0,8});
+
+    jansson_set("string", "ID", "$var(rtId)", "$var(rtValue)");
+    if (redis_cmd("realtime", "PUBLISH %s %s", "$var(rtChannel)", "$var(rtValue)", "r")) {
+        xnotice("[$var(cidhash)] RT-UNKNOWN-BYE: $var(rtChannel) -> $var(rtValue)");
+    } else {
+        xerr("[$var(cidhash)] RT-UNKNOWN-BYE: $var(rtChannel) -> $var(rtValue)");
+    }
 }
 #!endif
 
@@ -2198,6 +2238,14 @@ route[RTPENGINE] {
     }
 
     route(RECORD);
+}
+
+route[RTPENGINE_UNKNOWN_BYE] {
+    $var(callid) = "call-id=trunks-outbound-" + $ci;
+    rtpengine_delete("$var(callid)");
+
+    $var(callid) = "call-id=trunks-inbound-" + $ci;
+    rtpengine_delete("$var(callid)");
 }
 
 route[QUALITYLABELS] {

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -445,7 +445,7 @@ modparam("uac", "restore_dlg", 1)
 
 #!ifdef WITH_REALTIME
 # REDIS
-modparam("ndb_redis", "server", "name=realtime;sentinel_group=mymaster;sentinel_master=1;sentinel=data.ivozprovider.local:26379")
+modparam("ndb_redis", "server", "name=realtime;sentinel_group=mymaster;sentinel_master=1;sentinel=data.ivozprovider.local:26379;db=1")
 modparam("ndb_redis", "init_without_redis", 1)
 #!endif
 
@@ -1869,6 +1869,13 @@ route[WITHINDLG] {
         if (is_method("BYE")) {
             setflag(FLT_ACC);       # do accounting
             setflag(FLT_ACCFAILED); # even if the transaction fails
+            if (!is_known_dlg()) {
+                route(ANTIFLOOD);
+                #!ifdef WITH_REALTIME
+                route(RT_UNKNOWN_BYE); # Try to stop realtime call
+                #!endif
+                route(RTPENGINE_UNKNOWN_BYE); # Try to free rtpengine session
+            }
         } else if (is_method("ACK")) {
             # ACK is forwarded statelessly
             route(NATMANAGE);
@@ -2453,6 +2460,40 @@ route[RT_NEWCALL] {
     # Calculate session-id
     $dlg_var(rtId) = $(dlg_var(rtChannel){s.md5}{s.substr,0,8});
 }
+
+route[RT_UNKNOWN_BYE] {
+    # BYE of unknown dialog (probably after Kamailio crash/restart)
+    $var(cidhash) = $(ci{s.md5}{s.substr,0,8});
+    xwarn("[$var(cidhash)] RT-UNKNOWN-BYE: BYE of unknown dialog (probably after Kamailio crash/restart)\n");
+
+    # Reset JSON value
+    $var(rtValue) = 0;
+
+    # Common fields
+    jansson_set("string", "Event", "Terminated", "$var(rtValue)");
+    jansson_set("integer", "Time", "$TS", "$var(rtValue)");
+    jansson_set("string", "Call-ID", "$ci", "$var(rtValue)");
+
+    if(!redis_cmd("realtime", "KEYS %s", "users:*:$ci", "r")) {
+        xwarn("[$var(cidhash)] RT-UNKNOWN-BYE: problems getting realtime keys\n");
+        return;
+    }
+
+    if ($redis(r=>size) == 0) {
+        xwarn("[$var(cidhash)] RT-UNKNOWN-BYE: realtime key not found\n");
+        return;
+    }
+
+    $var(rtChannel) = $redis(r=>value[0]);
+    $var(rtId) = $(var(rtChannel){s.md5}{s.substr,0,8});
+
+    jansson_set("string", "ID", "$var(rtId)", "$var(rtValue)");
+    if (redis_cmd("realtime", "PUBLISH %s %s", "$var(rtChannel)", "$var(rtValue)", "r")) {
+        xnotice("[$var(cidhash)] RT-UNKNOWN-BYE: $var(rtChannel) -> $var(rtValue)");
+    } else {
+        xerr("[$var(cidhash)] RT-UNKNOWN-BYE: $var(rtChannel) -> $var(rtValue)");
+    }
+}
 #!endif
 
 # Reply generic route (all replies goes through this route)
@@ -2806,6 +2847,15 @@ route[RTPENGINE] {
     if (is_request() && is_method("BYE")) {
         route(QUALITY);
     }
+}
+
+route[RTPENGINE_UNKNOWN_BYE] {
+    # Totally best effort (only works for mediaRelaySetId 0, default value)
+    $var(callid) = "call-id=users-outbound-" + $ci;
+    rtpengine_delete("$var(callid)");
+
+    $var(callid) = "call-id=users-inbound-" + $ci;
+    rtpengine_delete("$var(callid)");
 }
 
 route[QUALITYLABELS] {


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

- After crash/restart, BYEs of active calls are correctly forwarded.

- But, realtime service is not updated when they hang up (as BYE is not recognized as coming from
  a known dialog).

- This causes that 'Active calls' section show these calls until they expire (3 hours later).

This commit searches call-ids of this kind of BYEs and, if found in redis, send Terminated event to redis.

#### Additional information

BYE of unknown dialogs will be counted by antiflood.