### PR TITLE
kamtrunks: remove duplicates from gws final avp

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -731,10 +731,51 @@ route[LOAD_GWS] {
     $(avp(gw_uri_avp)[*]) = $null;
     avp_copy("$avp(new_gw_uri_avp)", "$avp(gw_uri_avp)/gd");
 
+    # Clean duplicate routes
+    route(CLEAN_DUPLICATES);
+
     # Print final GWs (static + lcr + blocking)
     xinfo("[$dlg_var(cidhash)] LOAD-GWS: Final carriers (static + dynamic rules)\n");
     $var(step) = "final";
     route(PRINT_GWS);
+}
+
+route[CLEAN_DUPLICATES] {
+    $var(j) = 0;
+
+    while(is_avp_set("$(avp(gw_uri_avp)[$var(j)])")) {
+        $var(carrierServerId) = $(avp(gw_uri_avp)[$var(j)]{s.select,-2,|});
+
+        route(IS_IN_AVP);
+        if ($var(found)) {
+            xnotice("[$dlg_var(cidhash)] CLEAN-DUPLICATES: Remove repeated carrierServer $var(carrierServerId)\n");
+        } else {
+            $avp(nodup_gw_uri_avp) = $(avp(gw_uri_avp)[$var(j)]);
+            $avp(carrierserverids) = $var(carrierServerId);
+        }
+
+        $var(j) = $var(j) + 1;
+    }
+
+    $(avp(gw_uri_avp)[*]) = $null;
+    avp_copy("$avp(nodup_gw_uri_avp)", "$avp(gw_uri_avp)/gd");
+}
+
+# Iterates $avp(ids) and returns 1 if any value equals $var(carrierServerId). Otherwise, returns 0
+route[IS_IN_AVP] {
+    $var(k) = 0;
+
+    $var(found) = 0;
+    while(is_avp_set("$(avp(carrierserverids)[$var(k)])")) {
+        if ($(avp(carrierserverids)[$var(k)]) == $var(carrierServerId)) {
+            $var(found) = 1;
+            return;
+        }
+
+        $var(k) = $var(k) + 1;
+    }
+
+    return;
 }
 
 route[PRINT_GWS] {
@@ -882,7 +923,7 @@ route[ADD_LCR_CARRIERS] {
     jansson_array_size("result.Suppliers", $avp(response), "$var(size)");
     while($var(count) < $var(size)) {
         jansson_get("result.Suppliers[$var(count)].Supplier", $avp(response), "$var(carrier)");
-        xnotice("[$dlg_var(cidhash)] GET-LCR-CARRIERS: Add carrier $var(carrier)");
+        xinfo("[$dlg_var(cidhash)] GET-LCR-CARRIERS: Add carrier $var(carrier)");
 
         $var(carrierId) = $(var(carrier){s.numeric});
         route(ADD_LCR_CARRIER);
@@ -902,6 +943,7 @@ route[ADD_LCR_CARRIER] {
     $var(k) = 0;
     while ($var(k)<$dbr(ra=>rows)) {
         $var(carrierServerId) = $dbr(ra=>[$var(k), 0]);
+        xnotice("[$dlg_var(cidhash)] ADD-LCR-CARRIER: Add carrierServer $var(carrierServerId) ($var(carrier))\n");
         route(ADD_LCR_CARRIERSERVER);
         $var(k) = $var(k) + 1;
     }


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
Routing logic may add same carrierServer more than once (due to LCR).

This makes no sense as if a carrierServer fails for a call it will also fail for the same call some failover later.

#### Additional information
This PR modifies gateways AVP so that a carrier server is included only once (the first time).