### PR TITLE
Fix residential devices on new client portal

### DIFF
--- a/library/Ivoz/Provider/Application/Service/ResidentialDevice/ResidentialDeviceDtoAssembler.php
+++ b/library/Ivoz/Provider/Application/Service/ResidentialDevice/ResidentialDeviceDtoAssembler.php
@@ -30,7 +30,12 @@ class ResidentialDeviceDtoAssembler implements CustomDtoAssemblerInterface
 
         $dto = $residentialDevice->toDto($depth);
 
-        if (ResidentialDeviceDto::CONTEXT_STATUS !== $context) {
+        $statusContexts = [
+            ResidentialDeviceDto::CONTEXT_STATUS,
+            ResidentialDeviceDto::CONTEXT_COLLECTION,
+        ];
+
+        if (!in_array($context, $statusContexts)) {
             return $dto;
         }
 

--- a/library/Ivoz/Provider/Domain/Model/ResidentialDevice/ResidentialDeviceDto.php
+++ b/library/Ivoz/Provider/Domain/Model/ResidentialDevice/ResidentialDeviceDto.php
@@ -7,6 +7,9 @@ use Ivoz\Kam\Domain\Model\UsersLocation\RegistrationStatus;
 
 class ResidentialDeviceDto extends ResidentialDeviceDtoAbstract
 {
+    /**
+     * @deprecated as status it's already being served in collection responses
+     */
     public const CONTEXT_STATUS = 'status';
 
     /**
@@ -65,6 +68,7 @@ class ResidentialDeviceDto extends ResidentialDeviceDtoAbstract
                 'id' => 'id',
                 'name' => 'name',
                 'domainName' => 'domainName',
+                'directConnectivity' => 'directConnectivity',
                 'status' => [[
                     'contact',
                     'received',
@@ -85,7 +89,16 @@ class ResidentialDeviceDto extends ResidentialDeviceDtoAbstract
             $response = [
                 'id' => 'id',
                 'name' => 'name',
-                'transport' => 'transport'
+                'description' => 'description',
+                'domainName' => 'domainName',
+                'directConnectivity' => 'directConnectivity',
+                'status' => [[
+                    'contact',
+                    'received',
+                    'publicReceived',
+                    'expires',
+                    'userAgent'
+                ]]
             ];
         } else {
             $response = parent::getPropertyMap(...func_get_args());
@@ -163,16 +176,26 @@ class ResidentialDeviceDto extends ResidentialDeviceDtoAbstract
     private static function filterFieldsForCompanyAdmin(array $response): array
     {
         $allowedFields = [
+            'id',
             'name',
             'description',
-            'id',
-            'transformationRuleSetId',
-            'outgoingDdiId',
-            'languageId',
+            'password',
+            'directConnectivity',
             'transport',
             'ip',
             'port',
-            'password',
+            'multiContact',
+            'languageId',
+            'transformationRuleSetId',
+            'outgoingDdiId',
+            'allow',
+            'fromDomain',
+            'ddiIn',
+            't38Passthrough',
+            'maxCalls',
+            'rtpEncryption',
+            'domainName',
+            'status',
         ];
 
         return array_filter(

--- a/library/psalm.xml
+++ b/library/psalm.xml
@@ -23,6 +23,7 @@
         <MixedInferredReturnType errorLevel="suppress" />
         <MixedArrayAccess errorLevel="suppress" />
         <MixedAssignment errorLevel="suppress" />
+        <DeprecatedConstant errorLevel="info" />
     </issueHandlers>
     <projectFiles>
         <directory name="Ivoz" />

--- a/web/client/src/entities/ResidentialDevice/Form.tsx
+++ b/web/client/src/entities/ResidentialDevice/Form.tsx
@@ -1,0 +1,61 @@
+import useFkChoices from '@irontec/ivoz-ui/entities/data/useFkChoices';
+import defaultEntityBehavior, {
+  EntityFormProps,
+  FieldsetGroups,
+} from '@irontec/ivoz-ui/entities/DefaultEntityBehavior';
+import _ from '@irontec/ivoz-ui/services/translations/translate';
+import { foreignKeyGetter } from './foreignKeyGetter';
+
+const Form = (props: EntityFormProps): JSX.Element => {
+  const { entityService, row, match } = props;
+  const DefaultEntityForm = defaultEntityBehavior.Form;
+  const fkChoices = useFkChoices({
+    foreignKeyGetter,
+    entityService,
+    row,
+    match,
+  });
+
+  const groups: Array<FieldsetGroups> = [
+    {
+      legend: _('Basic Configuration'),
+      fields: [
+        'name',
+        'description',
+        'password',
+        'directConnectivity',
+        'transport',
+        'ip',
+        'port',
+        'multiContact',
+      ],
+    },
+    {
+      legend: _('Geographic Configuration'),
+      fields: ['language', 'transformationRuleSet'],
+    },
+    {
+      legend: _('Outgoing Configuration'),
+      fields: ['outgoingDdi'],
+    },
+    {
+      legend: _('Advanced Configuration'),
+      fields: [
+        'allow',
+        'fromDomain',
+        'ddiIn',
+        't38Passthrough',
+        'maxCalls',
+        'rtpEncryption',
+      ],
+    },
+    {
+      legend: '',
+      fields: ['status'],
+    },
+  ];
+
+  return <DefaultEntityForm {...props} fkChoices={fkChoices} groups={groups} />;
+};
+
+export default Form;

--- a/web/client/src/entities/ResidentialDevice/ResidentialDevice.tsx
+++ b/web/client/src/entities/ResidentialDevice/ResidentialDevice.tsx
@@ -1,20 +1,21 @@
-import SettingsApplications from '@mui/icons-material/SettingsApplications';
+import defaultEntityBehavior from '@irontec/ivoz-ui/entities/DefaultEntityBehavior';
 import EntityInterface from '@irontec/ivoz-ui/entities/EntityInterface';
 import _ from '@irontec/ivoz-ui/services/translations/translate';
-import defaultEntityBehavior from '@irontec/ivoz-ui/entities/DefaultEntityBehavior';
-import { PartialPropertyList } from '@irontec/ivoz-ui/services/api/ParsedApiSpecInterface';
+import SettingsApplications from '@mui/icons-material/SettingsApplications';
+import Status from '../RetailAccount/Field/Status';
+import StatusIcon from '../RetailAccount/Field/StatusIcon';
+import { ResidentialDeviceProperties } from './ResidentialDeviceProperties';
 import selectOptions from './SelectOptions';
+import Form from './Form';
+import { foreignKeyGetter } from './foreignKeyGetter';
+import Password from '../Terminal/Field/Password';
 
-const properties: PartialPropertyList = {
-  company: {
-    label: _('Client'),
-  },
+const properties: ResidentialDeviceProperties = {
   name: {
     label: _('Name'),
     pattern: new RegExp('^[a-zA-Z0-9_*]+$'),
-    helpText: _("Allowed characters: a-z, A-Z, 0-9, underscore and '*'"),
   },
-  domain: {
+  domainName: {
     label: _('Domain'),
   },
   description: {
@@ -46,7 +47,7 @@ const properties: PartialPropertyList = {
     helpText: _(
       "Minimal length 10, including 3 uppercase letters, 3 lowercase letters, 3 digits and one character in '+*_-'"
     ),
-    // @TODO generatePassword_command: true
+    component: Password,
   },
   outgoingDdi: {
     label: _('Fallback Outgoing DDI'),
@@ -196,11 +197,11 @@ const properties: PartialPropertyList = {
   },
   statusIcon: {
     label: _('Status'),
-    // @TODO IvozProvider_Klear_Ghost_RegisterStatus::getResidentialDeviceStatusIcon
+    component: StatusIcon,
   },
   status: {
     label: _('Status'),
-    // @TODO IvozProvider_Klear_Ghost_RegisterStatus::getResidentialDeviceStatus
+    component: Status,
   },
   transformationRuleSet: {
     label: _('Numeric transformation'),
@@ -209,8 +210,8 @@ const properties: PartialPropertyList = {
   maxCalls: {
     label: _('Call waiting'),
     default: 1,
-    // @TODO min: 0
-    // @TODO  max: 100
+    minimum: 0,
+    maximum: 100,
     helpText: _(
       'Limits received calls when already handling this number of calls. Set 0 for unlimited.'
     ),
@@ -254,6 +255,7 @@ const residentialDevice: EntityInterface = {
   title: _('Residential device', { count: 2 }),
   path: '/residential_devices',
   properties,
+  columns: ['name', 'domainName', 'description', 'statusIcon'],
   acl: {
     ...defaultEntityBehavior.acl,
     iden: 'ResidentialDevices',
@@ -262,6 +264,8 @@ const residentialDevice: EntityInterface = {
   selectOptions: (props, customProps) => {
     return selectOptions(props, customProps);
   },
+  Form,
+  foreignKeyGetter,
 };
 
 export default residentialDevice;

--- a/web/client/src/entities/ResidentialDevice/ResidentialDeviceProperties.tsx
+++ b/web/client/src/entities/ResidentialDevice/ResidentialDeviceProperties.tsx
@@ -4,7 +4,41 @@ import {
   EntityValues,
 } from '@irontec/ivoz-ui/services/entity/EntityService';
 
-export type ResidentialDevicePropertyList<T> = Record<string, T>;
+export type ResidentialDevicePropertyList<T> = {
+  name: T;
+  domainName: T;
+  description: T;
+  transport: T;
+  ip: T;
+  port: T;
+  password: T;
+  outgoingDdi: T;
+  disallow: T;
+  allow: T;
+  directMediaMethod: T;
+  ddiIn: T;
+  language: T;
+  transformationRuleSet: T;
+  calleridUpdateHeader: T;
+  updateCallerid: T;
+  fromDomain: T;
+  maxCalls: T;
+  t38Passthrough: T;
+  rtpEncryption: T;
+  multiContact: T;
+  status: T;
+  statusIcon: T;
+  directConnectivity: T;
+};
+
+export type ResidentialDeviceStatus = {
+  contact: string;
+  publicContact: boolean;
+  expires: string;
+  publicReceived: boolean;
+  received: string;
+  userAgent: string;
+};
 
 export type ResidentialDeviceProperties = ResidentialDevicePropertyList<
   Partial<PropertySpec>

--- a/web/client/src/entities/ResidentialDevice/foreignKeyGetter.tsx
+++ b/web/client/src/entities/ResidentialDevice/foreignKeyGetter.tsx
@@ -1,0 +1,24 @@
+import { ResidentialDevicePropertyList } from './ResidentialDeviceProperties';
+import { ForeignKeyGetterType } from '@irontec/ivoz-ui/entities/EntityInterface';
+import { autoSelectOptions } from '@irontec/ivoz-ui/entities/DefaultEntityBehavior';
+import entities from '../index';
+
+export const foreignKeyGetter: ForeignKeyGetterType = async ({
+  cancelToken,
+  entityService,
+}): Promise<any> => {
+  const response: Partial<
+    ResidentialDevicePropertyList<Array<string | number>>
+  > = {};
+
+  const promises = autoSelectOptions({
+    entities,
+    entityService,
+    cancelToken,
+    response,
+  });
+
+  await Promise.all(promises);
+
+  return response;
+};

--- a/web/rest/brand/features/provider/residentialDevice/getResidentialDevice.feature
+++ b/web/rest/brand/features/provider/residentialDevice/getResidentialDevice.feature
@@ -16,7 +16,8 @@ Feature: Retrieve residential devices
       [
           {
               "name": "residentialDevice",
-              "transport": "udp",
+              "description": "",
+              "directConnectivity": "no",
               "id": 1
           }
       ]

--- a/web/rest/brand/features/provider/residentialDevice/getResidentialDeviceStatus.feature
+++ b/web/rest/brand/features/provider/residentialDevice/getResidentialDeviceStatus.feature
@@ -16,6 +16,7 @@ Feature: Retrieve residential devices status
       [
           {
               "name": "residentialDevice",
+              "directConnectivity": "no",
               "id": 1,
               "company": 4,
               "domainName": "retail.irontec.com",

--- a/web/rest/client/features/provider/residentialDevices/getResidentialDevice.feature
+++ b/web/rest/client/features/provider/residentialDevices/getResidentialDevice.feature
@@ -16,8 +16,26 @@ Feature: Retrieve residential devices
       [
           {
               "name": "residentialDevice",
-              "transport": "udp",
-              "id": 1
+              "description": "",
+              "directConnectivity": "no",
+              "id": 1,
+              "domainName": "retail.irontec.com",
+              "status": [
+                  {
+                      "contact": "sip:yealinktest@10.10.1.108:5060",
+                      "received": "sip:212.64.172.25:5060",
+                      "publicReceived": true,
+                      "expires": "2031-01-01 00:59:59",
+                      "userAgent": "Yealink SIP-T23G 44.80.0.130"
+                  },
+                  {
+                      "contact": "sip:yealinktest@10.10.1.110:5060",
+                      "received": "",
+                      "publicReceived": false,
+                      "expires": "2031-01-01 00:59:59",
+                      "userAgent": "Yealink SIP-T23G 44.80.0.130"
+                  }
+              ]
           }
       ]
     """
@@ -29,13 +47,23 @@ Feature: Retrieve residential devices
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/json; charset=utf-8"
-    And the JSON should be like:
+    And the JSON should be equal to:
     """
       {
           "name": "residentialDevice",
           "description": "",
           "transport": "udp",
+          "ip": "1.2.3.4",
+          "port": 1024,
           "password": "+rA778LidL",
+          "allow": "alaw",
+          "fromDomain": null,
+          "directConnectivity": "no",
+          "ddiIn": "yes",
+          "maxCalls": 1,
+          "t38Passthrough": "no",
+          "rtpEncryption": false,
+          "multiContact": true,
           "id": 1,
           "transformationRuleSet": null,
           "outgoingDdi": null,

--- a/web/rest/client/features/provider/residentialDevices/getResidentialDeviceStatus.feature
+++ b/web/rest/client/features/provider/residentialDevices/getResidentialDeviceStatus.feature
@@ -16,6 +16,7 @@ Feature: Retrieve residential devices status
       [
           {
               "name": "residentialDevice",
+              "directConnectivity": "no",
               "id": 1,
               "domainName": "retail.irontec.com",
               "status": [
@@ -49,6 +50,7 @@ Feature: Retrieve residential devices status
     """
       {
           "name": "residentialDevice",
+          "directConnectivity": "no",
           "id": 1,
           "domainName": "retail.irontec.com",
           "status": [

--- a/web/rest/client/features/provider/residentialDevices/putResidentialDevice.feature
+++ b/web/rest/client/features/provider/residentialDevices/putResidentialDevice.feature
@@ -14,8 +14,7 @@ Feature: Update residential devices
           "name": "readOnlyResidentialDevice",
           "description": "",
           "transport": "udp",
-          "ip": null,
-          "port": null,
+          "ip": "127.10.10.10",
           "password": "ZGthe7E2+4",
           "disallow": "all",
           "allow": "alaw",
@@ -31,14 +30,25 @@ Feature: Update residential devices
     Then the response status code should be 200
      And the response should be in JSON
      And the header "Content-Type" should be equal to "application/json; charset=utf-8"
-     And the JSON should be like:
+     And the JSON should be equal to:
     """
       {
           "name": "residentialDevice",
           "description": "",
           "transport": "udp",
+          "ip": "127.10.10.10",
+          "port": 1024,
           "password": "ZGthe7E2+4",
+          "allow": "alaw",
+          "fromDomain": null,
+          "directConnectivity": "yes",
+          "ddiIn": "yes",
+          "maxCalls": 1,
+          "t38Passthrough": "no",
+          "rtpEncryption": false,
+          "multiContact": true,
           "id": 1,
+          "transformationRuleSet": null,
           "outgoingDdi": 2,
           "language": 1
       }

--- a/web/rest/client/features/provider/voicemail/postVoicemail.feature
+++ b/web/rest/client/features/provider/voicemail/postVoicemail.feature
@@ -56,12 +56,8 @@ Feature: Create voicemails
           "residentialDevice": {
               "name": "residentialDevice",
               "description": "",
-              "transport": "udp",
-              "password": "+rA778LidL",
-              "id": 1,
-              "transformationRuleSet": null,
-              "outgoingDdi": null,
-              "language": null
+              "directConnectivity": "no",
+              "id": 1
           },
           "company": {
               "type": "vpbx",


### PR DESCRIPTION
Removed API endpoints that are not supposed to be acccesed by client admin and fixed residential device list screen


#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
