### PR TITLE
core: assign ddi route type in users mass import

### DIFF
--- a/library/Ivoz/Provider/Application/Service/User/SyncFromCsv.php
+++ b/library/Ivoz/Provider/Application/Service/User/SyncFromCsv.php
@@ -5,6 +5,7 @@ namespace Ivoz\Provider\Application\Service\User;
 use Ivoz\Core\Application\Service\EntityTools;
 use Ivoz\Provider\Domain\Model\Company\CompanyInterface;
 use Ivoz\Provider\Domain\Model\Company\CompanyRepository;
+use Ivoz\Provider\Domain\Model\Ddi\DdiInterface;
 use Ivoz\Provider\Domain\Service\Ddi\DdiFactory;
 use Ivoz\Provider\Domain\Service\Extension\ExtensionFactory;
 use Ivoz\Provider\Domain\Service\Terminal\TerminalFactory;
@@ -111,8 +112,10 @@ class SyncFromCsv
                         ...$outboundDdiArgs
                     );
 
-                    if ($ddi->isNew()) {
-                        $user->setOutgoingDdi($ddi);
+                    if ($ddi->isNew() || $ddi->getRouteType() === null) {
+                        $ddi
+                            ->setRouteType(DdiInterface::ROUTETYPE_USER)
+                            ->setUser($user);
                     }
 
                     $entities[] = $ddi;

--- a/library/Ivoz/Provider/Domain/Model/Ddi/Ddi.php
+++ b/library/Ivoz/Provider/Domain/Model/Ddi/Ddi.php
@@ -3,6 +3,7 @@
 namespace Ivoz\Provider\Domain\Model\Ddi;
 
 use Assert\Assertion;
+use Ivoz\Provider\Domain\Model\User\UserInterface;
 use Ivoz\Provider\Domain\Traits\RoutableTrait;
 use \Ivoz\Provider\Domain\Model\Company\CompanyInterface;
 
@@ -101,6 +102,18 @@ class Ddi extends DdiAbstract implements DdiInterface
         }
 
         return $language->getIden();
+    }
+
+    /**
+     * Set user
+     *
+     * @param \Ivoz\Provider\Domain\Model\User\UserInterface $user | null
+     *
+     * @return static
+     */
+    public function setUser(UserInterface $user = null)
+    {
+        return parent::setUser($user);
     }
 
     public function setRouteType($routeType = null)

--- a/library/Ivoz/Provider/Domain/Model/Ddi/DdiInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/Ddi/DdiInterface.php
@@ -42,6 +42,15 @@ interface DdiInterface extends LoggableEntityInterface
 
     public function getLanguageCode();
 
+    /**
+     * Set user
+     *
+     * @param \Ivoz\Provider\Domain\Model\User\UserInterface $user | null
+     *
+     * @return static
+     */
+    public function setUser(\Ivoz\Provider\Domain\Model\User\UserInterface $user = null);
+
     public function setRouteType($routeType = null);
 
     /**


### PR DESCRIPTION
If users mass import has just created a DDI, assign it's user to it's route type

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
