### PR TITLE
Zero maxCalls is not valid anymore

### DIFF
--- a/doc/sphinx/administration_portal/brand/clients/residential.rst
+++ b/doc/sphinx/administration_portal/brand/clients/residential.rst
@@ -54,7 +54,7 @@ These are the fields shown when **adding** a new residential client:
         Describes the way the client will "talk" and the way the client wants to be "talked".
 
     Max calls
-        Limits both incoming and outgoing external calls (0 for unlimited).
+        Limits both incoming and outgoing external calls (must be equal or greater than 1).
 
     Filter by IP address
         If set, the platform will only allow calls coming from allowed IP/ranges or countries.

--- a/doc/sphinx/administration_portal/brand/clients/retail.rst
+++ b/doc/sphinx/administration_portal/brand/clients/retail.rst
@@ -78,7 +78,7 @@ These are the fields shown when **adding** a new retail client:
         Describes the way the client will "talk" and the way the client wants to be "talked".
 
     Max calls
-        Limits both incoming and outgoing external calls (0 for unlimited).
+        Limits both incoming and outgoing external calls (must be equal or greater than 1).
 
     Filter by IP address
         If set, the platform will only allow calls coming from allowed IP/ranges or countries.

--- a/doc/sphinx/administration_portal/brand/clients/virtual_pbx.rst
+++ b/doc/sphinx/administration_portal/brand/clients/virtual_pbx.rst
@@ -31,7 +31,7 @@ that require feature-full call flows.
         remaining money operations of this client.
 
     Max calls
-        Limits both incoming and outgoing external calls (0 for unlimited).
+        Limits both incoming and outgoing external calls (must be equal or greater than 1).
 
     Filter by IP address
         If set, the platform will only allow calls coming from allowed IP/ranges or countries.

--- a/doc/sphinx/administration_portal/brand/clients/wholesale.rst
+++ b/doc/sphinx/administration_portal/brand/clients/wholesale.rst
@@ -55,7 +55,7 @@ These are the fields shown when **adding** a new wholesale client:
         Describes the way the client will "talk" and the way the client wants to be "talked".
 
     Max calls
-        Limits outgoing external calls (0 for unlimited).
+        Limits outgoing external calls (must be equal or greater than 1).
 
     Max daily usage
         Limits external outbound calls when this limit is reached within a day. At midnight counters are reset and

--- a/doc/sphinx/administration_portal/platform/brands.rst
+++ b/doc/sphinx/administration_portal/platform/brands.rst
@@ -38,7 +38,7 @@ This are the fields shown when a new brand is created:
 
     Max calls
         Limits both user generated and **external** received calls to this value
-        (0 for unlimited).
+        (must be equal or greater than 1).
 
     Locales
         Define default Timezone, Language and Currency for clients of this brand.

--- a/library/DataFixtures/ORM/ProviderCompany.php
+++ b/library/DataFixtures/ORM/ProviderCompany.php
@@ -28,7 +28,7 @@ class ProviderCompany extends Fixture implements DependentFixtureInterface
             $this->setName("DemoCompany");
             $this->setDomainUsers("127.0.0.1");
             $this->setNif("12345678A");
-            $this->setMaxCalls(0);
+            $this->setMaxCalls(1000);
             $this->setPostalAddress("Company Address");
             $this->setPostalCode("54321");
             $this->setTown("Company Town");
@@ -68,7 +68,7 @@ class ProviderCompany extends Fixture implements DependentFixtureInterface
             $this->setName("Irontec Test Company");
             $this->setDomainUsers("test.irontec.com");
             $this->setNif("12345678-Z");
-            $this->setMaxCalls(0);
+            $this->setMaxCalls(1000);
             $this->setPostalAddress("Postal address");
             $this->setPostalCode("PC");
             $this->setTown("Town");
@@ -97,7 +97,7 @@ class ProviderCompany extends Fixture implements DependentFixtureInterface
             $this->setType("retail");
             $this->setDomainUsers(null);
             $this->setNif("12345679-Z");
