### PR TITLE
Fix unable to create faxes in out without call date

### DIFF
--- a/library/Ivoz/Provider/Domain/Model/FaxesInOut/FaxesInOut.php
+++ b/library/Ivoz/Provider/Domain/Model/FaxesInOut/FaxesInOut.php
@@ -51,15 +51,6 @@ class FaxesInOut extends FaxesInOutAbstract implements FileContainerInterface, F
         return $this->id;
     }
 
-    public function setCalldate(string|\DateTimeInterface $calldate = null): static
-    {
-        if (!$calldate) {
-            $calldate = new \DateTime('now', new \DateTimeZone('UTC'));
-        }
-
-        return parent::setCalldate($calldate);
-    }
-
     /**
      * Get the numberValue in E.164 format when routing to 'number'
      *

--- a/library/Ivoz/Provider/Domain/Model/FaxesInOut/FaxesInOutAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/FaxesInOut/FaxesInOutAbstract.php
@@ -250,7 +250,7 @@ abstract class FaxesInOutAbstract
         /** @var \Datetime */
         $calldate = DateTimeHelper::createOrFix(
             $calldate,
-            null
+            'CURRENT_TIMESTAMP'
         );
 
         if ($this->isInitialized() && $this->calldate == $calldate) {

--- a/library/Ivoz/Provider/Domain/Model/FaxesInOut/FaxesInOutDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/FaxesInOut/FaxesInOutDtoAbstract.php
@@ -18,7 +18,7 @@ abstract class FaxesInOutDtoAbstract implements DataTransferObjectInterface
     /**
      * @var \DateTimeInterface|string|null
      */
-    private $calldate = null;
+    private $calldate = 'CURRENT_TIMESTAMP';
 
     /**
      * @var string|null

--- a/library/Ivoz/Provider/Domain/Model/FaxesInOut/FaxesInOutInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/FaxesInOut/FaxesInOutInterface.php
@@ -4,7 +4,6 @@ namespace Ivoz\Provider\Domain\Model\FaxesInOut;
 
 use Ivoz\Core\Domain\Model\LoggableEntityInterface;
 use Ivoz\Core\Domain\Service\FileContainerInterface;
-use DateTimeInterface;
 use Ivoz\Core\Domain\Model\EntityInterface;
 use Ivoz\Core\Application\DataTransferObjectInterface;
 use Ivoz\Core\Application\ForeignKeyTransformerInterface;
@@ -46,8 +45,6 @@ interface FaxesInOutInterface extends LoggableEntityInterface, FileContainerInte
      * @return integer
      */
     public function getId(): ?int;
-
-    public function setCalldate(DateTimeInterface|string|null $calldate = null): static;
 
     /**
      * Get the numberValue in E.164 format when routing to 'number'

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/FaxesInOut.FaxesInOutAbstract.orm.xml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/FaxesInOut.FaxesInOutAbstract.orm.xml
@@ -2,7 +2,11 @@
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
   <mapped-superclass name="Ivoz\Provider\Domain\Model\FaxesInOut\FaxesInOutAbstract" table="faxes_in_out_abstract">
     <embedded name="file" class="Ivoz\Provider\Domain\Model\FaxesInOut\File" use-column-prefix="false" />
-    <field name="calldate" type="datetime" column="calldate" nullable="false"/>
+    <field name="calldate" type="datetime" column="calldate" nullable="false">
+      <options>
+        <option name="default">CURRENT_TIMESTAMP</option>
+      </options>
+    </field>
     <field name="src" type="string" column="src" length="128" nullable="true">
       <options>
         <option name="fixed"/>

--- a/schema/DoctrineMigrations/Version20220707125449.php
+++ b/schema/DoctrineMigrations/Version20220707125449.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20220707125449 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Set default FaxesInOut.calldate value';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE FaxesInOut CHANGE calldate calldate DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE FaxesInOut CHANGE calldate calldate DATETIME NOT NULL');
+    }
+}

--- a/web/rest/client/config/api/raw/provider.yml
+++ b/web/rest/client/config/api/raw/provider.yml
@@ -808,6 +808,11 @@ Ivoz\Provider\Domain\Model\FaxesInOut\FaxesInOut:
     delete: ~
   collectionOperations:
     get: ~
+  properties:
+    calldate:
+      attributes:
+        swagger_context:
+          readOnly: true
   attributes:
     access_control: '"ROLE_COMPANY_ADMIN" in roles && user.hasAccessPrivileges(_api_resource_class, request.getMethod())'
     read_access_control:


### PR DESCRIPTION
Because of recent model changes we've lost the hability to make required entity methods nullable (it's checked during fromDto execution). Fix FaxesInOut so that callDate is not requested

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
<!-- Describe your changes in detail -->

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
