### PR TITLE
External call filters: make calendar filtering optional

### DIFF
--- a/doc/sphinx/administration_portal/client/vpbx/routing_tools/external_call_filters.rst
+++ b/doc/sphinx/administration_portal/client/vpbx/routing_tools/external_call_filters.rst
@@ -32,6 +32,9 @@ The client admin can configure them in the following screen:
         destination, skipping the filter process. Take into account that black
         listed are checked before white lists.
 
+    Holiday enabled
+        Set this to no to totally ignore holidays filtering.
+
     Holiday locution
         The locution will be  played when the day is marked as holiday in any
         of the calendars associated with the filter **if the calendar entry has

--- a/library/DataFixtures/ORM/ProviderExternalCallFilter.php
+++ b/library/DataFixtures/ORM/ProviderExternalCallFilter.php
@@ -24,6 +24,7 @@ class ProviderExternalCallFilter extends Fixture implements DependentFixtureInte
         $item1 = $this->createEntityInstance(ExternalCallFilter::class);
         (function () use ($fixture) {
             $this->setName("testFilter");
+            $this->setHolidayEnabled(true);
             $this->setOutOfScheduleEnabled(true);
             $this->setCompany($fixture->getReference('_reference_ProviderCompany1'));
             $this->setHolidayNumberCountry($fixture->getReference('_reference_ProviderCountry70'));

--- a/library/Ivoz/Provider/Domain/Model/ExternalCallFilter/ExternalCallFilter.php
+++ b/library/Ivoz/Provider/Domain/Model/ExternalCallFilter/ExternalCallFilter.php
@@ -2,6 +2,7 @@
 
 namespace Ivoz\Provider\Domain\Model\ExternalCallFilter;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Ivoz\Core\Infrastructure\Persistence\Doctrine\Model\Helper\CriteriaHelper;
 use Ivoz\Provider\Domain\Model\Calendar\Calendar;
 use Ivoz\Provider\Domain\Model\ExternalCallFilterBlackList\ExternalCallFilterBlackList;
@@ -54,6 +55,28 @@ class ExternalCallFilter extends ExternalCallFilterAbstract implements ExternalC
     {
         $this->sanitizeRouteValues('Holiday');
         $this->sanitizeRouteValues('OutOfSchedule');
+
+        // Clear holiday filtering related fields
+        if (!$this->getHolidayEnabled()) {
+            $this->replaceCalendars(new ArrayCollection());
+            $this->setHolidayLocution(null);
+            $this->setHolidayTargetType(null);
+            $this->setHolidayNumberCountry(null);
+            $this->setHolidayNumberValue(null);
+            $this->setHolidayExtension(null);
+            $this->setHolidayVoicemail(null);
+        }
+
+        // Clear outOfSchedule filtering related fields
+        if (!$this->getOutOfScheduleEnabled()) {
+            $this->replaceSchedules(new ArrayCollection());
+            $this->setOutOfScheduleLocution(null);
+            $this->setOutOfScheduleTargetType(null);
+            $this->setOutOfScheduleNumberCountry(null);
+            $this->setOutOfScheduleNumberValue(null);
+            $this->setOutOfScheduleExtension(null);
+            $this->setOutOfScheduleVoicemail(null);
+        }
     }
 
     /**
@@ -107,6 +130,10 @@ class ExternalCallFilter extends ExternalCallFilterAbstract implements ExternalC
      */
     public function getHolidayDateForToday()
     {
+        if (!$this->getHolidayEnabled()) {
+            return null;
+        }
+
         $externalCallFilterRelCalendars = $this->getCalendars();
         if (empty($externalCallFilterRelCalendars)) {
             return null;
@@ -130,6 +157,10 @@ class ExternalCallFilter extends ExternalCallFilterAbstract implements ExternalC
 
     public function getCalendarPeriodForToday()
     {
+        if (!$this->getHolidayEnabled()) {
+            return null;
+        }
+
         $externalCallFilterRelCalendars = $this->getCalendars();
         if (empty($externalCallFilterRelCalendars)) {
             return null;

--- a/library/Ivoz/Provider/Domain/Model/ExternalCallFilter/ExternalCallFilterAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/ExternalCallFilter/ExternalCallFilterAbstract.php
@@ -34,6 +34,11 @@ abstract class ExternalCallFilterAbstract
     protected $name;
 
     /**
+     * @var bool
+     */
+    protected $holidayEnabled = true;
+
+    /**
      * @var ?string
      * comment: enum:number|extension|voicemail
      */
@@ -115,9 +120,11 @@ abstract class ExternalCallFilterAbstract
      */
     protected function __construct(
         string $name,
+        bool $holidayEnabled,
         bool $outOfScheduleEnabled
     ) {
         $this->setName($name);
+        $this->setHolidayEnabled($holidayEnabled);
         $this->setOutOfScheduleEnabled($outOfScheduleEnabled);
     }
 
@@ -181,6 +188,8 @@ abstract class ExternalCallFilterAbstract
         Assertion::isInstanceOf($dto, ExternalCallFilterDto::class);
         $name = $dto->getName();
         Assertion::notNull($name, 'getName value is null, but non null value was expected.');
+        $holidayEnabled = $dto->getHolidayEnabled();
+        Assertion::notNull($holidayEnabled, 'getHolidayEnabled value is null, but non null value was expected.');
         $outOfScheduleEnabled = $dto->getOutOfScheduleEnabled();
         Assertion::notNull($outOfScheduleEnabled, 'getOutOfScheduleEnabled value is null, but non null value was expected.');
         $company = $dto->getCompany();
@@ -188,6 +197,7 @@ abstract class ExternalCallFilterAbstract
 
         $self = new static(
             $name,
+            $holidayEnabled,
             $outOfScheduleEnabled
         );
 
@@ -224,6 +234,8 @@ abstract class ExternalCallFilterAbstract
 
         $name = $dto->getName();
         Assertion::notNull($name, 'getName value is null, but non null value was expected.');
+        $holidayEnabled = $dto->getHolidayEnabled();
+        Assertion::notNull($holidayEnabled, 'getHolidayEnabled value is null, but non null value was expected.');
         $outOfScheduleEnabled = $dto->getOutOfScheduleEnabled();
         Assertion::notNull($outOfScheduleEnabled, 'getOutOfScheduleEnabled value is null, but non null value was expected.');
         $company = $dto->getCompany();
@@ -231,6 +243,7 @@ abstract class ExternalCallFilterAbstract
 
         $this
             ->setName($name)
+            ->setHolidayEnabled($holidayEnabled)
             ->setHolidayTargetType($dto->getHolidayTargetType())
             ->setHolidayNumberValue($dto->getHolidayNumberValue())
             ->setOutOfScheduleEnabled($outOfScheduleEnabled)
@@ -257,6 +270,7 @@ abstract class ExternalCallFilterAbstract
     {
         return self::createDto()
             ->setName(self::getName())
+            ->setHolidayEnabled(self::getHolidayEnabled())
             ->setHolidayTargetType(self::getHolidayTargetType())
             ->setHolidayNumberValue(self::getHolidayNumberValue())
             ->setOutOfScheduleEnabled(self::getOutOfScheduleEnabled())
@@ -278,6 +292,7 @@ abstract class ExternalCallFilterAbstract
     {
         return [
             'name' => self::getName(),
+            'holidayEnabled' => self::getHolidayEnabled(),
             'holidayTargetType' => self::getHolidayTargetType(),
             'holidayNumberValue' => self::getHolidayNumberValue(),
             'outOfScheduleEnabled' => self::getOutOfScheduleEnabled(),
@@ -308,6 +323,18 @@ abstract class ExternalCallFilterAbstract
     public function getName(): string
     {
         return $this->name;
+    }
+
+    protected function setHolidayEnabled(bool $holidayEnabled): static
+    {
+        $this->holidayEnabled = $holidayEnabled;
+
+        return $this;
+    }
+
+    public function getHolidayEnabled(): bool
+    {
+        return $this->holidayEnabled;
     }
 
     protected function setHolidayTargetType(?string $holidayTargetType = null): static

--- a/library/Ivoz/Provider/Domain/Model/ExternalCallFilter/ExternalCallFilterDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/ExternalCallFilter/ExternalCallFilterDtoAbstract.php
@@ -28,6 +28,11 @@ abstract class ExternalCallFilterDtoAbstract implements DataTransferObjectInterf
     private $name = null;
 
     /**
+     * @var bool|null
+     */
+    private $holidayEnabled = true;
+
+    /**
      * @var string|null
      */
     private $holidayTargetType = null;
@@ -143,6 +148,7 @@ abstract class ExternalCallFilterDtoAbstract implements DataTransferObjectInterf
 
         return [
             'name' => 'name',
+            'holidayEnabled' => 'holidayEnabled',
             'holidayTargetType' => 'holidayTargetType',
             'holidayNumberValue' => 'holidayNumberValue',
             'outOfScheduleEnabled' => 'outOfScheduleEnabled',
@@ -169,6 +175,7 @@ abstract class ExternalCallFilterDtoAbstract implements DataTransferObjectInterf
     {
         $response = [
             'name' => $this->getName(),
+            'holidayEnabled' => $this->getHolidayEnabled(),
             'holidayTargetType' => $this->getHolidayTargetType(),
             'holidayNumberValue' => $this->getHolidayNumberValue(),
             'outOfScheduleEnabled' => $this->getOutOfScheduleEnabled(),
@@ -215,6 +222,18 @@ abstract class ExternalCallFilterDtoAbstract implements DataTransferObjectInterf
     public function getName(): ?string
     {
         return $this->name;
+    }
+
+    public function setHolidayEnabled(bool $holidayEnabled): static
+    {
+        $this->holidayEnabled = $holidayEnabled;
+
+        return $this;
+    }
+
+    public function getHolidayEnabled(): ?bool
+    {
+        return $this->holidayEnabled;
     }
 
     public function setHolidayTargetType(?string $holidayTargetType): static

--- a/library/Ivoz/Provider/Domain/Model/ExternalCallFilter/ExternalCallFilterInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/ExternalCallFilter/ExternalCallFilterInterface.php
@@ -138,6 +138,8 @@ interface ExternalCallFilterInterface extends LoggableEntityInterface
 
     public function getName(): string;
 
+    public function getHolidayEnabled(): bool;
+
     public function getHolidayTargetType(): ?string;
 
     public function getHolidayNumberValue(): ?string;

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/ExternalCallFilter.ExternalCallFilterAbstract.orm.xml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/ExternalCallFilter.ExternalCallFilterAbstract.orm.xml
@@ -9,6 +9,12 @@
         <option name="fixed"/>
       </options>
     </field>
+    <field name="holidayEnabled" type="boolean" column="holidayEnabled" nullable="false">
+      <options>
+        <option name="default">1</option>
+        <option name="unsigned">1</option>
+      </options>
+    </field>
     <field name="holidayTargetType" type="string" column="holidayTargetType" length="25" nullable="true">
       <options>
         <option name="fixed"/>

--- a/schema/DoctrineMigrations/Version20220324084602.php
+++ b/schema/DoctrineMigrations/Version20220324084602.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20220324084602 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add holidayEnable field to ExternalCallFilters table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE ExternalCallFilters ADD holidayEnabled TINYINT(1) UNSIGNED DEFAULT \'1\' NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE ExternalCallFilters DROP holidayEnabled');
+    }
+}

--- a/web/client/src/entities/ExternalCallFilter/ExternalCallFilter.tsx
+++ b/web/client/src/entities/ExternalCallFilter/ExternalCallFilter.tsx
@@ -42,6 +42,32 @@ const properties: ExternalCallFilterProperties = {
         default: '__null__',
         null: _('Unassigned'),
     },
+    'holidayEnabled': {
+        label: _('Holidays enabled'),
+        enum: {
+            '0': _('No'),
+            '1': _('Yes'),
+        },
+        default: '1',
+        visualToggle: {
+            '0': {
+                show: [],
+                hide: [
+                    'calendarIds',
+                    'holidayTargetType',
+                    'holidayLocution',
+                ],
+            },
+            '1': {
+                show: [
+                    'calendarIds',
+                    'holidayTargetType',
+                    'holidayLocution',
+                ],
+                hide: [],
+            }
+        }
+    },
     'holidayTargetType': {
         label: _('Holiday target type'),
         enum: {

--- a/web/client/src/entities/ExternalCallFilter/ExternalCallFilterProperties.tsx
+++ b/web/client/src/entities/ExternalCallFilter/ExternalCallFilterProperties.tsx
@@ -6,6 +6,7 @@ export type ExternalCallFilterPropertyList<T> = {
     'welcomeLocution'?: T,
     'holidayLocution'?: T,
     'outOfScheduleLocution'?: T,
+    'holidayEnabled'?: T,
     'holidayTargetType'?: T,
     'holidayNumberCountry'?: T,
     'holidayNumberValue'?: T,

--- a/web/client/src/entities/ExternalCallFilter/Form.tsx
+++ b/web/client/src/entities/ExternalCallFilter/Form.tsx
@@ -32,6 +32,7 @@ const Form = (props: EntityFormProps): JSX.Element => {
         {
             legend: _('Holidays configuration'),
             fields: [
+                'holidayEnabled',
                 'calendarIds',
                 'holidayLocution',
                 'holidayTargetType',

--- a/web/rest/client/features/provider/externalCallFilter/postExternalCallFilter.feature
+++ b/web/rest/client/features/provider/externalCallFilter/postExternalCallFilter.feature
@@ -12,6 +12,7 @@ Feature: Create external call filters
     """
       {
           "name": "newFilter",
+          "holidayEnabled": true,
           "holidayTargetType": "number",
           "holidayNumberValue": "946002021",
           "outOfScheduleEnabled": true,
@@ -47,6 +48,7 @@ Feature: Create external call filters
     """
       {
           "name": "newFilter",
+          "holidayEnabled": true,
           "holidayTargetType": "number",
           "holidayNumberValue": "946002021",
           "outOfScheduleEnabled": true,

--- a/web/rest/client/features/provider/externalCallFilter/putExternalCallFilter.feature
+++ b/web/rest/client/features/provider/externalCallFilter/putExternalCallFilter.feature
@@ -12,6 +12,7 @@ Feature: Update external call filters
     """
       {
           "name": "updatedFilter",
+          "holidayEnabled": true,
           "holidayTargetType": "number",
           "holidayNumberValue": "946002021",
           "outOfScheduleEnabled": true,
@@ -46,6 +47,7 @@ Feature: Update external call filters
     """
       {
           "name": "updatedFilter",
+          "holidayEnabled": true,
           "holidayTargetType": "number",
           "holidayNumberValue": "946002021",
           "outOfScheduleEnabled": true,

--- a/web/rest/client/features/provider/externalCallFilterBlackList/getExternalCallFilterBlackList.feature
+++ b/web/rest/client/features/provider/externalCallFilterBlackList/getExternalCallFilterBlackList.feature
@@ -18,6 +18,7 @@ Feature: Retrieve external call filter black lists
               "id": 1,
               "filter": {
                   "name": "testFilter",
+                  "holidayEnabled": true,
                   "holidayTargetType": null,
                   "holidayNumberValue": null,
                   "outOfScheduleEnabled": true,
@@ -55,6 +56,7 @@ Feature: Retrieve external call filter black lists
           "id": 1,
           "filter": {
               "name": "testFilter",
+              "holidayEnabled": true,
               "holidayTargetType": null,
               "holidayNumberValue": null,
               "outOfScheduleEnabled": true,

--- a/web/rest/client/features/provider/externalCallFilterBlackList/postExternalCallFilterBlackList.feature
+++ b/web/rest/client/features/provider/externalCallFilterBlackList/postExternalCallFilterBlackList.feature
@@ -25,6 +25,7 @@ Feature: Create external call filter black lists
           "id": 2,
           "filter": {
               "name": "testFilter",
+              "holidayEnabled": true,
               "holidayTargetType": null,
               "holidayNumberValue": null,
               "outOfScheduleEnabled": true,
@@ -61,6 +62,7 @@ Feature: Create external call filter black lists
           "id": 2,
           "filter": {
               "name": "testFilter",
+              "holidayEnabled": true,
               "holidayTargetType": null,
               "holidayNumberValue": null,
               "outOfScheduleEnabled": true,

--- a/web/rest/client/features/provider/externalCallFilterRelCalendar/getExternalCallFilterRelCalendar.feature
+++ b/web/rest/client/features/provider/externalCallFilterRelCalendar/getExternalCallFilterRelCalendar.feature
@@ -18,6 +18,7 @@ Feature: Retrieve external call filter rel calendars
               "id": 1,
               "filter": {
                   "name": "testFilter",
+                  "holidayEnabled": true,
                   "holidayTargetType": null,
                   "holidayNumberValue": null,
                   "outOfScheduleEnabled": true,
@@ -55,6 +56,7 @@ Feature: Retrieve external call filter rel calendars
           "id": 1,
           "filter": {
               "name": "testFilter",
+              "holidayEnabled": true,
               "holidayTargetType": null,
               "holidayNumberValue": null,
               "outOfScheduleEnabled": true,

--- a/web/rest/client/features/provider/externalCallFilterRelCalendar/postExternalCallFilterRelCalendar.feature
+++ b/web/rest/client/features/provider/externalCallFilterRelCalendar/postExternalCallFilterRelCalendar.feature
@@ -25,6 +25,7 @@ Feature: Create external call filter rel calendars
           "id": 2,
           "filter": {
               "name": "testFilter",
+              "holidayEnabled": true,
               "holidayTargetType": null,
               "holidayNumberValue": null,
               "outOfScheduleEnabled": true,
@@ -61,6 +62,7 @@ Feature: Create external call filter rel calendars
           "id": 2,
           "filter": {
               "name": "testFilter",
+              "holidayEnabled": true,
               "holidayTargetType": null,
               "holidayNumberValue": null,
               "outOfScheduleEnabled": true,

--- a/web/rest/client/features/provider/externalCallFilterRelSchedule/getExternalCallFilterRelSchedule.feature
+++ b/web/rest/client/features/provider/externalCallFilterRelSchedule/getExternalCallFilterRelSchedule.feature
@@ -18,6 +18,7 @@ Feature: Retrieve external call filter rel schedules
               "id": 1,
               "filter": {
                   "name": "testFilter",
+                  "holidayEnabled": true,
                   "holidayTargetType": null,
                   "holidayNumberValue": null,
                   "outOfScheduleEnabled": true,
@@ -64,6 +65,7 @@ Feature: Retrieve external call filter rel schedules
           "id": 1,
           "filter": {
               "name": "testFilter",
+              "holidayEnabled": true,
               "holidayTargetType": null,
               "holidayNumberValue": null,
               "outOfScheduleEnabled": true,

--- a/web/rest/client/features/provider/externalCallFilterRelSchedule/postExternalCallFilterRelSchedule.feature
+++ b/web/rest/client/features/provider/externalCallFilterRelSchedule/postExternalCallFilterRelSchedule.feature
@@ -24,6 +24,7 @@ Feature: Create external call filter rel schedules
           "id": 2,
           "filter": {
               "name": "testFilter",
+              "holidayEnabled": true,
               "holidayTargetType": null,
               "holidayNumberValue": null,
               "outOfScheduleEnabled": true,
@@ -69,6 +70,7 @@ Feature: Create external call filter rel schedules
           "id": 2,
           "filter": {
               "name": "testFilter",
+              "holidayEnabled": true,
               "holidayTargetType": null,
               "holidayNumberValue": null,
               "outOfScheduleEnabled": true,

--- a/web/rest/client/features/provider/externalCallFilterWhiteList/getExternalCallFilterWhiteList.feature
+++ b/web/rest/client/features/provider/externalCallFilterWhiteList/getExternalCallFilterWhiteList.feature
@@ -18,6 +18,7 @@ Feature: Retrieve external call filter white lists
               "id": 1,
               "filter": {
                   "name": "testFilter",
+                  "holidayEnabled": true,
                   "holidayTargetType": null,
                   "holidayNumberValue": null,
                   "outOfScheduleEnabled": true,
@@ -55,6 +56,7 @@ Feature: Retrieve external call filter white lists
           "id": 1,
           "filter": {
               "name": "testFilter",
+              "holidayEnabled": true,
               "holidayTargetType": null,
               "holidayNumberValue": null,
               "outOfScheduleEnabled": true,

--- a/web/rest/client/features/provider/externalCallFilterWhiteList/postExternalCallFilterWhiteList.feature
+++ b/web/rest/client/features/provider/externalCallFilterWhiteList/postExternalCallFilterWhiteList.feature
@@ -24,6 +24,7 @@ Feature: Create external call filter white lists
           "id": 2,
           "filter": {
               "name": "testFilter",
+              "holidayEnabled": true,
               "holidayTargetType": null,
               "holidayNumberValue": null,
               "outOfScheduleEnabled": true,
@@ -60,6 +61,7 @@ Feature: Create external call filter white lists
           "id": 2,
           "filter": {
               "name": "testFilter",
+              "holidayEnabled": true,
               "holidayTargetType": null,
               "holidayNumberValue": null,
               "outOfScheduleEnabled": true,


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
Add a new toggle field to External Call Filters calendar section to enable or disable holiday logics.
This is like #1740 for Calendars instead of Schedules

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
