### PR TITLE
Dynamic fixed costs by client maxCalls in scheduled invoices

### DIFF
--- a/doc/sphinx/administration_portal/brand/invoicing/invoice_schedulers.rst
+++ b/doc/sphinx/administration_portal/brand/invoicing/invoice_schedulers.rst
@@ -30,13 +30,25 @@ When adding a new definition, these fields are shown:
         Taxes to add to the final cost (e.g. VAT)
 
 
-.. tip:: Fixed concepts can be added in the same way as in manual invoice definitions
-
-Invoices generated due to an schedule can be seen in two ways:
+Invoices generated due to a schedule can be seen in two ways:
 
 - In each row of *Invoice schedulers* section, **List of Invoices** option.
 
 - In *Invoices* section, indistinguishable to manually generated invoices.
+
+Fixed costs
+===========
+
+When defining a scheduled invoice, you can add fixed costs in a static or dynamic way:
+
+- Type **'static'** is used for fixed quantities.
+
+- Type **'Max calls'** sets the quantity in the moment of the creation of the invoice to
+  "Max calls" value of the client in that specific moment.
+
+.. tip:: "Max calls" value is retrieved from client configuration in the date specified in "Next execution".
+         Regenerating the invoice later will not modify assigned value, but you can adapt it manually to
+         the desired value editing the fixed cost in Invoice section and regenerating the invoice.
 
 Frequency definition
 ====================

