### PR TITLE
Improved token exchange

### DIFF
--- a/library/DataFixtures/ORM/ProviderAdministrator.php
+++ b/library/DataFixtures/ORM/ProviderAdministrator.php
@@ -171,6 +171,33 @@ class ProviderAdministrator extends Fixture implements DependentFixtureInterface
         $this->sanitizeEntityValues($item9);
         $manager->persist($item9);
 
+        $item10 = $this->createEntityInstance(Administrator::class);
+        (function () use ($fixture) {
+            $this->setUsername("__b1_internal");
+            $this->setPass("[internal]");
+            $this->setActive(false);
+            $this->setRestricted(false);
+            $this->setInternal(true);
+            $this->setBrand($fixture->getReference('_reference_ProviderBrand1'));
+        })->call($item10);
+        $this->addReference('_reference_ProviderAdministrator10', $item10);
+        $this->sanitizeEntityValues($item10);
+        $manager->persist($item10);
+
+        $item11 = $this->createEntityInstance(Administrator::class);
+        (function () use ($fixture) {
+            $this->setUsername("__c1_internal");
+            $this->setPass("[internal]");
+            $this->setActive(false);
+            $this->setRestricted(false);
+            $this->setInternal(true);
+            $this->setBrand($fixture->getReference('_reference_ProviderBrand1'));
+            $this->setCompany($fixture->getReference('_reference_ProviderCompany1'));
+        })->call($item11);
+        $this->addReference('_reference_ProviderAdministrator11', $item11);
+        $this->sanitizeEntityValues($item11);
+        $manager->persist($item11);
+
         $manager->flush();
     }
 

--- a/library/Ivoz/Cgr/Domain/Service/TpDerivedCharger/CreatedByBrand.php
+++ b/library/Ivoz/Cgr/Domain/Service/TpDerivedCharger/CreatedByBrand.php
@@ -27,12 +27,7 @@ class CreatedByBrand implements BrandLifecycleEventHandlerInterface
         ];
     }
 
-    /**
-     * @param BrandInterface $brand
-     *
-     * @return void
-     */
-    public function execute(BrandInterface $brand)
+    public function execute(BrandInterface $brand): void
     {
         $isNew = $brand->isNew();
         if (!$isNew) {

--- a/library/Ivoz/Provider/Domain/Model/Administrator/AdministratorAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Administrator/AdministratorAbstract.php
@@ -35,6 +35,8 @@ abstract class AdministratorAbstract
 
     protected $active = true;
 
+    protected $internal = false;
+
     protected $restricted = false;
 
     protected $name;
@@ -64,12 +66,14 @@ abstract class AdministratorAbstract
         string $pass,
         string $email,
         bool $active,
+        bool $internal,
         bool $restricted
     ) {
         $this->setUsername($username);
         $this->setPass($pass);
         $this->setEmail($email);
         $this->setActive($active);
+        $this->setInternal($internal);
         $this->setRestricted($restricted);
     }
 
@@ -145,6 +149,7 @@ abstract class AdministratorAbstract
             $dto->getPass(),
             $dto->getEmail(),
             $dto->getActive(),
+            $dto->getInternal(),
             $dto->getRestricted()
         );
 
@@ -176,6 +181,7 @@ abstract class AdministratorAbstract
             ->setPass($dto->getPass())
             ->setEmail($dto->getEmail())
             ->setActive($dto->getActive())
+            ->setInternal($dto->getInternal())
             ->setRestricted($dto->getRestricted())
             ->setName($dto->getName())
             ->setLastname($dto->getLastname())
@@ -197,6 +203,7 @@ abstract class AdministratorAbstract
             ->setPass(self::getPass())
             ->setEmail(self::getEmail())
             ->setActive(self::getActive())
+            ->setInternal(self::getInternal())
             ->setRestricted(self::getRestricted())
             ->setName(self::getName())
             ->setLastname(self::getLastname())
@@ -215,6 +222,7 @@ abstract class AdministratorAbstract
             'pass' => self::getPass(),
             'email' => self::getEmail(),
             'active' => self::getActive(),
+            'internal' => self::getInternal(),
             'restricted' => self::getRestricted(),
             'name' => self::getName(),
             'lastname' => self::getLastname(),
@@ -276,6 +284,18 @@ abstract class AdministratorAbstract
     public function getActive(): bool
     {
         return $this->active;
+    }
+
+    protected function setInternal(bool $internal): static
+    {
+        $this->internal = $internal;
+
+        return $this;
+    }
+
+    public function getInternal(): bool
+    {
+        return $this->internal;
     }
 
     protected function setRestricted(bool $restricted): static