-            $this->setMaxCalls(0);
+            $this->setMaxCalls(1000);
             $this->setPostalAddress("");
             $this->setPostalCode("");
             $this->setTown("");
@@ -127,7 +127,7 @@ class ProviderCompany extends Fixture implements DependentFixtureInterface
             $this->setType("residential");
             $this->setDomainUsers(null);
             $this->setNif("12345679-Z");
-            $this->setMaxCalls(0);
+            $this->setMaxCalls(1000);
             $this->setPostalAddress("");
             $this->setPostalCode("");
             $this->setTown("");
@@ -156,7 +156,7 @@ class ProviderCompany extends Fixture implements DependentFixtureInterface
             $this->setType("wholesale");
             $this->setDomainUsers("wholesale.irontec.com");
             $this->setNif("12345689-Z");
-            $this->setMaxCalls(0);
+            $this->setMaxCalls(1000);
             $this->setPostalAddress("");
             $this->setPostalCode("");
             $this->setTown("");

--- a/library/Ivoz/Provider/Domain/Model/Brand/Brand.php
+++ b/library/Ivoz/Provider/Domain/Model/Brand/Brand.php
@@ -23,6 +23,22 @@ class Brand extends BrandAbstract implements FileContainerInterface, BrandInterf
     }
 
     /**
+     * Set maxCalls
+     *
+     * @param integer $maxCalls
+     *
+     * @return static
+     */
+    protected function setMaxCalls($maxCalls)
+    {
+        Assertion::notNull($maxCalls, 'maxCalls value "%s" is null, but non null value was expected.');
+        Assertion::integerish($maxCalls, 'maxCalls value "%s" is not an integer or a number castable to integer.');
+        Assertion::greaterOrEqualThan($maxCalls, 1, 'maxCalls provided "%s" is not greater or equal than "%s".');
+
+        return parent::setMaxCalls($maxCalls);
+    }
+
+    /**
      * @return array
      */
     public function getFileObjects(int $filter = null)

--- a/library/Ivoz/Provider/Domain/Model/Company/Company.php
+++ b/library/Ivoz/Provider/Domain/Model/Company/Company.php
@@ -29,6 +29,22 @@ class Company extends CompanyAbstract implements CompanyInterface
     }
 
     /**
+     * Set maxCalls
+     *
+     * @param integer $maxCalls
+     *
+     * @return static
+     */
+    protected function setMaxCalls($maxCalls)
+    {
+        Assertion::notNull($maxCalls, 'maxCalls value "%s" is null, but non null value was expected.');
+        Assertion::integerish($maxCalls, 'maxCalls value "%s" is not an integer or a number castable to integer.');
+        Assertion::greaterOrEqualThan($maxCalls, 1, 'maxCalls provided "%s" is not greater or equal than "%s".');
+
+        return parent::setMaxCalls($maxCalls);
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function setName($name)

--- a/schema/DoctrineMigrations/Version20220705142532.php
+++ b/schema/DoctrineMigrations/Version20220705142532.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20220705142532 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->addSql('UPDATE Companies SET maxCalls=1000 WHERE maxCalls=0');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $this->addSql('UPDATE Companies SET maxCalls=0 WHERE maxCalls=1000');
+    }
+}

--- a/web/admin/application/configs/klear/model/FixedCostsRelInvoices.yaml
+++ b/web/admin/application/configs/klear/model/FixedCostsRelInvoices.yaml
@@ -37,7 +37,7 @@ production:
       defaultValue: 1
       source:
         control: Spinner
-        min: 1
+        min: 0
         max: 100
 staging:
   _extends: production


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [x] New feature or enhancement
- [x] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

Brand or company maxCalls zero value are no longer valid. Prior to this PR 0 meant unlimited, now there is no such option.

#### Additional information

Existing companies/brands with 0 value will be updated to 1000.