--- a/library/Ivoz/Provider/Domain/Model/FixedCostsRelInvoice/FixedCostsRelInvoice.php
+++ b/library/Ivoz/Provider/Domain/Model/FixedCostsRelInvoice/FixedCostsRelInvoice.php
@@ -40,10 +40,16 @@ class FixedCostsRelInvoice extends FixedCostsRelInvoiceAbstract implements Fixed
         InvoiceInterface $invoice,
         FixedCostsRelInvoiceSchedulerInterface $fixedCostRelScheduler
     ) {
+        $quantity = $fixedCostRelScheduler->getQuantity();
+        if ($fixedCostRelScheduler->getType() === FixedCostsRelInvoiceSchedulerInterface::TYPE_MAXCALLS) {
+            $quantity = $invoice->getCompany()->getMaxCalls();
+        }
+
         $entity = new static();
+
         $entity
             ->setQuantity(
-                $fixedCostRelScheduler->getQuantity()
+                $quantity
             )
             ->setFixedCost(
                 $fixedCostRelScheduler->getFixedCost()

--- a/library/Ivoz/Provider/Domain/Model/FixedCostsRelInvoiceScheduler/FixedCostsRelInvoiceScheduler.php
+++ b/library/Ivoz/Provider/Domain/Model/FixedCostsRelInvoiceScheduler/FixedCostsRelInvoiceScheduler.php
@@ -27,4 +27,11 @@ class FixedCostsRelInvoiceScheduler extends FixedCostsRelInvoiceSchedulerAbstrac
     {
         return $this->id;
     }
+
+    protected function sanitizeValues()
+    {
+        if ($this->getType() !== self::TYPE_STATIC) {
+            $this->setQuantity(null);
+        }
+    }
 }

--- a/library/Ivoz/Provider/Domain/Model/FixedCostsRelInvoiceScheduler/FixedCostsRelInvoiceSchedulerAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/FixedCostsRelInvoiceScheduler/FixedCostsRelInvoiceSchedulerAbstract.php
@@ -19,6 +19,12 @@ abstract class FixedCostsRelInvoiceSchedulerAbstract
     protected $quantity;
 
     /**
+     * comment: enum:static|maxcalls
+     * @var string
+     */
+    protected $type = 'static';
+
+    /**
      * @var \Ivoz\Provider\Domain\Model\FixedCost\FixedCostInterface
      */
     protected $fixedCost;
@@ -34,8 +40,9 @@ abstract class FixedCostsRelInvoiceSchedulerAbstract
     /**
      * Constructor
      */
-    protected function __construct()
+    protected function __construct($type)
     {
+        $this->setType($type);
     }
 
     abstract public function getId();
@@ -106,7 +113,9 @@ abstract class FixedCostsRelInvoiceSchedulerAbstract
     ) {
         Assertion::isInstanceOf($dto, FixedCostsRelInvoiceSchedulerDto::class);
 
-        $self = new static();
+        $self = new static(
+            $dto->getType()
+        );
 
         $self
             ->setQuantity($dto->getQuantity())
@@ -132,6 +141,7 @@ abstract class FixedCostsRelInvoiceSchedulerAbstract
 
         $this
             ->setQuantity($dto->getQuantity())
+            ->setType($dto->getType())
             ->setFixedCost($fkTransformer->transform($dto->getFixedCost()))
             ->setInvoiceScheduler($fkTransformer->transform($dto->getInvoiceScheduler()));
 
@@ -149,6 +159,7 @@ abstract class FixedCostsRelInvoiceSchedulerAbstract
     {
         return self::createDto()
             ->setQuantity(self::getQuantity())
+            ->setType(self::getType())
             ->setFixedCost(\Ivoz\Provider\Domain\Model\FixedCost\FixedCost::entityToDto(self::getFixedCost(), $depth))
             ->setInvoiceScheduler(\Ivoz\Provider\Domain\Model\InvoiceScheduler\InvoiceScheduler::entityToDto(self::getInvoiceScheduler(), $depth));
     }
@@ -160,6 +171,7 @@ abstract class FixedCostsRelInvoiceSchedulerAbstract
     {
         return [
             'quantity' => self::getQuantity(),
+            'type' => self::getType(),
             'fixedCostId' => self::getFixedCost()->getId(),
             'invoiceSchedulerId' => self::getInvoiceScheduler() ? self::getInvoiceScheduler()->getId() : null
         ];
@@ -194,6 +206,37 @@ abstract class FixedCostsRelInvoiceSchedulerAbstract
     public function getQuantity()
     {
         return $this->quantity;
+    }
+
+    /**
+     * Set type
+     *
+     * @param string $type
+     *
+     * @return static
+     */
+    protected function setType($type)
+    {
+        Assertion::notNull($type, 'type value "%s" is null, but non null value was expected.');
+        Assertion::maxLength($type, 25, 'type value "%s" is too long, it should have no more than %d characters, but has %d characters.');
+        Assertion::choice($type, [
+            FixedCostsRelInvoiceSchedulerInterface::TYPE_STATIC,
+            FixedCostsRelInvoiceSchedulerInterface::TYPE_MAXCALLS
+        ], 'typevalue "%s" is not an element of the valid values: %s');
+
+        $this->type = $type;
+
+        return $this;
+    }
+
+    /**
+     * Get type
+     *
+     * @return string
+     */
+    public function getType(): string
+    {
+        return $this->type;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/FixedCostsRelInvoiceScheduler/FixedCostsRelInvoiceSchedulerDto.php
+++ b/library/Ivoz/Provider/Domain/Model/FixedCostsRelInvoiceScheduler/FixedCostsRelInvoiceSchedulerDto.php
@@ -16,6 +16,7 @@ class FixedCostsRelInvoiceSchedulerDto extends FixedCostsRelInvoiceSchedulerDtoA
         return [
             'quantity' => 'quantity',
             'id' => 'id',
+            'type' => 'type',
             'fixedCostId' => 'fixedCost',
             'invoiceSchedulerId' => 'invoiceScheduler'
         ];

--- a/library/Ivoz/Provider/Domain/Model/FixedCostsRelInvoiceScheduler/FixedCostsRelInvoiceSchedulerDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/FixedCostsRelInvoiceScheduler/FixedCostsRelInvoiceSchedulerDtoAbstract.php
@@ -16,6 +16,11 @@ abstract class FixedCostsRelInvoiceSchedulerDtoAbstract implements DataTransferO
     private $quantity;
 
     /**
+     * @var string
+     */
+    private $type = 'static';
+
+    /**
      * @var integer
      */
     private $id;
@@ -49,6 +54,7 @@ abstract class FixedCostsRelInvoiceSchedulerDtoAbstract implements DataTransferO
 
         return [
             'quantity' => 'quantity',
+            'type' => 'type',
             'id' => 'id',
             'fixedCostId' => 'fixedCost',
             'invoiceSchedulerId' => 'invoiceScheduler'
@@ -62,6 +68,7 @@ abstract class FixedCostsRelInvoiceSchedulerDtoAbstract implements DataTransferO
     {
         $response = [
             'quantity' => $this->getQuantity(),
+            'type' => $this->getType(),
             'id' => $this->getId(),
             'fixedCost' => $this->getFixedCost(),
             'invoiceScheduler' => $this->getInvoiceScheduler()
@@ -99,6 +106,26 @@ abstract class FixedCostsRelInvoiceSchedulerDtoAbstract implements DataTransferO
     public function getQuantity()
     {
         return $this->quantity;
+    }
+
+    /**
+     * @param string $type
+     *
+     * @return static
+     */
+    public function setType($type = null)
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    /**
+     * @return string | null
+     */
+    public function getType()
+    {
+        return $this->type;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/FixedCostsRelInvoiceScheduler/FixedCostsRelInvoiceSchedulerInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/FixedCostsRelInvoiceScheduler/FixedCostsRelInvoiceSchedulerInterface.php
@@ -6,6 +6,10 @@ use Ivoz\Core\Domain\Model\LoggableEntityInterface;
 
 interface FixedCostsRelInvoiceSchedulerInterface extends LoggableEntityInterface
 {
+    const TYPE_STATIC = 'static';
+    const TYPE_MAXCALLS = 'maxcalls';
+
+
     /**
      * @codeCoverageIgnore
      * @return array
@@ -18,6 +22,13 @@ interface FixedCostsRelInvoiceSchedulerInterface extends LoggableEntityInterface
      * @return integer | null
      */
     public function getQuantity();
+
+    /**
+     * Get type
+     *
+     * @return string
+     */
+    public function getType(): string;
 
     /**
      * Get fixedCost

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/FixedCostsRelInvoiceScheduler.FixedCostsRelInvoiceSchedulerAbstract.orm.yml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/FixedCostsRelInvoiceScheduler.FixedCostsRelInvoiceSchedulerAbstract.orm.yml
@@ -12,6 +12,14 @@ Ivoz\Provider\Domain\Model\FixedCostsRelInvoiceScheduler\FixedCostsRelInvoiceSch
       nullable: true
       options:
         unsigned: true
+    type:
+      type: string
+      nullable: false
+      length: 25
+      options:
+        fixed: false
+        comment: '[enum:static|maxcalls]'
+        default: 'static'
   manyToOne:
     fixedCost:
       targetEntity: \Ivoz\Provider\Domain\Model\FixedCost\FixedCostInterface

--- a/schema/DoctrineMigrations/Version20220701103822.php
+++ b/schema/DoctrineMigrations/Version20220701103822.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Application\Migrations;
+
+use Ivoz\Core\Infrastructure\Persistence\Doctrine\LoggableMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20220701103822 extends LoggableMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE FixedCostsRelInvoiceSchedulers ADD type VARCHAR(25) DEFAULT \'static\' NOT NULL COMMENT \'[enum:static|maxcalls]\'');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE FixedCostsRelInvoiceSchedulers DROP type');
+    }
+}

--- a/web/admin/application/configs/klear/FixedCostsRelInvoiceSchedulersList.yaml
+++ b/web/admin/application/configs/klear/FixedCostsRelInvoiceSchedulersList.yaml
@@ -23,6 +23,10 @@ production:
           dialogs:
             fixedCostsRelInvoiceSchedulersDel_dialog: true
           default: fixedCostsRelInvoiceSchedulersEdit_screen
+        order:
+          fixedCost: true
+          type: true
+          quantity: true
       options:
         title: _("Options")
         screens:
@@ -42,7 +46,8 @@ production:
         group0:
           colsPerRow: 12
           fields:
-            fixedCost: 9
+            fixedCost: 6
+            type: 3
             quantity: 3
     fixedCostsRelInvoiceSchedulersEdit_screen: &fixedCostsRelInvoiceSchedulersEdit_screenLink
       <<: *FixedCostsRelInvoiceSchedulers

--- a/web/admin/application/configs/klear/model/FixedCostsRelInvoiceSchedulers.yaml
+++ b/web/admin/application/configs/klear/model/FixedCostsRelInvoiceSchedulers.yaml
@@ -39,6 +39,22 @@ production:
         control: Spinner
         min: 1
         max: 100
+    type:
+      title: _('Type')
+      type: select
+      required: true
+      source:
+        data: inline
+        values:
+          'static':
+            title: _("Static")
+            visualFilter:
+              show: ["quantity"]
+          'maxcalls':
+            title: _('Max calls')
+            visualFilter:
+              hide: ["quantity"]
+
 staging:
   _extends: production
 testing:

--- a/web/rest/brand/features/provider/fixedCostsRelInvoiceScheduler/getFixedCostsRelInvoiceScheduler.feature
+++ b/web/rest/brand/features/provider/fixedCostsRelInvoiceScheduler/getFixedCostsRelInvoiceScheduler.feature
@@ -16,6 +16,7 @@ Feature: Retrieve fixed costs rel invoice schedulers
       [
           {
               "quantity": 1,
+              "type": "static",
               "id": 1,
               "fixedCost": {
                   "name": "Monitoring",
@@ -53,6 +54,7 @@ Feature: Retrieve fixed costs rel invoice schedulers
     """
       {
           "quantity": 1,
+          "type": "static",
           "id": 1,
           "fixedCost": {
               "name": "Monitoring",

--- a/web/rest/brand/features/provider/fixedCostsRelInvoiceScheduler/postFixedCostsRelInvoiceScheduler.feature
+++ b/web/rest/brand/features/provider/fixedCostsRelInvoiceScheduler/postFixedCostsRelInvoiceScheduler.feature
@@ -23,6 +23,7 @@ Feature: Create fixed costs rel invoice schedulers
     """
       {
           "quantity": 1,
+          "type": "static",
           "id": 2,
           "fixedCost": 2,
           "invoiceScheduler": 1


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
Add dynamic fixed costs in scheduled invoices. Quantity of this fixed costs are calculated on invoice generation.

This PR adds fixed costs by client _maxCalls_ value.

#### Additional information

- "Max calls" value is retrieved from client configuration at scheduled invoice "Next execution".
- Regenerating the invoice later would not modify assigned value.