--- a/library/Ivoz/Provider/Domain/Model/Administrator/AdministratorDto.php
+++ b/library/Ivoz/Provider/Domain/Model/Administrator/AdministratorDto.php
@@ -26,6 +26,7 @@ class AdministratorDto extends AdministratorDtoAbstract
             ];
         } else {
             $response = parent::getPropertyMap(...func_get_args());
+            unset($response['internal']);
         }
 
         if ($role === 'ROLE_BRAND_ADMIN') {

--- a/library/Ivoz/Provider/Domain/Model/Administrator/AdministratorDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Administrator/AdministratorDtoAbstract.php
@@ -40,6 +40,11 @@ abstract class AdministratorDtoAbstract implements DataTransferObjectInterface
     /**
      * @var bool
      */
+    private $internal = false;
+
+    /**
+     * @var bool
+     */
     private $restricted = false;
 
     /**
@@ -96,6 +101,7 @@ abstract class AdministratorDtoAbstract implements DataTransferObjectInterface
             'pass' => 'pass',
             'email' => 'email',
             'active' => 'active',
+            'internal' => 'internal',
             'restricted' => 'restricted',
             'name' => 'name',
             'lastname' => 'lastname',
@@ -116,6 +122,7 @@ abstract class AdministratorDtoAbstract implements DataTransferObjectInterface
             'pass' => $this->getPass(),
             'email' => $this->getEmail(),
             'active' => $this->getActive(),
+            'internal' => $this->getInternal(),
             'restricted' => $this->getRestricted(),
             'name' => $this->getName(),
             'lastname' => $this->getLastname(),
@@ -186,6 +193,18 @@ abstract class AdministratorDtoAbstract implements DataTransferObjectInterface
     public function getActive(): ?bool
     {
         return $this->active;
+    }
+
+    public function setInternal(bool $internal): static
+    {
+        $this->internal = $internal;
+
+        return $this;
+    }
+
+    public function getInternal(): ?bool
+    {
+        return $this->internal;
     }
 
     public function setRestricted(bool $restricted): static

--- a/library/Ivoz/Provider/Domain/Model/Administrator/AdministratorInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/Administrator/AdministratorInterface.php
@@ -59,6 +59,8 @@ interface AdministratorInterface extends LoggableEntityInterface
 
     public function getActive(): bool;
 
+    public function getInternal(): bool;
+
     public function getRestricted(): bool;
 
     public function getName(): ?string;

--- a/library/Ivoz/Provider/Domain/Service/Administrator/AdminLoginChecker.php
+++ b/library/Ivoz/Provider/Domain/Service/Administrator/AdminLoginChecker.php
@@ -18,6 +18,12 @@ class AdminLoginChecker implements UserCheckerInterface
             return;
         }
 
+        if ($admin->getInternal()) {
+            throw new CustomUserMessageAccountStatusException(
+                'Unable to login as an internal admin'
+            );
+        }
+
         if (!$admin->isEnabled()) {
             throw new CustomUserMessageAccountStatusException(
                 'Your admin account is disabled.'

--- a/library/Ivoz/Provider/Domain/Service/Administrator/CreatedByBrand.php
+++ b/library/Ivoz/Provider/Domain/Service/Administrator/CreatedByBrand.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Ivoz\Provider\Domain\Service\Administrator;
+
+use Ivoz\Core\Application\Service\EntityTools;
+use Ivoz\Provider\Domain\Model\Administrator\Administrator;
+use Ivoz\Provider\Domain\Model\Brand\BrandInterface;
+use Ivoz\Provider\Domain\Service\Brand\BrandLifecycleEventHandlerInterface;
+
+class CreatedByBrand implements BrandLifecycleEventHandlerInterface
+{
+    public const POST_PERSIST_PRIORITY = self::PRIORITY_NORMAL;
+
+    public function __construct(
+        private EntityTools $entityTools
+    ) {
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            self::EVENT_POST_PERSIST => self::POST_PERSIST_PRIORITY
+        ];
+    }
+
+    public function execute(BrandInterface $brand): void
+    {
+        $isNew = $brand->isNew();
+        if (!$isNew) {
+            return;
+        }
+
+        // Create a new TpDerivedCharger when brand is created
+        $administratorDto = Administrator::createDto();
+        /** @var int $brandId */
+        $brandId = $brand->getId();
+        $administratorDto
+            ->setUsername(
+                '__b' . $brandId . '_internal'
+            )
+            ->setPass(
+                '[internal]'
+            )
+            ->setBrandId(
+                $brandId
+            )
+            ->setActive(false)
+            ->setRestricted(false)
+            ->setInternal(true);
+
+        $this->entityTools->persistDto($administratorDto, null);
+    }
+}

--- a/library/Ivoz/Provider/Domain/Service/Administrator/CreatedByCompany.php
+++ b/library/Ivoz/Provider/Domain/Service/Administrator/CreatedByCompany.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Ivoz\Provider\Domain\Service\Administrator;
+
+use Ivoz\Core\Application\Service\EntityTools;
+use Ivoz\Provider\Domain\Model\Administrator\Administrator;
+use Ivoz\Provider\Domain\Model\Company\CompanyInterface;
+use Ivoz\Provider\Domain\Service\Company\CompanyLifecycleEventHandlerInterface;
+
+class CreatedByCompany implements CompanyLifecycleEventHandlerInterface
+{
+    public const POST_PERSIST_PRIORITY = self::PRIORITY_NORMAL;
+
+    public function __construct(
+        private EntityTools $entityTools
+    ) {
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            self::EVENT_POST_PERSIST => self::POST_PERSIST_PRIORITY
+        ];
+    }
+
+    public function execute(CompanyInterface $company): void
+    {
+        $isNew = $company->isNew();
+        if (!$isNew) {
+            return;
+        }
+
+        // Create a new TpDerivedCharger when brand is created
+        $administratorDto = Administrator::createDto();
+
+        /** @var int $companyId */
+        $companyId = $company->getId();
+        /** @var int $brandId */
+        $brandId = $company->getBrand()->getId();
+
+        $administratorDto
+            ->setUsername(
+                '__c' . $companyId . '_internal'
+            )
+            ->setPass(
+                '[internal]'
+            )
+            ->setBrandId(
+                $brandId
+            )
+            ->setCompanyId(
+                $companyId
+            )
+            ->setActive(false)
+            ->setRestricted(false)
+            ->setInternal(true);
+
+        $this->entityTools->persistDto(
+            $administratorDto,
+            null
+        );
+    }
+}

--- a/library/Ivoz/Provider/Domain/Service/BillableCall/MigrateFromTrunksCdr.php
+++ b/library/Ivoz/Provider/Domain/Service/BillableCall/MigrateFromTrunksCdr.php
@@ -7,7 +7,6 @@ use Ivoz\Core\Domain\Service\DomainEventPublisher;
 use Ivoz\Kam\Domain\Model\TrunksCdr\Event\TrunksCdrWasMigrated;
 use Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdrInterface;
 use Ivoz\Kam\Domain\Service\TrunksCdr\SetParsed;
-use Ivoz\Provider\Domain\Model\BillableCall\BillableCallInterface;
 use Ivoz\Provider\Domain\Model\BillableCall\BillableCallRepository;
 
 class MigrateFromTrunksCdr

--- a/library/Ivoz/Provider/Domain/Service/Brand/BrandLifecycleEventHandlerInterface.php
+++ b/library/Ivoz/Provider/Domain/Service/Brand/BrandLifecycleEventHandlerInterface.php
@@ -7,5 +7,5 @@ use Ivoz\Provider\Domain\Model\Brand\BrandInterface;
 
 interface BrandLifecycleEventHandlerInterface extends LifecycleEventHandlerInterface
 {
-    public function execute(BrandInterface $brand);
+    public function execute(BrandInterface $brand): void;
 }

