### PR TITLE
schema: make BillableCalls direction field not nullable

### DIFF
--- a/library/Ivoz/Provider/Domain/Model/BillableCall/BillableCallAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/BillableCall/BillableCallAbstract.php
@@ -109,7 +109,7 @@ abstract class BillableCallAbstract
     protected $endpointName = null;
 
     /**
-     * @var ?string
+     * @var string
      * comment: enum:inbound|outbound
      */
     protected $direction = 'outbound';
@@ -163,9 +163,11 @@ abstract class BillableCallAbstract
      * Constructor
      */
     protected function __construct(
-        float $duration
+        float $duration,
+        string $direction
     ) {
         $this->setDuration($duration);
+        $this->setDirection($direction);
     }
 
     abstract public function getId(): null|string|int;
@@ -228,9 +230,12 @@ abstract class BillableCallAbstract
         Assertion::isInstanceOf($dto, BillableCallDto::class);
         $duration = $dto->getDuration();
         Assertion::notNull($duration, 'getDuration value is null, but non null value was expected.');
+        $direction = $dto->getDirection();
+        Assertion::notNull($direction, 'getDirection value is null, but non null value was expected.');
 
         $self = new static(
-            $duration
+            $duration,
+            $direction
         );
 
         $self
@@ -247,7 +252,6 @@ abstract class BillableCallAbstract
             ->setEndpointType($dto->getEndpointType())
             ->setEndpointId($dto->getEndpointId())
             ->setEndpointName($dto->getEndpointName())
-            ->setDirection($dto->getDirection())
             ->setBrand($fkTransformer->transform($dto->getBrand()))
             ->setCompany($fkTransformer->transform($dto->getCompany()))
             ->setCarrier($fkTransformer->transform($dto->getCarrier()))
@@ -275,6 +279,8 @@ abstract class BillableCallAbstract
 
         $duration = $dto->getDuration();
         Assertion::notNull($duration, 'getDuration value is null, but non null value was expected.');
+        $direction = $dto->getDirection();
+        Assertion::notNull($direction, 'getDirection value is null, but non null value was expected.');
 
         $this
             ->setCallid($dto->getCallid())
@@ -291,7 +297,7 @@ abstract class BillableCallAbstract
             ->setEndpointType($dto->getEndpointType())
             ->setEndpointId($dto->getEndpointId())
             ->setEndpointName($dto->getEndpointName())
-            ->setDirection($dto->getDirection())
+            ->setDirection($direction)
             ->setBrand($fkTransformer->transform($dto->getBrand()))
             ->setCompany($fkTransformer->transform($dto->getCompany()))
             ->setCarrier($fkTransformer->transform($dto->getCarrier()))
@@ -603,25 +609,23 @@ abstract class BillableCallAbstract
         return $this->endpointName;
     }
 
-    protected function setDirection(?string $direction = null): static
+    protected function setDirection(string $direction): static
     {
-        if (!is_null($direction)) {
-            Assertion::choice(
-                $direction,
-                [
-                    BillableCallInterface::DIRECTION_INBOUND,
-                    BillableCallInterface::DIRECTION_OUTBOUND,
-                ],
-                'directionvalue "%s" is not an element of the valid values: %s'
-            );
-        }
+        Assertion::choice(
+            $direction,
+            [
+                BillableCallInterface::DIRECTION_INBOUND,
+                BillableCallInterface::DIRECTION_OUTBOUND,
+            ],
+            'directionvalue "%s" is not an element of the valid values: %s'
+        );
 
         $this->direction = $direction;
 
         return $this;
     }
 
-    public function getDirection(): ?string
+    public function getDirection(): string
     {
         return $this->direction;
     }

--- a/library/Ivoz/Provider/Domain/Model/BillableCall/BillableCallDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/BillableCall/BillableCallDtoAbstract.php
@@ -405,7 +405,7 @@ abstract class BillableCallDtoAbstract implements DataTransferObjectInterface
         return $this->endpointName;
     }
 
