### PR TITLE
kamtrunks: call rtpengine_delete on branch timeout with no reply

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -2020,6 +2020,7 @@ failure_route[MANAGE_FAILURE_GW] {
         exit;
     } else if (t_branch_timeout() && !t_branch_replied()) {
         route(INACTIVATE_GW);
+        route(RTPENGINE);
     } else if (t_check_status("3[0-9]{2}")) {
         xwarn("[$dlg_var(cidhash)] MANAGE-FAILURE-GW: $T_reply_code: Not allowed from GW\n");
     }
@@ -2045,9 +2046,6 @@ failure_route[MANAGE_FAILURE_AS] {
 
     route(IS_FROM_INSIDE);
 
-    # Avoid failover for static distribute method
-    if ($dlg_var(distributeMethod) == 'static') exit;
-
     # next DST - only for 404 or local timeout
     if (t_check_status("404") or (t_branch_timeout() and !t_branch_replied())) {
         # Invalidate AS only if no response received
@@ -2056,13 +2054,16 @@ failure_route[MANAGE_FAILURE_AS] {
             ds_mark_dst("ip");
         }
 
-        if(ds_next_dst()) {
-            t_on_failure("MANAGE_FAILURE_AS");
+        if($dlg_var(distributeMethod) != 'static' && ds_next_dst()) {
             xinfo("[$dlg_var(cidhash)] MANAGE-FAILURE-AS: going to <$ru> via <$du>\n");
+            t_on_failure("MANAGE_FAILURE_AS");
             route(RELAY);
-        } else {
-            xerr("[$dlg_var(cidhash)] MANAGE-FAILURE-AS: No more AS-s available\n");
             exit;
+        }
+
+        if (t_branch_timeout() and !t_branch_replied()) {
+            xinfo("[$dlg_var(cidhash)] MANAGE-FAILURE-AS: Free rtpengine session\n");
+            route(RTPENGINE);
         }
     }
 


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
RTPengine sessions need to be freed when no reply is received from AS or GW (remaining failure cases sessions are freed in onreply_route).

#### Additional information

Before this PR, unreachable gateways may cause rtpengine port exhaustion.