### PR TITLE
schema: change Voicemail User and Device constraints to cascade delete

### DIFF
--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/Voicemail.VoicemailAbstract.orm.xml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/Voicemail.VoicemailAbstract.orm.xml
@@ -40,12 +40,12 @@
     </many-to-one>
     <one-to-one field="user" target-entity="Ivoz\Provider\Domain\Model\User\UserInterface" inversed-by="voicemail" fetch="LAZY">
       <join-columns>
-        <join-column name="userId" referenced-column-name="id" on-delete="SET NULL" nullable="1"/>
+        <join-column name="userId" referenced-column-name="id" on-delete="CASCADE" nullable="1"/>
       </join-columns>
     </one-to-one>
     <one-to-one field="residentialDevice" target-entity="Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDeviceInterface" inversed-by="voicemail" fetch="LAZY">
       <join-columns>
-        <join-column name="residentialDeviceId" referenced-column-name="id" on-delete="SET NULL" nullable="1"/>
+        <join-column name="residentialDeviceId" referenced-column-name="id" on-delete="CASCADE" nullable="1"/>
       </join-columns>
     </one-to-one>
     <many-to-one field="locution" target-entity="Ivoz\Provider\Domain\Model\Locution\LocutionInterface" fetch="LAZY">

--- a/schema/DoctrineMigrations/Version20220520060237.php
+++ b/schema/DoctrineMigrations/Version20220520060237.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20220520060237 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Change Voicemail User and Residential constraints to ON DELETE CASCADE';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE Voicemails DROP FOREIGN KEY FK_5CE3741564B64DCC');
+        $this->addSql('ALTER TABLE Voicemails DROP FOREIGN KEY FK_5CE374158B329DCD');
+        $this->addSql('ALTER TABLE Voicemails ADD CONSTRAINT FK_5CE3741564B64DCC FOREIGN KEY (userId) REFERENCES Users (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE Voicemails ADD CONSTRAINT FK_5CE374158B329DCD FOREIGN KEY (residentialDeviceId) REFERENCES ResidentialDevices (id) ON DELETE CASCADE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE Voicemails DROP FOREIGN KEY FK_5CE3741564B64DCC');
+        $this->addSql('ALTER TABLE Voicemails DROP FOREIGN KEY FK_5CE374158B329DCD');
+        $this->addSql('ALTER TABLE Voicemails ADD CONSTRAINT FK_5CE3741564B64DCC FOREIGN KEY (userId) REFERENCES Users (id) ON UPDATE NO ACTION ON DELETE SET NULL');
+        $this->addSql('ALTER TABLE Voicemails ADD CONSTRAINT FK_5CE374158B329DCD FOREIGN KEY (residentialDeviceId) REFERENCES ResidentialDevices (id) ON UPDATE NO ACTION ON DELETE SET NULL');
+    }
+}


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
User and Residential Device constraints must be Cascade delete to remove Voicemails when owners are deleted.

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
