### PR TITLE
Dynamic fixed costs by client DDI in scheduled invoices

### DIFF
--- a/doc/sphinx/administration_portal/brand/invoicing/invoice_schedulers.rst
+++ b/doc/sphinx/administration_portal/brand/invoicing/invoice_schedulers.rst
@@ -46,7 +46,11 @@ When defining a scheduled invoice, you can add fixed costs in a static or dynami
 - Type **'Max calls'** sets the quantity in the moment of the creation of the invoice to
   "Max calls" value of the client in that specific moment.
 
-.. tip:: "Max calls" value is retrieved from client configuration in the date specified in "Next execution".
+- Type **'DDIs'** sets the quantity in the moment of the creation of the invoice to
+  the number of DDIS matching criteria (all, national, international or belonging to specific country)
+  in the client in that specific moment.
+
+.. tip:: Non-static values are retrieved from client configuration in the date specified in "Next execution".
          Regenerating the invoice later will not modify assigned value, but you can adapt it manually to
          the desired value editing the fixed cost in Invoice section and regenerating the invoice.
 

--- a/library/Ivoz/Provider/Domain/Model/Ddi/DdiRepository.php
+++ b/library/Ivoz/Provider/Domain/Model/Ddi/DdiRepository.php
@@ -17,4 +17,19 @@ interface DdiRepository extends ObjectRepository, Selectable
      * @return \Ivoz\Provider\Domain\Model\Ddi\DdiInterface | null
      */
     public function findOneByDdiAndCountry(string $ddi, int $countryId);
+
+    /**
+     * @return int Number of DDIs of the given Company
+     */
+    public function countByCompany(int $companyId): int;
+
+    /**
+     * @return int Number of DDIs of the given Company and Country as prefix
+     */
+    public function countByCompanyAndCountry(int $companyId, int $countryId): int;
+
+    /**
+     * @return int Number of DDIs of the given Company and not Country as prefix
+     */
+    public function countByCompanyAndNotCountry(int $companyId, int $countryId): int;
 }

--- a/library/Ivoz/Provider/Domain/Model/FixedCostsRelInvoice/FixedCostsRelInvoice.php
+++ b/library/Ivoz/Provider/Domain/Model/FixedCostsRelInvoice/FixedCostsRelInvoice.php
@@ -30,37 +30,4 @@ class FixedCostsRelInvoice extends FixedCostsRelInvoiceAbstract implements Fixed
     {
         return $this->id;
     }
-
-    /**
-     * @param \Ivoz\Provider\Domain\Model\Invoice\InvoiceInterface $invoice
-     * @param \Ivoz\Provider\Domain\Model\FixedCostsRelInvoiceScheduler\FixedCostsRelInvoiceSchedulerInterface $fixedCostRelScheduler
-     * @return static
-     */
-    public static function fromFixedCostsRelInvoiceScheduler(
-        InvoiceInterface $invoice,
-        FixedCostsRelInvoiceSchedulerInterface $fixedCostRelScheduler
-    ) {
-        $quantity = $fixedCostRelScheduler->getQuantity();
-        if ($fixedCostRelScheduler->getType() === FixedCostsRelInvoiceSchedulerInterface::TYPE_MAXCALLS) {
-            $quantity = $invoice->getCompany()->getMaxCalls();
-        }
-
-        $entity = new static();
-
-        $entity
-            ->setQuantity(
-                $quantity
-            )
-            ->setFixedCost(
-                $fixedCostRelScheduler->getFixedCost()
-            )
-            ->setInvoice(
-                $invoice
-            );
-
-        $entity->sanitizeValues();
-        $entity->initChangelog();
-
-        return $entity;
-    }
 }

--- a/library/Ivoz/Provider/Domain/Model/FixedCostsRelInvoice/FixedCostsRelInvoiceInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/FixedCostsRelInvoice/FixedCostsRelInvoiceInterface.php
@@ -3,12 +3,11 @@
 namespace Ivoz\Provider\Domain\Model\FixedCostsRelInvoice;
 
 use Ivoz\Core\Domain\Model\LoggableEntityInterface;
-use Ivoz\Provider\Domain\Model\Invoice\InvoiceInterface;
-use Ivoz\Provider\Domain\Model\FixedCostsRelInvoiceScheduler\FixedCostsRelInvoiceSchedulerInterface;
 use Ivoz\Core\Domain\Model\EntityInterface;
 use Ivoz\Core\Application\DataTransferObjectInterface;
 use Ivoz\Core\Application\ForeignKeyTransformerInterface;
 use Ivoz\Provider\Domain\Model\FixedCost\FixedCostInterface;
+use Ivoz\Provider\Domain\Model\Invoice\InvoiceInterface;
 
 /**
 * FixedCostsRelInvoiceInterface
@@ -27,13 +26,6 @@ interface FixedCostsRelInvoiceInterface extends LoggableEntityInterface
      * @return integer
      */
     public function getId(): ?int;
-
-    /**
-     * @param \Ivoz\Provider\Domain\Model\Invoice\InvoiceInterface $invoice
-     * @param \Ivoz\Provider\Domain\Model\FixedCostsRelInvoiceScheduler\FixedCostsRelInvoiceSchedulerInterface $fixedCostRelScheduler
-     * @return static
-     */
-    public static function fromFixedCostsRelInvoiceScheduler(InvoiceInterface $invoice, FixedCostsRelInvoiceSchedulerInterface $fixedCostRelScheduler);
 
     public static function createDto(string|int|null $id = null): FixedCostsRelInvoiceDto;
 

--- a/library/Ivoz/Provider/Domain/Model/FixedCostsRelInvoiceScheduler/FixedCostsRelInvoiceScheduler.php
+++ b/library/Ivoz/Provider/Domain/Model/FixedCostsRelInvoiceScheduler/FixedCostsRelInvoiceScheduler.php
@@ -33,5 +33,20 @@ class FixedCostsRelInvoiceScheduler extends FixedCostsRelInvoiceSchedulerAbstrac
         if ($this->getType() !== self::TYPE_STATIC) {
             $this->setQuantity(null);
         }
+        if ($this->getType() !== self::TYPE_DDIS) {
+            $this->setDdisCountryMatch(null);
+            $this->setDdisCountry(null);
+        }
+
+        // Check DDIs Country is set in specific match
+        if (
+            $this->getType() === self::TYPE_DDIS &&
+            $this->getDdisCountryMatch() == self::DDISCOUNTRYMATCH_SPECIFIC &&
+            !$this->getDdisCountry()
+        ) {
+            throw new \DomainException(
+                'DdisCountry is required for specific ddis type fixed costs',
+            );
+        }
     }
 }

