### PR TITLE
Dynamic fixed costs by client maxCalls in scheduled invoices

### DIFF
--- a/doc/sphinx/administration_portal/brand/invoicing/invoice_schedulers.rst
+++ b/doc/sphinx/administration_portal/brand/invoicing/invoice_schedulers.rst
@@ -30,13 +30,25 @@ When adding a new definition, these fields are shown:
         Taxes to add to the final cost (e.g. VAT)
 
 
-.. tip:: Fixed concepts can be added in the same way as in manual invoice definitions
-
-Invoices generated due to an schedule can be seen in two ways:
+Invoices generated due to a schedule can be seen in two ways:
 
 - In each row of *Invoice schedulers* section, **List of Invoices** option.
 
 - In *Invoices* section, indistinguishable to manually generated invoices.
+
+Fixed costs
+===========
+
+When defining a scheduled invoice, you can add fixed costs in a static or dynamic way:
+
+- Type **'static'** is used for fixed quantities.
+
+- Type **'Max calls'** sets the quantity in the moment of the creation of the invoice to
+  "Max calls" value of the client in that specific moment.
+
+.. tip:: "Max calls" value is retrieved from client configuration in the date specified in "Next execution".
+         Regenerating the invoice later will not modify assigned value, but you can adapt it manually to
+         the desired value editing the fixed cost in Invoice section and regenerating the invoice.
 
 Frequency definition
 ====================

