### PR TITLE
web/admin: replace OutgointRouting routing mode constants

### DIFF
--- a/web/admin/application/library/IvozProvider/Klear/Filter/OutgoingRoutingMode.php
+++ b/web/admin/application/library/IvozProvider/Klear/Filter/OutgoingRoutingMode.php
@@ -3,6 +3,7 @@
 use Ivoz\Core\Application\Service\DataGateway;
 use Ivoz\Provider\Domain\Model\OutgoingRouting\OutgoingRouting;
 use Ivoz\Provider\Domain\Model\OutgoingRouting\OutgoingRoutingDto;
+use Ivoz\Provider\Domain\Model\OutgoingRouting\OutgoingRoutingInterface;
 
 /**
  * Class IvozProvider_Klear_Filter_OutgoingRoutingMode
@@ -59,17 +60,17 @@ class IvozProvider_Klear_Filter_OutgoingRoutingMode implements KlearMatrix_Model
 
         if ($this->outgoingRouting) {
             switch ($this->outgoingRouting->getRoutingMode()) {
-                case OutgoingRouting::ROUTINGMODE_LCR:
-                    $excludedRoutingModes[] = OutgoingRouting::ROUTINGMODE_STATIC;
-                    $excludedRoutingModes[] = OutgoingRouting::ROUTINGMODE_BLOCK;
+                case OutgoingRoutingInterface::ROUTINGMODE_LCR:
+                    $excludedRoutingModes[] = OutgoingRoutingInterface::ROUTINGMODE_STATIC;
+                    $excludedRoutingModes[] = OutgoingRoutingInterface::ROUTINGMODE_BLOCK;
                     break;
-                case OutgoingRouting::MODE_STATIC:
-                    $excludedRoutingModes[] = OutgoingRouting::ROUTINGMODE_LCR;
-                    $excludedRoutingModes[] = OutgoingRouting::ROUTINGMODE_BLOCK;
+                case OutgoingRoutingInterface::ROUTINGMODE_STATIC:
+                    $excludedRoutingModes[] = OutgoingRoutingInterface::ROUTINGMODE_LCR;
+                    $excludedRoutingModes[] = OutgoingRoutingInterface::ROUTINGMODE_BLOCK;
                     break;
-                case OutgoingRouting::ROUTINGMODE_BLOCK:
-                    $excludedRoutingModes[] = OutgoingRouting::ROUTINGMODE_STATIC;
-                    $excludedRoutingModes[] = OutgoingRouting::ROUTINGMODE_LCR;
+                case OutgoingRoutingInterface::ROUTINGMODE_BLOCK:
+                    $excludedRoutingModes[] = OutgoingRoutingInterface::ROUTINGMODE_STATIC;
+                    $excludedRoutingModes[] = OutgoingRoutingInterface::ROUTINGMODE_LCR;
                     break;
             }
         }

--- a/web/admin/application/library/IvozProvider/Klear/Ghost/OutgoingRouting.php
+++ b/web/admin/application/library/IvozProvider/Klear/Ghost/OutgoingRouting.php
@@ -3,8 +3,8 @@
 use Ivoz\Core\Application\Service\DataGateway;
 use Ivoz\Provider\Domain\Model\Carrier\Carrier;
 use Ivoz\Provider\Domain\Model\Carrier\CarrierDto;
-use Ivoz\Provider\Domain\Model\OutgoingRouting\OutgoingRouting;
 use Ivoz\Provider\Domain\Model\OutgoingRouting\OutgoingRoutingDto;
+use Ivoz\Provider\Domain\Model\OutgoingRouting\OutgoingRoutingInterface;
 use Ivoz\Provider\Domain\Model\OutgoingRoutingRelCarrier\OutgoingRoutingRelCarrier;
 use Ivoz\Provider\Domain\Model\OutgoingRoutingRelCarrier\OutgoingRoutingRelCarrierDto;
 
@@ -23,12 +23,12 @@ class IvozProvider_Klear_Ghost_OutgoingRouting extends KlearMatrix_Model_Field_G
         $dataGateway = \Zend_Registry::get('data_gateway');
 
         switch ($outgoingRouting->getRoutingMode()) {
-            case OutgoingRouting::MODE_STATIC:
+            case OutgoingRoutingInterface::ROUTINGMODE_STATIC:
                 $carrierIds = array(
                     $outgoingRouting->getCarrierId()
                 );
                 break;
-            case OutgoingRouting::MODE_LCR:
+            case OutgoingRoutingInterface::ROUTINGMODE_LCR:
                 /** @var OutgoingRoutingRelCarrierDto[] $outgoingRoutingRelCarriers */
                 $outgoingRoutingRelCarriers = $dataGateway->findBy(OutgoingRoutingRelCarrier::class, [
                     "OutgoingRoutingRelCarrier.outgoingRouting = " . $outgoingRouting->getId()
@@ -41,7 +41,7 @@ class IvozProvider_Klear_Ghost_OutgoingRouting extends KlearMatrix_Model_Field_G
                     $outgoingRoutingRelCarriers
                 );
                 break;
-            case OutgoingRouting::ROUTINGMODE_BLOCK:
+            case OutgoingRoutingInterface::ROUTINGMODE_BLOCK:
                 return "";
             default:
                 return Klear_Model_Gettext::gettextCheck('_("Invalid route mode")');


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
Update Outgoing Routing ghost fields to replace obsolete constants from class with auto-generated from interface.

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
