### PR TITLE
Provider 183 web client acls

### DIFF
--- a/library/Ivoz/Provider/Domain/Model/AdministratorRelPublicEntity/AdministratorRelPublicEntityRepository.php
+++ b/library/Ivoz/Provider/Domain/Model/AdministratorRelPublicEntity/AdministratorRelPublicEntityRepository.php
@@ -28,4 +28,9 @@ interface AdministratorRelPublicEntityRepository extends ObjectRepository, Selec
     public function revokePermissionsByIds(array $ids): int;
 
     public function removeByAdministratorId(int $id): int;
+
+    /**
+     * @return AdministratorRelPublicEntityInterface[]
+     */
+    public function getByAdministratorId(int $id): array;
 }

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/AdministratorRelPublicEntityDoctrineRepository.php
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/AdministratorRelPublicEntityDoctrineRepository.php
@@ -9,6 +9,7 @@ use Ivoz\Core\Infrastructure\Domain\Service\DoctrineQueryRunner;
 use Ivoz\Core\Infrastructure\Persistence\Doctrine\Model\Helper\CriteriaHelper;
 use Ivoz\Provider\Domain\Model\Administrator\AdministratorInterface;
 use Ivoz\Provider\Domain\Model\AdministratorRelPublicEntity\AdministratorRelPublicEntity;
+use Ivoz\Provider\Domain\Model\AdministratorRelPublicEntity\AdministratorRelPublicEntityInterface;
 use Ivoz\Provider\Domain\Model\AdministratorRelPublicEntity\AdministratorRelPublicEntityRepository;
 
 /**
@@ -147,6 +148,30 @@ class AdministratorRelPublicEntityDoctrineRepository extends ServiceEntityReposi
             $this->getEntityName(),
             $qb->getQuery()
         );
+    }
+
+    /**
+     * @return AdministratorRelPublicEntityInterface[]
+     */
+    public function getByAdministratorId(int $id): array
+    {
+        $qb = $this
+            ->createQueryBuilder('self');
+        $expr = $qb->expr();
+
+        $qb
+            ->select(
+                'self, publicEntity'
+            )
+            ->innerJoin(
+                'self.publicEntity',
+                'publicEntity'
+            )
+            ->where(
+                $expr->eq('self.administrator', $id)
+            );
+
+        return $qb->getQuery()->getResult();
     }
 
     private function prepareUpdateQuery(bool $read, bool $write): QueryBuilder