--- a/library/Ivoz/Provider/Domain/Service/Brand/BrandLifecycleServiceCollection.php
+++ b/library/Ivoz/Provider/Domain/Service/Brand/BrandLifecycleServiceCollection.php
@@ -20,6 +20,7 @@ class BrandLifecycleServiceCollection implements LifecycleServiceCollectionInter
             \Ivoz\Provider\Domain\Service\RoutingPattern\UpdateByBrand::class => 20,
             \Ivoz\Provider\Domain\Service\BrandService\UpdateByBrand::class => 30,
             \Ivoz\Cgr\Domain\Service\TpDerivedCharger\CreatedByBrand::class => 200,
+            \Ivoz\Provider\Domain\Service\Administrator\CreatedByBrand::class => 200,
         ],
         "post_remove" =>
         [

--- a/library/Ivoz/Provider/Domain/Service/BrandService/UpdateByBrand.php
+++ b/library/Ivoz/Provider/Domain/Service/BrandService/UpdateByBrand.php
@@ -25,10 +25,7 @@ class UpdateByBrand implements BrandLifecycleEventHandlerInterface
         ];
     }
 
-    /**
-     * @return void
-     */
-    public function execute(BrandInterface $brand)
+    public function execute(BrandInterface $brand): void
     {
         $isNew = $brand->isNew();
         if (!$isNew) {

--- a/library/Ivoz/Provider/Domain/Service/Company/CompanyLifecycleServiceCollection.php
+++ b/library/Ivoz/Provider/Domain/Service/Company/CompanyLifecycleServiceCollection.php
@@ -24,6 +24,7 @@ class CompanyLifecycleServiceCollection implements LifecycleServiceCollectionInt
             \Ivoz\Provider\Domain\Service\MaxUsageNotification\SearchBrokenMaxDailyUsage::class => 10,
             \Ivoz\Cgr\Domain\Service\TpAccountAction\CreateByCompany::class => 20,
             \Ivoz\Provider\Domain\Service\CompanyService\PropagateBrandServices::class => 30,
+            \Ivoz\Provider\Domain\Service\Administrator\CreatedByCompany::class => 200,
         ],
         "post_remove" =>
         [

--- a/library/Ivoz/Provider/Domain/Service/Domain/DeleteByBrand.php
+++ b/library/Ivoz/Provider/Domain/Service/Domain/DeleteByBrand.php
@@ -27,10 +27,7 @@ class DeleteByBrand implements BrandLifecycleEventHandlerInterface
         ];
     }
 
-    /**
-     * @return void
-     */
-    public function execute(BrandInterface $brand)
+    public function execute(BrandInterface $brand): void
     {
         $domain = $brand->getDomain();
 

--- a/library/Ivoz/Provider/Domain/Service/Domain/UpdateByBrand.php
+++ b/library/Ivoz/Provider/Domain/Service/Domain/UpdateByBrand.php
@@ -30,10 +30,7 @@ class UpdateByBrand implements BrandLifecycleEventHandlerInterface
         ];
     }
 
-    /**
-     * @return void
-     */
-    public function execute(BrandInterface $brand)
+    public function execute(BrandInterface $brand): void
     {
         if (!$brand->hasChanged('domain_users')) {
             return;

--- a/library/Ivoz/Provider/Domain/Service/RoutingPattern/UpdateByBrand.php
+++ b/library/Ivoz/Provider/Domain/Service/RoutingPattern/UpdateByBrand.php
@@ -28,10 +28,7 @@ class UpdateByBrand implements BrandLifecycleEventHandlerInterface
         ];
     }
 
