### PR TITLE
Improved rerating

### DIFF
--- a/library/DataFixtures/ORM/KamTrunksCdr.php
+++ b/library/DataFixtures/ORM/KamTrunksCdr.php
@@ -46,6 +46,35 @@ class KamTrunksCdr extends Fixture implements DependentFixtureInterface
         $this->sanitizeEntityValues($item1);
         $manager->persist($item1);
 
+        /////////////////////////
+        ///
+        ////////////////////////
+
+        /** @var TrunksCdrInterface $item2 */
+        $item2 = $this->createEntityInstance(TrunksCdr::class);
+        (function () use ($fixture) {
+            $this->setStartTime(new \DateTime('2021-11-22 16:54:49'));
+            $this->setEndTime(new \DateTime('2021-11-22 16:54:54'));
+            $this->setDuration(4.765);
+            $this->setDirection('outbound');
+
+            $this->setCaller('+3494696823899');
+            $this->setCallee('+34676238611');
+            $this->setCallid('017cc7c8-eb38-4bbd-9318-524a274f7000');
+            $this->setCallidHash('2789d532');
+            $this->setXcallid('9297bdde-309cd48f@10.10.1.123');
+            $this->setParsed(1);
+            $this->setCgrid('5a364b1fe35e00fb2ac1923b43f84eeb78400e03');
+            $this->setParserScheduledAt(new \DateTime('2018-11-22 16:54:54'));
+            $this->setBrand($fixture->getReference('_reference_ProviderBrand1'));
+            $this->setCompany($fixture->getReference('_reference_ProviderCompany1'));
+            $this->setCarrier($fixture->getReference('_reference_ProviderCarrier1'));
+        })->call($item2);
+
+        $this->addReference('_reference_KamTrunksCdr2', $item2);
+        $this->sanitizeEntityValues($item2);
+        $manager->persist($item2);
+
         $manager->flush();
     }
 

--- a/library/Ivoz/Cgr/Infrastructure/Cgrates/Service/RerateCallService.php
+++ b/library/Ivoz/Cgr/Infrastructure/Cgrates/Service/RerateCallService.php
@@ -55,6 +55,11 @@ class RerateCallService extends AbstractApiBasedService implements RerateCallSer
     public function execute(array $pks)
     {
         $error = false;
+
+        $this
+            ->trunksCdrRepository
+            ->resetOrphanCgrids($pks);
+
         $cgrIds = $this
             ->billableCallRepository
             ->findRerateableCgridsInGroup($pks);

--- a/library/Ivoz/Kam/Domain/Model/TrunksCdr/TrunksCdrRepository.php
+++ b/library/Ivoz/Kam/Domain/Model/TrunksCdr/TrunksCdrRepository.php
@@ -24,6 +24,12 @@ interface TrunksCdrRepository extends ObjectRepository, Selectable
     public function resetParsed(array $ids);
 
     /**
+     * @param array $billableCallIds
+     * @return int affected rows
+     */
+    public function resetOrphanCgrids(array $billableCallIds) :int;
+
+    /**
      * @param string $callid
      * @return TrunksCdrInterface[]
      */

--- a/schema/tests/Kam/TrunksCdr/TrunksCdrRepositoryTest.php
+++ b/schema/tests/Kam/TrunksCdr/TrunksCdrRepositoryTest.php
@@ -22,6 +22,7 @@ class TrunksCdrRepositoryTest extends KernelTestCase
         $this->it_finds_one_by_callid();
         $this->it_finds_unparsedCalls();
         $this->it_resets_parsed_calls();
+        $this->it_resets_orphan_cgrids();
     }
 
     public function its_instantiable()
@@ -117,5 +118,21 @@ class TrunksCdrRepositoryTest extends KernelTestCase
         );
 
         $this->assertNotEmpty($result);
+    }
+
+    public function it_resets_orphan_cgrids()
+    {
+        /** @var TrunksCdrRepository $repository */
+        $repository = $this
+            ->em
+            ->getRepository(TrunksCdr::class);
+
+        $affectedRows = $repository
+            ->resetOrphanCgrids([1,2,3]);
+
+        $this->assertEquals(
+            1,
+            $affectedRows
+        );
     }
 }


### PR DESCRIPTION
Reset orphan cgrids before rerating ir order to avoid potential cgrates issues

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
