### PR TITLE
realtime: fix mysql reconnection check query

### DIFF
--- a/microservices/realtime/spec/Services/RegistrationChannelResolverSpec.php
+++ b/microservices/realtime/spec/Services/RegistrationChannelResolverSpec.php
@@ -81,7 +81,7 @@ class RegistrationChannelResolverSpec extends ObjectBehavior
         );
     }
 
-    function it_reconnectes_if_necessary()
+    function it_reconnects_if_necessary()
     {
         $this
             ->em
@@ -90,8 +90,8 @@ class RegistrationChannelResolverSpec extends ObjectBehavior
             ->shouldBeCalled();
 
         $this
-            ->connection
-            ->executeStatement('SELECT 1')
+            ->administratorRepository
+            ->find(0)
             ->willThrow(
                 new ConnectionLost(
                     new ConnectionFailed('something'),
@@ -289,8 +289,8 @@ class RegistrationChannelResolverSpec extends ObjectBehavior
             ->shouldBeCalled();
 
         $this
-            ->connection
-            ->executeStatement('SELECT 1')
+            ->administratorRepository
+            ->find(0)
             ->shouldBeCalled();
     }
 

--- a/microservices/realtime/src/Services/RegistrationChannelResolver.php
+++ b/microservices/realtime/src/Services/RegistrationChannelResolver.php
@@ -38,7 +38,7 @@ class RegistrationChannelResolver
     ) {
         $connection = $this->em->getConnection();
         try {
-            $connection->executeStatement('SELECT 1');
+            $this->administratorRepository->find(0);
         } catch (ConnectionLost $e) {
             $connection->close();
             $connection->connect();


### PR DESCRIPTION

<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
<!-- Describe your changes in detail -->
Looks like using executeStatements creates unbuffered queries
that triggers errors on new connections after the first one.

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
