### PR TITLE
Set External Call Filters toggles for Holidays & Calenders disabled by default

### DIFF
--- a/library/Ivoz/Provider/Domain/Model/ExternalCallFilter/ExternalCallFilterAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/ExternalCallFilter/ExternalCallFilterAbstract.php
@@ -36,7 +36,7 @@ abstract class ExternalCallFilterAbstract
     /**
      * @var bool
      */
-    protected $holidayEnabled = true;
+    protected $holidayEnabled = false;
 
     /**
      * @var ?string
@@ -52,7 +52,7 @@ abstract class ExternalCallFilterAbstract
     /**
      * @var bool
      */
-    protected $outOfScheduleEnabled = true;
+    protected $outOfScheduleEnabled = false;
 
     /**
      * @var ?string

--- a/library/Ivoz/Provider/Domain/Model/ExternalCallFilter/ExternalCallFilterDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/ExternalCallFilter/ExternalCallFilterDtoAbstract.php
@@ -30,7 +30,7 @@ abstract class ExternalCallFilterDtoAbstract implements DataTransferObjectInterf
     /**
      * @var bool|null
      */
-    private $holidayEnabled = true;
+    private $holidayEnabled = false;
 
     /**
      * @var string|null
@@ -45,7 +45,7 @@ abstract class ExternalCallFilterDtoAbstract implements DataTransferObjectInterf
     /**
      * @var bool|null
      */
-    private $outOfScheduleEnabled = true;
+    private $outOfScheduleEnabled = false;
 
     /**
      * @var string|null

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/ExternalCallFilter.ExternalCallFilterAbstract.orm.xml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/ExternalCallFilter.ExternalCallFilterAbstract.orm.xml
@@ -11,7 +11,7 @@
     </field>
     <field name="holidayEnabled" type="boolean" column="holidayEnabled" nullable="false">
       <options>
-        <option name="default">1</option>
+        <option name="default">0</option>
         <option name="unsigned">1</option>
       </options>
     </field>
@@ -28,7 +28,7 @@
     </field>
     <field name="outOfScheduleEnabled" type="boolean" column="outOfScheduleEnabled" nullable="false">
       <options>
-        <option name="default">1</option>
+        <option name="default">0</option>
         <option name="unsigned">1</option>
       </options>
     </field>

--- a/schema/DoctrineMigrations/Version20220328144016.php
+++ b/schema/DoctrineMigrations/Version20220328144016.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20220328144016 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'ExternalCallFilters: Holidays and Schedulers toggles disabled by default';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE ExternalCallFilters CHANGE outOfScheduleEnabled outOfScheduleEnabled TINYINT(1) UNSIGNED DEFAULT \'0\' NOT NULL');
+        $this->addSql('ALTER TABLE ExternalCallFilters CHANGE holidayEnabled holidayEnabled TINYINT(1) UNSIGNED DEFAULT \'0\' NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE ExternalCallFilters CHANGE holidayEnabled holidayEnabled TINYINT(1) DEFAULT \'1\' NOT NULL');
+        $this->addSql('ALTER TABLE ExternalCallFilters CHANGE outOfScheduleEnabled outOfScheduleEnabled TINYINT(1) DEFAULT \'1\' NOT NULL');
+    }
+}

--- a/web/client/src/entities/ExternalCallFilter/ExternalCallFilter.tsx
+++ b/web/client/src/entities/ExternalCallFilter/ExternalCallFilter.tsx
@@ -48,7 +48,7 @@ const properties: ExternalCallFilterProperties = {
             '0': _('No'),
             '1': _('Yes'),
         },
-        default: '1',
+        default: '0',
         visualToggle: {
             '0': {
                 show: [],
@@ -118,7 +118,7 @@ const properties: ExternalCallFilterProperties = {
             '0': _('No'),
             '1': _('Yes'),
         },
-        default: '1',
+        default: '0',
         visualToggle: {
             '0': {
                 show: [],


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
Set External Call Filters toggles for Holidays & Calenders disabled by default
Related with #1750 and #1740


#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
