### PR TITLE
schema: change kam_users_location_attrs id to bigint

### DIFF
--- a/library/Ivoz/Kam/Infrastructure/Persistence/Doctrine/Mapping/UsersLocationAttr.UsersLocationAttr.orm.xml
+++ b/library/Ivoz/Kam/Infrastructure/Persistence/Doctrine/Mapping/UsersLocationAttr.UsersLocationAttr.orm.xml
@@ -6,7 +6,7 @@
     table="kam_users_location_attrs"
     change-tracking-policy="DEFERRED_EXPLICIT"
   >
-    <id name="id" type="integer" column="id">
+    <id name="id" type="bigint" column="id">
       <generator strategy="IDENTITY"/>
       <options>
         <option name="unsigned">1</option>

--- a/schema/DoctrineMigrations/Version20220929101012.php
+++ b/schema/DoctrineMigrations/Version20220929101012.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20220929101012 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Change kam_users_location_attrs id to bigint';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE kam_users_location_attrs CHANGE id id BIGINT UNSIGNED AUTO_INCREMENT NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE kam_users_location_attrs CHANGE id id INT UNSIGNED AUTO_INCREMENT NOT NULL');
+    }
+}


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
<!-- Describe your changes in detail -->
Change kam_users_location_attrs id to bigint to avoid easily reaching max value.
This table has lots of inserts and deletes so auto increment id raises quite fast.


#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
