### PR TITLE
kamusers: fix fallback DDI selection validation

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -749,15 +749,16 @@ route[ADAPT_CALLER] {
 route[GET_FALLBACK_DDI] {
     sql_xquery("cb", "SELECT D.id, DDIE164 FROM RetailAccounts RA INNER JOIN Companies C ON C.id = RA.companyId INNER JOIN DDIs D ON D.id = COALESCE(RA.outgoingDdiId, C.outgoingDdiId) WHERE RA.id = $dlg_var(retailAccountId)", "ra");
 
+    $var(fallback_ddi_id) = $xavp(ra=>id);
     $var(fallback_ddi) = $xavp(ra=>DDIE164);
-    if (!$var(fallback_ddi)) {
+    if (!$var(fallback_ddi_id)) {
         xwarn("[$dlg_var(cidhash)] GET-FALLBACK-DDI: No fallback DDI for retail account $dlg_var(retailAccountId)\n");
         send_reply("403", "Forbidden (invalid CLID)");
         exit;
     }
 
     xwarn("[$dlg_var(cidhash)] GET-FALLBACK-DDI: Force $var(fallback_ddi) for retail account $dlg_var(retailAccountId)\n");
-    append_hf("X-Info-DdiId: $xavp(ra=>id)\r\n");
+    append_hf("X-Info-DdiId: $var(fallback_ddi_id)\r\n");
 }
 
 # Sets caller in $var(number) seeking in PAI/RPID/From (in this order)


### PR DESCRIPTION

<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
Using the E.164 number in this comparisson caused errors
in variable converssion to integer. Using DDI id should
also work here to check if the query has returned an
alternative DDI.

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
