### PR TITLE
kamtrunks: avoid gw failover on bounced calls

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -1973,6 +1973,8 @@ onreply_route[MANAGE_REPLY] {
 
 # Failure route for initial transactions to GW
 failure_route[MANAGE_FAILURE_GW] {
+    if ($dlg_var(bounced) == '1') exit; # Avoid carrier failover in bounced call
+
     if(!t_check_status("(401)|(407)")) {
         xwarn("[$dlg_var(cidhash)] MANAGE-FAILURE-GW: $rm FAILED: '$T_reply_code $T_reply_reason' to '$cs $rm' from '$fu' ($si:$sp) [$proto]\n");
     }


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
If AS returns a negative response, no failover needs to be done in failure, forward that response downstream.

#### Additional information
Bounced calls are calls to DDIs handled inside the platform, so no real carrier is involved. Failover logic in failure_route needs to be skipped.