### PR TITLE
kamusers: add P-Preferred-Identity support

### DIFF
--- a/doc/sphinx/administration_portal/client/residential/residential_devices.rst
+++ b/doc/sphinx/administration_portal/client/residential/residential_devices.rst
@@ -165,6 +165,7 @@ Device peer
 .. warning:: *Residential devices* MUST NOT challenge IvozProvider. That's
              why the *insecure* setting is used here.
 
-.. note:: As from username is used to identify the retail account, P-Asserted-Identity must be used to specify caller number.
+.. note:: As From username is used to identify the residential device, P-Asserted-Identity (or P-Preferred-Identity or Remote-Party-Id) must be used to specify caller number.
+          Prevalence among these source headers is: PAI > PPI > RPID.
 
 

--- a/doc/sphinx/administration_portal/client/retail/retail_accounts.rst
+++ b/doc/sphinx/administration_portal/client/retail/retail_accounts.rst
@@ -169,5 +169,6 @@ Account peer
 .. warning:: *Retail accounts* MUST NOT challenge IvozProvider. That's
              why the *insecure* setting is used here.
 
-.. note:: As from username is used to identify the retail account, P-Asserted-Identity must be used to specify caller number.
+.. note:: As From username is used to identify the retail account, P-Asserted-Identity (or P-Preferred-Identity or Remote-Party-Id) must be used to specify caller number.
+          Prevalence among these source headers is: PAI > PPI > RPID.
 

--- a/doc/sphinx/administration_portal/client/vpbx/routing_endpoints/friends/remote_friends.rst
+++ b/doc/sphinx/administration_portal/client/vpbx/routing_endpoints/friends/remote_friends.rst
@@ -159,7 +159,8 @@ Configuration will be something like this:
 .. warning:: *Friends*, like terminals, MUST NOT challenge IvozProvider. That's
              why the *insecure* setting is used here.
 
