### PR TITLE
kamtrunks: avoid inactivating gw if any reply received

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -2016,7 +2016,7 @@ failure_route[MANAGE_FAILURE_GW] {
     } else if (t_check_status("422")) {
         xwarn("[$dlg_var(cidhash)] MANAGE-FAILURE-GW: Session Interval Too Small, forward to AS (reply code: $T_reply_code)\n");
         exit;
-    } else if (t_check_status("408") && t_branch_timeout()) {
+    } else if (t_branch_timeout() && !t_branch_replied()) {
         route(INACTIVATE_GW);
     } else if (t_check_status("3[0-9]{2}")) {
         xwarn("[$dlg_var(cidhash)] MANAGE-FAILURE-GW: $T_reply_code: Not allowed from GW\n");


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
Avoids a GW being inactivated if 408 event raised (or response received) after any other response (e.g. 100-408 sequence)
