### PR TITLE
kam_user_cdrs start_time index

### DIFF
--- a/library/Ivoz/Kam/Infrastructure/Persistence/Doctrine/Mapping/UsersCdr.UsersCdrAbstract.orm.xml
+++ b/library/Ivoz/Kam/Infrastructure/Persistence/Doctrine/Mapping/UsersCdr.UsersCdrAbstract.orm.xml
@@ -3,6 +3,7 @@
   <mapped-superclass name="Ivoz\Kam\Domain\Model\UsersCdr\UsersCdrAbstract" table="users_cdr_abstract">
     <indexes>
       <index name="usersCdr_brandId" columns="brandId"/>
+      <index name="usersCdr_startTime" columns="start_time"/>
       <index name="usersCdr_companyId_hidden_startTime" columns="companyId,hidden,start_time"/>
       <index name="usersCdr_userId" columns="userId"/>
       <index name="usersCdr_friendId" columns="friendId"/>

--- a/schema/DoctrineMigrations/Version20220207102413.php
+++ b/schema/DoctrineMigrations/Version20220207102413.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Application\Migrations;
+
+use Ivoz\Core\Infrastructure\Persistence\Doctrine\LoggableMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20220207102413 extends LoggableMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create startTime index in kam_users_cdrs table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE INDEX usersCdr_startTime ON kam_users_cdrs (start_time)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX usersCdr_startTime ON kam_users_cdrs');
+    }
+}


### PR DESCRIPTION
Add db index on kam_user_cdrs.start_time so that it can be rotated easily

Upport from #1708 for halliday

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
