### PR TITLE
Residential devices must be editable by residential admins

### DIFF
--- a/web/admin/application/configs/klear/ResidentialDevicesList.yaml
+++ b/web/admin/application/configs/klear/ResidentialDevicesList.yaml
@@ -58,7 +58,7 @@ production:
         options:
           title: _("Options")
           screens:
-            residentialDevicesEdit_screen: $[${auth.acls.ResidentialDevices.update} && ${auth.canSeeBrand} && ${auth.companyResidential}]
+            residentialDevicesEdit_screen: $[${auth.acls.ResidentialDevices.update} && ${auth.companyResidential}]
             callForwardSettingsList_screen: $[${auth.acls.CallForwardSettings.read} && ${auth.acls.CallForwardSettings.read} && ${auth.companyResidential}]
           dialogs:
             residentialDevicesDel_dialog: $[${auth.canSeeBrand} && ${auth.companyResidential}]
@@ -169,6 +169,8 @@ production:
         name: jquery.passwordgenedit.js
       plugin: passwordgen
       fields:
+        readOnly:
+          name: ${auth.isCompanyOperator}
         order:
           <<: *residentialDevices_orderLink
         blacklist:

--- a/web/rest/client/config/api/raw/provider.yml
+++ b/web/rest/client/config/api/raw/provider.yml
@@ -1483,6 +1483,11 @@ Ivoz\Provider\Domain\Model\Recording\Recording:
 Ivoz\Provider\Domain\Model\Recording\RecordedFile: ~
 
 Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDevice:
+  properties:
+    name:
+      attributes:
+        swagger_context:
+          readOnly: true
   attributes:
     access_control: >-
         "ROLE_COMPANY_ADMIN" in roles

--- a/web/rest/client/features/provider/residentialDevices/putResidentialDevice.feature
+++ b/web/rest/client/features/provider/residentialDevices/putResidentialDevice.feature
@@ -11,7 +11,7 @@ Feature: Update residential devices
       And I send a "PUT" request to "/residential_devices/1" with body:
     """
       {
-          "name": "updatedResidentialDevice",
+          "name": "readOnlyResidentialDevice",
           "description": "",
           "transport": "udp",
           "ip": null,
@@ -34,7 +34,7 @@ Feature: Update residential devices
      And the JSON should be like:
     """
       {
-          "name": "updatedResidentialDevice",
+          "name": "residentialDevice",
           "description": "",
           "transport": "udp",
           "password": "ZGthe7E2+4",


### PR DESCRIPTION
Residential devices must be editable by residential admins (everything but name)

This PR is an upport for #1745 

<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
