### PR TITLE
as: set max call duration to 3 hours

### DIFF
--- a/asterisk/config/dialplan/default.conf
+++ b/asterisk/config/dialplan/default.conf
@@ -55,17 +55,17 @@ exten => _[+*0-9]!,1,NoOp(Call from queue ${QUEUE} to extension ${EXTEN})
 ;; Context for calling a user (and handle User call forwards after the call)
 [call-user-cfw]
 exten => _[+*0-9]!,1,NoOp(Calling from ${CALLERID(all)} to ${DIAL_DST})
-    same => n,Dial(${DIAL_DST},${DIAL_TIMEOUT},${DIAL_OPTS}b(add-headers^${EXTEN}^1))
+    same => n,Dial(${DIAL_DST},${DIAL_TIMEOUT},${DIAL_OPTS}b(add-headers^${EXTEN}^1)L(${MAX_DURATION}))
     same => n,AGI(agi://127.0.0.1:4573/fastagi-runner.php?command=dialplan/userstatus)
 
 [call-user]
 exten => _[+*0-9]!,1,NoOp(Calling from ${CALLERID(all)} to ${DIAL_DST})
-    same => n,Dial(${DIAL_DST},${DIAL_TIMEOUT},${DIAL_OPTS}b(add-headers^${EXTEN}^1))
+    same => n,Dial(${DIAL_DST},${DIAL_TIMEOUT},${DIAL_OPTS}b(add-headers^${EXTEN}^1)L(${MAX_DURATION}))
 
 ;; Context for Calling an external number through a trunk proxy
 [call-world]
 exten => _[+*0-9]!,1,NoOp(Calling external number)
-    same => n,Dial(${DIAL_DST},${DIAL_TIMEOUT},${DIAL_OPTS}ib(add-headers^${EXTEN}^1))
+    same => n,Dial(${DIAL_DST},${DIAL_TIMEOUT},${DIAL_OPTS}ib(add-headers^${EXTEN}^1)L(${MAX_DURATION}))
 
 ;; Context for Calling a user from an IVR (and handle IVR Noanswer call forwards)
 [call-ivr]
@@ -91,7 +91,7 @@ exten => _[+*0-9]!,1,NoOp(Calling conference room ${EXTEN})
 ;; Context for calling through a friendly trunk
 [call-friend]
 exten => _[+*0-9]!,1,NoOp(Calling ${EXTEN} through ${DIAL_ENDPOINT})
-    same => n,Dial(${DIAL_DST},${DIAL_TIMEOUT},${DIAL_OPTS}b(add-headers^${EXTEN}^1))
+    same => n,Dial(${DIAL_DST},${DIAL_TIMEOUT},${DIAL_OPTS}b(add-headers^${EXTEN}^1)L(${MAX_DURATION}))
 
 ;; Context for calling a queue
 [call-queue]
@@ -103,13 +103,13 @@ exten => _[+*0-9]!,1,NoOp(Calling to ${QUEUE})
 ;; Context for calling through a residential device
 [call-residential]
 exten => _[+*0-9]!,1,NoOp(Calling ${EXTEN} through ${DIAL_ENDPOINT})
-    same => n,Dial(${DIAL_DST},${DIAL_TIMEOUT},${DIAL_OPTS}b(add-headers^${EXTEN}^1))
+    same => n,Dial(${DIAL_DST},${DIAL_TIMEOUT},${DIAL_OPTS}b(add-headers^${EXTEN}^1)L(${MAX_DURATION}))
     same => n,AGI(agi://127.0.0.1:4573/fastagi-runner.php?command=dialplan/residentialstatus)
 
 ;; Context for calling to a retail account
 [call-retail]
 exten => _[+*0-9]!,1,NoOp(Calling ${DIAL_ENDPOINT})
-    same => n,Dial(${DIAL_DST},${DIAL_TIMEOUT},${DIAL_OPTS}b(add-headers^${EXTEN}^1))
+    same => n,Dial(${DIAL_DST},${DIAL_TIMEOUT},${DIAL_OPTS}b(add-headers^${EXTEN}^1)L(${MAX_DURATION}))
 
 ;;---------------------------------------------------------------------------------------------------
 ;;------------------------------------[      Subroutines      ]--------------------------------------

--- a/asterisk/config/extensions.conf
+++ b/asterisk/config/extensions.conf
@@ -1,1 +1,6 @@
+; General dialplan configration variables
+[globals]
+MAX_DURATION=10800000       ; Max call duration in ms (3h)
+
+; Dialplan files
 #include "dialplan/*.conf"


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
Like kamailio configuration, limit the call duration to 3 hours.
This avoids infinite duration channels in case of missed or not properly routed BYE requests.

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
