### PR TITLE
kamtrunks: use contact_addr uacreg field

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -2133,11 +2133,6 @@ event_route[tm:local-request] {
             $ru = $dlg_var(contact);
         }
     }
-
-    # UACREG sends REGISTER requests whose Contact domain must be adapted
-    if (is_method("REGISTER")) {
-        subst_hf("Contact", "/127.0.0.1/$sndfrom(ip):$sndfrom(port)/", "a");
-    }
 }
 
 onsend_route {

--- a/library/Ivoz/Kam/Domain/Service/TrunksUacreg/CreatedByDdiProviderRegistration.php
+++ b/library/Ivoz/Kam/Domain/Service/TrunksUacreg/CreatedByDdiProviderRegistration.php
@@ -56,7 +56,7 @@ class CreatedByDdiProviderRegistration implements DdiProviderRegistrationLifecyc
             ->setAuthProxy($ddiProviderRegistration->getAuthProxy())
             ->setExpires($ddiProviderRegistration->getExpires());
 
-        // Set socket depending on DDIProvider proxytrunks address
+        // Set socket and contactAddr depending on DDIProvider proxytrunks address
         $trunks = $ddiProviderRegistration->getDdiProvider()->getProxyTrunk();
         if (is_null($trunks)) {
             $trunks = $this->proxyTrunkRepository->getProxyMainAddress();
@@ -65,8 +65,11 @@ class CreatedByDdiProviderRegistration implements DdiProviderRegistrationLifecyc
         $trunksIp  = $trunks->getIp();
 
         $socket = 'udp:' . $trunksIp . ':5060';
+        $contactAddr = $trunksIp . ':5060';
 
-        $trunksUacregDto->setSocket($socket);
+        $trunksUacregDto
+            ->setSocket($socket)
+            ->setContactAddr($contactAddr);
 
         // Update registration contact if required
         $contactUsernameChanged = $ddiProviderRegistration->hasChanged('multiDdi')

--- a/schema/DoctrineMigrations/Version20220624114352.php
+++ b/schema/DoctrineMigrations/Version20220624114352.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20220624114352 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Set contactAddr value for uacreg entries';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('UPDATE kam_trunks_uacreg KTU JOIN DDIProviderRegistrations DPR ON DPR.id=KTU.ddiProviderRegistrationId JOIN DDIProviders DP ON DP.id=DPR.ddiProviderId LEFT JOIN ProxyTrunks PT ON PT.id=COALESCE(DP.proxyTrunkId, 1) SET contact_addr=CONCAT(PT.ip, ":5060")');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql("UPDATE kam_trunks_uacreg SET contact_addr=''");
+    }
+}

--- a/schema/tests/Provider/DdiProviderRegistration/DdiProviderRegistrationLifeCycleTest.php
+++ b/schema/tests/Provider/DdiProviderRegistration/DdiProviderRegistrationLifeCycleTest.php
@@ -132,7 +132,7 @@ class DdiProviderRegistrationLifeCycleTest extends KernelTestCase
             'flags' => 0,
             'reg_delay' => 0,
             'socket' => 'udp:127.0.0.1:5060',
-            'contact_addr' => ''
+            'contact_addr' => '127.0.0.1:5060'
         ];
 
         $this->assertEquals(


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

Use contact_addr uacreg database field instead of kamailio.cfg logic.

#### Additional information

No functional change.