### PR TITLE
Api device status error

### DIFF
--- a/library/DataFixtures/ORM/KamUsersLocation.php
+++ b/library/DataFixtures/ORM/KamUsersLocation.php
@@ -71,6 +71,10 @@ class KamUsersLocation extends Fixture implements DependentFixtureInterface
             $this->setRuid('uloc-5cf7df4e-2b02-bc');
         })->call($item3);
 
+        $this->addReference('_reference_KamUsersLocation3', $item3);
+        $this->sanitizeEntityValues($item3);
+        $manager->persist($item3);
+
         /** @var UsersLocation $item4 */
         $item4 = $this->createEntityInstance(UsersLocation::class);
         $domain = $fixture->getReference('_reference_ProviderDomain6');
@@ -89,9 +93,26 @@ class KamUsersLocation extends Fixture implements DependentFixtureInterface
         $this->sanitizeEntityValues($item4);
         $manager->persist($item4);
 
-        $this->addReference('_reference_KamUsersLocation3', $item3);
-        $this->sanitizeEntityValues($item3);
-        $manager->persist($item3);
+        /** @var UsersLocation $item5 */
+        $item5 = $this->createEntityInstance(UsersLocation::class);
+        $domain = $fixture->getReference('_reference_ProviderDomain6');
+        (function () use ($domain, $fixture) {
+            $this->setExpires(
+                new \DateTime('2030-12-31 23:59:59')
+            );
+            $this->setContact('sip:yealinktest@10.10.1.110:5060');
+            $this->setUserAgent('Yealink SIP-T23G 44.80.0.130');
+            $this->setDomain($domain->getDomain());
+            $this->setUsername('residentialDevice');
+            $this->setLastmodified(
+                new \DateTime('1900-01-01 00:00:01')
+            );
+            $this->setRuid('uloc-5cf7df4e-2b12-be');
+        })->call($item5);
+
+        $this->addReference('_reference_KamUsersLocation5', $item5);
+        $this->sanitizeEntityValues($item5);
+        $manager->persist($item5);
 
         $manager->flush();
     }

--- a/library/Ivoz/Provider/Domain/Model/BillableCall/BillableCallDto.php
+++ b/library/Ivoz/Provider/Domain/Model/BillableCall/BillableCallDto.php
@@ -75,7 +75,6 @@ class BillableCallDto extends BillableCallDtoAbstract
         return $response;
     }
 
-
     /**
      * @param array $response
      * @return array

--- a/web/rest/brand/features/provider/residentialDevice/getResidentialDeviceStatus.feature
+++ b/web/rest/brand/features/provider/residentialDevice/getResidentialDeviceStatus.feature
@@ -26,6 +26,13 @@ Feature: Retrieve residential devices status
                       "publicReceived": true,
                       "expires": "2031-01-01 00:59:59",
                       "userAgent": "Yealink SIP-T23G 44.80.0.130"
+                  },
+                  {
+                      "contact": "sip:yealinktest@10.10.1.110:5060",
+                      "received": "",
+                      "publicReceived": false,
+                      "expires": "2031-01-01 00:59:59",
+                      "userAgent": "Yealink SIP-T23G 44.80.0.130"
                   }
               ]
           }

--- a/web/rest/client/features/provider/residentialDevices/getResidentialDeviceStatus.feature
+++ b/web/rest/client/features/provider/residentialDevices/getResidentialDeviceStatus.feature
@@ -25,6 +25,13 @@ Feature: Retrieve residential devices status
                       "publicReceived": true,
                       "expires": "2031-01-01 00:59:59",
                       "userAgent": "Yealink SIP-T23G 44.80.0.130"
+                  },
+                  {
+                      "contact": "sip:yealinktest@10.10.1.110:5060",
+                      "received": "",
+                      "publicReceived": false,
+                      "expires": "2031-01-01 00:59:59",
+                      "userAgent": "Yealink SIP-T23G 44.80.0.130"
                   }
               ]
           }
@@ -38,7 +45,7 @@ Feature: Retrieve residential devices status
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/json; charset=utf-8"
-    And the JSON should be like:
+    And the JSON should be equal to:
     """
       {
           "name": "residentialDevice",
@@ -49,6 +56,13 @@ Feature: Retrieve residential devices status
                   "contact": "sip:yealinktest@10.10.1.108:5060",
                   "received": "sip:212.64.172.25:5060",
                   "publicReceived": true,
+                  "expires": "2031-01-01 00:59:59",
+                  "userAgent": "Yealink SIP-T23G 44.80.0.130"
+              },
+              {
+                  "contact": "sip:yealinktest@10.10.1.110:5060",
+                  "received": "",
+                  "publicReceived": false,
                   "expires": "2031-01-01 00:59:59",
                   "userAgent": "Yealink SIP-T23G 44.80.0.130"
               }


### PR DESCRIPTION
Fixed devices/status API responses. It was showing only the first status row

Upport from #1689 for halliday

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
