### PR TITLE
Remove Locution field from Residential Device voicemails

### DIFF
--- a/web/admin/application/configs/klear/VoicemailsList.yaml
+++ b/web/admin/application/configs/klear/VoicemailsList.yaml
@@ -118,6 +118,7 @@ production:
         blacklist:
           user: true
           residentialDevice: true
+          locution: ${auth.companyResidential}
         readOnly:
           name: true
           email: ${auth.companyVPBX}

--- a/web/portal/client/src/entities/Voicemail/Form.tsx
+++ b/web/portal/client/src/entities/Voicemail/Form.tsx
@@ -5,6 +5,7 @@ import defaultEntityBehavior, {
 } from '@irontec/ivoz-ui/entities/DefaultEntityBehavior';
 import _ from '@irontec/ivoz-ui/services/translations/translate';
 import { foreignKeyGetter } from '../Queue/foreignKeyGetter';
+import { useStoreState } from '../../store';
 
 const Form = (props: EntityFormProps): JSX.Element => {
   const { entityService, row, match } = props;
@@ -17,6 +18,8 @@ const Form = (props: EntityFormProps): JSX.Element => {
     row,
     match,
   });
+
+  const aboutMe = useStoreState((state) => state.clientSession.aboutMe.profile);
 
   const readOnlyProperties = {
     name: userVoicemail,
@@ -34,7 +37,7 @@ const Form = (props: EntityFormProps): JSX.Element => {
     },
     {
       legend: _('Customization'),
-      fields: ['locution'],
+      fields: [!aboutMe?.residential && 'locution'],
     },
   ];
 

--- a/web/portal/client/src/entities/Voicemail/Voicemail.tsx
+++ b/web/portal/client/src/entities/Voicemail/Voicemail.tsx
@@ -72,7 +72,7 @@ export const ChildDecorator: ChildDecoratorType = (props) => {
     routeMapItem.entity.iden === Voicemail.iden
   ) {
     const isDeletePath = routeMapItem.route === `${Voicemail.path}/:id`;
-    const allowDelete = row.user === null;
+    const allowDelete = row.user === null && row.residential === null;
     if (isDeletePath && !allowDelete) {
       return null;
     }


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
This field doesn't make sense for Residential clients, because there is no way to upload Locutions for this client type.

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