-    /**
-     * @return void
-     */
-    public function execute(BrandInterface $brand)
+    public function execute(BrandInterface $brand): void
     {
         $isNew = $brand->isNew();
         if (!$isNew) {

--- a/library/Ivoz/Provider/Infrastructure/Api/Jwt/UserTokenAuthenticator.php
+++ b/library/Ivoz/Provider/Infrastructure/Api/Jwt/UserTokenAuthenticator.php
@@ -105,8 +105,7 @@ class UserTokenAuthenticator extends JWTTokenAuthenticator
 
         /** @var MutableUserProviderInterface $userProvider */
         $provider
-            ->setEntityClass(User::class)
-            ->setUserIdentityField('email');
+            ->setEntityClass(User::class);
 
         return $provider->loadUserByUsername($identity);
     }

--- a/library/Ivoz/Provider/Infrastructure/Api/Security/User/MutableUserProviderInterface.php
+++ b/library/Ivoz/Provider/Infrastructure/Api/Security/User/MutableUserProviderInterface.php
@@ -6,8 +6,5 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
 
 interface MutableUserProviderInterface extends UserProviderInterface
 {
-
     public function setEntityClass(string $class): self;
-
-    public function setUserIdentityField(string $identifierField): self;
 }

--- a/library/Ivoz/Provider/Infrastructure/Api/Security/User/UserProviderTrait.php
+++ b/library/Ivoz/Provider/Infrastructure/Api/Security/User/UserProviderTrait.php
@@ -3,11 +3,13 @@
 namespace Ivoz\Provider\Infrastructure\Api\Security\User;
 
 use Doctrine\Persistence\ManagerRegistry;
+use Ivoz\Provider\Domain\Model\Administrator\AdministratorInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
-use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserInterface as SymfonyUserInterface;
+use Ivoz\Provider\Domain\Model\User\UserInterface;
 
 trait UserProviderTrait
 {
@@ -16,7 +18,6 @@ trait UserProviderTrait
         private RequestStack $requestStack,
         private LoggerInterface $logger,
         private string $entityClass,
-        private string $identifierField,
         private $managerName = null
     ) {
     }
@@ -27,9 +28,7 @@ trait UserProviderTrait
     public function loadUserByUsername($username)
     {
         try {
-            $user = $this->findUser([
-                $this->identifierField => $username
-            ]);
+            $user = $this->findUser($username);
         } catch (\Exception $e) {
             $this->logger->error($e->getMessage());
             throw $e;
@@ -44,12 +43,12 @@ trait UserProviderTrait
         return $user;
     }
 
-    abstract protected function findUser(array $criteria);
+    abstract protected function findUser(string $identity): null|AdministratorInterface|UserInterface;
 
     /**
      * {@inheritdoc}
      */
-    public function refreshUser(UserInterface $user)
+    public function refreshUser(SymfonyUserInterface $user)
     {
         if (!$user instanceof $this->entityClass) {
             throw new UnsupportedUserException(sprintf('Instances of "%s" are not supported.', $user::class));

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/Administrator.AdministratorAbstract.orm.xml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/Administrator.AdministratorAbstract.orm.xml
@@ -26,6 +26,11 @@
         <option name="default">1</option>
       </options>
     </field>
+    <field name="internal" type="boolean" column="internal" nullable="false">
+      <options>
+        <option name="default">0</option>
+      </options>
+    </field>
     <field name="restricted" type="boolean" column="restricted" nullable="false">
       <options>
         <option name="default">0</option>

--- a/library/phpstan-baseline.neon
+++ b/library/phpstan-baseline.neon
@@ -7876,6 +7876,11 @@ parameters:
 			path: Ivoz/Provider/Domain/Model/Administrator/AdministratorAbstract.php
 
 		-
+			message: "#^Parameter \\#1 \\$internal of method Ivoz\\\\Provider\\\\Domain\\\\Model\\\\Administrator\\\\AdministratorAbstract\\:\\:setInternal\\(\\) expects bool, bool\\|null given\\.$#"
+			count: 1
+			path: Ivoz/Provider/Domain/Model/Administrator/AdministratorAbstract.php
+
+		-
 			message: "#^Parameter \\#1 \\$pass of method Ivoz\\\\Provider\\\\Domain\\\\Model\\\\Administrator\\\\AdministratorAbstract\\:\\:setPass\\(\\) expects string, string\\|null given\\.$#"
 			count: 1
 			path: Ivoz/Provider/Domain/Model/Administrator/AdministratorAbstract.php
@@ -7897,6 +7902,11 @@ parameters:
 
 		-
 			message: "#^Property Ivoz\\\\Provider\\\\Domain\\\\Model\\\\Administrator\\\\AdministratorAbstract\\:\\:\\$email has no typehint specified\\.$#"
+			count: 1
+			path: Ivoz/Provider/Domain/Model/Administrator/AdministratorAbstract.php
+
+		-
+			message: "#^Property Ivoz\\\\Provider\\\\Domain\\\\Model\\\\Administrator\\\\AdministratorAbstract\\:\\:\\$internal has no typehint specified\\.$#"
 			count: 1
 			path: Ivoz/Provider/Domain/Model/Administrator/AdministratorAbstract.php
 
@@ -30394,11 +30404,6 @@ parameters:
 			message: "#^Cannot call method getLanguageCode\\(\\) on Ivoz\\\\Provider\\\\Domain\\\\Model\\\\Brand\\\\BrandInterface\\|null\\.$#"
 			count: 1
 			path: Ivoz/Provider/Domain/Service/BillableCall/UpdateDtoByDefaultRunTpCdr.php
-
-		-
-			message: "#^Method Ivoz\\\\Provider\\\\Domain\\\\Service\\\\Brand\\\\BrandLifecycleEventHandlerInterface\\:\\:execute\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: Ivoz/Provider/Domain/Service/Brand/BrandLifecycleEventHandlerInterface.php
 
 		-
 			message: "#^Method Ivoz\\\\Provider\\\\Domain\\\\Service\\\\Brand\\\\BrandLifecycleServiceCollection\\:\\:addService\\(\\) has parameter \\$service with no typehint specified\\.$#"

--- a/library/psalm-baseline.xml
+++ b/library/psalm-baseline.xml
@@ -6199,9 +6199,10 @@
     <ImplementedReturnTypeMismatch occurrences="1">
       <code>AdministratorDto</code>
     </ImplementedReturnTypeMismatch>
-    <MissingPropertyType occurrences="7">
+    <MissingPropertyType occurrences="8">
       <code>$active</code>
       <code>$email</code>
+      <code>$internal</code>
       <code>$lastname</code>
       <code>$name</code>
       <code>$pass</code>
@@ -6220,18 +6221,20 @@
       <code>$fkTransformer-&gt;transform($dto-&gt;getTimezone())</code>
       <code>$this-&gt;getId()</code>
     </MixedArgument>
-    <MixedInferredReturnType occurrences="7">
+    <MixedInferredReturnType occurrences="8">
       <code>?string</code>
       <code>?string</code>
+      <code>bool</code>
       <code>bool</code>
       <code>bool</code>
       <code>string</code>
       <code>string</code>
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="7">
+    <MixedReturnStatement occurrences="8">
       <code>$this-&gt;active</code>
       <code>$this-&gt;email</code>
+      <code>$this-&gt;internal</code>
       <code>$this-&gt;lastname</code>
       <code>$this-&gt;name</code>
       <code>$this-&gt;pass</code>
@@ -6241,11 +6244,13 @@
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$entity</code>
     </MoreSpecificImplementedParamType>
-    <PossiblyNullArgument occurrences="10">
+    <PossiblyNullArgument occurrences="12">
       <code>$dto-&gt;getActive()</code>
       <code>$dto-&gt;getActive()</code>
       <code>$dto-&gt;getEmail()</code>
       <code>$dto-&gt;getEmail()</code>
+      <code>$dto-&gt;getInternal()</code>
+      <code>$dto-&gt;getInternal()</code>
       <code>$dto-&gt;getPass()</code>
       <code>$dto-&gt;getPass()</code>
       <code>$dto-&gt;getRestricted()</code>
@@ -22013,11 +22018,6 @@
     <TypeDoesNotContainNull occurrences="1">
       <code>isset($untilId)</code>
     </TypeDoesNotContainNull>
-  </file>
-  <file src="Ivoz/Provider/Domain/Service/Brand/BrandLifecycleEventHandlerInterface.php">
-    <MissingReturnType occurrences="1">
-      <code>execute</code>
-    </MissingReturnType>
   </file>
   <file src="Ivoz/Provider/Domain/Service/Brand/BrandLifecycleServiceCollection.php">
     <MissingParamType occurrences="1">

--- a/schema/DoctrineMigrations/Version20211105124136.php
+++ b/schema/DoctrineMigrations/Version20211105124136.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20211105124136 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE Administrators ADD internal TINYINT(1) DEFAULT \'0\' NOT NULL');
+        $this->addSql(
+            'INSERT INTO `Administrators` (`username`, `pass`, `active`, `internal`, `brandId`) SELECT CONCAT("__b", id, "_internal"), "[internal]", 0, 1, `id` FROM `Brands`'
+        );
+        $this->addSql(
+            'INSERT INTO `Administrators` (`username`, `pass`, `active`, `internal`, `brandId`, `companyId`) SELECT CONCAT("__c", id, "_internal"), "[internal]", 0, 1, `brandId`, `id` FROM `Companies`'
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('DELETE FROM `Administrators` where `internal` = 1');
+        $this->addSql('ALTER TABLE Administrators DROP internal');
+    }
+}

--- a/schema/tests/Provider/Brand/BrandLifeCycleTest.php
+++ b/schema/tests/Provider/Brand/BrandLifeCycleTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Provider\Brand;
 
+use Ivoz\Provider\Domain\Model\Administrator\Administrator;
 use Ivoz\Provider\Domain\Model\Changelog\Changelog;
 use Ivoz\Provider\Domain\Model\CompanyRelRoutingTag\CompanyRelRoutingTag;
 use Ivoz\Provider\Domain\Model\Country\Country;
@@ -234,6 +235,7 @@ class BrandLifeCycleTest extends KernelTestCase
             BrandService::class,
             TpDerivedCharger::class,
             RoutingPatternGroupsRelPattern::class,
+            Administrator::class,
         ]);
     }
 

