### PR TITLE
Api active calls from redis

### DIFF
--- a/asterisk/agi/composer.lock
+++ b/asterisk/agi/composer.lock
@@ -1366,11 +1366,11 @@
         },
         {
             "name": "irontec/ivoz-core",
-            "version": "3.3.9",
+            "version": "3.4.4",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/irontec/ivoz-core",
-                "reference": "2d2fb1b9c31578cd0c482f47e5eaec6cd07f2fc6"
+                "reference": "3eccde9473af434e448ed7cf15736d21852508cb"
             },
             "require": {
                 "beberlei/assert": "2.9.*",
@@ -1416,16 +1416,16 @@
         },
         {
             "name": "irontec/ivoz-core-bundle",
-            "version": "3.4.1.0",
+            "version": "3.5.1",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/irontec/ivoz-core-bundle",
-                "reference": "9e628723cc793d960af320d4e661abba3f7b36ca"
+                "reference": "4d344148268f287bdfa1dd4e6dd8da337353353b"
             },
             "require": {
                 "doctrine/doctrine-bundle": "^1.6",
                 "doctrine/doctrine-cache-bundle": "^1.3",
-                "irontec/ivoz-core": "^3.3.2",
+                "irontec/ivoz-core": "^3.4",
                 "ocramius/proxy-manager": "~2.0",
                 "php": ">=7.0.19",
                 "symfony/monolog-bundle": "3.1.*",
@@ -1463,11 +1463,11 @@
         },
         {
             "name": "irontec/ivoz-provider-bundle",
-            "version": "2.5.9",
+            "version": "2.5.10",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/irontec/ivoz-provider-bundle",
-                "reference": "bf63c0c60b4c0f676556fbb36f60691007ced249"
+                "reference": "0a62fd51534ca37a96150bb229b36a1b3fcc0b75"
             },
             "require": {
                 "beberlei/doctrineextensions": "^1.1",
@@ -1516,7 +1516,8 @@
             ],
             "description": "Symfony bridge for IvozProvider",
             "transport-options": {
-                "symlink": true
+                "symlink": true,
+                "relative": true
             }
         },
         {

--- a/debian/control
+++ b/debian/control
@@ -228,7 +228,7 @@ Description: IVOZ Provider - Rest API files
 Package: ivozprovider-common-library
 Architecture: all
 Section: php
-Depends: php7.0-cli, php7.0-mysql, php7.0-mbstring, php7.0-xml, acl, klear-library, php-mailparse, php7.0-intl, php7.0-igbinary
+Depends: php7.0-cli, php7.0-mysql, php7.0-mbstring, php7.0-xml, acl, klear-library, php-mailparse, php7.0-intl, php7.0-igbinary, php-redis
 Provides: ivozprovider-data-library
 Conflicts: ivozprovider-data-library
 Priority: optional
@@ -273,7 +273,7 @@ Description: IVOZ Provider - Rating updater - Symfony microservice
 Package: ivozprovider-realtime
 Architecture: all
 Priority: optional
-Depends: ivozprovider-common-library (=${binary:Version}), php-redis, php-swoole
+Depends: ivozprovider-common-library (=${binary:Version}), php-swoole
 Homepage: http://www.irontec.com
 Description: IVOZ Provider - Realtime Websocket server - Symfony microservice
   .

--- a/library/Ivoz/Kam/Domain/Service/TrunksClientInterface.php
+++ b/library/Ivoz/Kam/Domain/Service/TrunksClientInterface.php
@@ -33,7 +33,7 @@ interface TrunksClientInterface
      * @param int $companyId
      * @return int[] inbound/outbound
      */
-    public function getCompanyActiveCalls(int $companyId): array;
+    public function getCompanyActiveCalls(int $brandId, int $companyId): array;
 
     /**
      * @param int $brandId

--- a/library/Ivoz/Kam/Infrastructure/Gearman/TrunksClient.php
+++ b/library/Ivoz/Kam/Infrastructure/Gearman/TrunksClient.php
@@ -3,6 +3,7 @@
 namespace Ivoz\Kam\Infrastructure\Gearman;
 
 use Ivoz\Core\Infrastructure\Domain\Service\Gearman\Client\XmlRpcTrunksRequestInterface;
+use Ivoz\Core\Infrastructure\Persistence\Redis\RedisMasterFactory;
 use Ivoz\Kam\Domain\Service\TrunksClientInterface;
 use Ivoz\Kam\Infrastructure\Kamailio\JsonRpcRequestTrait;
 use Ivoz\Kam\Infrastructure\Kamailio\RpcClient;
@@ -12,17 +13,23 @@ class TrunksClient implements TrunksClientInterface
 {
     use JsonRpcRequestTrait;
 
+    const REDIS_RT_CALLS_DB = 1;
+    const REDIS_SCAN_COUNT = 1000;
+
     protected $rpcClient;
     protected $germanClient;
+    protected $redisMasterFactory;
     protected $logger;
 
     public function __construct(
         RpcClient $rpcClient,
         XmlRpcTrunksRequestInterface $germanClient,
+        RedisMasterFactory $redisMasterFactory,
         LoggerInterface $logger
     ) {
         $this->rpcClient = $rpcClient;
         $this->germanClient = $germanClient;
+        $this->redisMasterFactory = $redisMasterFactory;
         $this->logger = $logger;
     }
 
@@ -147,20 +154,23 @@ class TrunksClient implements TrunksClientInterface
     }
 
     /**
-     * @param int $companyId
      * @return int[] inbound/outbound
      */
-    public function getCompanyActiveCalls(int $companyId): array
+    public function getCompanyActiveCalls(int $brandId, int $companyId): array
     {
-        $inbound = $this->getActiveCalls([
-            'inboundCallsCompany',
+        $inboundFilterPattern = sprintf(
+            'trunks:b%d:c%d:dp*',
+            $brandId,
             $companyId
-        ]);
+        );
+        $inbound = $this->getRedisActiveCalls($inboundFilterPattern);
 
-        $outbound = $this->getActiveCalls([
-            'outboundCallsCompany',
+        $outboundFilterPattern = sprintf(
+            'trunks:b%d:c%d:cr*',
+            $brandId,
             $companyId
-        ]);
+        );
+        $outbound = $this->getRedisActiveCalls($outboundFilterPattern);
 
         return [
             $inbound,
@@ -174,15 +184,17 @@ class TrunksClient implements TrunksClientInterface
      */
     public function getBrandActiveCalls(int $brandId): array
     {
-        $inbound = $this->getActiveCalls([
-            'inboundCallsBrand',
+        $inboundFilterPattern = sprintf(
+            'trunks:b%d:*:dp*',
             $brandId
-        ]);
+        );
+        $inbound = $this->getRedisActiveCalls($inboundFilterPattern);
 
-        $outbound = $this->getActiveCalls([
-            'outboundCallsBrand',
+        $outboundFilterPattern = sprintf(
+            'trunks:b%d:*:cr*',
             $brandId
-        ]);
+        );
+        $outbound = $this->getRedisActiveCalls($outboundFilterPattern);
 
         return [
             $inbound,
@@ -195,13 +207,8 @@ class TrunksClient implements TrunksClientInterface
      */
     public function getPlatformActiveCalls(): array
     {
-        $inbound = $this->getActiveCalls([
-            'inboundCallsBrand'
-        ]);
-
-        $outbound = $this->getActiveCalls([
-            'outboundCallsBrand'
-        ]);
+        $inbound = $this->getRedisActiveCalls('trunks:*:dp*');
+        $outbound = $this->getRedisActiveCalls('trunks:*:cr*');
 
         return [
             $inbound,
@@ -210,21 +217,59 @@ class TrunksClient implements TrunksClientInterface
     }
 
     /**
-     * @param array $payload
+     * @param string $filterPattern
      * @return int
      */
-    private function getActiveCalls(array $payload)
+    private function getRedisActiveCalls(string $filterPattern)
     {
-        $response = $this->sendRequest(
-            self::DLG_PROFILE_GET_SIZE,
-            $payload
-        );
+        $callNum = 0;
+        try {
+            $redisClient = $this->redisMasterFactory->create(
+                self::REDIS_RT_CALLS_DB
+            );
 
-        if (!isset($response->result)) {
-            return -1;
+            /** @var int|null $redisScanIterator */
+            $redisScanIterator = null;
+
+            while (true) {
+                $keys = $redisClient->scan(
+                    $redisScanIterator,
+                    $filterPattern,
+                    self::REDIS_SCAN_COUNT
+                );
+
+                if (!is_array($keys)) {
+                    break;
+                }
+
+                $callNum += count($keys);
+                if ($redisScanIterator === 0) {
+                    break;
+                }
+            }
+
+            $redisClient->close();
+        } catch (\Exception $e) {
+            $classMethod = substr(
+                __METHOD__,
+                strrpos(__METHOD__, '\\') +1
+            );
+
+            $erroMsg = sprintf(
+                '%s(%s): %s',
+                $classMethod,
+                $filterPattern,
+                $e->getMessage()
+            );
+
+            $this
+                ->logger
+                ->error(
+                    $erroMsg
+                );
         }
 
-        return $response->result;
+        return $callNum;
     }
 
     public function isCgrEnabled()

--- a/library/composer.lock
+++ b/library/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "22d8a55d576845af60a4ad875c2d19f5",
+    "content-hash": "688fc113afd8f76f9865b924586af3de",
     "packages": [
         {
             "name": "api-platform/core",
@@ -1757,17 +1757,11 @@
         },
         {
             "name": "irontec/ivoz-core",
-            "version": "3.3.9",
+            "version": "3.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/irontec/ivoz-core.git",
-                "reference": "2d2fb1b9c31578cd0c482f47e5eaec6cd07f2fc6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/irontec/ivoz-core/zipball/2d2fb1b9c31578cd0c482f47e5eaec6cd07f2fc6",
-                "reference": "2d2fb1b9c31578cd0c482f47e5eaec6cd07f2fc6",
-                "shasum": ""
+                "reference": "3eccde9473af434e448ed7cf15736d21852508cb"
             },
             "require": {
                 "beberlei/assert": "2.9.*",
@@ -1788,7 +1782,6 @@
                     "Ivoz\\Core\\": ""
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-3.0-or-later"
             ],
@@ -1807,26 +1800,26 @@
                 }
             ],
             "description": "Core library for ivozprovider",
-            "time": "2021-09-16T09:06:37+00:00"
+            "time": "2021-11-03T14:28:21+00:00"
         },
         {
             "name": "irontec/ivoz-core-bundle",
-            "version": "3.4.1",
+            "version": "3.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/irontec/ivoz-core-bundle.git",
-                "reference": "9e628723cc793d960af320d4e661abba3f7b36ca"
+                "reference": "4d344148268f287bdfa1dd4e6dd8da337353353b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/irontec/ivoz-core-bundle/zipball/9e628723cc793d960af320d4e661abba3f7b36ca",
-                "reference": "9e628723cc793d960af320d4e661abba3f7b36ca",
+                "url": "https://api.github.com/repos/irontec/ivoz-core-bundle/zipball/4d344148268f287bdfa1dd4e6dd8da337353353b",
+                "reference": "4d344148268f287bdfa1dd4e6dd8da337353353b",
                 "shasum": ""
             },
             "require": {
                 "doctrine/doctrine-bundle": "^1.6",
                 "doctrine/doctrine-cache-bundle": "^1.3",
-                "irontec/ivoz-core": "^3.3.2",
+                "irontec/ivoz-core": "^3.4",
                 "ocramius/proxy-manager": "~2.0",
                 "php": ">=7.0.19",
                 "symfony/monolog-bundle": "3.1.*",
@@ -1858,7 +1851,7 @@
                 }
             ],
             "description": "Symfony bridge for ivoz-core",
-            "time": "2021-02-16T12:32:27+00:00"
+            "time": "2021-11-03T11:00:28+00:00"
         },
         {
             "name": "irontec/ivoz-dev-tools",
@@ -1909,11 +1902,11 @@
         },
         {
             "name": "irontec/ivoz-provider-bundle",
-            "version": "2.5.9",
+            "version": "2.5.10",
             "dist": {
                 "type": "path",
                 "url": "./composer-packages/irontec/ivoz-provider-bundle",
-                "reference": "55001ea4c5ebdb30f4493fbb1f35c0ea2c9a227c"
+                "reference": "d3928ec5e0d48375f62d069ad699178c2eaa1acc"
             },
             "require": {
                 "beberlei/doctrineextensions": "^1.1",
@@ -1962,7 +1955,8 @@
             ],
             "description": "Symfony bridge for IvozProvider",
             "transport-options": {
-                "symlink": false
+                "symlink": false,
+                "relative": true
             }
         },
         {
@@ -7110,6 +7104,12 @@
                 "future",
                 "non-blocking",
                 "promise"
+            ],
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
             ],
             "time": "2020-07-14T21:47:18+00:00"
         },

--- a/microservices/balances/composer.lock
+++ b/microservices/balances/composer.lock
@@ -1366,11 +1366,11 @@
         },
         {
             "name": "irontec/ivoz-core",
-            "version": "3.3.9",
+            "version": "3.4.4",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/irontec/ivoz-core",
-                "reference": "2d2fb1b9c31578cd0c482f47e5eaec6cd07f2fc6"
+                "reference": "3eccde9473af434e448ed7cf15736d21852508cb"
             },
             "require": {
                 "beberlei/assert": "2.9.*",
@@ -1416,16 +1416,16 @@
         },
         {
             "name": "irontec/ivoz-core-bundle",
-            "version": "3.4.1.0",
+            "version": "3.5.1",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/irontec/ivoz-core-bundle",
-                "reference": "9e628723cc793d960af320d4e661abba3f7b36ca"
+                "reference": "4d344148268f287bdfa1dd4e6dd8da337353353b"
             },
             "require": {
                 "doctrine/doctrine-bundle": "^1.6",
                 "doctrine/doctrine-cache-bundle": "^1.3",
-                "irontec/ivoz-core": "^3.3.2",
+                "irontec/ivoz-core": "^3.4",
                 "ocramius/proxy-manager": "~2.0",
                 "php": ">=7.0.19",
                 "symfony/monolog-bundle": "3.1.*",
@@ -1463,11 +1463,11 @@
         },
         {
             "name": "irontec/ivoz-provider-bundle",
-            "version": "2.5.9",
+            "version": "2.5.10",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/irontec/ivoz-provider-bundle",
-                "reference": "bf63c0c60b4c0f676556fbb36f60691007ced249"
+                "reference": "0a62fd51534ca37a96150bb229b36a1b3fcc0b75"
             },
             "require": {
                 "beberlei/doctrineextensions": "^1.1",
@@ -1516,7 +1516,8 @@
             ],
             "description": "Symfony bridge for IvozProvider",
             "transport-options": {
-                "symlink": true
+                "symlink": true,
+                "relative": true
             }
         },
         {

--- a/microservices/realtime/composer.lock
+++ b/microservices/realtime/composer.lock
@@ -1636,11 +1636,11 @@
         },
         {
             "name": "irontec/ivoz-core",
-            "version": "3.3.9",
+            "version": "3.4.4",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/irontec/ivoz-core",
-                "reference": "2d2fb1b9c31578cd0c482f47e5eaec6cd07f2fc6"
+                "reference": "3eccde9473af434e448ed7cf15736d21852508cb"
             },
             "require": {
                 "beberlei/assert": "2.9.*",
@@ -1686,16 +1686,16 @@
         },
         {
             "name": "irontec/ivoz-core-bundle",
-            "version": "3.4.1.0",
+            "version": "3.5.1",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/irontec/ivoz-core-bundle",
-                "reference": "9e628723cc793d960af320d4e661abba3f7b36ca"
+                "reference": "4d344148268f287bdfa1dd4e6dd8da337353353b"
             },
             "require": {
                 "doctrine/doctrine-bundle": "^1.6",
                 "doctrine/doctrine-cache-bundle": "^1.3",
-                "irontec/ivoz-core": "^3.3.2",
+                "irontec/ivoz-core": "^3.4",
                 "ocramius/proxy-manager": "~2.0",
                 "php": ">=7.0.19",
                 "symfony/monolog-bundle": "3.1.*",
@@ -1733,11 +1733,11 @@
         },
         {
             "name": "irontec/ivoz-provider-bundle",
-            "version": "2.5.9",
+            "version": "2.5.10",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/irontec/ivoz-provider-bundle",
-                "reference": "bf63c0c60b4c0f676556fbb36f60691007ced249"
+                "reference": "0a62fd51534ca37a96150bb229b36a1b3fcc0b75"
             },
             "require": {
                 "beberlei/doctrineextensions": "^1.1",
@@ -1786,7 +1786,8 @@
             ],
             "description": "Symfony bridge for IvozProvider",
             "transport-options": {
-                "symlink": true
+                "symlink": true,
+                "relative": true
             }
         },
         {

--- a/microservices/realtime/src/Services/AbstractWsServer.php
+++ b/microservices/realtime/src/Services/AbstractWsServer.php
@@ -11,7 +11,8 @@ use Swoole\Http\Request as HttpRequest;
 
 abstract class AbstractWsServer
 {
-    const REDIS_KEYS_TTL = 60*60*3+30;
+    const REDIS_KEYS_IN_CALL_TTL = 60*60*3+30;
+    const REDIS_KEYS_TTL = 60*2;
 
     /** @var Server */
     protected $server;

--- a/microservices/realtime/src/Services/WsServer.php
+++ b/microservices/realtime/src/Services/WsServer.php
@@ -317,11 +317,16 @@ class WsServer extends AbstractWsServer
         $this->logger->debug(
             "[SETEX] " . $channel . " " . $logInfo
         );
+
+        $ttl = $event === AbstractCall::IN_CALL
+            ? self::REDIS_KEYS_IN_CALL_TTL
+            : self::REDIS_KEYS_TTL;
+
         $this
             ->controlRedisClient
             ->setEx(
                 $channel,
-                self::REDIS_KEYS_TTL,
+                $ttl,
                 json_encode($data)
             );
     }

--- a/microservices/recordings/composer.lock
+++ b/microservices/recordings/composer.lock
@@ -1395,11 +1395,11 @@
         },
         {
             "name": "irontec/ivoz-core",
-            "version": "3.3.9",
+            "version": "3.4.4",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/irontec/ivoz-core",
-                "reference": "2d2fb1b9c31578cd0c482f47e5eaec6cd07f2fc6"
+                "reference": "3eccde9473af434e448ed7cf15736d21852508cb"
             },
             "require": {
                 "beberlei/assert": "2.9.*",
@@ -1445,16 +1445,16 @@
         },
         {
             "name": "irontec/ivoz-core-bundle",
-            "version": "3.4.1.0",
+            "version": "3.5.1",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/irontec/ivoz-core-bundle",
-                "reference": "9e628723cc793d960af320d4e661abba3f7b36ca"
+                "reference": "4d344148268f287bdfa1dd4e6dd8da337353353b"
             },
             "require": {
                 "doctrine/doctrine-bundle": "^1.6",
                 "doctrine/doctrine-cache-bundle": "^1.3",
-                "irontec/ivoz-core": "^3.3.2",
+                "irontec/ivoz-core": "^3.4",
                 "ocramius/proxy-manager": "~2.0",
                 "php": ">=7.0.19",
                 "symfony/monolog-bundle": "3.1.*",
@@ -1492,11 +1492,11 @@
         },
         {
             "name": "irontec/ivoz-provider-bundle",
-            "version": "2.5.9",
+            "version": "2.5.10",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/irontec/ivoz-provider-bundle",
-                "reference": "bf63c0c60b4c0f676556fbb36f60691007ced249"
+                "reference": "0a62fd51534ca37a96150bb229b36a1b3fcc0b75"
             },
             "require": {
                 "beberlei/doctrineextensions": "^1.1",
@@ -1545,7 +1545,8 @@
             ],
             "description": "Symfony bridge for IvozProvider",
             "transport-options": {
-                "symlink": true
+                "symlink": true,
+                "relative": true
             }
         },
         {

--- a/microservices/scheduler/composer.lock
+++ b/microservices/scheduler/composer.lock
@@ -1366,11 +1366,11 @@
         },
         {
             "name": "irontec/ivoz-core",
-            "version": "3.3.9",
+            "version": "3.4.4",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/irontec/ivoz-core",
-                "reference": "2d2fb1b9c31578cd0c482f47e5eaec6cd07f2fc6"
+                "reference": "3eccde9473af434e448ed7cf15736d21852508cb"
             },
             "require": {
                 "beberlei/assert": "2.9.*",
@@ -1416,16 +1416,16 @@
         },
         {
             "name": "irontec/ivoz-core-bundle",
-            "version": "3.4.1.0",
+            "version": "3.5.1",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/irontec/ivoz-core-bundle",
-                "reference": "9e628723cc793d960af320d4e661abba3f7b36ca"
+                "reference": "4d344148268f287bdfa1dd4e6dd8da337353353b"
             },
             "require": {
                 "doctrine/doctrine-bundle": "^1.6",
                 "doctrine/doctrine-cache-bundle": "^1.3",
-                "irontec/ivoz-core": "^3.3.2",
+                "irontec/ivoz-core": "^3.4",
                 "ocramius/proxy-manager": "~2.0",
                 "php": ">=7.0.19",
                 "symfony/monolog-bundle": "3.1.*",
@@ -1463,11 +1463,11 @@
         },
         {
             "name": "irontec/ivoz-provider-bundle",
-            "version": "2.5.9",
+            "version": "2.5.10",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/irontec/ivoz-provider-bundle",
-                "reference": "bf63c0c60b4c0f676556fbb36f60691007ced249"
+                "reference": "0a62fd51534ca37a96150bb229b36a1b3fcc0b75"
             },
             "require": {
                 "beberlei/doctrineextensions": "^1.1",
@@ -1516,7 +1516,8 @@
             ],
             "description": "Symfony bridge for IvozProvider",
             "transport-options": {
-                "symlink": true
+                "symlink": true,
+                "relative": true
             }
         },
         {

--- a/microservices/workers/composer.lock
+++ b/microservices/workers/composer.lock
@@ -1366,11 +1366,11 @@
         },
         {
             "name": "irontec/ivoz-core",
-            "version": "3.3.9",
+            "version": "3.4.4",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/irontec/ivoz-core",
-                "reference": "2d2fb1b9c31578cd0c482f47e5eaec6cd07f2fc6"
+                "reference": "3eccde9473af434e448ed7cf15736d21852508cb"
             },
             "require": {
                 "beberlei/assert": "2.9.*",
@@ -1416,16 +1416,16 @@
         },
         {
             "name": "irontec/ivoz-core-bundle",
-            "version": "3.4.1.0",
+            "version": "3.5.1",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/irontec/ivoz-core-bundle",
-                "reference": "9e628723cc793d960af320d4e661abba3f7b36ca"
+                "reference": "4d344148268f287bdfa1dd4e6dd8da337353353b"
             },
             "require": {
                 "doctrine/doctrine-bundle": "^1.6",
                 "doctrine/doctrine-cache-bundle": "^1.3",
-                "irontec/ivoz-core": "^3.3.2",
+                "irontec/ivoz-core": "^3.4",
                 "ocramius/proxy-manager": "~2.0",
                 "php": ">=7.0.19",
                 "symfony/monolog-bundle": "3.1.*",
@@ -1463,11 +1463,11 @@
         },
         {
             "name": "irontec/ivoz-provider-bundle",
-            "version": "2.5.9",
+            "version": "2.5.10",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/irontec/ivoz-provider-bundle",
-                "reference": "bf63c0c60b4c0f676556fbb36f60691007ced249"
+                "reference": "0a62fd51534ca37a96150bb229b36a1b3fcc0b75"
             },
             "require": {
                 "beberlei/doctrineextensions": "^1.1",
@@ -1516,7 +1516,8 @@
             ],
             "description": "Symfony bridge for IvozProvider",
             "transport-options": {
-                "symlink": true
+                "symlink": true,
+                "relative": true
             }
         },
         {

--- a/schema/composer.lock
+++ b/schema/composer.lock
@@ -1552,11 +1552,11 @@
         },
         {
             "name": "irontec/ivoz-core",
-            "version": "3.3.9",
+            "version": "3.4.4",
             "dist": {
                 "type": "path",
                 "url": "../library/vendor/irontec/ivoz-core",
-                "reference": "2d2fb1b9c31578cd0c482f47e5eaec6cd07f2fc6"
+                "reference": "3eccde9473af434e448ed7cf15736d21852508cb"
             },
             "require": {
                 "beberlei/assert": "2.9.*",
@@ -1602,16 +1602,16 @@
         },
         {
             "name": "irontec/ivoz-core-bundle",
-            "version": "3.4.1.0",
+            "version": "3.5.1",
             "dist": {
                 "type": "path",
                 "url": "../library/vendor/irontec/ivoz-core-bundle",
-                "reference": "9e628723cc793d960af320d4e661abba3f7b36ca"
+                "reference": "4d344148268f287bdfa1dd4e6dd8da337353353b"
             },
             "require": {
                 "doctrine/doctrine-bundle": "^1.6",
                 "doctrine/doctrine-cache-bundle": "^1.3",
-                "irontec/ivoz-core": "^3.3.2",
+                "irontec/ivoz-core": "^3.4",
                 "ocramius/proxy-manager": "~2.0",
                 "php": ">=7.0.19",
                 "symfony/monolog-bundle": "3.1.*",
@@ -1692,11 +1692,11 @@
         },
         {
             "name": "irontec/ivoz-provider-bundle",
-            "version": "2.5.9",
+            "version": "2.5.10",
             "dist": {
                 "type": "path",
                 "url": "../library/vendor/irontec/ivoz-provider-bundle",
-                "reference": "bf63c0c60b4c0f676556fbb36f60691007ced249"
+                "reference": "0a62fd51534ca37a96150bb229b36a1b3fcc0b75"
             },
             "require": {
                 "beberlei/doctrineextensions": "^1.1",
@@ -1745,7 +1745,8 @@
             ],
             "description": "Symfony bridge for IvozProvider",
             "transport-options": {
-                "symlink": true
+                "symlink": true,
+                "relative": true
             }
         },
         {

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get install --assume-yes --force-yes \
         php7.0-fpm \
         php-yaml \
         php-gearman \
+        php-redis \
         php-mailparse \
         php-imagick \
         php-xdebug \

--- a/web/rest/brand/composer.lock
+++ b/web/rest/brand/composer.lock
@@ -1636,11 +1636,11 @@
         },
         {
             "name": "irontec/ivoz-core",
-            "version": "3.3.9",
+            "version": "3.4.4",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/irontec/ivoz-core",
-                "reference": "2d2fb1b9c31578cd0c482f47e5eaec6cd07f2fc6"
+                "reference": "3eccde9473af434e448ed7cf15736d21852508cb"
             },
             "require": {
                 "beberlei/assert": "2.9.*",
@@ -1686,16 +1686,16 @@
         },
         {
             "name": "irontec/ivoz-core-bundle",
-            "version": "3.4.1.0",
+            "version": "3.5.1",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/irontec/ivoz-core-bundle",
-                "reference": "9e628723cc793d960af320d4e661abba3f7b36ca"
+                "reference": "4d344148268f287bdfa1dd4e6dd8da337353353b"
             },
             "require": {
                 "doctrine/doctrine-bundle": "^1.6",
                 "doctrine/doctrine-cache-bundle": "^1.3",
-                "irontec/ivoz-core": "^3.3.2",
+                "irontec/ivoz-core": "^3.4",
                 "ocramius/proxy-manager": "~2.0",
                 "php": ">=7.0.19",
                 "symfony/monolog-bundle": "3.1.*",
@@ -1733,11 +1733,11 @@
         },
         {
             "name": "irontec/ivoz-provider-bundle",
-            "version": "2.5.9",
+            "version": "2.5.10",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/irontec/ivoz-provider-bundle",
-                "reference": "bf63c0c60b4c0f676556fbb36f60691007ced249"
+                "reference": "0a62fd51534ca37a96150bb229b36a1b3fcc0b75"
             },
             "require": {
                 "beberlei/doctrineextensions": "^1.1",
@@ -1786,7 +1786,8 @@
             ],
             "description": "Symfony bridge for IvozProvider",
             "transport-options": {
-                "symlink": true
+                "symlink": true,
+                "relative": true
             }
         },
         {

--- a/web/rest/brand/features/my/activeCalls/getActiveCalls.feature
+++ b/web/rest/brand/features/my/activeCalls/getActiveCalls.feature
@@ -11,9 +11,9 @@ Feature: Retrieve active calls
       And the JSON should be equal to:
     """
       {
-          "inbound": -1,
-          "outbound": -1,
-          "total": -2
+          "inbound": 1,
+          "outbound": 1,
+          "total": 2
       }
     """
 
@@ -27,9 +27,9 @@ Feature: Retrieve active calls
     And the JSON should be equal to:
     """
       {
-          "inbound": -1,
-          "outbound": -1,
-          "total": -2
+          "inbound": 1,
+          "outbound": 1,
+          "total": 2
       }
     """
 

--- a/web/rest/brand/src/Controller/My/ActiveCallsAction.php
+++ b/web/rest/brand/src/Controller/My/ActiveCallsAction.php
@@ -73,6 +73,7 @@ class ActiveCallsAction
         $activeCalls = $this
             ->trunksClient
             ->getCompanyActiveCalls(
+                $brand->getId(),
                 intval($companyId)
             );
 

--- a/web/rest/client/composer.lock
+++ b/web/rest/client/composer.lock
@@ -1636,11 +1636,11 @@
         },
         {
             "name": "irontec/ivoz-core",
-            "version": "3.3.9",
+            "version": "3.4.4",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/irontec/ivoz-core",
-                "reference": "2d2fb1b9c31578cd0c482f47e5eaec6cd07f2fc6"
+                "reference": "3eccde9473af434e448ed7cf15736d21852508cb"
             },
             "require": {
                 "beberlei/assert": "2.9.*",
@@ -1686,16 +1686,16 @@
         },
         {
             "name": "irontec/ivoz-core-bundle",
-            "version": "3.4.1.0",
+            "version": "3.5.1",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/irontec/ivoz-core-bundle",
-                "reference": "9e628723cc793d960af320d4e661abba3f7b36ca"
+                "reference": "4d344148268f287bdfa1dd4e6dd8da337353353b"
             },
             "require": {
                 "doctrine/doctrine-bundle": "^1.6",
                 "doctrine/doctrine-cache-bundle": "^1.3",
-                "irontec/ivoz-core": "^3.3.2",
+                "irontec/ivoz-core": "^3.4",
                 "ocramius/proxy-manager": "~2.0",
                 "php": ">=7.0.19",
                 "symfony/monolog-bundle": "3.1.*",
@@ -1733,11 +1733,11 @@
         },
         {
             "name": "irontec/ivoz-provider-bundle",
-            "version": "2.5.9",
+            "version": "2.5.10",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/irontec/ivoz-provider-bundle",
-                "reference": "bf63c0c60b4c0f676556fbb36f60691007ced249"
+                "reference": "0a62fd51534ca37a96150bb229b36a1b3fcc0b75"
             },
             "require": {
                 "beberlei/doctrineextensions": "^1.1",
@@ -1786,7 +1786,8 @@
             ],
             "description": "Symfony bridge for IvozProvider",
             "transport-options": {
-                "symlink": true
+                "symlink": true,
+                "relative": true
             }
         },
         {

--- a/web/rest/client/features/my/activeCalls/getActiveCalls.feature
+++ b/web/rest/client/features/my/activeCalls/getActiveCalls.feature
@@ -11,8 +11,8 @@ Feature: Retrieve active calls
       And the JSON should be equal to:
     """
       {
-          "inbound": -1,
-          "outbound": -1,
-          "total": -2
+          "inbound": 1,
+          "outbound": 1,
+          "total": 2
       }
     """

--- a/web/rest/client/src/Controller/My/ActiveCallsAction.php
+++ b/web/rest/client/src/Controller/My/ActiveCallsAction.php
@@ -48,6 +48,7 @@ class ActiveCallsAction
         $activeCalls = $this
             ->trunksClient
             ->getCompanyActiveCalls(
+                $company->getBrand()->getId(),
                 $company->getId()
             );
 

--- a/web/rest/platform/composer.lock
+++ b/web/rest/platform/composer.lock
@@ -1636,11 +1636,11 @@
         },
         {
             "name": "irontec/ivoz-core",
-            "version": "3.3.9",
+            "version": "3.4.4",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/irontec/ivoz-core",
-                "reference": "2d2fb1b9c31578cd0c482f47e5eaec6cd07f2fc6"
+                "reference": "3eccde9473af434e448ed7cf15736d21852508cb"
             },
             "require": {
                 "beberlei/assert": "2.9.*",
@@ -1686,16 +1686,16 @@
         },
         {
             "name": "irontec/ivoz-core-bundle",
-            "version": "3.4.1.0",
+            "version": "3.5.1",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/irontec/ivoz-core-bundle",
-                "reference": "9e628723cc793d960af320d4e661abba3f7b36ca"
+                "reference": "4d344148268f287bdfa1dd4e6dd8da337353353b"
             },
             "require": {
                 "doctrine/doctrine-bundle": "^1.6",
                 "doctrine/doctrine-cache-bundle": "^1.3",
-                "irontec/ivoz-core": "^3.3.2",
+                "irontec/ivoz-core": "^3.4",
                 "ocramius/proxy-manager": "~2.0",
                 "php": ">=7.0.19",
                 "symfony/monolog-bundle": "3.1.*",
@@ -1733,11 +1733,11 @@
         },
         {
             "name": "irontec/ivoz-provider-bundle",
-            "version": "2.5.9",
+            "version": "2.5.10",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/irontec/ivoz-provider-bundle",
-                "reference": "bf63c0c60b4c0f676556fbb36f60691007ced249"
+                "reference": "0a62fd51534ca37a96150bb229b36a1b3fcc0b75"
             },
             "require": {
                 "beberlei/doctrineextensions": "^1.1",
@@ -1786,7 +1786,8 @@
             ],
             "description": "Symfony bridge for IvozProvider",
             "transport-options": {
-                "symlink": true
+                "symlink": true,
+                "relative": true
             }
         },
         {

--- a/web/rest/platform/features/my/activeCalls/getActiveCalls.feature
+++ b/web/rest/platform/features/my/activeCalls/getActiveCalls.feature
@@ -11,9 +11,9 @@ Feature: Retrieve active calls
       And the JSON should be equal to:
     """
       {
-          "inbound": -1,
-          "outbound": -1,
-          "total": -2
+          "inbound": 1,
+          "outbound": 1,
+          "total": 2
       }
     """
 
@@ -27,8 +27,8 @@ Feature: Retrieve active calls
     And the JSON should be equal to:
     """
       {
-          "inbound": -1,
-          "outbound": -1,
-          "total": -2
+          "inbound": 1,
+          "outbound": 1,
+          "total": 2
       }
     """


### PR DESCRIPTION
Resolve Active calls through redis so that kamailio reloads do not show zero active calls

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
