### PR TITLE
kam_user_cdrs start_time index

### DIFF
--- a/library/Ivoz/Kam/Infrastructure/Persistence/Doctrine/Mapping/UsersCdr.UsersCdrAbstract.orm.yml
+++ b/library/Ivoz/Kam/Infrastructure/Persistence/Doctrine/Mapping/UsersCdr.UsersCdrAbstract.orm.yml
@@ -9,6 +9,9 @@ Ivoz\Kam\Domain\Model\UsersCdr\UsersCdrAbstract:
     usersCdr_brandId:
       columns:
         - brandId
+    usersCdr_startTime:
+      columns:
+        - start_time
     usersCdr_companyId_hidden_startTime:
       columns:
         - companyId

--- a/schema/DoctrineMigrations/Version20220207102413.php
+++ b/schema/DoctrineMigrations/Version20220207102413.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Application\Migrations;
+
+use Ivoz\Core\Infrastructure\Persistence\Doctrine\LoggableMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20220207102413 extends LoggableMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('CREATE INDEX usersCdr_startTime ON kam_users_cdrs (start_time)');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP INDEX usersCdr_startTime ON kam_users_cdrs');
+    }
+}


### PR DESCRIPTION
Add db index on kam_user_cdrs.start_time so that it can be rotated easily

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
