### PR TITLE
Enable HTTP/2 protocol

### DIFF
--- a/profiles/portal/etc/apache2/sites-available/020-ivozprovider-portals.conf
+++ b/profiles/portal/etc/apache2/sites-available/020-ivozprovider-portals.conf
@@ -12,7 +12,6 @@
 
 # Generic Document path configuration
 <Directory /opt/irontec/ivozprovider/web/admin/public>
-    php_value include_path "/usr/share/php:/opt/irontec/ivozprovider/library:/opt/irontec/klear/library:/opt/irontec/ivozprovider/web/admin/library"
     Options -Indexes +FollowSymLinks -MultiViews
     AllowOverride All
      <Limit GET HEAD POST PUT DELETE OPTIONS PATCH>
@@ -85,5 +84,6 @@ Alias /client /opt/irontec/ivozprovider/web/client/build
     SSLEngine on
     SSLCertificateFile    /etc/ssl/certs/ivozprovider-portals.pem
     SSLCertificateKeyFile /etc/ssl/private/ivozprovider-portals.key
+    Protocols h2 h2c http/1.1
 </VirtualHost>
 

--- a/profiles/portal/etc/apache2/sites-available/060-ivozprovider-api.conf
+++ b/profiles/portal/etc/apache2/sites-available/060-ivozprovider-api.conf
@@ -1,7 +1,6 @@
 # Platform
 Alias /api/platform /opt/irontec/ivozprovider/web/rest/platform/public
 <Directory /opt/irontec/ivozprovider/web/rest/platform/public/>
-    php_value include_path "/usr/share/php:/opt/irontec/ivozprovider/library:/opt/irontec/klear/library:/opt/irontec/ivozprovider/web/admin/library"
     Options -Indexes +FollowSymLinks -MultiViews
     AllowOverride All
      <Limit GET HEAD POST PUT DELETE OPTIONS PATCH>
@@ -17,7 +16,6 @@ Alias /api/platform /opt/irontec/ivozprovider/web/rest/platform/public
 # Brand
 Alias /api/brand /opt/irontec/ivozprovider/web/rest/brand/public
 <Directory /opt/irontec/ivozprovider/web/rest/brand/public/>
-    php_value include_path "/usr/share/php:/opt/irontec/ivozprovider/library:/opt/irontec/klear/library:/opt/irontec/ivozprovider/web/admin/library"
     Options -Indexes +FollowSymLinks -MultiViews
     AllowOverride All
      <Limit GET HEAD POST PUT DELETE OPTIONS PATCH>
@@ -33,7 +31,6 @@ Alias /api/brand /opt/irontec/ivozprovider/web/rest/brand/public
 # Client
 Alias /api/client /opt/irontec/ivozprovider/web/rest/client/public
 <Directory /opt/irontec/ivozprovider/web/rest/client/public/>
-    php_value include_path "/usr/share/php:/opt/irontec/ivozprovider/library:/opt/irontec/klear/library:/opt/irontec/ivozprovider/web/admin/library"
     Options -Indexes +FollowSymLinks -MultiViews
     AllowOverride All
      <Limit GET HEAD POST PUT DELETE OPTIONS PATCH>
@@ -49,7 +46,6 @@ Alias /api/client /opt/irontec/ivozprovider/web/rest/client/public
 # User
 Alias /api/user /opt/irontec/ivozprovider/web/rest/user/public
 <Directory /opt/irontec/ivozprovider/web/rest/user/public/>
-    php_value include_path "/usr/share/php:/opt/irontec/ivozprovider/library:/opt/irontec/klear/library:/opt/irontec/ivozprovider/web/admin/library"
     Options -Indexes +FollowSymLinks -MultiViews
     AllowOverride All
      <Limit GET HEAD POST PUT DELETE OPTIONS PATCH>


### PR DESCRIPTION
Enable H2 protocol on apache and removed php settings that conflic with php-fpm

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
<!-- Describe your changes in detail -->

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
