### PR TITLE
web/admin: create route locks open by default

### DIFF
--- a/web/admin/application/configs/klear/RouteLocksList.yaml
+++ b/web/admin/application/configs/klear/RouteLocksList.yaml
@@ -56,11 +56,12 @@ production:
         order:
           name: true
           description: true
-          open: true
         blacklist:
           status: true
           openExtension: true
           closeExtension: true
+          toggleExtension: true
+          open: true
       fixedPositions:
         group0:
           colsPerRow: 12

--- a/web/admin/application/configs/klear/model/RouteLocks.yaml
+++ b/web/admin/application/configs/klear/model/RouteLocks.yaml
@@ -28,7 +28,7 @@ production:
     open:
       title: _('Status')
       type: select
-      defaultValue: 0
+      defaultValue: 1
       source:
         data: inline
         values:


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
This is part of the implementation of #1759 for web/admin component

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
