### PR TITLE
web/admin: fix DDI PRovider Registation status check

### DIFF
--- a/web/admin/application/library/IvozProvider/Klear/Ghost/RegisterStatus.php
+++ b/web/admin/application/library/IvozProvider/Klear/Ghost/RegisterStatus.php
@@ -56,9 +56,13 @@ class IvozProvider_Klear_Ghost_RegisterStatus extends KlearMatrix_Model_Field_Gh
             \Ivoz\Kam\Domain\Service\TrunksClientInterface::class
         );
 
-        $regInfo = $trunksClient->getUacRegistrationInfo(
-            $kamTrunksUacreg->getLUuid()
-        );
+        try {
+            $regInfo = $trunksClient->getUacRegistrationInfo(
+                $kamTrunksUacreg->getLUuid()
+            );
+        } catch (\Exception $e) {
+            $regInfo = null;
+        };
 
         $status = $regInfo['flags'] ?? '';
 


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
When a DDI Provider registration witn non random username is created, the status field ghost queries proxytrunks to check registration status. This raises an exception if no information is found that renders the screen unusable.

This PR aims to fix that problem.

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
