### PR TITLE
kamtrunks: skip gw inactivation on bounced calls

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -1922,6 +1922,8 @@ route[RT_UNKNOWN_BYE] {
 
 # Do not inactivate carriers that are stopper in any OutgoingRouting
 route[INACTIVATE_GW] {
+    if ($dlg_var(carrierId) == $null) return; # bounced call
+
     sql_query("cb", "SELECT O.id FROM OutgoingRouting O LEFT JOIN OutgoingRoutingRelCarriers ORRC ON O.id=ORRC.outgoingRoutingId WHERE O.stopper=1 AND ( O.carrierId=$dlg_var(carrierId) OR ORRC.carrierId=$dlg_var(carrierId) )", "isStopper");
     if ($dbr(isStopper=>rows) == 0) {
         xwarn("[$dlg_var(cidhash)] INACTIVATE-GW: $T_reply_code: Inactivate carrier server $dlg_var(carrierServerId) (carrier: $dlg_var(carrierId)) (no reply received)\n");


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
Bounced calls may cause gw inactivation if bounced call causes t_branch_timeout event. In this situation, gateway of external carrier that would be chosen if call was not bounced may be inactivated.

This PR fixes this weird behaviour.