--- a/library/Ivoz/Provider/Domain/Model/FixedCostsRelInvoiceScheduler/FixedCostsRelInvoiceSchedulerDto.php
+++ b/library/Ivoz/Provider/Domain/Model/FixedCostsRelInvoiceScheduler/FixedCostsRelInvoiceSchedulerDto.php
@@ -17,6 +17,8 @@ class FixedCostsRelInvoiceSchedulerDto extends FixedCostsRelInvoiceSchedulerDtoA
             'quantity' => 'quantity',
             'id' => 'id',
             'type' => 'type',
+            'ddisCountryMatch' => 'ddisCountryMatch',
+            'ddisCountry' => 'ddisCountry',
             'fixedCostId' => 'fixedCost',
             'invoiceSchedulerId' => 'invoiceScheduler'
         ];

--- a/library/Ivoz/Provider/Domain/Model/FixedCostsRelInvoiceScheduler/FixedCostsRelInvoiceSchedulerDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/FixedCostsRelInvoiceScheduler/FixedCostsRelInvoiceSchedulerDtoAbstract.php
@@ -6,6 +6,7 @@ use Ivoz\Core\Application\DataTransferObjectInterface;
 use Ivoz\Core\Application\Model\DtoNormalizer;
 use Ivoz\Provider\Domain\Model\FixedCost\FixedCostDto;
 use Ivoz\Provider\Domain\Model\InvoiceScheduler\InvoiceSchedulerDto;
+use Ivoz\Provider\Domain\Model\Country\CountryDto;
 
 /**
 * FixedCostsRelInvoiceSchedulerDtoAbstract
@@ -26,6 +27,11 @@ abstract class FixedCostsRelInvoiceSchedulerDtoAbstract implements DataTransferO
     private $type = 'static';
 
     /**
+     * @var string|null
+     */
+    private $ddisCountryMatch = 'all';
+
+    /**
      * @var int|null
      */
     private $id = null;
@@ -39,6 +45,11 @@ abstract class FixedCostsRelInvoiceSchedulerDtoAbstract implements DataTransferO
      * @var InvoiceSchedulerDto | null
      */
     private $invoiceScheduler = null;
