### PR TITLE
web/client: replace route lock status icons

### DIFF
--- a/web/client/src/entities/RouteLock/Field/Status.tsx
+++ b/web/client/src/entities/RouteLock/Field/Status.tsx
@@ -1,14 +1,15 @@
-import FiberManualRecordIcon from '@mui/icons-material/FiberManualRecord';
+import LockIcon from '@mui/icons-material/Lock';
+import LockOpenIcon from '@mui/icons-material/LockOpen';
 import withCustomComponentWrapper, {
     PropertyCustomFunctionComponent,
     PropertyCustomFunctionComponentProps
 } from '@irontec/ivoz-ui/services/form/Field/CustomComponentWrapper';
 import { RouteLockPropertyList } from '../RouteLockProperties';
 
-type HuntGroupsRelUserValues = RouteLockPropertyList<
+type RouteLockValues = RouteLockPropertyList<
     string | number | boolean
 >;
-type TargetGhostType = PropertyCustomFunctionComponent<PropertyCustomFunctionComponentProps<HuntGroupsRelUserValues>>;
+type TargetGhostType = PropertyCustomFunctionComponent<PropertyCustomFunctionComponentProps<RouteLockValues>>;
 
 const Status: TargetGhostType = (props): JSX.Element => {
 
@@ -16,10 +17,10 @@ const Status: TargetGhostType = (props): JSX.Element => {
     const { open } = values;
 
     if (open === true) {
-        return (<FiberManualRecordIcon style={{ color: 'green' }} />);
+        return (<LockOpenIcon />);
     }
 
-    return (<FiberManualRecordIcon style={{ color: 'red' }} />);
+    return (<LockIcon />);
 }
 
-export default withCustomComponentWrapper<HuntGroupsRelUserValues>(Status);
+export default withCustomComponentWrapper<RouteLockValues>(Status);


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [ ] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [ ] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
Replace status icons from red/green circles to a open/closed lock
Also fix some typos in the status field code.

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
