### PR TITLE
web/admin: Call Filters toggles for Holidays & Calendars disabled by default 

### DIFF
--- a/web/admin/application/configs/klear/model/ExternalCallFilters.yaml
+++ b/web/admin/application/configs/klear/model/ExternalCallFilters.yaml
@@ -75,7 +75,7 @@ production:
     holidayEnabled:
       title: _('Holiday enabled')
       type: select
-      defaultValue: 1
+      defaultValue: 0
       source:
         data: inline
         values:
@@ -189,7 +189,7 @@ production:
     outOfScheduleEnabled:
       title: _('Out of schedule enabled')
       type: select
-      defaultValue: 1
+      defaultValue: 0
       source:
         data: inline
         values:


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
Set External Call Filters toggles for Holidays & Calenders disabled by default
Implementation of #1752 for web/admin component


#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
