### PR TITLE
schema: add unique constraint to TerminalModel genericUrlPattern field

### DIFF
--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/TerminalModel.TerminalModelAbstract.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/TerminalModel.TerminalModelAbstract.orm.yml
@@ -4,6 +4,9 @@ Ivoz\Provider\Domain\Model\TerminalModel\TerminalModelAbstract:
     terminalModel_iden:
       columns:
         - iden
+    terminalModel_genericUrlPattern:
+      columns:
+        - genericUrlPattern
   fields:
     iden:
       type: string

--- a/schema/DoctrineMigrations/Version20220207084804.php
+++ b/schema/DoctrineMigrations/Version20220207084804.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Application\Migrations;
+
+use Ivoz\Core\Infrastructure\Persistence\Doctrine\LoggableMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20220207084804 extends LoggableMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+        $this->addSql('CREATE UNIQUE INDEX terminalModel_genericUrlPattern ON TerminalModels (genericUrlPattern)');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+        $this->addSql('DROP INDEX terminalModel_genericUrlPattern ON TerminalModels');
+    }
+}

--- a/schema/tests/Provider/TerminalModel/TerminalModelLifeCycleTest.php
+++ b/schema/tests/Provider/TerminalModel/TerminalModelLifeCycleTest.php
@@ -23,8 +23,8 @@ class TerminalModelLifeCycleTest extends KernelTestCase
             ->setDescription('Test SIP Model')
             ->setGenericTemplate('')
             ->setSpecificTemplate('')
-            ->setGenericUrlPattern('')
-            ->setSpecificUrlPattern('')
+            ->setGenericUrlPattern('genericUrlPattern')
+            ->setSpecificUrlPattern('specificUrlPattern')
             ->setTerminalManufacturerId(1);
 
         return $terminalModelDto;
@@ -73,7 +73,7 @@ class TerminalModelLifeCycleTest extends KernelTestCase
     /**
      * @test
      */
-    public function it_persists_routing_tags()
+    public function it_persists_terminal_model()
     {
         $terminalModelRepository = $this->em
             ->getRepository(TerminalModel::class);

--- a/web/rest/platform/features/provider/terminalModel/postTerminalModel.feature
+++ b/web/rest/platform/features/provider/terminalModel/postTerminalModel.feature
@@ -16,8 +16,8 @@ Feature: Create terminal models
           "description": "New SIP Model",
           "genericTemplate": "",
           "specificTemplate": "",
-          "genericUrlPattern": "",
-          "specificUrlPattern": "",
+          "genericUrlPattern": "genericUrlPattern",
+          "specificUrlPattern": "specificUrlPattern",
           "terminalManufacturer": 1
       }
     """
@@ -32,8 +32,8 @@ Feature: Create terminal models
           "description": "New SIP Model",
           "genericTemplate": "",
           "specificTemplate": "",
-          "genericUrlPattern": "",
-          "specificUrlPattern": "",
+          "genericUrlPattern": "genericUrlPattern",
+          "specificUrlPattern": "specificUrlPattern",
           "id": 3,
           "terminalManufacturer": 1
       }
@@ -54,8 +54,8 @@ Feature: Create terminal models
           "description": "New SIP Model",
           "genericTemplate": "",
           "specificTemplate": "",
-          "genericUrlPattern": "",
-          "specificUrlPattern": "",
+          "genericUrlPattern": "genericUrlPattern",
+          "specificUrlPattern": "specificUrlPattern",
           "id": 3,
           "terminalManufacturer": {
               "iden": "Generic",


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
This change make genericUrlPattern unique to avoid any missconfigurations in terminal provisioning.

If there are genericUrlPatterns duplicated in database, this schema change may fail and human interaction will be required to fix the data before reapplying the migration.

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