--- a/library/Ivoz/Provider/Domain/Model/FixedCostsRelInvoice/FixedCostsRelInvoice.php
+++ b/library/Ivoz/Provider/Domain/Model/FixedCostsRelInvoice/FixedCostsRelInvoice.php
@@ -40,10 +40,16 @@ class FixedCostsRelInvoice extends FixedCostsRelInvoiceAbstract implements Fixed
         InvoiceInterface $invoice,
         FixedCostsRelInvoiceSchedulerInterface $fixedCostRelScheduler
     ) {
+        $quantity = $fixedCostRelScheduler->getQuantity();
+        if ($fixedCostRelScheduler->getType() === FixedCostsRelInvoiceSchedulerInterface::TYPE_MAXCALLS) {
+            $quantity = $invoice->getCompany()->getMaxCalls();
+        }
+
         $entity = new static();
+
         $entity
             ->setQuantity(
-                $fixedCostRelScheduler->getQuantity()
+                $quantity
             )
             ->setFixedCost(
                 $fixedCostRelScheduler->getFixedCost()

--- a/library/Ivoz/Provider/Domain/Model/FixedCostsRelInvoiceScheduler/FixedCostsRelInvoiceScheduler.php
+++ b/library/Ivoz/Provider/Domain/Model/FixedCostsRelInvoiceScheduler/FixedCostsRelInvoiceScheduler.php
@@ -27,4 +27,11 @@ class FixedCostsRelInvoiceScheduler extends FixedCostsRelInvoiceSchedulerAbstrac
     {
         return $this->id;
     }
+
+    protected function sanitizeValues(): void
+    {
+        if ($this->getType() !== self::TYPE_STATIC) {
+            $this->setQuantity(null);
+        }
+    }
 }

--- a/library/Ivoz/Provider/Domain/Model/FixedCostsRelInvoiceScheduler/FixedCostsRelInvoiceSchedulerDto.php
+++ b/library/Ivoz/Provider/Domain/Model/FixedCostsRelInvoiceScheduler/FixedCostsRelInvoiceSchedulerDto.php
@@ -16,6 +16,7 @@ class FixedCostsRelInvoiceSchedulerDto extends FixedCostsRelInvoiceSchedulerDtoA
         return [
             'quantity' => 'quantity',
             'id' => 'id',
+            'type' => 'type',
             'fixedCostId' => 'fixedCost',
             'invoiceSchedulerId' => 'invoiceScheduler'
         ];

--- a/library/Ivoz/Provider/Domain/Model/FixedCostsRelInvoiceScheduler/FixedCostsRelInvoiceSchedulerDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/FixedCostsRelInvoiceScheduler/FixedCostsRelInvoiceSchedulerDtoAbstract.php
@@ -21,6 +21,11 @@ abstract class FixedCostsRelInvoiceSchedulerDtoAbstract implements DataTransferO
     private $quantity = null;
 
     /**
+     * @var string|null
+     */
+    private $type = 'static';
+
+    /**
      * @var int|null
      */
     private $id = null;
@@ -54,6 +59,7 @@ abstract class FixedCostsRelInvoiceSchedulerDtoAbstract implements DataTransferO
 
         return [
             'quantity' => 'quantity',
+            'type' => 'type',
             'id' => 'id',
             'fixedCostId' => 'fixedCost',
             'invoiceSchedulerId' => 'invoiceScheduler'
@@ -67,6 +73,7 @@ abstract class FixedCostsRelInvoiceSchedulerDtoAbstract implements DataTransferO
     {
         $response = [
             'quantity' => $this->getQuantity(),
+            'type' => $this->getType(),
             'id' => $this->getId(),
             'fixedCost' => $this->getFixedCost(),
             'invoiceScheduler' => $this->getInvoiceScheduler()
@@ -96,6 +103,18 @@ abstract class FixedCostsRelInvoiceSchedulerDtoAbstract implements DataTransferO
     public function getQuantity(): ?int
     {
         return $this->quantity;
+    }
+
+    public function setType(string $type): static
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    public function getType(): ?string
+    {
+        return $this->type;
     }
 
     public function setId($id): static

--- a/library/Ivoz/Provider/Domain/Model/FixedCostsRelInvoiceScheduler/FixedCostsRelInvoiceSchedulerInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/FixedCostsRelInvoiceScheduler/FixedCostsRelInvoiceSchedulerInterface.php
@@ -14,6 +14,10 @@ use Ivoz\Provider\Domain\Model\InvoiceScheduler\InvoiceSchedulerInterface;
 */
 interface FixedCostsRelInvoiceSchedulerInterface extends LoggableEntityInterface
 {
+    public const TYPE_STATIC = 'static';
+
+    public const TYPE_MAXCALLS = 'maxcalls';
+
     /**
      * @codeCoverageIgnore
      * @return array<string, mixed>
@@ -48,6 +52,8 @@ interface FixedCostsRelInvoiceSchedulerInterface extends LoggableEntityInterface
     public function toDto(int $depth = 0): FixedCostsRelInvoiceSchedulerDto;
 
     public function getQuantity(): ?int;
+
+    public function getType(): string;
 
     public function getFixedCost(): FixedCostInterface;
 

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/FixedCostsRelInvoiceScheduler.FixedCostsRelInvoiceSchedulerAbstract.orm.xml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/FixedCostsRelInvoiceScheduler.FixedCostsRelInvoiceSchedulerAbstract.orm.xml
@@ -9,6 +9,12 @@
         <option name="unsigned">1</option>
       </options>
     </field>
+    <field name="type" type="string" column="type" length="25" nullable="false">
+      <options>
+        <option name="comment">[enum:static|maxcalls]</option>
+        <option name="default">static</option>
+      </options>
+    </field>
     <many-to-one field="fixedCost" target-entity="Ivoz\Provider\Domain\Model\FixedCost\FixedCostInterface" fetch="LAZY">
       <join-columns>
         <join-column name="fixedCostId" referenced-column-name="id" on-delete="CASCADE" nullable=""/>

--- a/library/psalm-baseline.xml
+++ b/library/psalm-baseline.xml
@@ -5185,9 +5185,7 @@
       <code>$fkTransformer-&gt;transform($fixedCost)</code>
       <code>$fkTransformer-&gt;transform($fixedCost)</code>
     </MixedArgument>
-    <UnsafeInstantiation occurrences="1">
-      <code>new static()</code>
-    </UnsafeInstantiation>
+    <UnsafeInstantiation occurrences="1"/>
   </file>
   <file src="Ivoz/Provider/Domain/Model/FixedCostsRelInvoiceScheduler/FixedCostsRelInvoiceSchedulerDtoAbstract.php">
     <MissingParamType occurrences="3">
@@ -5210,9 +5208,9 @@
     </PossiblyUnusedReturnValue>
   </file>
   <file src="Ivoz/Provider/Domain/Model/FixedCostsRelInvoiceScheduler/FixedCostsRelInvoiceSchedulerTrait.php">
-    <TooManyArguments occurrences="1">
-      <code>parent::__construct(...func_get_args())</code>
-    </TooManyArguments>
+    <MixedArgument occurrences="1">
+      <code>func_get_args()</code>
+    </MixedArgument>
   </file>
   <file src="Ivoz/Provider/Domain/Model/Friend/Friend.php">
     <DocblockTypeContradiction occurrences="1">

--- a/schema/initial.sql
+++ b/schema/initial.sql
@@ -2179,6 +2179,7 @@ CREATE TABLE `FixedCostsRelInvoiceSchedulers` (
   `quantity` int unsigned DEFAULT NULL,
   `fixedCostId` int unsigned NOT NULL,
   `invoiceSchedulerId` int unsigned NOT NULL,
+  `type` varchar(25) COLLATE utf8_unicode_ci NOT NULL DEFAULT 'static' COMMENT '[enum:static|maxcalls]',
   PRIMARY KEY (`id`),
   UNIQUE KEY `FixedCostsRelInvoiceScheduler_invoiceScheduler_fixedCost` (`invoiceSchedulerId`,`fixedCostId`),
   KEY `IDX_D9D0952B81256364` (`fixedCostId`),
@@ -6151,4 +6152,4 @@ UNLOCK TABLES;
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2022-06-30 13:26:01
+-- Dump completed

--- a/web/admin/application/configs/klear/FixedCostsRelInvoiceSchedulersList.yaml
+++ b/web/admin/application/configs/klear/FixedCostsRelInvoiceSchedulersList.yaml
@@ -23,6 +23,10 @@ production:
           dialogs:
             fixedCostsRelInvoiceSchedulersDel_dialog: true
           default: fixedCostsRelInvoiceSchedulersEdit_screen
+        order:
+          fixedCost: true
+          type: true
+          quantity: true
       options:
         title: _("Options")
         screens:
@@ -42,7 +46,8 @@ production:
         group0:
           colsPerRow: 12
           fields:
-            fixedCost: 9
+            fixedCost: 6
+            type: 3
             quantity: 3
     fixedCostsRelInvoiceSchedulersEdit_screen: &fixedCostsRelInvoiceSchedulersEdit_screenLink
       <<: *FixedCostsRelInvoiceSchedulers

--- a/web/admin/application/configs/klear/model/FixedCostsRelInvoiceSchedulers.yaml
+++ b/web/admin/application/configs/klear/model/FixedCostsRelInvoiceSchedulers.yaml
@@ -39,6 +39,22 @@ production:
         control: Spinner
         min: 1
         max: 100
+    type:
+      title: _('Type')
+      type: select
+      required: true
+      source:
+        data: inline
+        values:
+          'static':
+            title: _("Static")
+            visualFilter:
+              show: ["quantity"]
+          'maxcalls':
+            title: _('Max calls')
+            visualFilter:
+              hide: ["quantity"]
+
 staging:
   _extends: production
 testing:

--- a/web/rest/brand/features/provider/fixedCostsRelInvoiceScheduler/getFixedCostsRelInvoiceScheduler.feature
+++ b/web/rest/brand/features/provider/fixedCostsRelInvoiceScheduler/getFixedCostsRelInvoiceScheduler.feature
@@ -16,6 +16,7 @@ Feature: Retrieve fixed costs rel invoice schedulers
       [
           {
               "quantity": 1,
+              "type": "static",
               "id": 1,
               "fixedCost": {
                   "name": "Monitoring",
@@ -53,6 +54,7 @@ Feature: Retrieve fixed costs rel invoice schedulers
     """
       {
           "quantity": 1,
+          "type": "static",
           "id": 1,
           "fixedCost": {
               "name": "Monitoring",

--- a/web/rest/brand/features/provider/fixedCostsRelInvoiceScheduler/postFixedCostsRelInvoiceScheduler.feature
+++ b/web/rest/brand/features/provider/fixedCostsRelInvoiceScheduler/postFixedCostsRelInvoiceScheduler.feature
@@ -23,6 +23,7 @@ Feature: Create fixed costs rel invoice schedulers
     """
       {
           "quantity": 1,
+          "type": "static",
           "id": 2,
           "fixedCost": 2,
           "invoiceScheduler": 1


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
Add dynamic fixed costs in scheduled invoices. Quantity of this fixed costs are calculated on invoice generation.

This PR adds fixed costs by client _maxCalls_ value.

Upport from #1847 

#### Additional information

- "Max calls" value is retrieved from client configuration at scheduled invoice "Next execution".
- Regenerating the invoice later would not modify assigned value.