### PR TITLE
Improved rerating

### DIFF
--- a/library/DataFixtures/ORM/KamTrunksCdr.php
+++ b/library/DataFixtures/ORM/KamTrunksCdr.php
@@ -46,6 +46,35 @@ class KamTrunksCdr extends Fixture implements DependentFixtureInterface
         $this->sanitizeEntityValues($item1);
         $manager->persist($item1);
 
+        /////////////////////////
+        ///
+        ////////////////////////
+
+        /** @var TrunksCdrInterface $item2 */
+        $item2 = $this->createEntityInstance(TrunksCdr::class);
+        (function () use ($fixture) {
+            $this->setStartTime(new \DateTime('2021-11-22 16:54:49'));
+            $this->setEndTime(new \DateTime('2021-11-22 16:54:54'));
+            $this->setDuration(4.765);
+            $this->setDirection('outbound');
+
+            $this->setCaller('+3494696823899');
+            $this->setCallee('+34676238611');
+            $this->setCallid('017cc7c8-eb38-4bbd-9318-524a274f7000');
+            $this->setCallidHash('2789d532');
+            $this->setXcallid('9297bdde-309cd48f@10.10.1.123');
+            $this->setParsed(1);
+            $this->setCgrid('5a364b1fe35e00fb2ac1923b43f84eeb78400e03');
+            $this->setParserScheduledAt(new \DateTime('2018-11-22 16:54:54'));
+            $this->setBrand($fixture->getReference('_reference_ProviderBrand1'));
+            $this->setCompany($fixture->getReference('_reference_ProviderCompany1'));
+            $this->setCarrier($fixture->getReference('_reference_ProviderCarrier1'));
+        })->call($item2);
+
+        $this->addReference('_reference_KamTrunksCdr2', $item2);
+        $this->sanitizeEntityValues($item2);
+        $manager->persist($item2);
+
         $manager->flush();
     }
 