-    public function setDirection(?string $direction): static
+    public function setDirection(string $direction): static
     {
         $this->direction = $direction;
 

--- a/library/Ivoz/Provider/Domain/Model/BillableCall/BillableCallInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/BillableCall/BillableCallInterface.php
@@ -98,7 +98,7 @@ interface BillableCallInterface extends LoggableEntityInterface
 
     public function getEndpointName(): ?string;
 
-    public function getDirection(): ?string;
+    public function getDirection(): string;
 
     public function getBrand(): ?BrandInterface;
 

--- a/library/Ivoz/Provider/Domain/Service/BillableCall/CreateOrUpdateByTrunksCdr.php
+++ b/library/Ivoz/Provider/Domain/Service/BillableCall/CreateOrUpdateByTrunksCdr.php
@@ -83,11 +83,15 @@ class CreateOrUpdateByTrunksCdr
                 $trunksCdrDto->getCallid()
             )->setCaller(
                 $caller
-            )->setDirection(
-                $trunksCdrDto->getDirection()
             )->setDdiId(
                 $trunksCdrDto->getDdiId()
             );
+
+        $direction = $trunksCdrDto->getDirection();
+        if ($direction) {
+            $billableCallDto
+                ->setDirection($direction);
+        }
 
         $isNew = is_null($billableCall);
         if ($isNew) {

--- a/library/Ivoz/Provider/Domain/Service/BillableCall/UpdateByTpCdr.php
+++ b/library/Ivoz/Provider/Domain/Service/BillableCall/UpdateByTpCdr.php
@@ -51,7 +51,7 @@ class UpdateByTpCdr implements TrunksCdrWasMigratedSubscriberInterface
         if ($isNotOutbound) {
             $msg = sprintf(
                 'Skipping %s call #%d',
-                $billableCall->getDirection() ?? '',
+                $billableCall->getDirection(),
                 (int) $billableCall->getId()
             );
             $this->logger->info($msg);

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/BillableCall.BillableCallAbstract.orm.xml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/BillableCall.BillableCallAbstract.orm.xml
@@ -64,7 +64,7 @@
         <option name="fixed"/>
       </options>
     </field>
-    <field name="direction" type="string" column="direction" nullable="true">
+    <field name="direction" type="string" column="direction" nullable="false">
       <options>
         <option name="fixed"/>
         <option name="comment">[enum:inbound|outbound]</option>

--- a/library/spec/Ivoz/Provider/Domain/Service/BillableCall/CreateOrUpdateByTrunksCdrSpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Service/BillableCall/CreateOrUpdateByTrunksCdrSpec.php
@@ -175,6 +175,7 @@ class CreateOrUpdateByTrunksCdrSpec extends ObjectBehavior
                 'getCallee' => '+34600',
                 'getStartTime' => new \DateTime(),
                 'getDuration' => 3.6,
+                'getDirection' => 'outbound',
             ],
             true
         );
@@ -205,6 +206,13 @@ class CreateOrUpdateByTrunksCdrSpec extends ObjectBehavior
     {
         $billableCallDto = $this->mockBillableCallDto();
         $trunksCdrDto = $this->mockTrunksCdrDto();
+        $this->getterProphecy(
+            $trunksCdrDto,
+            [
+                'getDirection' => 'outbound',
+            ],
+            true
+        );
 
         $trunksCdrDto
             ->getRetailAccountId()
@@ -223,8 +231,15 @@ class CreateOrUpdateByTrunksCdrSpec extends ObjectBehavior
 
     function it_sets_endpoint_info_if_retail_account_exists()
     {
-        $trunksCdrDto = $this->mockTrunksCdrDto();
         $billableCallDto = $this->mockBillableCallDto();
+        $trunksCdrDto = $this->mockTrunksCdrDto();
+        $this->getterProphecy(
+            $trunksCdrDto,
+            [
+                'getDirection' => 'outbound',
+            ],
+            true
+        );
 
         $trunksCdrDto
             ->getRetailAccountId()
@@ -263,6 +278,7 @@ class CreateOrUpdateByTrunksCdrSpec extends ObjectBehavior
                 'startTime' => new \DateTime(),
                 'endTime' => new \DateTime(),
                 'parserScheduledAt' => new \DateTime(),
+                'direction' => 'outbound',
             ]
         );
 

--- a/schema/DoctrineMigrations/Version20220603083243.php
+++ b/schema/DoctrineMigrations/Version20220603083243.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20220603083243 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Make BillableCalls direction not nullable';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE BillableCalls CHANGE direction direction VARCHAR(255) DEFAULT \'outbound\' NOT NULL COMMENT \'[enum:inbound|outbound]\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE BillableCalls CHANGE direction direction VARCHAR(255) DEFAULT \'outbound\' COMMENT \'[enum:inbound|outbound]\'');
+    }
+}


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [x] Fixes an existing issue (Fixes #1682) <!-- Replace XXXX with issue id -->

#### Description
BillableCalls.direction should not be nullable and it also has a default value.

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