--- a/schema/tests/Provider/Company/CompanyLifeCycleTest.php
+++ b/schema/tests/Provider/Company/CompanyLifeCycleTest.php
@@ -5,6 +5,7 @@ namespace Tests\Provider\Company;
 use Ivoz\Ast\Domain\Model\PsEndpoint\PsEndpoint;
 use Ivoz\Cgr\Domain\Model\TpAccountAction\TpAccountAction;
 use Ivoz\Cgr\Domain\Model\TpRatingProfile\TpRatingProfile;
+use Ivoz\Provider\Domain\Model\Administrator\Administrator;
 use Ivoz\Provider\Domain\Model\Company\Company;
 use Ivoz\Provider\Domain\Model\Company\CompanyDto;
 use Ivoz\Provider\Domain\Model\CompanyRelRoutingTag\CompanyRelRoutingTag;
@@ -362,6 +363,7 @@ class CompanyLifeCycleTest extends KernelTestCase
             Company::class,
             TpAccountAction::class,
             CompanyService::class,
+            Administrator::class,
         ]);
     }
 

--- a/web/admin/application/configs/klear/AdministratorsList.yaml
+++ b/web/admin/application/configs/klear/AdministratorsList.yaml
@@ -15,7 +15,7 @@ production:
       <<: *Administrators
       class: ui-silk-tux
       title: _("List of %s %2s", ngettext('Main operator', 'Main operators', 0), "[format| (%parent%)]")
-      rawCondition: "Administrator.id != 0"
+      rawCondition: "Administrator.id != 0 AND Administrator.internal != 1"
       info:
         <<: *documentationLink
         href: "/doc/en/administration_portal/platform/main_operators.html"

--- a/web/rest/brand/config/api/raw/provider.yml
+++ b/web/rest/brand/config/api/raw/provider.yml
@@ -8,6 +8,8 @@ Ivoz\Provider\Domain\Model\Administrator\Administrator:
       ROLE_BRAND_ADMIN:
         company:
           in: "companyRepository.getSupervisedCompanyIdsByAdmin(user)"
+        internal:
+          neq: "1"
     write_access_control:
       ROLE_BRAND_ADMIN:
         raw: "id > 0 or id === null"

--- a/web/rest/brand/config/services.yaml
+++ b/web/rest/brand/config/services.yaml
@@ -26,7 +26,10 @@ services:
 
     Service\UserProvider:
         arguments:
-            $identifierField: 'username'
+            $entityClass: 'Ivoz\Provider\Domain\Model\Administrator\Administrator'
+
+    Service\TokenExchangeUserProvider:
+        arguments:
             $entityClass: 'Ivoz\Provider\Domain\Model\Administrator\Administrator'
 
     Service\AuthEndpointDecorator:
@@ -40,7 +43,7 @@ services:
 
     Ivoz\Api\Operation\ExchangeToken:
         arguments:
-            $userProvider: '@Service\UserProvider'
+            $userProvider: '@Service\TokenExchangeUserProvider'
 
     Ivoz\Api\Core\Security\DataAccessControlParser:
         public: true

--- a/web/rest/brand/features/auth.feature
+++ b/web/rest/brand/features/auth.feature
@@ -22,3 +22,10 @@ Feature: Authorization checking
     And  I send a "GET" request to "companies"
     Then the response status code should be 200
     And  the response should be in JSON
+
+  Scenario: A higher order admin can exchange internal token
+    When I exchange internal Brand Authorization header
+    And  I add "Accept" header equal to "application/ld+json"
+    And  I send a "GET" request to "companies"
+    Then the response status code should be 200
+    And  the response should be in JSON

--- a/web/rest/brand/features/provider/administrator/postAdministrators.feature
+++ b/web/rest/brand/features/provider/administrator/postAdministrators.feature
@@ -36,7 +36,7 @@ Feature: Create administrators
           "restricted": false,
           "name": "post",
           "lastname": "test",
-          "id": 10,
+          "id": 12,
           "company": 1,
           "timezone": 145
       }
@@ -45,7 +45,7 @@ Feature: Create administrators
   Scenario: Retrieve created administrator
     Given I add Brand Authorization header
      When I add "Accept" header equal to "application/json"
