### PR TITLE
Retail account access fix

### DIFF
--- a/web/admin/application/configs/klear/RetailAccountsList.yaml
+++ b/web/admin/application/configs/klear/RetailAccountsList.yaml
@@ -51,7 +51,7 @@ production:
         options:
           title: _("Options")
           screens:
-            retailAccountsEdit_screen: $[${auth.acls.RetailAccounts.update} && ${auth.canSeeBrand} && ${auth.companyRetail}]
+            retailAccountsEdit_screen: $[${auth.acls.RetailAccounts.update} && ${auth.companyRetail}]
             ddisList_screen: ${auth.acls.DDIs.read}
             callForwardSettingsList_screen: $[${auth.acls.CallForwardSettings.read} && ${auth.companyRetail}]
           dialogs:
@@ -151,6 +151,8 @@ production:
         name: jquery.passwordgenedit.js
       plugin: passwordgen
       fields:
+        readOnly:
+          name: ${auth.isCompanyOperator}
         order:
           <<: *retailAccounts_orderLink
         blacklist:

--- a/web/rest/client/config/api/raw/provider.yml
+++ b/web/rest/client/config/api/raw/provider.yml
@@ -1502,11 +1502,16 @@ Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDevice:
         groups: ['status']
 
 Ivoz\Provider\Domain\Model\RetailAccount\RetailAccount:
+  properties:
+    name:
+      attributes:
+        swagger_context:
+          readOnly: true
   attributes:
     access_control: >-
-        "ROLE_COMPANY_ADMIN" in roles
-        && user.isRetailAdmin()
-        && user.hasAccessPrivileges(_api_resource_class, request.getMethod())
+      "ROLE_COMPANY_ADMIN" in roles
+      && user.isRetailAdmin()
+      && user.hasAccessPrivileges(_api_resource_class, request.getMethod())
     read_access_control:
       ROLE_COMPANY_ADMIN:
         company:

--- a/web/rest/client/features/provider/retailAccount/putRetailAccount.feature
+++ b/web/rest/client/features/provider/retailAccount/putRetailAccount.feature
@@ -11,7 +11,7 @@ Feature: Update retail accounts
       And I send a "PUT" request to "/retail_accounts/1" with body:
     """
       {
-          "name": "updatedRetailAccount",
+          "name": "readOnlyRetailAccount",
           "description": "updated desc",
           "transformationRuleSet": 1,
           "outgoingDdi": 3
@@ -23,7 +23,7 @@ Feature: Update retail accounts
      And the JSON should be like:
     """
       {
-          "name": "updatedRetailAccount",
+          "name": "testRetailAccount",
           "description": "updated desc",
           "transport": "udp",
           "password": "9rv6G3TVc-",


### PR DESCRIPTION
Retail accounts must be editable by retail admins (everything but name)

Upport from #1699 for halliday

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
