### PR TITLE
core: properly validate Retail Account Call forward settings

### DIFF
--- a/library/Ivoz/Provider/Domain/Model/CallForwardSetting/CallForwardSetting.php
+++ b/library/Ivoz/Provider/Domain/Model/CallForwardSetting/CallForwardSetting.php
@@ -46,6 +46,19 @@ class CallForwardSetting extends CallForwardSettingAbstract implements CallForwa
 
         $this->sanitizeRouteValues();
 
+        // Retail target type in Call Forward Settings is an exception in routes naming convention and must
+        // be checked individually instead of using RoutableTrait::sanitizeRouteValues()
+        // @see CallForwardSettings::getCallForwardTarget()
+        if ($this->getRouteType() == CallForwardSettingInterface::TARGETTYPE_RETAIL) {
+            if (!$this->cfwToRetailAccount) {
+                throw new \DomainException(
+                    "Target Retail Account (cfwToRetailAccountId) is required for targetType 'retail'"
+                );
+            }
+        } else {
+            $this->setCfwToRetailAccount(null);
+        }
+
         // Timeout only makes sense in NoAnswer Call Forwards
         if ($this->callForwardType != self::CALLFORWARDTYPE_NOANSWER) {
             $this->setNoAnswerTimeout(0);
@@ -57,6 +70,9 @@ class CallForwardSetting extends CallForwardSettingAbstract implements CallForwa
             $this->setDdi(null);
 
             return;
+        } else {
+            // Force filter type in Retail account Call Forward Settings
+            $this->setCallTypeFilter(self::CALLTYPEFILTER_BOTH);
         }
 
         $isValidRetailCfs = in_array(


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
Properly validate Retail account call forward settings to avoid data inconsistency.
CfwRetailAccountId is mandatory for retail route types
Also CallFilterType must be forced to 'both' (other filters types doesn't even show the CFW in web admin)


#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