-      And I send a "GET" request to "administrators/10"
+      And I send a "GET" request to "administrators/12"
      Then the response status code should be 200
       And the response should be in JSON
       And the header "Content-Type" should be equal to "application/json; charset=utf-8"
@@ -59,7 +59,7 @@ Feature: Create administrators
           "restricted": false,
           "name": "post",
           "lastname": "test",
-          "id": 10,
+          "id": 12,
           "company": "~",
           "timezone": {
               "tz": "Europe/Madrid",

--- a/web/rest/brand/phpstan-baseline.neon
+++ b/web/rest/brand/phpstan-baseline.neon
@@ -96,11 +96,6 @@ parameters:
 			path: src/Service/AuthEndpointDecorator.php
 
 		-
-			message: "#^Method Service\\\\UserProvider\\:\\:findUser\\(\\) has parameter \\$criteria with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Service/UserProvider.php
-
-		-
 			message: "#^Method Service\\\\UserProvider\\:\\:supportsClass\\(\\) has parameter \\$class with no typehint specified\\.$#"
 			count: 1
 			path: src/Service/UserProvider.php

--- a/web/rest/brand/psalm-baseline.xml
+++ b/web/rest/brand/psalm-baseline.xml
@@ -170,12 +170,5 @@
     <MixedArgument occurrences="1">
       <code>$class</code>
     </MixedArgument>
-    <MixedInferredReturnType occurrences="1">
-      <code>null | AdministratorInterface</code>
-    </MixedInferredReturnType>
-    <MixedMethodCall occurrences="1">
-      <code>findOneBy</code>
-    </MixedMethodCall>
-    <MixedReturnStatement occurrences="1"/>
   </file>
 </files>

--- a/web/rest/brand/src/Service/Behat/FeatureContext.php
+++ b/web/rest/brand/src/Service/Behat/FeatureContext.php
@@ -25,4 +25,14 @@ class FeatureContext extends BaseFeatureContext
     {
         $this->exchangeAuthorizationHeader('admin', 'test_brand_admin');
     }
+
+    /**
+     * @Given I exchange internal Brand Authorization header
+     *
+     * @return void
+     */
+    public function setInternalBrandAuthorizationHeaderByExchange(): void
+    {
+        $this->exchangeAuthorizationHeader('admin', '__b1_internal');
+    }
 }

--- a/web/rest/brand/src/Service/TokenExchangeUserProvider.php
+++ b/web/rest/brand/src/Service/TokenExchangeUserProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Service;
+
+use Ivoz\Provider\Domain\Model\Administrator\AdministratorRepository;
+use Ivoz\Provider\Infrastructure\Api\Security\User\UserProviderTrait;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+use Ivoz\Provider\Domain\Model\Administrator\Administrator;
+use Ivoz\Provider\Domain\Model\Administrator\AdministratorInterface;
+
+class TokenExchangeUserProvider extends UserProvider
+{
+    protected function findUser(string $identity): ?AdministratorInterface
+    {
+        $user = parent::findUser($identity);
+
+        if (!$user) {
+            return null;
+        }
+
+        if (!$user->isEnabled() && !$user->getInternal()) {
+            throw new \Exception('User not found');
+        }
+
+        return $user;
+    }
+}

--- a/web/rest/brand/src/Service/UserProvider.php
+++ b/web/rest/brand/src/Service/UserProvider.php
@@ -2,6 +2,7 @@
 
 namespace Service;
 
+use Ivoz\Provider\Domain\Model\Administrator\AdministratorRepository;
 use Ivoz\Provider\Infrastructure\Api\Security\User\UserProviderTrait;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Ivoz\Provider\Domain\Model\Administrator\Administrator;
