### PR TITLE
kam: use rtimer instead of timer

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -182,7 +182,7 @@ loadmodule    "xhttp.so"
 loadmodule    "jsonrpcs.so"
 loadmodule    "http_client.so"
 loadmodule    "ipops.so"
-loadmodule    "timer.so"
+loadmodule    "rtimer.so"
 
 #!ifdef WITH_REALTIME
 loadmodule    "ndb_redis.so"
@@ -383,9 +383,11 @@ modparam("permissions", "trusted_table", "kam_trusted") # Not used but necessary
 # JSONRPCS
 modparam("jsonrpcs", "transport", 1)
 
-# TIMER
-modparam("timer", "declare_timer", "EXIT_NOW=EXIT_NOW,3000,slow,enable");
-modparam("timer", "declare_timer", "EXIT_WHEN_NO_CALLS=EXIT_WHEN_NO_CALLS,3000,slow,enable");
+# RTIMER
+modparam("rtimer", "timer", "name=EXIT_NOW;interval=3;mode=0;")
+modparam("rtimer", "exec", "timer=EXIT_NOW;route=EXIT_NOW")
+modparam("rtimer", "timer", "name=EXIT_WHEN_NO_CALLS;interval=3;mode=0;")
+modparam("rtimer", "exec", "timer=EXIT_WHEN_NO_CALLS;route=EXIT_WHEN_NO_CALLS")
 
 ####### Routing Logic ########
 

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -198,7 +198,7 @@ loadmodule    "dialplan.so"
 loadmodule    "diversion.so"
 loadmodule    "cfgutils.so"
 loadmodule    "uac.so"
-loadmodule    "timer.so"
+loadmodule    "rtimer.so"
 
 #!ifdef WITH_ANTIFLOOD
 loadmodule    "pike.so"
@@ -393,9 +393,11 @@ modparam("ndb_redis", "server", "name=realtime;sentinel_group=mymaster;sentinel_
 modparam("ndb_redis", "init_without_redis", 1)
 #!endif
 
-# TIMER
-modparam("timer", "declare_timer", "EXIT_NOW=EXIT_NOW,3000,slow,enable");
-modparam("timer", "declare_timer", "EXIT_WHEN_NO_CALLS=EXIT_WHEN_NO_CALLS,3000,slow,enable");
+# RTIMER
+modparam("rtimer", "timer", "name=EXIT_NOW;interval=3;mode=0;")
+modparam("rtimer", "exec", "timer=EXIT_NOW;route=EXIT_NOW")
+modparam("rtimer", "timer", "name=EXIT_WHEN_NO_CALLS;interval=3;mode=0;")
+modparam("rtimer", "exec", "timer=EXIT_WHEN_NO_CALLS;route=EXIT_WHEN_NO_CALLS")
 
 ####### Routing Logic ########
 


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
Use rtimer module instead of timer

#### Additional information

timer module causes problems (see https://lists.kamailio.org/pipermail/sr-dev/2021-October/064151.html)