### PR TITLE
Easier internal token exchange

### DIFF
--- a/doc/sphinx/administration_portal/brand/clients/index.rst
+++ b/doc/sphinx/administration_portal/brand/clients/index.rst
@@ -12,5 +12,6 @@ This group will show all available client types for a given (emulated/logged in)
     residential
     retail
     wholesale
+    operators
 
 .. tip:: Available client types can be configured through *Brand Features*.

--- a/doc/sphinx/administration_portal/brand/clients/operators.rst
+++ b/doc/sphinx/administration_portal/brand/clients/operators.rst
@@ -1,0 +1,9 @@
+.. _client operators:
+
+****************
+Client Operators
+****************
+
+**List of client operators** subsection allows adding/editing/deleting credentials for client portal access.
+
+Read :ref:`acls` for further explanation about restricted administrators.

--- a/doc/sphinx/api_rest/multilevel.rst
+++ b/doc/sphinx/api_rest/multilevel.rst
@@ -2,13 +2,15 @@
 Multi-level API
 ################
 
-IvozProvider API is divided in same three levels as the web administration portal:
+IvozProvider API is divided in same three levels as the web administration portal plus user API:
 
 - God
 
 - Brand
 
 - Client
+
+- User
 
 This split allows different roles with different responsibilities to be integrated against it without compromising
 security (read, edit, update or delete the data they should not).
@@ -25,21 +27,19 @@ In order to access to each level, **you will need a corresponding level URL and 
 
 .. rubric:: God API access
 
-- URL: God URL defined in :ref:`Platform Portals` + /api/platform
-
 - Credentials: God credentials defined in :ref:`Main operators`.
 
 .. rubric:: Brand API access
-
-- URL: Brand URL defined in :ref:`Brand Portals` + /api/brand
 
 - Credentials: Brand credentials defined in :ref:`Brand operators`.
 
 .. rubric:: Client API access
 
-- URL: Client URL defined in :ref:`Client Portals` + /api/client
+- Credentials: Client credentials defined in :ref:`Client operators`.
 
-- Credentials: Client credentials defined in :ref:`Main operators`.
+.. rubric:: User API access
+
+- Credentials: User credentials defined in :ref:`users`.
 
 .. warning:: All credentials usernames are unique at brand level. This is why *username + brand URL* duple is needed to
              identify a user (both in API and in web portal).

--- a/doc/sphinx/api_rest/use_case.rst
+++ b/doc/sphinx/api_rest/use_case.rst
@@ -12,13 +12,9 @@ Let's put a little use case as an example: A platform admin wants to obtain the 
 
 #. Search target brand on /brands
 
-#. Get it's domain on /web_portals
-
-#. Get a valid brand administrator on /administrators
-
 .. rubric:: On Brand API (https://brand-domain/api/brand)
 
-#. Impersonate as a brand admin on Auth> /token/exchange (requires a god token and a brand administrator user name obtained in 1-d)
+#. Impersonate as a brand admin on Auth> /token/exchange (requires a god token and the brand Id. You can impersonate by the username of a brand administrator instead of a brand id as well)
 
 #. Request brand companies using the endpoint /companies
 

--- a/web/rest/brand/config/api/resources.yml
+++ b/web/rest/brand/config/api/resources.yml
@@ -24,8 +24,13 @@ Model\Token:
           - name: username
             in: formData
             type: string
-            required: true
+            required: false
             description: 'Target brand admin user name'
+          - name: brandId
+            in: formData
+            type: integer
+            required: false
+            description: 'Target brand ID'
 
 Model\ActiveCalls:
   itemOperations:

--- a/web/rest/brand/src/Controller/Auth/TokenExchangeAction.php
+++ b/web/rest/brand/src/Controller/Auth/TokenExchangeAction.php
@@ -50,14 +50,34 @@ class TokenExchangeAction
         /** @var Request $request */
         $request = $this->requestStack->getCurrentRequest();
 
-        /** @var string  $inputToken */
-        $inputToken =  $request->get('token');
-        /** @var string $username */
+        /** @var ?string  $inputToken */
+        $inputToken =  $request->get('token', null);
+        if (is_null($inputToken)) {
+            throw new \DomainException(
+                'Token not found'
+            );
+        }
+
+        /** @var ?string $username */
         $username = $request->get('username');
+
+        /** @var ?int  $brandId */
+        $brandId = $request->get('brandId', null);
+
+        if (!$username && !$brandId) {
+            throw new \DomainException(
+                'Either username or brandId must be set'
+            );
+        }
+
+        /** @var string $identity */
+        $identity = $brandId
+            ? '__b' . $brandId . '_internal'
+            : $username;
 
         $tokenStr = $this->exchangeToken->execute(
             $inputToken,
-            $username
+            $identity
         );
 
         return new Token($tokenStr);

--- a/web/rest/client/config/api/resources.yml
+++ b/web/rest/client/config/api/resources.yml
@@ -25,8 +25,13 @@ Model\Token:
         - name: username
           in: formData
           type: string
-          required: true
+          required: false
           description: 'Target client admin user name'
+        - name: clientId
+          in: formData
+          type: integer
+          required: false
+          description: 'Target client ID'
 
 Model\RatingPlanPrices:
   attributes:

--- a/web/rest/client/src/Controller/Auth/TokenExchangeAction.php
+++ b/web/rest/client/src/Controller/Auth/TokenExchangeAction.php
@@ -50,14 +50,34 @@ class TokenExchangeAction
         /** @var Request $request */
         $request = $this->requestStack->getCurrentRequest();
 
-        /** @var string  $inputToken */
-        $inputToken =  $request->get('token');
-        /** @var string $username */
-        $username = $request->get('username');
+        /** @var ?string  $inputToken */
+        $inputToken =  $request->get('token', null);
+        if (is_null($inputToken)) {
+            throw new \DomainException(
+                'Token not found'
+            );
+        }
+
+        /** @var ?string $username */
+        $username = $request->get('username', null);
+
+        /** @var ?int  $clientId */
+        $clientId = $request->get('clientId', null);
+
+        if (!$username && !$clientId) {
+            throw new \DomainException(
+                'Either username or clientId must be set'
+            );
+        }
+
+        /** @var string $identity */
+        $identity = $clientId
+            ? '__c' . $clientId . '_internal'
+            : $username;
 
         $tokenStr = $this->exchangeToken->execute(
             $inputToken,
-            $username
+            $identity
         );
 
         return new Token($tokenStr);


### PR DESCRIPTION
Allow to impersonate just by entity id as an alternative to administrator username in /token_exchange API endpoint 

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
