### PR TITLE
kamusers: decode R-URI before matching tags

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -681,6 +681,8 @@ route[ADAPT_RURI_IN] {
 
 # Iterates through $drb, sets $var(prefix) and $var(prefixId) if R-URI matches prefix and strips it
 route[SEARCH_AND_STRIP_PREFIX] {
+    $rU = $(rU{s.urldecode.param}); # Just in case it is sent decoded (123%23 instead of 123#)
+
     $var(prefix) = "";
     if ($dbr(rb=>rows) > 0) {
         $var(i) = 0;


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
Some UACs send encoded R-URI usernames (e.g. %23 instead of #), making routing tag matching fail.

#### Additional information
This PR decodes R-URI username before search for occurrences.