+
+    /**
+     * @var CountryDto | null
+     */
+    private $ddisCountry = null;
 
     /**
      * @param string|int|null $id
@@ -60,9 +71,11 @@ abstract class FixedCostsRelInvoiceSchedulerDtoAbstract implements DataTransferO
         return [
             'quantity' => 'quantity',
             'type' => 'type',
+            'ddisCountryMatch' => 'ddisCountryMatch',
             'id' => 'id',
             'fixedCostId' => 'fixedCost',
-            'invoiceSchedulerId' => 'invoiceScheduler'
+            'invoiceSchedulerId' => 'invoiceScheduler',
+            'ddisCountryId' => 'ddisCountry'
         ];
     }
 
@@ -74,9 +87,11 @@ abstract class FixedCostsRelInvoiceSchedulerDtoAbstract implements DataTransferO
         $response = [
             'quantity' => $this->getQuantity(),
             'type' => $this->getType(),
+            'ddisCountryMatch' => $this->getDdisCountryMatch(),
             'id' => $this->getId(),
             'fixedCost' => $this->getFixedCost(),
-            'invoiceScheduler' => $this->getInvoiceScheduler()
+            'invoiceScheduler' => $this->getInvoiceScheduler(),
+            'ddisCountry' => $this->getDdisCountry()
         ];
 
         if (!$hideSensitiveData) {
@@ -115,6 +130,18 @@ abstract class FixedCostsRelInvoiceSchedulerDtoAbstract implements DataTransferO
     public function getType(): ?string
     {
         return $this->type;
+    }
+
+    public function setDdisCountryMatch(?string $ddisCountryMatch): static
+    {
+        $this->ddisCountryMatch = $ddisCountryMatch;
+
+        return $this;
+    }
+
+    public function getDdisCountryMatch(): ?string
+    {
+        return $this->ddisCountryMatch;
     }
 
     public function setId($id): static
@@ -183,6 +210,36 @@ abstract class FixedCostsRelInvoiceSchedulerDtoAbstract implements DataTransferO
     public function getInvoiceSchedulerId()
     {
         if ($dto = $this->getInvoiceScheduler()) {
+            return $dto->getId();
+        }
+
+        return null;
+    }
+
+    public function setDdisCountry(?CountryDto $ddisCountry): static
+    {
+        $this->ddisCountry = $ddisCountry;
+
+        return $this;
+    }
+
+    public function getDdisCountry(): ?CountryDto
+    {
+        return $this->ddisCountry;
+    }
+
+    public function setDdisCountryId($id): static
+    {
+        $value = !is_null($id)
+            ? new CountryDto($id)
+            : null;
+
+        return $this->setDdisCountry($value);
+    }
+
+    public function getDdisCountryId()
+    {
+        if ($dto = $this->getDdisCountry()) {
             return $dto->getId();
         }
 

--- a/library/Ivoz/Provider/Domain/Model/FixedCostsRelInvoiceScheduler/FixedCostsRelInvoiceSchedulerInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/FixedCostsRelInvoiceScheduler/FixedCostsRelInvoiceSchedulerInterface.php
@@ -8,6 +8,7 @@ use Ivoz\Core\Application\DataTransferObjectInterface;
 use Ivoz\Core\Application\ForeignKeyTransformerInterface;
 use Ivoz\Provider\Domain\Model\FixedCost\FixedCostInterface;
 use Ivoz\Provider\Domain\Model\InvoiceScheduler\InvoiceSchedulerInterface;
+use Ivoz\Provider\Domain\Model\Country\CountryInterface;
 
 /**
 * FixedCostsRelInvoiceSchedulerInterface
@@ -17,6 +18,16 @@ interface FixedCostsRelInvoiceSchedulerInterface extends LoggableEntityInterface
     public const TYPE_STATIC = 'static';
 
     public const TYPE_MAXCALLS = 'maxcalls';
+
+    public const TYPE_DDIS = 'ddis';
+
+    public const DDISCOUNTRYMATCH_ALL = 'all';
+
+    public const DDISCOUNTRYMATCH_NATIONAL = 'national';
+
+    public const DDISCOUNTRYMATCH_INTERNATIONAL = 'international';
+
+    public const DDISCOUNTRYMATCH_SPECIFIC = 'specific';
 
     /**
      * @codeCoverageIgnore
@@ -55,11 +66,15 @@ interface FixedCostsRelInvoiceSchedulerInterface extends LoggableEntityInterface
 
     public function getType(): string;
 
+    public function getDdisCountryMatch(): ?string;
+
     public function getFixedCost(): FixedCostInterface;
 
     public function setInvoiceScheduler(?InvoiceSchedulerInterface $invoiceScheduler = null): static;
 
     public function getInvoiceScheduler(): ?InvoiceSchedulerInterface;
+
+    public function getDdisCountry(): ?CountryInterface;
 
     public function isInitialized(): bool;
 }

--- a/library/Ivoz/Provider/Domain/Service/FixedCostsRelInvoice/CreateByScheduler.php
+++ b/library/Ivoz/Provider/Domain/Service/FixedCostsRelInvoice/CreateByScheduler.php
@@ -3,7 +3,8 @@
 namespace Ivoz\Provider\Domain\Service\FixedCostsRelInvoice;
 
 use Ivoz\Core\Application\Service\EntityTools;
-use Ivoz\Provider\Domain\Model\FixedCostsRelInvoice\FixedCostsRelInvoice;
+use Ivoz\Provider\Domain\Model\Ddi\DdiRepository;
+use Ivoz\Provider\Domain\Model\FixedCostsRelInvoice\FixedCostsRelInvoiceDto;
 use Ivoz\Provider\Domain\Model\FixedCostsRelInvoiceScheduler\FixedCostsRelInvoiceSchedulerInterface;
 use Ivoz\Provider\Domain\Model\Invoice\InvoiceInterface;
 use Ivoz\Provider\Domain\Model\InvoiceScheduler\InvoiceSchedulerInterface;
@@ -11,28 +12,74 @@ use Ivoz\Provider\Domain\Model\InvoiceScheduler\InvoiceSchedulerInterface;
 class CreateByScheduler
 {
     public function __construct(
-        private EntityTools $entityTools
+        private EntityTools $entityTools,
+        private DdiRepository $ddiRepository
     ) {
     }
 
-    /**
-     * @param InvoiceSchedulerInterface $scheduler
-     * @param InvoiceInterface $invoice
-     *
-     * @return void
-     */
     public function execute(
         InvoiceSchedulerInterface $scheduler,
         InvoiceInterface $invoice
-    ) {
-        /** @var FixedCostsRelInvoiceSchedulerInterface[] $relFixedCosts */
+    ): void {
+        $company = $invoice->getCompany();
         $relFixedCosts = $scheduler->getRelFixedCosts();
         foreach ($relFixedCosts as $relFixedCost) {
-            $fixedCostRelInvoice = FixedCostsRelInvoice::fromFixedCostsRelInvoiceScheduler(
-                $invoice,
-                $relFixedCost
-            );
-            $this->entityTools->persist($fixedCostRelInvoice);
+            // Calculate Dynamic quantities
+            $quantity = $relFixedCost->getQuantity();
+            $type = $relFixedCost->getType();
+            if ($type === FixedCostsRelInvoiceSchedulerInterface::TYPE_MAXCALLS) {
+                // Quantity based on Client Max Calls setting
+                $quantity = $company->getMaxCalls();
+            } elseif ($type === FixedCostsRelInvoiceSchedulerInterface::TYPE_DDIS) {
+                // Quantity based on Client DDI Count
+                $ddisMatch = $relFixedCost->getDdisCountryMatch();
+                $companyCountry = $company->getCountry();
+                // DDI Match All Countries
+                if ($ddisMatch == FixedCostsRelInvoiceSchedulerInterface::DDISCOUNTRYMATCH_ALL) {
+                    $quantity = $this->ddiRepository->countByCompany(
+                        (int) $company->getId()
+                    );
+                }
+                // DDI Match from client country
+                if ($ddisMatch == FixedCostsRelInvoiceSchedulerInterface::DDISCOUNTRYMATCH_NATIONAL) {
+                    $quantity = $this->ddiRepository->countByCompanyAndCountry(
+                        (int) $company->getId(),
+                        (int) $companyCountry->getId()
+                    );
+                }
+                // DDI Match NOT from client country
+                if ($ddisMatch == FixedCostsRelInvoiceSchedulerInterface::DDISCOUNTRYMATCH_INTERNATIONAL) {
+                    $quantity = $this->ddiRepository->countByCompanyAndNotCountry(
+                        (int) $company->getId(),
+                        (int) $companyCountry->getId()
+                    );
+                }
+                // DDI Match from specific country
+                if ($ddisMatch == FixedCostsRelInvoiceSchedulerInterface::DDISCOUNTRYMATCH_SPECIFIC) {
+                    $ddisCountry = $relFixedCost->getDdisCountry();
+                    if (!$ddisCountry) {
+                        return;
+                    }
+                    $quantity = $this->ddiRepository->countByCompanyAndCountry(
+                        (int) $company->getId(),
+                        (int) $ddisCountry->getId()
+                    );
+                }
+            }
+
+            $fixedCostRelInvoiceDto = new FixedCostsRelInvoiceDto();
+            $fixedCostRelInvoiceDto
+                ->setQuantity(
+                    $quantity
+                )
+                ->setFixedCostId(
+                    $relFixedCost->getFixedCost()->getId()
+                )
+                ->setInvoiceId(
+                    $invoice->getId()
+                );
+
+            $this->entityTools->persistDto($fixedCostRelInvoiceDto);
         }
     }
 }

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/DdiDoctrineRepository.php
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/DdiDoctrineRepository.php
@@ -50,4 +50,39 @@ class DdiDoctrineRepository extends ServiceEntityRepository implements DdiReposi
 
         return $response;
     }
