### PR TITLE
portals: redirect apache2 logs to journald

### DIFF
--- a/profiles/portal/etc/apache2/sites-available/020-ivozprovider-portals.conf
+++ b/profiles/portal/etc/apache2/sites-available/020-ivozprovider-portals.conf
@@ -27,8 +27,8 @@
 
 # Logging Directives
 LogLevel warn
-CustomLog ${APACHE_LOG_DIR}/access.log combined
-ErrorLog ${APACHE_LOG_DIR}/error.log
+CustomLog "|/usr/bin/logger -thttpd -plocal6.notice" combined
+ErrorLog  "|/usr/bin/logger -thttpd -plocal6.err"
 
 # VirtualHost configuration
 DocumentRoot /opt/irontec/ivozprovider/web/admin/public

--- a/profiles/portal/etc/apache2/sites-available/030-ivozprovider-prov.conf
+++ b/profiles/portal/etc/apache2/sites-available/030-ivozprovider-prov.conf
@@ -4,8 +4,8 @@ Listen 3443
 
 <VirtualHost *:1443>
     LogLevel warn
-    CustomLog ${APACHE_LOG_DIR}/prov_accessyealink.log combined
-    ErrorLog ${APACHE_LOG_DIR}/prov_erroryealink.log
+    CustomLog "|/usr/bin/logger -tprov_yealink -plocal6.notice" combined
+    ErrorLog  "|/usr/bin/logger -tprov_yealink -plocal6.err"
 
     # Enable/Disable SSL for this virtual host.
     SSLEngine on
@@ -23,8 +23,8 @@ Listen 3443
 
 <VirtualHost *:2443>
     LogLevel warn
-    CustomLog ${APACHE_LOG_DIR}/prov_accesscisco.log combined
-    ErrorLog ${APACHE_LOG_DIR}/prov_errorcisco.log
+    CustomLog "|/usr/bin/logger -tprov_cisco -plocal6.notice" combined
+    ErrorLog  "|/usr/bin/logger -tprov_cisco -plocal6.err"
 
     # Enable/Disable SSL for this virtual host.
     SSLEngine on
@@ -39,8 +39,8 @@ Listen 3443
 
 <VirtualHost *:3443>
     LogLevel warn
-    CustomLog ${APACHE_LOG_DIR}/prov_accesssnom.log combined
-    ErrorLog ${APACHE_LOG_DIR}/prov_errorsnom.log
+    CustomLog "|/usr/bin/logger -tprov_snom -plocal6.notice" combined
+    ErrorLog  "|/usr/bin/logger -tprov_snom -plocal6.err"
 
     # Enable/Disable SSL for this virtual host.
     SSLEngine on


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
Use logger to send logs to rsyslog/journald instead of files in /var/log/apache2
This allows more control over the created log files.

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
