### PR TITLE
Fix Swagger gen path at install

### DIFF
--- a/debian/ivozprovider-web-rest.postinst
+++ b/debian/ivozprovider-web-rest.postinst
@@ -14,7 +14,7 @@ setfacl  -R -m u:www-data:rwX -m u:root:rwX var
 # Create project cache
 bin/console cache:clear --no-warmup -q -n
 # generate swagger spec
-bin/console api:swagger:export > web/swagger.json
+bin/console api:swagger:export > public/swagger.json
 
 # Create jwt certificates
 [ ! -e /opt/irontec/ivozprovider/storage/jwt/private.pem ] && bin/generate-keys --initial
@@ -28,7 +28,7 @@ if [ -d /opt/irontec/ivozprovider/web/rest/brand/ ]; then
         # Create project cache
         bin/console cache:clear --no-warmup -q -n
         # generate swagger spec
-        bin/console api:swagger:export > web/swagger.json
+        bin/console api:swagger:export > public/swagger.json
     popd
 fi
 
@@ -41,7 +41,7 @@ if [ -d /opt/irontec/ivozprovider/web/rest/client/ ]; then
         # Create project cache
         bin/console cache:clear --no-warmup -q -n
         # generate swagger spec
-        bin/console api:swagger:export > web/swagger.json
+        bin/console api:swagger:export > public/swagger.json
     popd
 fi
 


### PR DESCRIPTION

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [ ] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue 

#### Description
Replace swagger export path web/swagger.json for Platform/Brand/Client REST API with correct path public/swagger.json

#### Additional information
The current export path for swagger.json is incorrect and so the task fails at post-install, resulting in no swagger API docs - also visible at https://irontec.github.io/
