### PR TITLE
Kamusers: minimize presence database usage

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -1137,15 +1137,36 @@ route[REQINIT] {
     }
 }
 
+route[CHECK_WATCHERS] {
+    $var(hasWatchers) = 0;
+
+    # Check R-URI against monitorizable vPBX user extensions
+    $xavp(watcher) = $null;
+    sql_xquery("cb", "SELECT id FROM kam_users_active_watchers WHERE presentity_uri = '$avp(pres_uri)'", "watcher");
+    if ($xavp(watcher=>id) != $null) {
+        $var(hasWatchers) = 1;
+    }
+
+    return;
+}
+
 route[GENERATE_PUBLISH] {
     if ($avp(endpointType) != 'Terminals') return; # Skip logic for non terminal calls
 
     if ($var(is_from_inside)) {
-        # Set X-Info-Callee as 'callee' instead of user in To header
-        $avp(pubruri_callee)= "sip:" + $hdr(X-Info-Callee) + "@" + $fd;
+        $avp(pres_uri) = "sip:" + $hdr(X-Info-Callee) + "@" + $fd;
+        route(CHECK_WATCHERS);
+        if ($var(hasWatchers)) {
+            # Set X-Info-Callee as 'callee' instead of user in To header
+            $avp(pubruri_callee) = $avp(pres_uri);
+        }
     } else {
-        # Set user extension as 'caller' instead of user in From header
-        $avp(pubruri_caller)= "sip:" + $avp(extension) + "@" + $fd;
+        $avp(pres_uri)= "sip:" + $avp(extension) + "@" + $fd;
+        route(CHECK_WATCHERS);
+        if ($var(hasWatchers)) {
+            # Set user extension as 'caller' instead of user in From header
+            $avp(pubruri_caller)= $avp(pres_uri);
+        }
 
         $dlg_var(caller) = $avp(extension); # Set accounting dlg_var too
     }

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -406,7 +406,7 @@ modparam("presence", "max_expires", 3600)
 modparam("presence", "db_update_period", 100)
 modparam("presence", "subs_db_mode", 2)
 modparam("presence", "db_table_lock_type", 0)
-modparam("presence", "clean_period", 15)
+modparam("presence", "clean_period", 100)
 
 # PRESENCE XML
 modparam("presence_xml", "db_url", DBURL)

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -2952,6 +2952,19 @@ route[LOCAL_PUBLISH] {
     exit;
 }
 
+route[CHECK_SUBSCRIBE] {
+    $var(subsOk) = 0;
+
+    # Check R-URI against monitorizable vPBX user extensions
+    $xavp(user) = $null;
+    sql_xquery("cb", "SELECT U.id FROM Users U JOIN Extensions E ON U.extensionId=E.id JOIN Companies C ON U.companyId=C.id JOIN Domains D ON D.id=C.domainId WHERE E.number='$tU' AND D.domain='$td'", "user");
+    if ($xavp(user=>id) != $null) {
+        $var(subsOk) = 1;
+    }
+
+    return;
+}
+
 route[PRESENCE] {
     if(!is_method("PUBLISH|SUBSCRIBE|NOTIFY")) return;
 
@@ -2969,8 +2982,14 @@ route[PRESENCE] {
         handle_publish();
         t_release();
     } else if(is_method("SUBSCRIBE")) {
-        handle_subscribe();
-        t_release();
+        route(CHECK_SUBSCRIBE);
+        if ($var(subsOk)) {
+            handle_subscribe();
+            t_release();
+        } else {
+            send_reply("404", "Not Found");
+            exit;
+        }
     } else if(is_method("NOTIFY")) {
         # Handle unsolicited NOTIFY messages (non-related to previous SUBSCRIBE)
         if (!$var(is_from_inside)) {


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
- Increase presence _clean_period_ from 15 to 100 seconds.
- Do not generate PUBLISH if no active watcher.
- Do not admit SUBSCRIBE to non-existent users.

#### Additional information

About _clean_period_ change:

    clean_period was set to 15 instead of default 100 value in f6addae35 (PR #1570)
    to have BLF light off asap in case of rejected call establishments.
    
    To avoid extensive database usage, this value goes back to its default value of 100.
    With this change, BLF light will be off a bit later (not 3 hours as the Kamailio
    patch persists, but neither 30 seconds... new intermediate reasonable value: 2-3 minutes)
    
    It is a valid value because this reject call establishment are quite rare and database
    access is expensive.

About not generating PUBLISH if no active watcher found:

    Drawback: the first watcher of a given extension will need 100 seconds to get notified
    about changes in that extension (presence db_update_period value), as no PUBLISH
    will be generated until an entry in kam_users_active_watchers exists for that extension.