### PR TITLE
core: fix unassigned terminals repository query

### DIFF
--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/TerminalDoctrineRepository.php
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/TerminalDoctrineRepository.php
@@ -122,16 +122,19 @@ class TerminalDoctrineRepository extends ServiceEntityRepository implements Term
         $terminalIdsInUse = $this
             ->findAssociatedTerminalIdsByCompanyId($companyId);
 
-        $excludedIds = array_diff($terminalIdsInUse, $includeIds);
-
         $qb
             ->select('terminal')
             ->where(
                 $expression->eq('terminal.company', $companyId)
-            )
-            ->andWhere(
+            );
+
+        $excludedIds = array_diff($terminalIdsInUse, $includeIds);
+
+        if (!empty($excludedIds)) {
+            $qb->andWhere(
                 $expression->notIn('terminal.id', $excludedIds),
             );
+        }
 
         $query = $qb->getQuery();
 


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
When no terminal is excluded, the query generated has syntax errors.
This can be easly reproduced by creating a new company with no terminals, the user creation screen won't load Terminal field.

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
