### PR TITLE
schema: add unique constraint to TerminalModel genericUrlPattern field

### DIFF
--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/TerminalModel.TerminalModelAbstract.orm.xml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/TerminalModel.TerminalModelAbstract.orm.xml
@@ -3,6 +3,7 @@
   <mapped-superclass name="Ivoz\Provider\Domain\Model\TerminalModel\TerminalModelAbstract" table="terminal_model_abstract">
     <unique-constraints>
       <unique-constraint name="terminalModel_iden" columns="iden"/>
+      <unique-constraint name="terminalModel_genericUrlPattern" columns="genericUrlPattern"/>
     </unique-constraints>
     <field name="iden" type="string" column="iden" length="100" nullable="false">
       <options>

--- a/schema/DoctrineMigrations/Version20220207084804.php
+++ b/schema/DoctrineMigrations/Version20220207084804.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Application\Migrations;
+
+use Ivoz\Core\Infrastructure\Persistence\Doctrine\LoggableMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20220207084804 extends LoggableMigration
+{
+    public function getDescription(): string
+    {
+        return 'Avoid duplicated Url Patterns in TerminalModels table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE UNIQUE INDEX terminalModel_genericUrlPattern ON TerminalModels (genericUrlPattern)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX terminalModel_genericUrlPattern ON TerminalModels');
+    }
+}

--- a/schema/tests/Provider/TerminalModel/TerminalModelLifeCycleTest.php
+++ b/schema/tests/Provider/TerminalModel/TerminalModelLifeCycleTest.php
@@ -23,8 +23,8 @@ class TerminalModelLifeCycleTest extends KernelTestCase
             ->setDescription('Test SIP Model')
             ->setGenericTemplate('')
             ->setSpecificTemplate('')
-            ->setGenericUrlPattern('')
-            ->setSpecificUrlPattern('')
+            ->setGenericUrlPattern('genericUrlPattern')
+            ->setSpecificUrlPattern('specificUrlPattern')
             ->setTerminalManufacturerId(1);
 
         return $terminalModelDto;
@@ -73,7 +73,7 @@ class TerminalModelLifeCycleTest extends KernelTestCase
     /**
      * @test
      */
-    public function it_persists_routing_tags()
+    public function it_persists_terminal_model()
     {
         $terminalModelRepository = $this->em
             ->getRepository(TerminalModel::class);

--- a/web/rest/platform/features/provider/terminalModel/postTerminalModel.feature
+++ b/web/rest/platform/features/provider/terminalModel/postTerminalModel.feature
@@ -16,8 +16,8 @@ Feature: Create terminal models
           "description": "New SIP Model",
           "genericTemplate": "",
           "specificTemplate": "",
-          "genericUrlPattern": "",
-          "specificUrlPattern": "",
+          "genericUrlPattern": "genericUrlPattern",
+          "specificUrlPattern": "specificUrlPattern",
           "terminalManufacturer": 1
       }
     """
@@ -32,8 +32,8 @@ Feature: Create terminal models
           "description": "New SIP Model",
           "genericTemplate": "",
           "specificTemplate": "",
-          "genericUrlPattern": "",
-          "specificUrlPattern": "",
+          "genericUrlPattern": "genericUrlPattern",
+          "specificUrlPattern": "specificUrlPattern",
           "id": 3,
           "terminalManufacturer": 1
       }
@@ -54,8 +54,8 @@ Feature: Create terminal models
           "description": "New SIP Model",
           "genericTemplate": "",
           "specificTemplate": "",
-          "genericUrlPattern": "",
-          "specificUrlPattern": "",
+          "genericUrlPattern": "genericUrlPattern",
+          "specificUrlPattern": "specificUrlPattern",
           "id": 3,
           "terminalManufacturer": {
               "iden": "Generic",


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

Upport fro #1707 for halliday


#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
This change make genericUrlPattern unique to avoid any missconfigurations in terminal provisioning.

If there are genericUrlPatterns duplicated in database, this schema change may fail and human interaction will be required to fix the data before reapplying the migration.

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