@@ -11,15 +12,14 @@ class UserProvider implements UserProviderInterface
 {
     use UserProviderTrait;
 
-    /**
-     * @param array $criteria
-     * @return null | AdministratorInterface
-     */
-    protected function findUser(array $criteria)
+    protected function findUser(string $identity): ?AdministratorInterface
     {
-        return $this
-            ->getRepository()
-            ->findOneBy($criteria);
+        /** @var AdministratorRepository $repository */
+        $repository = $this->getRepository();
+
+        $user = $repository->findBrandAdminByUsername($identity);
+
+        return $user;
     }
 
     /**

--- a/web/rest/brand/tests/DataAccessControl/Provider/AdministratorRelPublicEntitiesTest.php
+++ b/web/rest/brand/tests/DataAccessControl/Provider/AdministratorRelPublicEntitiesTest.php
@@ -34,7 +34,7 @@ class AdministratorRelPublicEntitiesTest extends KernelTestCase
         $this->assertEquals(
             $accessControl,
             [
-                ['administrator', 'in', 'AdministratorRepository([["company","IN",["companyRepository.getSupervisedCompanyIdsByAdmin(user)"]]])'],
+                ['administrator', 'in', 'AdministratorRepository([["company","IN",["companyRepository.getSupervisedCompanyIdsByAdmin(user)"]],["internal","neq","1"]])'],
             ]
         );
     }
@@ -53,7 +53,7 @@ class AdministratorRelPublicEntitiesTest extends KernelTestCase
         $this->assertEquals(
             $accessControl,
             [
-                ['administrator', 'in', 'AdministratorRepository([["company","IN",["companyRepository.getSupervisedCompanyIdsByAdmin(user)"]]])'],
+                ['administrator', 'in', 'AdministratorRepository([["company","IN",["companyRepository.getSupervisedCompanyIdsByAdmin(user)"]],["internal","neq","1"]])'],
                 ['publicEntity', 'in', 'PublicEntityRepository([["client","eq","1"]])'],
             ]
         );

--- a/web/rest/brand/tests/DataAccessControl/Provider/AdministratorTest.php
+++ b/web/rest/brand/tests/DataAccessControl/Provider/AdministratorTest.php
@@ -35,6 +35,7 @@ class AdministratorTest extends KernelTestCase
             $accessControl,
             [
                 ['company', 'in', 'companyRepository.getSupervisedCompanyIdsByAdmin(user)'],
+                ['internal', 'neq', '1'],
             ]
         );
     }

--- a/web/rest/client/config/services.yaml
+++ b/web/rest/client/config/services.yaml
@@ -27,7 +27,6 @@ services:
     Service\UserProvider:
         class: Service\UserProvider
         arguments:
-            $identifierField: 'username'
             $entityClass: 'Ivoz\Provider\Domain\Model\Administrator\Administrator'
 
     Service\AuthEndpointDecorator:

--- a/web/rest/client/features/auth.feature
+++ b/web/rest/client/features/auth.feature
@@ -23,3 +23,10 @@ Feature: Authorization checking
     And  I send a "GET" request to "users"
     Then the response status code should be 200
     And  the response should be in JSON
+
+  Scenario: A higher order admin can exchange token
+    When I exchange internal Client Authorization header
+    And  I add "Accept" header equal to "application/ld+json"
+    And  I send a "GET" request to "users"
+    Then the response status code should be 200
+    And  the response should be in JSON

--- a/web/rest/client/phpstan-baseline.neon
+++ b/web/rest/client/phpstan-baseline.neon
@@ -156,12 +156,17 @@ parameters:
 			path: src/Service/BillableCallNormalizer.php
 
 		-
-			message: "#^Method Service\\\\UserProvider\\:\\:findUser\\(\\) has parameter \\$criteria with no value type specified in iterable type array\\.$#"
+			message: "#^Cannot call method getShowInvoices\\(\\) on Ivoz\\\\Provider\\\\Domain\\\\Model\\\\Company\\\\CompanyInterface\\|null\\.$#"
 			count: 1
 			path: src/Service/UserProvider.php
 
 		-
 			message: "#^Method Service\\\\UserProvider\\:\\:supportsClass\\(\\) has parameter \\$class with no typehint specified\\.$#"
+			count: 1
+			path: src/Service/UserProvider.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$criteria$#"
 			count: 1
 			path: src/Service/UserProvider.php
 

--- a/web/rest/client/psalm-baseline.xml
+++ b/web/rest/client/psalm-baseline.xml
@@ -179,19 +179,5 @@
       <code>$class</code>
       <code>$class</code>
     </MixedArgument>
-    <MixedAssignment occurrences="1">
-      <code>$admin</code>
-    </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
-      <code>null | AdministratorInterface</code>
-    </MixedInferredReturnType>
-    <MixedMethodCall occurrences="3">
-      <code>findOneBy</code>
-      <code>getCompany</code>
-      <code>getShowInvoices</code>
-    </MixedMethodCall>
-    <MixedReturnStatement occurrences="1">
-      <code>$admin</code>
-    </MixedReturnStatement>
   </file>
 </files>

--- a/web/rest/client/src/Service/AuthEndpointDecorator.php
+++ b/web/rest/client/src/Service/AuthEndpointDecorator.php
@@ -37,7 +37,6 @@ class AuthEndpointDecorator implements NormalizerInterface
 
         $auth = [
             '/admin_login' => $this->getAdminLoginSpec(),
-            '/user_login' => $this->getUserLoginSpec(),
             '/token/refresh' => $this->getTokenRefreshSpec()
         ];
 

--- a/web/rest/client/src/Service/Behat/FeatureContext.php
+++ b/web/rest/client/src/Service/Behat/FeatureContext.php
@@ -34,10 +34,16 @@ class FeatureContext extends BaseFeatureContext
 
     /**
      * @Given I exchange Client Authorization header
-     *
-     * @return void
      */
     public function setBrandAuthorizationHeaderByExchange(): void
+    {
+        $this->exchangeAuthorizationHeader('test_brand_admin', 'test_company_admin');
+    }
+
+    /**
+     * @Given I exchange internal Client Authorization header
+     */
+    public function setInternalBrandAuthorizationHeaderByExchange(): void
     {
         $this->exchangeAuthorizationHeader('test_brand_admin', 'test_company_admin');
     }

--- a/web/rest/client/src/Service/UserProvider.php
+++ b/web/rest/client/src/Service/UserProvider.php
@@ -2,6 +2,7 @@
 
 namespace Service;
 
+use Ivoz\Provider\Domain\Model\Administrator\AdministratorRepository;
 use Ivoz\Provider\Infrastructure\Api\Security\User\MutableUserProviderInterface;
 use Ivoz\Provider\Infrastructure\Api\Security\User\UserProviderTrait;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
@@ -17,11 +18,12 @@ class UserProvider implements UserProviderInterface, MutableUserProviderInterfac
      * @param array $criteria
      * @return null | AdministratorInterface
      */
-    protected function findUser(array $criteria)
+    protected function findUser(string $identity): ?AdministratorInterface
     {
-        $admin = $this
-            ->getRepository()
-            ->findOneBy($criteria);
+        /** @var AdministratorRepository $repository */
+        $repository = $this->getRepository();
+
+        $admin = $repository->findClientAdminByUsername($identity);
 
         if ($admin) {
             /**
@@ -44,17 +46,6 @@ class UserProvider implements UserProviderInterface, MutableUserProviderInterfac
     public function setEntityClass(string $class): MutableUserProviderInterface
     {
         $this->entityClass = $class;
-
-        return $this;
-    }
-
-    /**
-     * @param string $identifierField
-     * @return $this
-     */
-    public function setUserIdentityField(string $identifierField): MutableUserProviderInterface
-    {
-        $this->identifierField = $identifierField;
 
         return $this;
     }

--- a/web/rest/platform/config/api/raw/provider.yml
+++ b/web/rest/platform/config/api/raw/provider.yml
@@ -92,6 +92,8 @@ Ivoz\Provider\Domain\Model\Administrator\Administrator:
       ROLE_SUPER_ADMIN:
         id:
           neq: "0"
+        internal:
+          neq: "1"
         company:
           isNull: ~
     write_access_control:

--- a/web/rest/platform/config/services.yaml
+++ b/web/rest/platform/config/services.yaml
@@ -26,7 +26,6 @@ services:
 
     Service\UserProvider:
         arguments:
-            $identifierField: 'username'
             $entityClass: 'Ivoz\Provider\Domain\Model\Administrator\Administrator'
 
     Service\AuthEndpointDecorator:

--- a/web/rest/platform/features/provider/administrator/postAdministrators.feature
+++ b/web/rest/platform/features/provider/administrator/postAdministrators.feature
@@ -37,7 +37,7 @@ Feature: Create administrators
           "restricted": false,
           "name": "post",
           "lastname": "test",
-          "id": 10,
+          "id": 12,
           "brand": null,
           "company": null,
           "timezone": 145
@@ -47,7 +47,7 @@ Feature: Create administrators
   Scenario: Retrieve created administrator
     Given I add Authorization header
      When I add "Accept" header equal to "application/json"
-      And I send a "GET" request to "administrators/10"
+      And I send a "GET" request to "administrators/12"
      Then the response status code should be 200
       And the response should be in JSON
       And the header "Content-Type" should be equal to "application/json; charset=utf-8"
@@ -61,7 +61,7 @@ Feature: Create administrators
           "restricted": false,
           "name": "post",
           "lastname": "test",
-          "id": 10,
+          "id": 12,
           "brand": null,
           "company": null,
           "timezone": {

--- a/web/rest/platform/phpstan-baseline.neon
+++ b/web/rest/platform/phpstan-baseline.neon
@@ -61,11 +61,6 @@ parameters:
 			path: src/Service/AuthEndpointDecorator.php
 
 		-
-			message: "#^Method Service\\\\UserProvider\\:\\:findUser\\(\\) has parameter \\$criteria with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Service/UserProvider.php
-
-		-
 			message: "#^Method Service\\\\UserProvider\\:\\:supportsClass\\(\\) has parameter \\$class with no typehint specified\\.$#"
 			count: 1
 			path: src/Service/UserProvider.php

--- a/web/rest/platform/psalm-baseline.xml
+++ b/web/rest/platform/psalm-baseline.xml
@@ -119,12 +119,5 @@
     <MixedArgument occurrences="1">
       <code>$class</code>
     </MixedArgument>
-    <MixedInferredReturnType occurrences="1">
-      <code>null | AdministratorInterface</code>
-    </MixedInferredReturnType>
-    <MixedMethodCall occurrences="1">
-      <code>findOneBy</code>
-    </MixedMethodCall>
-    <MixedReturnStatement occurrences="1"/>
   </file>
 </files>

--- a/web/rest/platform/src/Service/UserProvider.php
+++ b/web/rest/platform/src/Service/UserProvider.php
@@ -2,7 +2,9 @@
 
 namespace Service;
 
+use Ivoz\Provider\Domain\Model\Administrator\AdministratorRepository;
 use Ivoz\Provider\Infrastructure\Api\Security\User\UserProviderTrait;
+use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Ivoz\Provider\Domain\Model\Administrator\Administrator;
 use Ivoz\Provider\Domain\Model\Administrator\AdministratorInterface;
@@ -11,15 +13,12 @@ class UserProvider implements UserProviderInterface
 {
     use UserProviderTrait;
 
-    /**
-     * @param array $criteria
-     * @return null | AdministratorInterface
-     */
-    protected function findUser(array $criteria)
+    protected function findUser(string $identity): ?AdministratorInterface
     {
-        return $this
-            ->getRepository()
-            ->findOneBy($criteria);
+        /** @var AdministratorRepository $repository */
+        $repository = $this->getRepository();
+
+        return $repository->findPlatformAdminByUsername($identity);
     }
 
     /**

--- a/web/rest/user/config/services.yaml
+++ b/web/rest/user/config/services.yaml
@@ -26,7 +26,6 @@ services:
 
     Service\UserProvider:
         arguments:
-            $identifierField: 'email'
             $entityClass: 'Ivoz\Provider\Domain\Model\User\User'
 
     Service\AuthEndpointDecorator:

--- a/web/rest/user/phpstan-baseline.neon
+++ b/web/rest/user/phpstan-baseline.neon
@@ -211,11 +211,6 @@ parameters:
 			path: src/Service/Behat/FeatureContext.php
 
 		-
-			message: "#^Method Service\\\\UserProvider\\:\\:findUser\\(\\) has parameter \\$criteria with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Service/UserProvider.php
-
-		-
 			message: "#^Method Service\\\\UserProvider\\:\\:supportsClass\\(\\) has parameter \\$class with no typehint specified\\.$#"
 			count: 1
 			path: src/Service/UserProvider.php

--- a/web/rest/user/psalm-baseline.xml
+++ b/web/rest/user/psalm-baseline.xml
@@ -266,7 +266,7 @@
       <code>$user</code>
     </MixedAssignment>
     <MixedInferredReturnType occurrences="1">
-      <code>null | UserInterface</code>
+      <code>?UserInterface</code>
     </MixedInferredReturnType>
     <MixedMethodCall occurrences="1">
       <code>findOneBy</code>

--- a/web/rest/user/src/Service/UserProvider.php
+++ b/web/rest/user/src/Service/UserProvider.php
@@ -12,15 +12,13 @@ class UserProvider implements UserProviderInterface, MutableUserProviderInterfac
 {
     use UserProviderTrait;
 
-    /**
-     * @param array $criteria
-     * @return null | UserInterface
-     */
-    protected function findUser(array $criteria)
+    protected function findUser(string $identity): ?UserInterface
     {
         $user = $this
             ->getRepository()
-            ->findOneBy($criteria);
+            ->findOneBy([
+                'email' => $identity
+            ]);
 
         return $user;
     }
@@ -32,17 +30,6 @@ class UserProvider implements UserProviderInterface, MutableUserProviderInterfac
     public function setEntityClass(string $class): MutableUserProviderInterface
     {
         $this->entityClass = $class;
-
-        return $this;
-    }
-
-    /**
-     * @param string $identifierField
-     * @return $this
-     */
-    public function setUserIdentityField(string $identifierField): MutableUserProviderInterface
-    {
-        $this->identifierField = $identifierField;
 
         return $this;
     }


### PR DESCRIPTION
Create internal admins for each brand and client so that they can be "token exchanged" in the APIs.  This way you don't have to create them in order to manage an entity you've access to. 

Internal admins are hidden and cannot be used to login into the admin portal nor APIs using identity & password.

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
