### PR TITLE
kamusers: no savp when talking to as

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -1250,6 +1250,9 @@ route[DISPATCH_TO_AS] {
 
     # Save CallID <-> AS relationship
     $sht(dialogs=>$ci::applicationserver) = $du;
+
+    # Disable srtp when talking to AS
+    $dlg_var(srtp) = $null;
 }
 
 route[LOOKUP] {


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

Call-forward from retail accounts are sent through Asterisk. If the retail account has media encryption enabled, INVITE to AS was sent with RTP/SAVP transport, causing 488 failure.

This PR fixes this situation.
