### PR TITLE
New local dns entry cache.ivozprovider.local

### DIFF
--- a/cgrates/config/cgrates.json
+++ b/cgrates/config/cgrates.json
@@ -19,7 +19,7 @@
 	},
 	"data_db": {
 		"db_type": "redis",
-		"db_host": "data.ivozprovider.local",
+		"db_host": "cache.ivozprovider.local",
 		"db_port": 26379,
 		"db_name": "10",
 		"db_user": "cgrates",

--- a/debian/ivozprovider-profile-common.config
+++ b/debian/ivozprovider-profile-common.config
@@ -90,7 +90,7 @@ function configure_trunks_address()
 
 function configure_jobs_address()
 {
-    # Request Kamalio jobs listen address
+    # Request jobs listen address
     db_input high ivozprovider/jobs_address              || true
     db_go                                                  || true
     db_get ivozprovider/jobs_address                       || true
@@ -105,7 +105,7 @@ function configure_jobs_address()
 
 function configure_data_address()
 {
-    # Request Kamalio data listen address
+    # Request data listen address
     db_input high ivozprovider/data_address              || true
     db_go                                                  || true
     db_get ivozprovider/data_address                       || true
@@ -118,9 +118,24 @@ function configure_data_address()
     fi
 }
 
+function configure_cache_address()
+{
+    # Request cache listen address
+    db_input high ivozprovider/cache_address               || true
+    db_go                                                  || true
+    db_get ivozprovider/cache_address                      || true
+
+    # Check entered IP is valid
+    if ! check_valid_ip4 $RET; then
+        db_input high ivozprovider/invalid_ip            || true
+        db_go                                              || true
+        configure_cache_address
+    fi
+}
+
 function configure_storage_address()
 {
-    # Request Kamalio storage listen address
+    # Request storage address
     db_input high ivozprovider/storage_address           || true
     db_go                                                  || true
     db_get ivozprovider/storage_address                    || true
@@ -135,7 +150,7 @@ function configure_storage_address()
 
 function configure_logs_address()
 {
-    # Request Kamalio logs listen address
+    # Request log server address
     db_input high ivozprovider/logs_address              || true
     db_go                                                  || true
     db_get ivozprovider/logs_address                       || true

--- a/debian/ivozprovider-profile-data.postinst
+++ b/debian/ivozprovider-profile-data.postinst
@@ -22,6 +22,8 @@ function setup_bind()
     sed -r -i "s/(trunks          IN      A      ) .*/\1 $RET/"     /etc/bind/db.ivozprovider.local
     db_get ivozprovider/data_address            || true
     sed -r -i "s/(data            IN      A      ) .*/\1 $RET/"     /etc/bind/db.ivozprovider.local
+    db_get ivozprovider/cache_address           || true
+    sed -r -i "s/(cache           IN      A      ) .*/\1 $RET/"     /etc/bind/db.ivozprovider.local
     db_get ivozprovider/storage_address         || true
     sed -r -i "s/(storage         IN      A      ) .*/\1 $RET/"     /etc/bind/db.ivozprovider.local
     db_get ivozprovider/logs_address            || true

--- a/debian/ivozprovider-profile-data.templates
+++ b/debian/ivozprovider-profile-data.templates
@@ -22,8 +22,8 @@ Description-es.UTF-8:
 Template: ivozprovider/menu_dns_server
 Type: select
 Choices: configure_users_address, configure_trunks_address, configure_jobs_address, configure_data_address, configure_storage_address, configure_logs_address, configure_back
-Choices-es.UTF-8: users.ivozprovider.local, trunks.ivozprovider.local, jobs.ivozprovider.local, data.ivozprovider.local, storage.ivozprovider.local, logs.ivozprovider.local, << Atrás
-Choices-en.UTF-8: users.ivozprovider.local, trunks.ivozprovider.local, jobs.ivozprovider.local, data.ivozprovider.local, storage.ivozprovider.local, logs.ivozprovider.local, << Back
+Choices-es.UTF-8: users.ivozprovider.local, trunks.ivozprovider.local, jobs.ivozprovider.local, data.ivozprovider.local, cache.ivozprovider.local, storage.ivozprovider.local, logs.ivozprovider.local, << Atrás
+Choices-en.UTF-8: users.ivozprovider.local, trunks.ivozprovider.local, jobs.ivozprovider.local, data.ivozprovider.local, cache.ivozprovider.local, storage.ivozprovider.local, logs.ivozprovider.local, << Back
 Default: configure_dns_address
 Description: Configure DNS server resolution for .local domain
 Description-es.UTF-8: Configure las entradas DNS para el dominio .local
@@ -51,6 +51,12 @@ Type: string
 Default: 127.0.0.1
 Description: Enter MySQL Database listen IP address:
 Description-es.UTF-8: Introduzca la IP para base de datos MySQL:
+
+Template: ivozprovider/cache_address
+Type: string
+Default: 127.0.0.1
+Description: Enter Redis server listen IP address:
+Description-es.UTF-8: Introduzca la IP para Redis server:
 
 Template: ivozprovider/storage_address
 Type: string

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -179,7 +179,7 @@ loadmodule    "pike.so"
 
 #!ifdef WITH_REALTIME
 # REDIS
-modparam("ndb_redis", "server", "name=realtime;sentinel_group=mymaster;sentinel_master=1;sentinel=data.ivozprovider.local:26379")
+modparam("ndb_redis", "server", "name=realtime;sentinel_group=mymaster;sentinel_master=1;sentinel=cache.ivozprovider.local:26379")
 modparam("ndb_redis", "init_without_redis", 1)
 #!endif
 

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -416,7 +416,7 @@ modparam("uac", "restore_dlg", 1)
 
 #!ifdef WITH_REALTIME
 # REDIS
-modparam("ndb_redis", "server", "name=realtime;sentinel_group=mymaster;sentinel_master=1;sentinel=data.ivozprovider.local:26379")
+modparam("ndb_redis", "server", "name=realtime;sentinel_group=mymaster;sentinel_master=1;sentinel=cache.ivozprovider.local:26379")
 modparam("ndb_redis", "init_without_redis", 1)
 #!endif
 

--- a/library/composer-packages/irontec/ivoz-provider-bundle/Resources/config/parameters.yml
+++ b/library/composer-packages/irontec/ivoz-provider-bundle/Resources/config/parameters.yml
@@ -33,5 +33,5 @@ parameters:
     local_storage_path: /opt/irontec/ivozprovider/storage
     raw_recordings_dir: /opt/irontec/ivozprovider/storage/ivozprovider_model_recordings.originalfile/
     sentinels:
-        - { host: 'data.ivozprovider.local', port: '26379' }
+        - { host: 'cache.ivozprovider.local', port: '26379' }
     redis_jobs_db: 2

--- a/library/composer-packages/irontec/ivoz-provider-bundle/Resources/config/parameters.yml.dist
+++ b/library/composer-packages/irontec/ivoz-provider-bundle/Resources/config/parameters.yml.dist
@@ -32,5 +32,5 @@ parameters:
     local_storage_path: /opt/irontec/ivozprovider/storage
     raw_recordings_dir: /opt/irontec/ivozprovider/storage/ivozprovider_model_recordings.originalfile/
     sentinels:
-        - { host: 'data.ivozprovider.local', port: '26379' }
+        - { host: 'cache.ivozprovider.local', port: '26379' }
     redis_jobs_db: 2

--- a/microservices/realtime/config/services.yaml
+++ b/microservices/realtime/config/services.yaml
@@ -8,7 +8,7 @@ imports:
 # https://symfony.com/doc/current/best_practices/configuration.html#application-related-configuration
 parameters:
     sentinels:
-        - {host: 'data.ivozprovider.local', port: '26379'}
+        - {host: 'cache.ivozprovider.local', port: '26379'}
     ws_host: '127.0.0.1'
     ws_port: 8081
     ws_worker_num: 1

--- a/profiles/data/etc/bind/db.ivozprovider.local
+++ b/profiles/data/etc/bind/db.ivozprovider.local
@@ -17,5 +17,6 @@ users           IN      A       127.0.0.1
 trunks          IN      A       127.0.0.1
 jobs            IN      A       127.0.0.1
 data            IN      A       127.0.0.1
+cache           IN      A       127.0.0.1
 storage         IN      A       127.0.0.1
 logs            IN      A       127.0.0.1


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
New local dns entry for redis sentinel.
This allows spliting redis and mysql in differents hosts.

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