-.. note:: As from username is used to identify the friend, P-Asserted-Identity must be used to specify caller number.
+.. note:: As From username is used to identify the friend, P-Asserted-Identity (or P-Preferred-Identity or Remote-Party-Id) must be used to specify caller number.
+          Prevalence among these source headers is: PAI > PPI > RPID.
 
 Summary of remote friends
 -------------------------

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -760,7 +760,7 @@ route[ADAPT_REFERTO] {
 route[ADAPT_CALLER] {
     # First of all: do I have to mangle caller?
     if (!$var(is_from_inside)) {
-        if ($dlg_var(type) == "retail" && !is_present_hf("P-Asserted-Identity") && !is_present_hf("Remote-Party-ID")) {
+        if ($dlg_var(type) == "retail" && !is_present_hf("P-Asserted-Identity") && !is_present_hf("P-Preferred-Identity") &&!is_present_hf("Remote-Party-ID")) {
             if (is_request() && !has_totag()) {
                 route(GET_FALLBACK_DDI);
                 $dlg_var(caller) = $var(fallback_ddi);
@@ -770,23 +770,24 @@ route[ADAPT_CALLER] {
             return;
         }
 
-        if ($dlg_var(type) == "residential" && !is_present_hf("P-Asserted-Identity") && !is_present_hf("Remote-Party-ID")) {
+        if ($dlg_var(type) == "residential" && !is_present_hf("P-Asserted-Identity") && !is_present_hf("P-Preferred-Identity") && !is_present_hf("Remote-Party-ID")) {
             return;
         }
 
         if ($dlg_var(type) == 'vpbx') {
             if ($dlg_var(userId) != $null) {
                 remove_hf("P-Asserted-Identity");
+                remove_hf("P-Preferred-Identity");
                 remove_hf("Remote-Party-ID");
                 return;
             } else if ($dlg_var(friendId) != $null) {
-                if (!is_present_hf("P-Asserted-Identity") && !is_present_hf("Remote-Party-ID")) {
+                if (!is_present_hf("P-Asserted-Identity") && !is_present_hf("P-Preferred-Identity") && !is_present_hf("Remote-Party-ID")) {
                     return;
                 }
             }
         }
     } else {
-        if ($dlg_var(type) == "vpbx" && !is_present_hf("P-Asserted-Identity") && !is_present_hf("Remote-Party-ID")) {
+        if ($dlg_var(type) == "vpbx" && !is_present_hf("P-Asserted-Identity") && !is_present_hf("P-Preferred-Identity") && !is_present_hf("Remote-Party-ID")) {
             return;
         }
     }
@@ -853,6 +854,9 @@ route[GET_CALLER] {
     if (is_present_hf("P-Asserted-Identity")) {
         xinfo("[$dlg_var(cidhash)] GET-CALLER: PAI present: $(ai{uri.user})\n");
         $var(number) = $(ai{uri.user});
+    } else if (is_present_hf("P-Preferred-Identity")) {
+        xinfo("[$dlg_var(cidhash)] GET-CALLER: PPI present: $(pu{uri.user})\n");
+        $var(number) = $(pu{uri.user});
     } else if (is_present_hf("Remote-Party-ID")) {
         xinfo("[$dlg_var(cidhash)] GET-CALLER: RPID present: $(re{uri.user})\n");
         $var(number) = $(re{uri.user});
@@ -866,7 +870,7 @@ route[GET_CALLER] {
 route[SET_CALLER] {
     # Mangle From only for initial requests from wholesale clients without PAI nor RPID
     if (is_request() && !has_totag()) {
-        if ($dlg_var(type) == 'wholesale' && !is_present_hf("P-Asserted-Identity") && !is_present_hf("Remote-Party-ID")) {
+        if ($dlg_var(type) == 'wholesale' && !is_present_hf("P-Asserted-Identity") && !is_present_hf("P-Preferred-Identity") && !is_present_hf("Remote-Party-ID")) {
             if ($fU != $var(transformated)) {
                 $var(newfromuri) = 'sip:' + $var(transformated) + '@' + $fd;
                 uac_replace_from("","$var(newfromuri)");
@@ -878,6 +882,13 @@ route[SET_CALLER] {
         if ($(ai{uri.user}) != $var(transformated)) { # If new value differs from previous, change
             remove_hf("P-Asserted-Identity");
             append_hf("P-Asserted-Identity: <sip:$var(transformated)@$(ai{uri.host})>\r\n");
+        }
+    }
+
+    if (is_present_hf("P-Preferred-Identity")) {
+        if ($(pu{uri.user}) != $var(transformated)) { # If new value differs from previous, change
+            remove_hf("P-Preferred-Identity");
+            append_hf("P-Preferred-Identity: <sip:$var(transformated)@$(pu{uri.host})>\r\n");
         }
     }
 
@@ -905,6 +916,8 @@ route[SET_PAI] {
     }
 
     if (is_present_hf("Remote-Party-ID")) remove_hf("Remote-Party-ID");
+
+    if (is_present_hf("P-Preferred-Identity")) remove_hf("P-Preferred-Identity");
 
     if (is_present_hf("P-Asserted-Identity")) {
         $var(newpai) = 'sip:' + $var(transformated) + '@' + $(ai{uri.host});
@@ -957,7 +970,7 @@ route[ADAPT_DIVERSION] {
             return;
         } else {
             # Diversion without PAI/RPID from friend/retail/residential
-            if (!is_present_hf("P-Asserted-Identity") && !is_present_hf("Remote-Party-ID")) {
+            if (!is_present_hf("P-Asserted-Identity") && !is_present_hf("P-Preferred-Identity") && !is_present_hf("Remote-Party-ID")) {
                 xwarn("[$dlg_var(cidhash)] ADAPT-DIVERSION: Remove Diversion as no PAI/RPID header found\n");
                 remove_hf("Diversion");
                 return;
@@ -2535,7 +2548,7 @@ onreply_route[MANAGE_REPLY] {
         exit;
     }
 
-    if (is_present_hf("P-Asserted-Identity") || is_present_hf("Remote-Party-ID")) {
+    if (is_present_hf("P-Asserted-Identity") || is_present_hf("P-Preferred-Identity") || is_present_hf("Remote-Party-ID")) {
         route(ADAPT_CALLER);
     }
 


### PR DESCRIPTION

<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
<!-- Describe your changes in detail -->
- Prevalence order in incoming requests: PAI > PPI > RPID > From

- IvozProvider will always use PAI when it needs to add an identity header.