+
+    public function countByCompany(int $companyId): int
+    {
+        $qb = $this->createQueryBuilder('self');
+
+        return $qb
+            ->select('count(self.id)')
+            ->where($qb->expr()->eq('self.company', $companyId))
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    public function countByCompanyAndCountry(int $companyId, int $countryId): int
+    {
+        $qb = $this->createQueryBuilder('self');
+
+        return $qb
+            ->select('count(self.id)')
+            ->where($qb->expr()->eq('self.company', $companyId))
+            ->andWhere($qb->expr()->eq('self.country', $countryId))
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    public function countByCompanyAndNotCountry(int $companyId, int $countryId): int
+    {
+        $qb = $this->createQueryBuilder('self');
+
+        return $qb
+            ->select('count(self.id)')
+            ->where($qb->expr()->eq('self.company', $companyId))
+            ->andWhere($qb->expr()->neq('self.country', $countryId))
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
 }

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/FixedCostsRelInvoiceScheduler.FixedCostsRelInvoiceSchedulerAbstract.orm.xml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/FixedCostsRelInvoiceScheduler.FixedCostsRelInvoiceSchedulerAbstract.orm.xml
@@ -11,8 +11,14 @@
     </field>
     <field name="type" type="string" column="type" length="25" nullable="false">
       <options>
-        <option name="comment">[enum:static|maxcalls]</option>
+        <option name="comment">[enum:static|maxcalls|ddis]</option>
         <option name="default">static</option>
+      </options>
+    </field>
+    <field name="ddisCountryMatch" type="string" column="ddisCountryMatch" length="25" nullable="true">
+      <options>
+        <option name="comment">[enum:all|national|international|specific]</option>
+        <option name="default">all</option>
       </options>
     </field>
     <many-to-one field="fixedCost" target-entity="Ivoz\Provider\Domain\Model\FixedCost\FixedCostInterface" fetch="LAZY">
@@ -23,6 +29,11 @@
     <many-to-one field="invoiceScheduler" target-entity="Ivoz\Provider\Domain\Model\InvoiceScheduler\InvoiceSchedulerInterface" inversed-by="relFixedCosts" fetch="LAZY">
       <join-columns>
         <join-column name="invoiceSchedulerId" referenced-column-name="id" on-delete="CASCADE" nullable=""/>
+      </join-columns>
+    </many-to-one>
+    <many-to-one field="ddisCountry" target-entity="Ivoz\Provider\Domain\Model\Country\CountryInterface" fetch="LAZY">
+      <join-columns>
+        <join-column name="ddisCountryId" referenced-column-name="id" on-delete="SET NULL" nullable="true"/>
       </join-columns>
     </many-to-one>
   </mapped-superclass>

--- a/library/phpstan-baseline.neon
+++ b/library/phpstan-baseline.neon
@@ -6181,12 +6181,22 @@ parameters:
 			path: Ivoz/Provider/Domain/Model/FixedCostsRelInvoice/FixedCostsRelInvoiceRepository.php
 
 		-
+			message: "#^Method Ivoz\\\\Provider\\\\Domain\\\\Model\\\\FixedCostsRelInvoiceScheduler\\\\FixedCostsRelInvoiceSchedulerDtoAbstract\\:\\:getDdisCountryId\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: Ivoz/Provider/Domain/Model/FixedCostsRelInvoiceScheduler/FixedCostsRelInvoiceSchedulerDtoAbstract.php
+
+		-
 			message: "#^Method Ivoz\\\\Provider\\\\Domain\\\\Model\\\\FixedCostsRelInvoiceScheduler\\\\FixedCostsRelInvoiceSchedulerDtoAbstract\\:\\:getFixedCostId\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: Ivoz/Provider/Domain/Model/FixedCostsRelInvoiceScheduler/FixedCostsRelInvoiceSchedulerDtoAbstract.php
 
 		-
 			message: "#^Method Ivoz\\\\Provider\\\\Domain\\\\Model\\\\FixedCostsRelInvoiceScheduler\\\\FixedCostsRelInvoiceSchedulerDtoAbstract\\:\\:getInvoiceSchedulerId\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: Ivoz/Provider/Domain/Model/FixedCostsRelInvoiceScheduler/FixedCostsRelInvoiceSchedulerDtoAbstract.php
+
+		-
+			message: "#^Method Ivoz\\\\Provider\\\\Domain\\\\Model\\\\FixedCostsRelInvoiceScheduler\\\\FixedCostsRelInvoiceSchedulerDtoAbstract\\:\\:setDdisCountryId\\(\\) has parameter \\$id with no typehint specified\\.$#"
 			count: 1
 			path: Ivoz/Provider/Domain/Model/FixedCostsRelInvoiceScheduler/FixedCostsRelInvoiceSchedulerDtoAbstract.php
 

--- a/library/psalm-baseline.xml
+++ b/library/psalm-baseline.xml
@@ -4922,12 +4922,10 @@
     </MixedArgument>
   </file>
   <file src="Ivoz/Provider/Domain/Model/FaxesInOut/FaxesInOut.php">
-    <LessSpecificReturnStatement occurrences="2">
-      <code>parent::setCalldate($calldate)</code>
+    <LessSpecificReturnStatement occurrences="1">
       <code>parent::setDst($dst)</code>
     </LessSpecificReturnStatement>
-    <MoreSpecificReturnType occurrences="2">
-      <code>static</code>
+    <MoreSpecificReturnType occurrences="1">
       <code>static</code>
     </MoreSpecificReturnType>
     <PossiblyNullArgument occurrences="1">
@@ -5128,9 +5126,6 @@
     <MethodSignatureMismatch occurrences="1">
       <code>FixedCostsRelInvoice</code>
     </MethodSignatureMismatch>
-    <UnsafeInstantiation occurrences="1">
-      <code>new static()</code>
-    </UnsafeInstantiation>
   </file>
   <file src="Ivoz/Provider/Domain/Model/FixedCostsRelInvoice/FixedCostsRelInvoiceAbstract.php">
     <MixedArgument occurrences="4">
@@ -5162,6 +5157,9 @@
       <code>$id</code>
       <code>$id</code>
     </MixedArgument>
+    <PossiblyUnusedReturnValue occurrences="1">
+      <code>static</code>
+    </PossiblyUnusedReturnValue>
   </file>
   <file src="Ivoz/Provider/Domain/Model/FixedCostsRelInvoice/FixedCostsRelInvoiceInterface.php">
     <PossiblyUnusedReturnValue occurrences="1">
@@ -5179,7 +5177,9 @@
     </MethodSignatureMismatch>
   </file>
   <file src="Ivoz/Provider/Domain/Model/FixedCostsRelInvoiceScheduler/FixedCostsRelInvoiceSchedulerAbstract.php">
-    <MixedArgument occurrences="4">
+    <MixedArgument occurrences="6">
+      <code>$fkTransformer-&gt;transform($dto-&gt;getDdisCountry())</code>
+      <code>$fkTransformer-&gt;transform($dto-&gt;getDdisCountry())</code>
       <code>$fkTransformer-&gt;transform($dto-&gt;getInvoiceScheduler())</code>
       <code>$fkTransformer-&gt;transform($dto-&gt;getInvoiceScheduler())</code>
       <code>$fkTransformer-&gt;transform($fixedCost)</code>
@@ -5188,16 +5188,19 @@
     <UnsafeInstantiation occurrences="1"/>
   </file>
   <file src="Ivoz/Provider/Domain/Model/FixedCostsRelInvoiceScheduler/FixedCostsRelInvoiceSchedulerDtoAbstract.php">
-    <MissingParamType occurrences="3">
+    <MissingParamType occurrences="4">
+      <code>$id</code>
       <code>$id</code>
       <code>$id</code>
       <code>$id</code>
     </MissingParamType>
-    <MissingReturnType occurrences="2">
+    <MissingReturnType occurrences="3">
+      <code>getDdisCountryId</code>
       <code>getFixedCostId</code>
       <code>getInvoiceSchedulerId</code>
     </MissingReturnType>
-    <MixedArgument occurrences="2">
+    <MixedArgument occurrences="3">
+      <code>$id</code>
       <code>$id</code>
       <code>$id</code>
     </MixedArgument>
@@ -8877,11 +8880,6 @@
     <MixedArrayAssignment occurrences="1">
       <code>$this-&gt;services[$event][]</code>
     </MixedArrayAssignment>
-  </file>
-  <file src="Ivoz/Provider/Domain/Service/FixedCostsRelInvoice/CreateByScheduler.php">
-    <UnnecessaryVarAnnotation occurrences="1">
-      <code>FixedCostsRelInvoiceSchedulerInterface[]</code>
-    </UnnecessaryVarAnnotation>
   </file>
   <file src="Ivoz/Provider/Domain/Service/FixedCostsRelInvoice/FixedCostsRelInvoiceLifecycleEventHandlerInterface.php">
     <MissingReturnType occurrences="1">

--- a/schema/initial.sql
+++ b/schema/initial.sql
@@ -2179,11 +2179,15 @@ CREATE TABLE `FixedCostsRelInvoiceSchedulers` (
   `quantity` int unsigned DEFAULT NULL,
   `fixedCostId` int unsigned NOT NULL,
   `invoiceSchedulerId` int unsigned NOT NULL,
-  `type` varchar(25) COLLATE utf8_unicode_ci NOT NULL DEFAULT 'static' COMMENT '[enum:static|maxcalls]',
+  `type` varchar(25) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL DEFAULT 'static' COMMENT '[enum:static|maxcalls|ddis]',
+  `ddisCountryMatch` varchar(25) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT 'all' COMMENT '[enum:all|national|international|specific]',
+  `ddisCountryId` int unsigned DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `FixedCostsRelInvoiceScheduler_invoiceScheduler_fixedCost` (`invoiceSchedulerId`,`fixedCostId`),
   KEY `IDX_D9D0952B81256364` (`fixedCostId`),
+  KEY `IDX_D9D0952B43D707A2` (`ddisCountryId`),
   CONSTRAINT `FK_D9D0952B1D113CF5` FOREIGN KEY (`invoiceSchedulerId`) REFERENCES `InvoiceSchedulers` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `FK_D9D0952B43D707A2` FOREIGN KEY (`ddisCountryId`) REFERENCES `Countries` (`id`) ON DELETE SET NULL,
   CONSTRAINT `FK_D9D0952B81256364` FOREIGN KEY (`fixedCostId`) REFERENCES `FixedCosts` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/schema/tests/Provider/BrandService/BrandServiceRepositoryTest.php
+++ b/schema/tests/Provider/BrandService/BrandServiceRepositoryTest.php
@@ -19,6 +19,7 @@ class BrandServiceRepositoryTest extends KernelTestCase
     {
         $this->its_instantiable();
         $this->its_finds_by_brandId();
+        $this->its_finds_services_by_brandId();
     }
 
     public function its_instantiable()
@@ -63,13 +64,11 @@ class BrandServiceRepositoryTest extends KernelTestCase
 
         $results = $repository->getServiceIdsByBrand(1);
 
-        $this->assertInternalType(
-            'array',
+        $this->assertIsArray(
             $results
         );
 
-        $this->assertInternalType(
-            'int',
+        $this->assertIsInt(
             $results[0]
         );
     }

--- a/schema/tests/Provider/Ddi/DdiRepositoryTest.php
+++ b/schema/tests/Provider/Ddi/DdiRepositoryTest.php
@@ -76,8 +76,7 @@ class DdiRepositoryTest extends KernelTestCase
 
         $num = $repository->countByCompany(1);
 
-        $this->assertInternalType(
-            'int',
+        $this->assertIsInt(
             $num
         );
     }
@@ -91,8 +90,7 @@ class DdiRepositoryTest extends KernelTestCase
 
         $num = $repository->countByCompanyAndCountry(1, 68);
 
-        $this->assertInternalType(
-            'int',
+        $this->assertIsInt(
             $num
         );
     }
@@ -106,8 +104,7 @@ class DdiRepositoryTest extends KernelTestCase
 
         $num = $repository->countByCompanyAndNotCountry(1, 68);
 
-        $this->assertInternalType(
-            'int',
+        $this->assertIsInt(
             $num
         );
     }

--- a/schema/tests/Provider/Ddi/DdiRepositoryTest.php
+++ b/schema/tests/Provider/Ddi/DdiRepositoryTest.php
@@ -18,6 +18,10 @@ class DdiRepositoryTest extends KernelTestCase
     {
         $this->its_instantiable();
         $this->it_finds_one_by_ddi_e164();
+        $this->it_finds_one_by_ddi_and_country();
+        $this->it_counts_by_company();
+        $this->it_counts_by_company_and_country();
+        $this->it_counts_by_company_and_not_country();
     }
 
     public function its_instantiable()
@@ -45,6 +49,66 @@ class DdiRepositoryTest extends KernelTestCase
         $this->assertInstanceOf(
             Ddi::class,
             $ddi
+        );
+    }
+
+    public function it_finds_one_by_ddi_and_country()
+    {
+        /** @var DdiRepository $repository */
+        $repository = $this
+            ->em
+            ->getRepository(Ddi::class);
+
+        $ddi = $repository->findOneByDdiAndCountry('123', 68);
+
+        $this->assertInstanceOf(
+            Ddi::class,
+            $ddi
+        );
+    }
+
+    public function it_counts_by_company()
+    {
+        /** @var DdiRepository $repository */
+        $repository = $this
+            ->em
+            ->getRepository(Ddi::class);
+
+        $num = $repository->countByCompany(1);
+
+        $this->assertInternalType(
+            'int',
+            $num
+        );
+    }
+
+    public function it_counts_by_company_and_country()
+    {
+        /** @var DdiRepository $repository */
+        $repository = $this
+            ->em
+            ->getRepository(Ddi::class);
+
+        $num = $repository->countByCompanyAndCountry(1, 68);
+
+        $this->assertInternalType(
+            'int',
+            $num
+        );
+    }
+
+    public function it_counts_by_company_and_not_country()
+    {
+        /** @var DdiRepository $repository */
+        $repository = $this
+            ->em
+            ->getRepository(Ddi::class);
+
+        $num = $repository->countByCompanyAndNotCountry(1, 68);
+
+        $this->assertInternalType(
+            'int',
+            $num
         );
     }
 }

--- a/web/admin/application/configs/klear/FixedCostsRelInvoiceSchedulersList.yaml
+++ b/web/admin/application/configs/klear/FixedCostsRelInvoiceSchedulersList.yaml
@@ -26,7 +26,11 @@ production:
         order:
           fixedCost: true
           type: true
+          quantityGhost: true
+        blacklist:
           quantity: true
+          ddisCountryMatch: true
+          ddisCountry: true
       options:
         title: _("Options")
         screens:
@@ -42,6 +46,11 @@ production:
       title: _("Add %s", ngettext('Fixed cost', 'Fixed costs', 1), "[format| (%parent%)]")
       shortcutOption: N
       filterField: invoiceScheduler
+      defaultValues:
+        country: 70
+      fields:
+        blacklist:
+          quantityGhost: true
       fixedPositions: &fixedCostsRelInvoiceSchedulers_fixedPositions_Link
         group0:
           colsPerRow: 12
@@ -49,6 +58,8 @@ production:
             fixedCost: 6
             type: 3
             quantity: 3
+            ddisCountryMatch: 7
+            ddisCountry: 5
     fixedCostsRelInvoiceSchedulersEdit_screen: &fixedCostsRelInvoiceSchedulersEdit_screenLink
       <<: *FixedCostsRelInvoiceSchedulers
       controller: edit
@@ -57,6 +68,9 @@ production:
       labelOnPostAction: _("Edit %s %2s", ngettext('Fixed cost', 'Fixed costs', 1), "[format| (%item%)]")
       title: _("Edit %s %2s", ngettext('Fixed cost', 'Fixed costs', 1), "[format| (%item%)]")
       filterField: invoiceScheduler
+      fields:
+        blacklist:
+          quantityGhost: true
       fixedPositions:
         <<: *fixedCostsRelInvoiceSchedulers_fixedPositions_Link
   dialogs: &fixedCostsRelInvoiceSchedulers_dialogsLink

--- a/web/admin/application/configs/klear/conf.d/ddisMatchHelp.yaml
+++ b/web/admin/application/configs/klear/conf.d/ddisMatchHelp.yaml
@@ -1,0 +1,14 @@
+ddisMatchHelp: &ddisMatchHelp
+    info:
+      type: box
+      position: left
+      icon: help
+      label: _("Need help?")
+      text: "
+            Calculate quantity based on the number of DDIs:
+            <pre>
+               <b>all          </b>  <i>Any country</i><br/>
+               <b>national     </b>  <i>Client's country</i><br/>
+               <b>international</b>  <i>NOT Client's country</i><br/>
+               <b>specific     </b>  <i>Specific country</i><br/>
+            </pre>"

--- a/web/admin/application/configs/klear/model/FixedCostsRelInvoiceSchedulers.yaml
+++ b/web/admin/application/configs/klear/model/FixedCostsRelInvoiceSchedulers.yaml
@@ -1,3 +1,5 @@
+#include ../conf.d/ddisMatchHelp.yaml
+
 production:
   entity: Ivoz\Provider\Domain\Model\FixedCostsRelInvoiceScheduler\FixedCostsRelInvoiceScheduler
   fields:
@@ -49,12 +51,63 @@ production:
           'static':
             title: _("Static")
             visualFilter:
-              show: ["quantity"]
+              show: [ quantity ]
+              hide: [ ddisCountry, ddisCountryMatch ]
           'maxcalls':
             title: _('Max calls')
             visualFilter:
-              hide: ["quantity"]
-
+              hide: [ quantity, ddisCountryMatch, ddisCountry ]
+          'ddis':
+            title: ngettext('DDI', 'DDIs', 2)
+            visualFilter:
+              hide: [ quantity ]
+              show: [ ddisCountryMatch ]
+    ddisCountryMatch:
+      title: _('DDIs Match mode')
+      type: select
+      required: true
+      <<: *ddisMatchHelp
+      source:
+        data: inline
+        values:
+          'all':
+            title: _("All Countries")
+            visualFilter:
+              hide: [ ddisCountry ]
+          'national':
+            title: _("National")
+            visualFilter:
+              hide: [ ddisCountry ]
+          'international':
+            title: _("International")
+            visualFilter:
+              hide: [ ddisCountry ]
+          'specific':
+            title: _("Specific")
+            visualFilter:
+              show: [ ddisCountry ]
+    ddisCountry:
+      title: _('Country')
+      type: select
+      required: true
+      defaultValue: 70
+      source:
+        data: mapper
+        config:
+          entity: \Ivoz\Provider\Domain\Model\Country\Country
+          fieldName:
+            fields:
+              - name${lang}
+              - countryCode
+            template: '%name${lang}% (%countryCode%)'
+          order:
+            Country.name.${lang}: asc
+    quantityGhost:
+      title: _('Quantity')
+      type: ghost
+      source:
+        class: IvozProvider_Klear_Ghost_FixedCostsRelInvoiceSchedulers
+        method: getQuantity
 staging:
   _extends: production
 testing:

--- a/web/admin/application/languages/ca_ES/ca_ES.po
+++ b/web/admin/application/languages/ca_ES/ca_ES.po
@@ -144,6 +144,9 @@ msgstr[1] "Aliases"
 msgid "All"
 msgstr "Tots"
 
+msgid "All Countries"
+msgstr "Tots els països"
+
 msgid "Allow Call Forwards"
 msgstr "Permet desviament de trucada"
 
@@ -553,6 +556,9 @@ msgstr[1] "Administradors de client"
 msgid "Client filters"
 msgstr "Filtros de cliente"
 
+msgid "Client's Max Calls setting"
+msgstr "Configuración Limite de llamadas de Cliente"
+
 msgid "Client's default"
 msgstr "Per defecte del client"
 
@@ -687,6 +693,22 @@ msgid "DDI Provider Registration"
 msgid_plural "DDI Provider Registrations"
 msgstr[0] "Registre del proveïdor de DDI"
 msgstr[1] "Registres del proveïdor de DDI"
+
+msgid "DDIs Match mode"
+msgstr "Coincidència DDI"
+
+msgid "DDIs NOT from client's country"
+msgstr "DDIs de paises distintos al cliente"
+
+#, php-format
+msgid "DDIs from %s (%s)"
+msgstr "DDIs de %s (%s)"
+
+msgid "DDIs from any country"
+msgstr "DDIs de cualquier país"
+
+msgid "DDIs from client's country"
+msgstr "DDIs del paises del cliente"
 
 msgid "Day"
 msgstr "Dia"
@@ -1563,6 +1585,9 @@ msgstr "Intra vPBX"
 msgid "Internal"
 msgstr "Interna"
 
+msgid "International"
+msgstr "International"
+
 msgid "International Code"
 msgstr "Codi internacional"
 
@@ -1962,6 +1987,9 @@ msgid ""
 msgstr ""
 "El nom serà mostrat com a orígen quan s0enviin correus (exemple: "
 "Notificacions IvozProvider)"
+
+msgid "National"
+msgstr "National"
 
 msgid "National number length"
 msgstr "Longitud números nacionals"
@@ -2727,6 +2755,9 @@ msgstr[1] "Números especiales"
 
 msgid "Special treatments"
 msgstr "Tratamientos especiales"
+
+msgid "Specific"
+msgstr "Específico"
 
 msgid "Specific Template"
 msgstr "Plantilla específica"

--- a/web/admin/application/languages/en_US/en_US.po
+++ b/web/admin/application/languages/en_US/en_US.po
@@ -139,6 +139,9 @@ msgstr[1] "Aliases"
 msgid "All"
 msgstr "All"
 
+msgid "All Countries"
+msgstr "All Countries"
+
 msgid "Allow Call Forwards"
 msgstr "Allow Call Forwards"
 
@@ -548,6 +551,9 @@ msgstr[1] "Clients admins"
 msgid "Client filters"
 msgstr "Client filters"
 
+msgid "Client's Max Calls setting"
+msgstr "Client's Max Calls setting"
+
 msgid "Client's default"
 msgstr "Client's default"
 
@@ -682,6 +688,22 @@ msgid "DDI Provider Registration"
 msgid_plural "DDI Provider Registrations"
 msgstr[0] "DDI Provider Registration"
 msgstr[1] "DDI Provider Registrations"
+
+msgid "DDIs Match mode"
+msgstr "DDIs Match mode"
+
+msgid "DDIs NOT from client's country"
+msgstr "DDIs NOT from client's country"
+
+#, php-format
+msgid "DDIs from %s (%s)"
+msgstr "DDIs from %s (%s)"
+
+msgid "DDIs from any country"
+msgstr "DDIs from any country"
+
+msgid "DDIs from client's country"
+msgstr "DDIs from client's country"
 
 msgid "Day"
 msgstr "Day"
@@ -1546,6 +1568,9 @@ msgstr "Inter vPBX"
 msgid "Internal"
 msgstr "Internal"
 
+msgid "International"
+msgstr "International"
+
 msgid "International Code"
 msgstr "International Code"
 
@@ -1943,6 +1968,9 @@ msgid ""
 "Name shown as source when sending mails (e.g. IvozProvider Notifications)"
 msgstr ""
 "Name shown as source when sending mails (e.g. IvozProvider Notifications)"
+
+msgid "National"
+msgstr "National"
 
 msgid "National number length"
 msgstr "National number length"
@@ -2704,6 +2732,9 @@ msgstr[1] "Special Numbers"
 
 msgid "Special treatments"
 msgstr "Special treatments"
+
+msgid "Specific"
+msgstr "Specific"
 
 msgid "Specific Template"
 msgstr "Specific Template"

--- a/web/admin/application/languages/es_ES/es_ES.po
+++ b/web/admin/application/languages/es_ES/es_ES.po
@@ -143,6 +143,9 @@ msgstr[1] "Aliases"
 msgid "All"
 msgstr "Todos"
 
+msgid "All Countries"
+msgstr "Todos los paises"
+
 msgid "Allow Call Forwards"
 msgstr "Permitir desvíos de llamada"
 
@@ -555,6 +558,9 @@ msgstr[1] "Administradores de clientes"
 msgid "Client filters"
 msgstr "Filtros de cliente"
 
+msgid "Client's Max Calls setting"
+msgstr "Configuración Limite de llamadas de Cliente"
+
 msgid "Client's default"
 msgstr "Usar configuración cliente"
 
@@ -689,6 +695,22 @@ msgid "DDI Provider Registration"
 msgid_plural "DDI Provider Registrations"
 msgstr[0] "Registro Proveedor"
 msgstr[1] "Registros Proveedor"
+
+msgid "DDIs Match mode"
+msgstr "Coincidència DDI"
+
+msgid "DDIs NOT from client's country"
+msgstr "DDIs de paises distintos al cliente"
+
+#, php-format
+msgid "DDIs from %s (%s)"
+msgstr "DDIs de %s (%s)"
+
+msgid "DDIs from any country"
+msgstr "DDIs de cualquier país"
+
+msgid "DDIs from client's country"
+msgstr "DDIs del paises del cliente"
 
 msgid "Day"
 msgstr "Día"
@@ -1568,6 +1590,9 @@ msgstr "Inter vPBX"
 msgid "Internal"
 msgstr "Interna"
 
+msgid "International"
+msgstr "International"
+
 msgid "International Code"
 msgstr "Código de llamada internacional"
 
@@ -1973,6 +1998,9 @@ msgid ""
 msgstr ""
 "Nombre mostrado como origen en los correos enviados (e.g. Notificaciones "
 "IvozProvider). "
+
+msgid "National"
+msgstr "National"
 
 msgid "National number length"
 msgstr "Longitud números nacionales"
@@ -2741,6 +2769,9 @@ msgstr[1] "Números especiales"
 
 msgid "Special treatments"
 msgstr "Tratamientos especiales"
+
+msgid "Specific"
+msgstr "Específico"
 
 msgid "Specific Template"
 msgstr "Plantilla específica"

--- a/web/admin/application/languages/it_IT/it_IT.po
+++ b/web/admin/application/languages/it_IT/it_IT.po
@@ -145,6 +145,9 @@ msgstr[1] "Aliases"
 msgid "All"
 msgstr "Tutti"
 
+msgid "All Countries"
+msgstr "All Countries"
+
 msgid "Allow Call Forwards"
 msgstr "Consenti deviazioni di Chiamata"
 
@@ -558,6 +561,9 @@ msgstr[1] "Amministratori Client"
 msgid "Client filters"
 msgstr "Filtri Cliente"
 
+msgid "Client's Max Calls setting"
+msgstr "Client's Max Calls setting"
+
 msgid "Client's default"
 msgstr "Impostazione predefinita del client"
 
@@ -692,6 +698,22 @@ msgid "DDI Provider Registration"
 msgid_plural "DDI Provider Registrations"
 msgstr[0] "Regsitrazione DDI Provider"
 msgstr[1] "Registrazioni DDI Provider"
+
+msgid "DDIs Match mode"
+msgstr "DDIs Match mode"
+
+msgid "DDIs NOT from client's country"
+msgstr "DDIs NOT from client's country"
+
+#, php-format
+msgid "DDIs from %s (%s)"
+msgstr "DDIs from %s (%s)"
+
+msgid "DDIs from any country"
+msgstr "DDIs from any country"
+
+msgid "DDIs from client's country"
+msgstr "DDIs from client's country"
 
 msgid "Day"
 msgstr "Giorno"
@@ -1568,6 +1590,9 @@ msgstr "Tra vPBX"
 msgid "Internal"
 msgstr "Interno"
 
+msgid "International"
+msgstr "Internazionale"
+
 msgid "International Code"
 msgstr "Codice internazionale"
 
@@ -1973,6 +1998,9 @@ msgid ""
 msgstr ""
 "Nome visualizzato come origine quando si inviano mail (ad esempio notifiche "
 "IvozProvider)"
+
+msgid "National"
+msgstr "Nazionale"
 
 msgid "National number length"
 msgstr "Lunghezza del numero nazionale"
@@ -2741,6 +2769,9 @@ msgstr[1] "Numeri Speciali"
 
 msgid "Special treatments"
 msgstr "Trattamento Speciale"
+
+msgid "Specific"
+msgstr "Specifico"
 
 msgid "Specific Template"
 msgstr "Modello specifico"

--- a/web/admin/application/library/IvozProvider/Klear/Ghost/FixedCostsRelInvoiceSchedulers.php
+++ b/web/admin/application/library/IvozProvider/Klear/Ghost/FixedCostsRelInvoiceSchedulers.php
@@ -1,0 +1,68 @@
+<?php
+
+use Ivoz\Core\Application\Service\DataGateway;
+use Ivoz\Provider\Domain\Model\Company\Company;
+use Ivoz\Provider\Domain\Model\Country\Country;
+use Ivoz\Provider\Domain\Model\FixedCostsRelInvoiceScheduler\FixedCostsRelInvoiceSchedulerDto;
+use Ivoz\Provider\Domain\Model\FixedCostsRelInvoiceScheduler\FixedCostsRelInvoiceSchedulerInterface;
+use Ivoz\Provider\Domain\Model\Invoice\InvoiceDto;
+
+class IvozProvider_Klear_Ghost_FixedCostsRelInvoiceSchedulers extends KlearMatrix_Model_Field_Ghost_Abstract
+{
+    /**
+     * @param FixedCostsRelInvoiceSchedulerDto $fixedCostsRelInvoiceScheduler
+     * @return mixed|string
+     * @throws Exception
+     */
+    public function getQuantity(FixedCostsRelInvoiceSchedulerDto $fixedCostsRelInvoiceScheduler)
+    {
+        if ($fixedCostsRelInvoiceScheduler->getType() == FixedCostsRelInvoiceSchedulerInterface::TYPE_STATIC) {
+            return $fixedCostsRelInvoiceScheduler->getQuantity();
+        }
+
+        if ($fixedCostsRelInvoiceScheduler->getType() == FixedCostsRelInvoiceSchedulerInterface::TYPE_MAXCALLS) {
+            return _("Client's Max Calls setting");
+        }
+
+        if ($fixedCostsRelInvoiceScheduler->getType() == FixedCostsRelInvoiceSchedulerInterface::TYPE_DDIS) {
+            $ddiCountryMatch = $fixedCostsRelInvoiceScheduler->getDdisCountryMatch();
+            // Any Country
+            if ($ddiCountryMatch == FixedCostsRelInvoiceSchedulerInterface::DDISCOUNTRYMATCH_ALL) {
+                return _("DDIs from any country");
+            }
+            // Client Country
+            if ($ddiCountryMatch == FixedCostsRelInvoiceSchedulerInterface::DDISCOUNTRYMATCH_NATIONAL) {
+                return _("DDIs from client's country");
+            }
+            // Not client Country
+            if ($ddiCountryMatch == FixedCostsRelInvoiceSchedulerInterface::DDISCOUNTRYMATCH_INTERNATIONAL) {
+                return _("DDIs NOT from client's country");
+            }
+
+            if ($ddiCountryMatch == FixedCostsRelInvoiceSchedulerInterface::DDISCOUNTRYMATCH_SPECIFIC) {
+                // Specific Country DDI Matching
+                /** @var DataGateway $dataGateway */
+                $dataGateway = \Zend_Registry::get('data_gateway');
+
+                /** @var \Ivoz\Provider\Domain\Model\Country\Name $countryName */
+                $countryName = $dataGateway->remoteProcedureCall(
+                    Country::class,
+                    $fixedCostsRelInvoiceScheduler->getDdisCountryId(),
+                    'getName',
+                    []
+                );
+
+                $countryCode = $dataGateway->remoteProcedureCall(
+                    Country::class,
+                    $fixedCostsRelInvoiceScheduler->getDdisCountryId(),
+                    'getCountryCode',
+                    []
+                );
+
+                return sprintf(_("DDIs from %s (%s)"), $countryName->getEn(), $countryCode);
+            }
+        }
+
+        return "";
+    }
+}

--- a/web/rest/brand/features/provider/fixedCostsRelInvoiceScheduler/getFixedCostsRelInvoiceScheduler.feature
+++ b/web/rest/brand/features/provider/fixedCostsRelInvoiceScheduler/getFixedCostsRelInvoiceScheduler.feature
@@ -17,6 +17,7 @@ Feature: Retrieve fixed costs rel invoice schedulers
           {
               "quantity": 1,
               "type": "static",
+              "ddisCountryMatch": null,
               "id": 1,
               "fixedCost": {
                   "name": "Monitoring",
@@ -38,7 +39,8 @@ Feature: Retrieve fixed costs rel invoice schedulers
                   "brand": 1,
                   "company": 1,
                   "numberSequence": null
-              }
+              },
+              "ddisCountry": null
           }
       ]
     """
@@ -55,6 +57,7 @@ Feature: Retrieve fixed costs rel invoice schedulers
       {
           "quantity": 1,
           "type": "static",
+          "ddisCountryMatch": null,
           "id": 1,
           "fixedCost": {
               "name": "Monitoring",
@@ -76,6 +79,7 @@ Feature: Retrieve fixed costs rel invoice schedulers
               "brand": 1,
               "company": 1,
               "numberSequence": null
-          }
+          },
+          "ddisCountry": null
       }
     """

--- a/web/rest/brand/features/provider/fixedCostsRelInvoiceScheduler/postFixedCostsRelInvoiceScheduler.feature
+++ b/web/rest/brand/features/provider/fixedCostsRelInvoiceScheduler/postFixedCostsRelInvoiceScheduler.feature
@@ -24,9 +24,11 @@ Feature: Create fixed costs rel invoice schedulers
       {
           "quantity": 1,
           "type": "static",
+          "ddisCountryMatch": null,
           "id": 2,
           "fixedCost": 2,
-          "invoiceScheduler": 1
+          "invoiceScheduler": 1,
+          "ddisCountry": null
       }
     """
 


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
Add DDI criteria in dynamic fixed costs added in https://github.com/irontec/ivozprovider/pull/1847

You may choose the country you want and only DDIs of that country will be taken into account.

This is an upport from 1849