--- a/library/composer.lock
+++ b/library/composer.lock
@@ -2434,16 +2434,16 @@
         },
         {
             "name": "irontec/ivoz-api",
-            "version": "4.7",
+            "version": "4.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/irontec/ivoz-api.git",
-                "reference": "b52f543f28481363866fbb2b8fc06b7487ca7e05"
+                "reference": "6bc653821f75185906608319a4d0bdc59272409b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/irontec/ivoz-api/zipball/b52f543f28481363866fbb2b8fc06b7487ca7e05",
-                "reference": "b52f543f28481363866fbb2b8fc06b7487ca7e05",
+                "url": "https://api.github.com/repos/irontec/ivoz-api/zipball/6bc653821f75185906608319a4d0bdc59272409b",
+                "reference": "6bc653821f75185906608319a4d0bdc59272409b",
                 "shasum": ""
             },
             "require": {
@@ -2496,27 +2496,27 @@
             "description": "Api library built on api-platform for ivozprovider",
             "support": {
                 "issues": "https://github.com/irontec/ivoz-api/issues",
-                "source": "https://github.com/irontec/ivoz-api/tree/4.7"
+                "source": "https://github.com/irontec/ivoz-api/tree/4.7.1"
             },
-            "time": "2022-03-15T10:43:37+00:00"
+            "time": "2022-04-06T10:01:14+00:00"
         },
         {
             "name": "irontec/ivoz-api-bundle",
-            "version": "4.4.1",
+            "version": "4.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/irontec/ivoz-api-bundle.git",
-                "reference": "7616053175e1985aa9cceaa3e24fd6ff1c428fa1"
+                "reference": "c766db1394b1f2c430e86ffa29bf6728066057cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/irontec/ivoz-api-bundle/zipball/7616053175e1985aa9cceaa3e24fd6ff1c428fa1",
-                "reference": "7616053175e1985aa9cceaa3e24fd6ff1c428fa1",
+                "url": "https://api.github.com/repos/irontec/ivoz-api-bundle/zipball/c766db1394b1f2c430e86ffa29bf6728066057cf",
+                "reference": "c766db1394b1f2c430e86ffa29bf6728066057cf",
                 "shasum": ""
             },
             "require": {
                 "gesdinet/jwt-refresh-token-bundle": "^0.12",
-                "irontec/ivoz-api": "^4.6.4",
+                "irontec/ivoz-api": "^4.7.1",
                 "irontec/ivoz-core-bundle": "^4.0.6",
                 "lexik/jwt-authentication-bundle": "^2.5",
                 "nelmio/cors-bundle": "^2.0",
@@ -2549,9 +2549,9 @@
             "description": "Symfony bridge for ivoz-api",
             "support": {
                 "issues": "https://github.com/irontec/ivoz-api-bundle/issues",
-                "source": "https://github.com/irontec/ivoz-api-bundle/tree/4.4.1"
+                "source": "https://github.com/irontec/ivoz-api-bundle/tree/4.4.2"
             },
-            "time": "2022-03-03T13:57:13+00:00"
+            "time": "2022-04-06T10:03:09+00:00"
         },
         {
             "name": "irontec/ivoz-core",

--- a/microservices/realtime/composer.lock
+++ b/microservices/realtime/composer.lock
@@ -2125,11 +2125,11 @@
         },
         {
             "name": "irontec/ivoz-api",
-            "version": "4.7",
+            "version": "4.7.1",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/irontec/ivoz-api",
-                "reference": "b52f543f28481363866fbb2b8fc06b7487ca7e05"
+                "reference": "6bc653821f75185906608319a4d0bdc59272409b"
             },
             "require": {
                 "api-platform/core": "2.6.*",
@@ -2185,15 +2185,15 @@
         },
         {
             "name": "irontec/ivoz-api-bundle",
-            "version": "4.4",
+            "version": "4.4.2",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/irontec/ivoz-api-bundle",
-                "reference": "7616053175e1985aa9cceaa3e24fd6ff1c428fa1"
+                "reference": "c766db1394b1f2c430e86ffa29bf6728066057cf"
             },
             "require": {
                 "gesdinet/jwt-refresh-token-bundle": "^0.12",
-                "irontec/ivoz-api": "^4.6.4",
+                "irontec/ivoz-api": "^4.7.1",
                 "irontec/ivoz-core-bundle": "^4.0.6",
                 "lexik/jwt-authentication-bundle": "^2.5",
                 "nelmio/cors-bundle": "^2.0",

--- a/schema/composer.json
+++ b/schema/composer.json
@@ -71,7 +71,7 @@
         "doctrine/doctrine-fixtures-bundle": "^3.0",
         "phpunit/phpunit": "^9.4.4",
         "dms/phpunit-arraysubset-asserts": "^0.2.1",
-        "squizlabs/php_codesniffer": "^4.0",
+        "squizlabs/php_codesniffer": "^3.0",
         "symfony/phpunit-bridge": "^5.1.6"
     },
     "extra": {

--- a/schema/composer.lock
+++ b/schema/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3bafbd63f3864016a2db9c2edd2bc959",
+    "content-hash": "d2de821d599fb480e2f3b0d0875ab998",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -2035,11 +2035,11 @@
         },
         {
             "name": "irontec/ivoz-dev-tools",
-            "version": "5.8.8",
+            "version": "5.8.9",
             "dist": {
                 "type": "path",
                 "url": "../library/vendor/irontec/ivoz-dev-tools",
-                "reference": "acc408c5831e446d72183880fbd2889511b2af1f"
+                "reference": "aa5f913a434d343d2856ddea208d5da4d24aecfe"
             },
             "require": {
                 "doctrine/doctrine-bundle": "^2.0",
@@ -8863,20 +8863,20 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "4.0.x-dev",
+            "version": "3.6.2",
             "dist": {
                 "type": "path",
                 "url": "../library/vendor/squizlabs/php_codesniffer",
-                "reference": "669b4ea91a971d772afe6450edee60c0b1e0aa83"
+                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a"
             },
             "require": {
                 "ext-simplexml": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
-                "php": ">=7.2.0"
+                "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.0 || ^9.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "bin": [
                 "bin/phpcs",

--- a/schema/symfony.lock
+++ b/schema/symfony.lock
@@ -300,16 +300,13 @@
         "version": "2.0.1"
     },
     "squizlabs/php_codesniffer": {
-        "version": "3.0",
+        "version": "3.6",
         "recipe": {
             "repo": "github.com/symfony/recipes-contrib",
             "branch": "master",
-            "version": "3.0",
-            "ref": "0dc9cceda799fd3a08b96987e176a261028a3709"
-        },
-        "files": [
-            "phpcs.xml.dist"
-        ]
+            "version": "3.6",
+            "ref": "1019e5c08d4821cb9b77f4891f8e9c31ff20ac6f"
+        }
     },
     "swiftmailer/swiftmailer": {
         "version": "v6.2.3"

--- a/schema/tests/Provider/AdministratorRelPublicEntity/AdministratorRelPublicEntityRepositoryTest.php
+++ b/schema/tests/Provider/AdministratorRelPublicEntity/AdministratorRelPublicEntityRepositoryTest.php
@@ -5,10 +5,10 @@ namespace Tests\Provider\AdministratorRelPublicEntity;
 use Ivoz\Provider\Domain\Model\Administrator\Administrator;
 use Ivoz\Provider\Domain\Model\Administrator\AdministratorInterface;
 use Ivoz\Provider\Domain\Model\Administrator\AdministratorRepository;
+use Ivoz\Provider\Domain\Model\AdministratorRelPublicEntity\AdministratorRelPublicEntity;
 use Ivoz\Provider\Domain\Model\AdministratorRelPublicEntity\AdministratorRelPublicEntityRepository;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Tests\DbIntegrationTestHelperTrait;
-use Ivoz\Provider\Domain\Model\AdministratorRelPublicEntity\AdministratorRelPublicEntity;
 
 class AdministratorRelPublicEntityRepositoryTest extends KernelTestCase
 {
@@ -24,6 +24,7 @@ class AdministratorRelPublicEntityRepositoryTest extends KernelTestCase
         $this->its_instantiable();
         $this->it_sets_write_permissions();
         $this->it_sets_readOnly_permissions();
+        $this->it_finds_by_admin_id();
     }
 
     /**
@@ -109,31 +110,28 @@ class AdministratorRelPublicEntityRepositoryTest extends KernelTestCase
         $this->assertNotEmpty($changes);
     }
 
-
-    public function it_removes_by_admin_id()
+    public function it_finds_by_admin_id()
     {
         /** @var AdministratorRelPublicEntityRepository $administratorRelPublicEntityRepository */
         $administratorRelPublicEntityRepository = $this
             ->em
             ->getRepository(AdministratorRelPublicEntity::class);
 
-        $admin = $this->getAdmin(6);
+        $response = $administratorRelPublicEntityRepository->getByAdministratorId(7);
 
-        $affectedRows = $administratorRelPublicEntityRepository
-            ->revokePermissionsByIds(
-                $admin->getId()
-            );
+        $this->assertIsArray(
+            $response
+        );
 
-        $this->assertGreaterThan(
+        $this->assertGreaterThanOrEqual(
             1,
-            $affectedRows
+            count($response)
         );
 
-        $changes = $this->getChangelogByClass(
-            AdministratorRelPublicEntity::class
+        $this->assertInstanceOf(
+            AdministratorRelPublicEntity::class,
+            $response[0]
         );
-
-        $this->assertNotEmpty($changes);
     }
 
     private function getAdmin(int $id = 5): AdministratorInterface

--- a/web/rest/brand/composer.lock
+++ b/web/rest/brand/composer.lock
@@ -2125,11 +2125,11 @@
         },
         {
             "name": "irontec/ivoz-api",
-            "version": "4.7",
+            "version": "4.7.1",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/irontec/ivoz-api",
-                "reference": "b52f543f28481363866fbb2b8fc06b7487ca7e05"
+                "reference": "6bc653821f75185906608319a4d0bdc59272409b"
             },
             "require": {
                 "api-platform/core": "2.6.*",
@@ -2185,15 +2185,15 @@
         },
         {
             "name": "irontec/ivoz-api-bundle",
-            "version": "4.4",
+            "version": "4.4.2",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/irontec/ivoz-api-bundle",
-                "reference": "7616053175e1985aa9cceaa3e24fd6ff1c428fa1"
+                "reference": "c766db1394b1f2c430e86ffa29bf6728066057cf"
             },
             "require": {
                 "gesdinet/jwt-refresh-token-bundle": "^0.12",
-                "irontec/ivoz-api": "^4.6.4",
+                "irontec/ivoz-api": "^4.7.1",
                 "irontec/ivoz-core-bundle": "^4.0.6",
                 "lexik/jwt-authentication-bundle": "^2.5",
                 "nelmio/cors-bundle": "^2.0",

--- a/web/rest/client/composer.lock
+++ b/web/rest/client/composer.lock
@@ -2125,11 +2125,11 @@
         },
         {
             "name": "irontec/ivoz-api",
-            "version": "4.7",
+            "version": "4.7.1",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/irontec/ivoz-api",
-                "reference": "b52f543f28481363866fbb2b8fc06b7487ca7e05"
+                "reference": "6bc653821f75185906608319a4d0bdc59272409b"
             },
             "require": {
                 "api-platform/core": "2.6.*",
@@ -2185,15 +2185,15 @@
         },
         {
             "name": "irontec/ivoz-api-bundle",
-            "version": "4.4",
+            "version": "4.4.2",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/irontec/ivoz-api-bundle",
-                "reference": "7616053175e1985aa9cceaa3e24fd6ff1c428fa1"
+                "reference": "c766db1394b1f2c430e86ffa29bf6728066057cf"
             },
             "require": {
                 "gesdinet/jwt-refresh-token-bundle": "^0.12",
-                "irontec/ivoz-api": "^4.6.4",
+                "irontec/ivoz-api": "^4.7.1",
                 "irontec/ivoz-core-bundle": "^4.0.6",
                 "lexik/jwt-authentication-bundle": "^2.5",
                 "nelmio/cors-bundle": "^2.0",

--- a/web/rest/client/config/api/raw/provider.yml
+++ b/web/rest/client/config/api/raw/provider.yml
@@ -1730,6 +1730,7 @@ Ivoz\Provider\Domain\Model\TransformationRuleSet\TransformationRuleSet:
     write_access_control:
       ROLE_COMPANY_ADMIN:
         raw: 'FALSE'
+Ivoz\Provider\Domain\Model\TransformationRuleSet\Name: ~
 
 Ivoz\Provider\Domain\Model\User\User:
   itemOperations:

--- a/web/rest/client/config/api/resources.yml
+++ b/web/rest/client/config/api/resources.yml
@@ -69,3 +69,23 @@ Model\ActiveCalls:
         - My
         parameters: []
   collectionOperations: []
+
+Model\ProfileAcl:
+  itemOperations: []
+  collectionOperations: []
+
+Model\Profile:
+  itemOperations:
+    get_my_profile:
+      access_control: '"ROLE_COMPANY_ADMIN" in roles'
+      depth: 2
+      method: 'GET'
+      path: '/my/profile'
+      route_name: 'get_my_profile'
+      swagger_context:
+        produces:
+          - 'application/json'
+        tags:
+          - My
+        parameters: []
+  collectionOperations: []

--- a/web/rest/client/config/routes.yaml
+++ b/web/rest/client/config/routes.yaml
@@ -44,6 +44,23 @@ get_my_active_calls:
     _api_item_operation_name: 'get_my_active_calls'
     _api_receive: false
 
+get_my_profile:
+  path: '/my/profile'
+  methods: ['GET']
+  defaults:
+    _controller: Controller\My\ProfileAction
+    _api_resource_class: 'Model\Profile'
+    _api_item_operation_name: 'get_my_profile'
+    _api_receive: false
+
+# fake endpoint, required in serialization by api-platform in order to calculate it's iri
+get_my_profile_acl:
+  path: '/my/profile/acls'
+  methods: ['GET']
+  defaults:
+    _api_resource_class: 'Model\ProfileAcl'
+    _api_item_operation_name: 'get_my_profile_acl'
+
 get_services_unassigned:
   path: '/services/unassigned'
   methods: ['GET']

--- a/web/rest/client/features/my/activeCalls/getActiveCalls.feature
+++ b/web/rest/client/features/my/activeCalls/getActiveCalls.feature
@@ -1,0 +1,18 @@
+Feature: Retrieve active calls
+
+  @createSchema
+  Scenario: Retrieve company total active calls json
+    Given I add Company Authorization header
+    When I add "Accept" header equal to "application/json"
+    And I send a "GET" request to "my/active_calls"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+      {
+          "inbound": -1,
+          "outbound": -1,
+          "total": -2
+      }
+    """

--- a/web/rest/client/features/my/profile/getProfile.feature
+++ b/web/rest/client/features/my/profile/getProfile.feature
@@ -1,0 +1,541 @@
+Feature: Retrieve active calls
+
+  @createSchema
+  Scenario: Retrieve company admin profile json
+    Given I add Company Authorization header
+     When I add "Accept" header equal to "application/json"
+      And I send a "GET" request to "my/profile"
+     Then the response status code should be 200
+      And the response should be in JSON
+      And the header "Content-Type" should be equal to "application/json; charset=utf-8"
+      And the JSON should be equal to:
+    """
+      {
+          "restricted": false,
+          "pbx": true,
+          "residential": false,
+          "retail": false,
+          "wholesale": false,
+          "acls": []
+      }
+    """
+
+  Scenario: Retrieve company admin profile json
+    Given I add Residential Company Authorization header
+     When I add "Accept" header equal to "application/json"
+      And I send a "GET" request to "my/profile"
+     Then the response status code should be 200
+      And the response should be in JSON
+      And the header "Content-Type" should be equal to "application/json; charset=utf-8"
+      And the JSON should be equal to:
+    """
+      {
+          "restricted": false,
+          "pbx": false,
+          "residential": true,
+          "retail": false,
+          "wholesale": false,
+          "acls": []
+      }
+    """
+
+  Scenario: Retrieve company admin profile json
+    Given I add Retail Company Authorization header
+     When I add "Accept" header equal to "application/json"
+      And I send a "GET" request to "my/profile"
+     Then the response status code should be 200
+      And the response should be in JSON
+      And the header "Content-Type" should be equal to "application/json; charset=utf-8"
+      And the JSON should be equal to:
+    """
+      {
+          "restricted": false,
+          "pbx": false,
+          "residential": false,
+          "retail": true,
+          "wholesale": false,
+          "acls": []
+      }
+    """
+
+  Scenario: Retrieve company admin profile json
+    Given I add restricted Company Authorization header
+     When I add "Accept" header equal to "application/json"
+      And I send a "GET" request to "my/profile"
+     Then the response status code should be 200
+      And the response should be in JSON
+      And the header "Content-Type" should be equal to "application/json; charset=utf-8"
+      And the JSON should be equal to:
+    """
+      {
+          "restricted": true,
+          "pbx": true,
+          "residential": false,
+          "retail": false,
+          "wholesale": false,
+          "acls": [
+              {
+                  "iden": "_RatingPlanPrices",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "BillableCalls",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "Calendars",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "CalendarPeriods",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "CalendarPeriodsRelSchedules",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "CallACL",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "CallAclRelMatchLists",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "CallCsvSchedulers",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "CallCsvReports",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "CallForwardSettings",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "Companies",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "CompanyServices",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "ConditionalRoutes",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "ConditionalRoutesConditions",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "ConditionalRoutesConditionsRelMatchLists",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "ConditionalRoutesConditionsRelSchedules",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "ConditionalRoutesConditionsRelCalendars",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "ConditionalRoutesConditionsRelRouteLocks",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "ConferenceRooms",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "Countries",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "DDIs",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "Extensions",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "ExternalCallFilters",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "ExternalCallFilterBlackLists",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "ExternalCallFilterRelCalendars",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "ExternalCallFilterRelSchedules",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "ExternalCallFilterWhiteLists",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "FaxesInOut",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "Faxes",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "Features",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "FeaturesRelCompanies",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "Friends",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "FriendsPatterns",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "HolidayDates",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "HuntGroups",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "HuntGroupsRelUsers",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "Invoices",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "IVREntries",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "IVRs",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "IVRExcludedExtensions",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "Languages",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "Locutions",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "NotificationTemplates",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "MatchLists",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "MatchListPatterns",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "MusicOnHold",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "OutgoingDDIRules",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "OutgoingDDIRulesPatterns",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "PickUpGroups",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "PickUpRelUsers",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "QueueMembers",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "Queues",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "RatingPlanGroups",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "RatingProfiles",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "Recordings",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "ResidentialDevices",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "RetailAccounts",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "RouteLocks",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "Schedules",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "Services",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "Terminals",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "TerminalModels",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "Timezones",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "TransformationRuleSets",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "Users",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              },
+              {
+                  "iden": "_RegistrationSummary",
+                  "create": false,
+                  "read": true,
+                  "update": false,
+                  "delete": false
+              }
+          ]
+      }
+    """

--- a/web/rest/client/phpstan-baseline.neon
+++ b/web/rest/client/phpstan-baseline.neon
@@ -96,21 +96,6 @@ parameters:
 			path: src/Service/AuthEndpointDecorator.php
 
 		-
-			message: "#^Method Service\\\\Behat\\\\FeatureContext\\:\\:setCompanyAuthorizationHeader\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: src/Service/Behat/FeatureContext.php
-
-		-
-			message: "#^Method Service\\\\Behat\\\\FeatureContext\\:\\:setResidentialCompanyAuthorizationHeader\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: src/Service/Behat/FeatureContext.php
-
-		-
-			message: "#^Method Service\\\\Behat\\\\FeatureContext\\:\\:setRetailCompanyAuthorizationHeader\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: src/Service/Behat/FeatureContext.php
-
-		-
 			message: "#^Method Service\\\\Behat\\\\FeatureContext\\:\\:setUserAuthorizationHeader\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: src/Service/Behat/FeatureContext.php

--- a/web/rest/client/src/Controller/My/ProfileAction.php
+++ b/web/rest/client/src/Controller/My/ProfileAction.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Controller\My;
+
+use ApiPlatform\Core\Exception\ResourceClassNotFoundException;
+use Ivoz\Provider\Domain\Model\Administrator\AdministratorInterface;
+use Ivoz\Provider\Domain\Model\AdministratorRelPublicEntity\AdministratorRelPublicEntityInterface;
+use Ivoz\Provider\Domain\Model\AdministratorRelPublicEntity\AdministratorRelPublicEntityRepository;
+use Model\Profile;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+class ProfileAction
+{
+    public function __construct(
+        private TokenStorageInterface $tokenStorage,
+        private AdministratorRelPublicEntityRepository $adminRelPublicEntityRepository
+    ) {
+    }
+
+    public function __invoke(): Profile
+    {
+        $token =  $this->tokenStorage->getToken();
+
+        if (!$token || !$token->getUser()) {
+            throw new ResourceClassNotFoundException('User not found');
+        }
+
+        /** @var AdministratorInterface $user */
+        $user = $token->getUser();
+        $company = $user->getCompany();
+        if (!$company) {
+            throw new NotFoundHttpException('Company not found');
+        }
+
+        $restricted = $user->getRestricted();
+
+        /** @var AdministratorRelPublicEntityInterface[] $adminRelPublicEntities */
+        $adminRelPublicEntities = [];
+        if ($restricted) {
+            $adminRelPublicEntities = $this
+                ->adminRelPublicEntityRepository
+                ->getByAdministratorId(
+                    (int) $user->getId()
+                );
+        }
+
+        $type = $company->getType();
+
+        return new Profile(
+            $restricted,
+            $type,
+            $adminRelPublicEntities
+        );
+    }
+}

--- a/web/rest/client/src/Model/Profile.php
+++ b/web/rest/client/src/Model/Profile.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Model;
+
+use Assert\Assertion;
+use Ivoz\Api\Core\Annotation\AttributeDefinition;
+use Ivoz\Provider\Domain\Model\AdministratorRelPublicEntity\AdministratorRelPublicEntityInterface;
+use Ivoz\Provider\Domain\Model\Company\CompanyInterface;
+
+/**
+ * @codeCoverageIgnore
+ */
+class Profile
+{
+    /**
+     * @var bool
+     * @AttributeDefinition(type="bool")
+     */
+    private $restricted;
+
+    /**
+     * @var bool
+     * @AttributeDefinition(type="bool")
+     */
+    private $pbx = false;
+
+    /**
+     * @var bool
+     * @AttributeDefinition(type="bool")
+     */
+    private $residential = false;
+
+    /**
+     * @var bool
+     * @AttributeDefinition(type="bool")
+     */
+    private $retail = false;
+
+    /**
+     * @var bool
+     * @AttributeDefinition(type="bool")
+     */
+    private $wholesale = false;
+
+    /**
+     * @var ProfileAcl[]
+     * @AttributeDefinition(
+     *     type="array",
+     *     class="Model\ProfileAcl"
+     * )
+     */
+    private $acls = [];
+
+    /**
+     * @param AdministratorRelPublicEntityInterface[] $adminRelPublicEntities
+     */
+    public function __construct(
+        bool $restricted,
+        string $type,
+        array $adminRelPublicEntities
+    ) {
+        $this->restricted = $restricted;
+        $this->setType($type);
+
+        foreach ($adminRelPublicEntities as $adminRelPublicEntity) {
+            $this->addAcl(
+                new ProfileAcl($adminRelPublicEntity)
+            );
+        }
+    }
+
+    private function setType(string $type): static
+    {
+        Assertion::choice(
+            $type,
+            [
+                CompanyInterface::TYPE_VPBX,
+                CompanyInterface::TYPE_RETAIL,
+                CompanyInterface::TYPE_WHOLESALE,
+                CompanyInterface::TYPE_RESIDENTIAL,
+            ],
+            'typevalue "%s" is not an element of the valid values: %s'
+        );
+
+        switch ($type) {
+            case CompanyInterface::TYPE_VPBX:
+                $this->pbx = true;
+                break;
+            case CompanyInterface::TYPE_RETAIL:
+                $this->retail = true;
+                break;
+            case CompanyInterface::TYPE_WHOLESALE:
+                $this->wholesale = true;
+                break;
+            case CompanyInterface::TYPE_RESIDENTIAL:
+                $this->residential = true;
+                break;
+        }
+
+        return $this;
+    }
+
+    private function addAcl(ProfileAcl $acl): static
+    {
+        $this->acls[] = $acl;
+
+        return $this;
+    }
+
+    public function isRestricted(): bool
+    {
+        return $this->restricted;
+    }
+
+    public function isPbx(): bool
+    {
+        return $this->pbx;
+    }
+
+    public function isResidential(): bool
+    {
+        return $this->residential;
+    }
+
+    public function isRetail(): bool
+    {
+        return $this->retail;
+    }
+
+    public function isWholesale(): bool
+    {
+        return $this->wholesale;
+    }
+
+    /**
+     * @return ProfileAcl[]
+     */
+    public function getAcls(): array
+    {
+        return $this->acls;
+    }
+}

--- a/web/rest/client/src/Model/ProfileAcl.php
+++ b/web/rest/client/src/Model/ProfileAcl.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Model;
+
+use Assert\Assertion;
+use Ivoz\Api\Core\Annotation\AttributeDefinition;
+use Ivoz\Provider\Domain\Model\AdministratorRelPublicEntity\AdministratorRelPublicEntity;
+use Ivoz\Provider\Domain\Model\AdministratorRelPublicEntity\AdministratorRelPublicEntityInterface;
+use Ivoz\Provider\Domain\Model\Company\CompanyInterface;
+use Ivoz\Provider\Domain\Model\PublicEntity\PublicEntityInterface;
+
+/**
+ * @codeCoverageIgnore
+ */
+class ProfileAcl
+{
+    /**
+     * @var string
+     * @AttributeDefinition(type="string")
+     */
+    private $iden;
+
+    /**
+     * @var bool
+     * @AttributeDefinition(type="bool")
+     */
+    private $create = false;
+
+    /**
+     * @var bool
+     * @AttributeDefinition(type="bool")
+     */
+    private $read = false;
+
+    /**
+     * @var bool
+     * @AttributeDefinition(type="bool")
+     */
+    private $update = false;
+
+    /**
+     * @var bool
+     * @AttributeDefinition(type="bool")
+     */
+    private $delete = false;
+
+    public function __construct(
+        AdministratorRelPublicEntityInterface $administratorRelPublicEntity
+    ) {
+        $publicEntity = $administratorRelPublicEntity->getPublicEntity();
+
+        $this->iden = $publicEntity->getIden();
+        $this->create = $administratorRelPublicEntity->getCreate();
+        $this->read = $administratorRelPublicEntity->getRead();
+        $this->update = $administratorRelPublicEntity->getUpdate();
+        $this->delete = $administratorRelPublicEntity->getDelete();
+    }
+
+    public function getIden(): string
+    {
+        return $this->iden;
+    }
+
+    public function canCreate(): bool
+    {
+        return $this->create;
+    }
+
+    public function canRead(): bool
+    {
+        return $this->read;
+    }
+
+    public function canUpdate(): bool
+    {
+        return $this->update;
+    }
+
+    public function canDelete(): bool
+    {
+        return $this->delete;
+    }
+}

--- a/web/rest/client/src/Service/Behat/FeatureContext.php
+++ b/web/rest/client/src/Service/Behat/FeatureContext.php
@@ -11,25 +11,34 @@ class FeatureContext extends BaseFeatureContext
     /**
      * @Given I add Company Authorization header
      */
-    public function setCompanyAuthorizationHeader()
+    public function setCompanyAuthorizationHeader(): void
     {
-        return $this->setAuthorizationHeader('test_company_admin');
+        $this->setAuthorizationHeader('test_company_admin');
     }
+
+    /**
+     * @Given I add restricted Company Authorization header
+     */
+    public function setRestrictedCompanyAuthorizationHeader(): void
+    {
+        $this->setAuthorizationHeader('restrictedCompanyAdmin');
+    }
+
 
     /**
      * @Given I add Residential Company Authorization header
      */
-    public function setResidentialCompanyAuthorizationHeader()
+    public function setResidentialCompanyAuthorizationHeader(): void
     {
-        return $this->setAuthorizationHeader('test_residential_admin');
+        $this->setAuthorizationHeader('test_residential_admin');
     }
 
     /**
      * @Given I add Retail Company Authorization header
      */
-    public function setRetailCompanyAuthorizationHeader()
+    public function setRetailCompanyAuthorizationHeader(): void
     {
-        return $this->setAuthorizationHeader('test_retail_admin');
+        $this->setAuthorizationHeader('test_retail_admin');
     }
 
     /**

--- a/web/rest/platform/composer.lock
+++ b/web/rest/platform/composer.lock
@@ -2125,11 +2125,11 @@
         },
         {
             "name": "irontec/ivoz-api",
-            "version": "4.7",
+            "version": "4.7.1",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/irontec/ivoz-api",
-                "reference": "b52f543f28481363866fbb2b8fc06b7487ca7e05"
+                "reference": "6bc653821f75185906608319a4d0bdc59272409b"
             },
             "require": {
                 "api-platform/core": "2.6.*",
@@ -2185,15 +2185,15 @@
         },
         {
             "name": "irontec/ivoz-api-bundle",
-            "version": "4.4",
+            "version": "4.4.2",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/irontec/ivoz-api-bundle",
-                "reference": "7616053175e1985aa9cceaa3e24fd6ff1c428fa1"
+                "reference": "c766db1394b1f2c430e86ffa29bf6728066057cf"
             },
             "require": {
                 "gesdinet/jwt-refresh-token-bundle": "^0.12",
-                "irontec/ivoz-api": "^4.6.4",
+                "irontec/ivoz-api": "^4.7.1",
                 "irontec/ivoz-core-bundle": "^4.0.6",
                 "lexik/jwt-authentication-bundle": "^2.5",
                 "nelmio/cors-bundle": "^2.0",

--- a/web/rest/user/composer.lock
+++ b/web/rest/user/composer.lock
@@ -2125,11 +2125,11 @@
         },
         {
             "name": "irontec/ivoz-api",
-            "version": "4.7",
+            "version": "4.7.1",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/irontec/ivoz-api",
-                "reference": "b52f543f28481363866fbb2b8fc06b7487ca7e05"
+                "reference": "6bc653821f75185906608319a4d0bdc59272409b"
             },
             "require": {
                 "api-platform/core": "2.6.*",
@@ -2185,15 +2185,15 @@
         },
         {
             "name": "irontec/ivoz-api-bundle",
-            "version": "4.4",
+            "version": "4.4.2",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/irontec/ivoz-api-bundle",
-                "reference": "7616053175e1985aa9cceaa3e24fd6ff1c428fa1"
+                "reference": "c766db1394b1f2c430e86ffa29bf6728066057cf"
             },
             "require": {
                 "gesdinet/jwt-refresh-token-bundle": "^0.12",
-                "irontec/ivoz-api": "^4.6.4",
+                "irontec/ivoz-api": "^4.7.1",
                 "irontec/ivoz-core-bundle": "^4.0.6",
                 "lexik/jwt-authentication-bundle": "^2.5",
                 "nelmio/cors-bundle": "^2.0",


### PR DESCRIPTION
Expose /my/profile endpoint in client API in order to allow admins to know their ACLs and admin type.
API dependencies has been updated:
  - Upgrading irontec/ivoz-api (4.7 => 4.7.1)
  - Upgrading irontec/ivoz-api-bundle (4.4 => 4.4.2)


#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