--- a/library/Ivoz/Cgr/Infrastructure/Cgrates/Service/RerateCallService.php
+++ b/library/Ivoz/Cgr/Infrastructure/Cgrates/Service/RerateCallService.php
@@ -55,6 +55,11 @@ class RerateCallService extends AbstractApiBasedService implements RerateCallSer
     public function execute(array $pks)
     {
         $error = false;
+
+        $this
+            ->trunksCdrRepository
+            ->resetOrphanCgrids($pks);
+
         $cgrIds = $this
             ->billableCallRepository
             ->findRerateableCgridsInGroup($pks);

--- a/library/Ivoz/Kam/Domain/Model/TrunksCdr/TrunksCdrRepository.php
+++ b/library/Ivoz/Kam/Domain/Model/TrunksCdr/TrunksCdrRepository.php
@@ -24,6 +24,13 @@ interface TrunksCdrRepository extends ObjectRepository, Selectable
     public function resetParsed(array $ids);
 
     /**
+     * @param array<int> $billableCallIds
+     * @return int affected rows
+     * @psalm-suppress PossiblyUnusedReturnValue
+     */
+    public function resetOrphanCgrids(array $billableCallIds): int;
+
+    /**
      * @param string $callid
      * @return TrunksCdrInterface[]
      */

--- a/library/Ivoz/Kam/Domain/Service/TrunksCdr/RerateCallServiceInterface.php
+++ b/library/Ivoz/Kam/Domain/Service/TrunksCdr/RerateCallServiceInterface.php
@@ -5,7 +5,7 @@ namespace Ivoz\Kam\Domain\Service\TrunksCdr;
 interface RerateCallServiceInterface
 {
     /**
-     * @param array $pks
+     * @param array<int> $pks
      * @return void
      * @throws \DomainException
      */

--- a/library/Ivoz/Kam/Infrastructure/Persistence/Doctrine/TrunksCdrDoctrineRepository.php
+++ b/library/Ivoz/Kam/Infrastructure/Persistence/Doctrine/TrunksCdrDoctrineRepository.php
@@ -3,12 +3,15 @@
 namespace Ivoz\Kam\Infrastructure\Persistence\Doctrine;
 
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Ivoz\Cgr\Domain\Model\TpCdr\TpCdr;
 use Ivoz\Core\Infrastructure\Domain\Service\DoctrineQueryRunner;
 use Ivoz\Core\Infrastructure\Persistence\Doctrine\Model\Helper\CriteriaHelper;
 use Ivoz\Core\Infrastructure\Persistence\Doctrine\Traits\GetGeneratorByConditionsTrait;
 use Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdr;
 use Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdrInterface;
 use Ivoz\Kam\Domain\Model\TrunksCdr\TrunksCdrRepository;
+use Ivoz\Provider\Domain\Model\BillableCall\BillableCall;
+use Doctrine\ORM\Query\Lexer;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
@@ -114,6 +117,72 @@ class TrunksCdrDoctrineRepository extends ServiceEntityRepository implements Tru
             ->setParameter(':parserScheduledAt', $now->format('Y-m-d H:i:s'))
             ->where('self.id in (:ids)')
             ->setParameter(':ids', $ids);
+
+        return $this->queryRunner->execute(
+            $this->getEntityName(),
+            $qb->getQuery()
+        );
+    }
+
+    /**
+     * @inheritdoc
+     * @see TrunksCdrRepository::resetOrphanCgrids
+     */
+    public function resetOrphanCgrids(array $billableCallIds): int
+    {
+        $qb = $this->_em
+            ->createQueryBuilder()
+            ->select('self.callid')
+            ->from(BillableCall::class, 'self')
+            ->where('self.id in (:ids)')
+            ->setParameter(':ids', $billableCallIds);
+
+        $result = $qb->getQuery()->getScalarResult();
+
+        $callIds = array_column(
+            $result,
+            'callid'
+        );
+
+        if (empty($callIds)) {
+            return 0;
+        }
+
+        $qb = $this
+            ->createQueryBuilder('self')
+            ->select('self.id, tpCdr.cgrid')
+            ->leftJoin(
+                TpCdr::class,
+                'tpCdr',
+                'WITH',
+                'self.cgrid = tpCdr.cgrid'
+            )
+            ->where('self.callid in (:callIds)')
+            ->andWhere('self.cgrid IS NOT NULL')
+            ->andWhere('tpCdr.cgrid IS NULL')
+            ->setParameter(':callIds', $callIds);
+
+        $result = $qb->getQuery()->getScalarResult();
+
+        $idsToReset = array_map(
+            'intval',
+            array_column(
+                $result,
+                'id'
+            )
+        );
+
+        if (empty($idsToReset)) {
+            return 0;
+        }
+
+        $qb = $this
+            ->createQueryBuilder('self')
+            ->update($this->_entityName, 'self')
+            ->set('self.cgrid', ':nullValue')
+            ->setParameter(':nullValue', null)
+            ->where('self.id in (:idsToReset)')
+            ->setParameter(':idsToReset', $idsToReset);
 
         return $this->queryRunner->execute(
             $this->getEntityName(),

--- a/library/Ivoz/Provider/Domain/Model/BillableCall/BillableCallRepository.php
+++ b/library/Ivoz/Provider/Domain/Model/BillableCall/BillableCallRepository.php
@@ -71,7 +71,7 @@ interface BillableCallRepository extends ObjectRepository, Selectable
 
     /**
      * @param InvoiceInterface $invoice
-     * @return array
+     * @return array<int>
      */
     public function getUnratedCallIdsByInvoice(InvoiceInterface $invoice): array;
 

--- a/library/phpstan-baseline.neon
+++ b/library/phpstan-baseline.neon
@@ -1121,11 +1121,6 @@ parameters:
 			path: Ivoz/Cgr/Infrastructure/Cgrates/Service/ProcessExternalCdr.php
 
 		-
-			message: "#^Method Ivoz\\\\Cgr\\\\Infrastructure\\\\Cgrates\\\\Service\\\\RerateCallService\\:\\:execute\\(\\) has parameter \\$pks with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: Ivoz/Cgr/Infrastructure/Cgrates/Service/RerateCallService.php
-
-		-
 			message: "#^Method Ivoz\\\\Cgr\\\\Infrastructure\\\\Cgrates\\\\Service\\\\RerateCallService\\:\\:rerate\\(\\) has parameter \\$cgrIds with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: Ivoz/Cgr/Infrastructure/Cgrates/Service/RerateCallService.php
@@ -2071,11 +2066,6 @@ parameters:
 			path: Ivoz/Kam/Domain/Service/TrunksAddress/UpdateByDdiProviderAddress.php
 
 		-
-			message: "#^Method Ivoz\\\\Kam\\\\Domain\\\\Service\\\\TrunksCdr\\\\RerateCallServiceInterface\\:\\:execute\\(\\) has parameter \\$pks with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: Ivoz/Kam/Domain/Service/TrunksCdr/RerateCallServiceInterface.php
-
-		-
 			message: "#^Method Ivoz\\\\Kam\\\\Domain\\\\Service\\\\TrunksCdr\\\\TrunksCdrLifecycleServiceCollection\\:\\:addService\\(\\) has parameter \\$service with no typehint specified\\.$#"
 			count: 1
 			path: Ivoz/Kam/Domain/Service/TrunksCdr/TrunksCdrLifecycleServiceCollection.php
@@ -3012,11 +3002,6 @@ parameters:
 
 		-
 			message: "#^Method Ivoz\\\\Provider\\\\Domain\\\\Model\\\\BillableCall\\\\BillableCallRepository\\:\\:getGeneratorByConditions\\(\\) return type has no value type specified in iterable type Generator\\.$#"
-			count: 1
-			path: Ivoz/Provider/Domain/Model/BillableCall/BillableCallRepository.php
-
-		-
-			message: "#^Method Ivoz\\\\Provider\\\\Domain\\\\Model\\\\BillableCall\\\\BillableCallRepository\\:\\:getUnratedCallIdsByInvoice\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: Ivoz/Provider/Domain/Model/BillableCall/BillableCallRepository.php
 
@@ -14542,11 +14527,6 @@ parameters:
 
 		-
 			message: "#^Method Ivoz\\\\Provider\\\\Infrastructure\\\\Persistence\\\\Doctrine\\\\BillableCallDoctrineRepository\\:\\:getGeneratorByInvoice\\(\\) return type has no value type specified in iterable type Generator\\.$#"
-			count: 1
-			path: Ivoz/Provider/Infrastructure/Persistence/Doctrine/BillableCallDoctrineRepository.php
-
-		-
-			message: "#^Method Ivoz\\\\Provider\\\\Infrastructure\\\\Persistence\\\\Doctrine\\\\BillableCallDoctrineRepository\\:\\:getUnratedCallIdsByInvoice\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: Ivoz/Provider/Infrastructure/Persistence/Doctrine/BillableCallDoctrineRepository.php
 

--- a/schema/tests/Kam/TrunksCdr/TrunksCdrRepositoryTest.php
+++ b/schema/tests/Kam/TrunksCdr/TrunksCdrRepositoryTest.php
@@ -22,6 +22,7 @@ class TrunksCdrRepositoryTest extends KernelTestCase
         $this->it_finds_one_by_callid();
         $this->it_finds_unparsedCalls();
         $this->it_resets_parsed_calls();
+        $this->it_resets_orphan_cgrids();
     }
 
     public function its_instantiable()
@@ -117,5 +118,21 @@ class TrunksCdrRepositoryTest extends KernelTestCase
         );
 
         $this->assertNotEmpty($result);
+    }
+
+    public function it_resets_orphan_cgrids()
+    {
+        /** @var TrunksCdrRepository $repository */
+        $repository = $this
+            ->em
+            ->getRepository(TrunksCdr::class);
+
+        $affectedRows = $repository
+            ->resetOrphanCgrids([1,2,3]);
+
+        $this->assertEquals(
+            1,
+            $affectedRows
+        );
     }
 }


### PR DESCRIPTION
Reset orphan cgrids before rerating ir order to avoid potential cgrates issues

Upport from #1709 for halliday

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
