### PR TITLE
core: convert routing tag company type validation into a service

### DIFF
--- a/library/Ivoz/Provider/Domain/Model/CompanyRelRoutingTag/CompanyRelRoutingTag.php
+++ b/library/Ivoz/Provider/Domain/Model/CompanyRelRoutingTag/CompanyRelRoutingTag.php
@@ -13,31 +13,6 @@ class CompanyRelRoutingTag extends CompanyRelRoutingTagAbstract implements Compa
     use CompanyRelRoutingTagTrait;
 
     /**
-     * @param CompanyInterface|null $company
-     * @return static
-     */
-    public function setCompany(CompanyInterface $company = null): static
-    {
-        $companyType = $company->getType();
-        $validCompanyTypes = [
-            CompanyInterface::TYPE_RETAIL,
-            CompanyInterface::TYPE_WHOLESALE,
-        ];
-
-        if (!in_array($companyType, $validCompanyTypes)) {
-            $erroMsg = sprintf(
-                'Company type must be either %s or %s',
-                CompanyInterface::TYPE_RETAIL,
-                CompanyInterface::TYPE_WHOLESALE
-            );
-
-            throw new \DomainException($erroMsg);
-        }
-
-        return parent::setCompany($company);
-    }
-
-    /**
      * @codeCoverageIgnore
      * @return array<string, mixed>
      */

--- a/library/Ivoz/Provider/Domain/Model/CompanyRelRoutingTag/CompanyRelRoutingTagInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/CompanyRelRoutingTag/CompanyRelRoutingTagInterface.php
@@ -3,10 +3,10 @@
 namespace Ivoz\Provider\Domain\Model\CompanyRelRoutingTag;
 
 use Ivoz\Core\Domain\Model\LoggableEntityInterface;
-use Ivoz\Provider\Domain\Model\Company\CompanyInterface;
 use Ivoz\Core\Domain\Model\EntityInterface;
 use Ivoz\Core\Application\DataTransferObjectInterface;
 use Ivoz\Core\Application\ForeignKeyTransformerInterface;
+use Ivoz\Provider\Domain\Model\Company\CompanyInterface;
 use Ivoz\Provider\Domain\Model\RoutingTag\RoutingTagInterface;
 
 /**
@@ -14,12 +14,6 @@ use Ivoz\Provider\Domain\Model\RoutingTag\RoutingTagInterface;
 */
 interface CompanyRelRoutingTagInterface extends LoggableEntityInterface
 {
-    /**
-     * @param CompanyInterface|null $company
-     * @return static
-     */
-    public function setCompany(?CompanyInterface $company = null): static;
-
     /**
      * @codeCoverageIgnore
      * @return array<string, mixed>
@@ -52,6 +46,8 @@ interface CompanyRelRoutingTagInterface extends LoggableEntityInterface
      * @internal use EntityTools instead
      */
     public function toDto(int $depth = 0): CompanyRelRoutingTagDto;
+
+    public function setCompany(?CompanyInterface $company = null): static;
 
     public function getCompany(): ?CompanyInterface;
 

--- a/library/Ivoz/Provider/Domain/Service/CompanyRelRoutingTag/CheckCompanyType.php
+++ b/library/Ivoz/Provider/Domain/Service/CompanyRelRoutingTag/CheckCompanyType.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Ivoz\Provider\Domain\Service\CompanyRelRoutingTag;
+
+use Ivoz\Provider\Domain\Model\Company\CompanyInterface;
+use Ivoz\Provider\Domain\Model\CompanyRelRoutingTag\CompanyRelRoutingTagInterface;
+
+class CheckCompanyType implements CompanyRelRoutingTagLifecycleEventHandlerInterface
+{
+    public const PRE_PERSIST_PRIORITY = self::PRIORITY_NORMAL;
+
+    /**
+     * @return array<string,integer>
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            self::EVENT_PRE_PERSIST => self::PRE_PERSIST_PRIORITY,
+        ];
+    }
+
+    public function execute(CompanyRelRoutingTagInterface $entity): void
+    {
+        $company = $entity->getCompany();
+        if (!$company) {
+            throw new \DomainException('CompanyRelRoutingTag without assigned company');
+        }
+
+        $companyType = $company->getType();
+        $validCompanyTypes = [
+            CompanyInterface::TYPE_RETAIL,
+            CompanyInterface::TYPE_WHOLESALE,
+        ];
+
+        if (!in_array($companyType, $validCompanyTypes)) {
+            $erroMsg = sprintf(
+                'Company type must be either %s or %s',
+                CompanyInterface::TYPE_RETAIL,
+                CompanyInterface::TYPE_WHOLESALE
+            );
+
+            throw new \DomainException($erroMsg);
+        }
+    }
+}

--- a/library/Ivoz/Provider/Domain/Service/CompanyRelRoutingTag/CompanyRelRoutingTagLifecycleServiceCollection.php
+++ b/library/Ivoz/Provider/Domain/Service/CompanyRelRoutingTag/CompanyRelRoutingTagLifecycleServiceCollection.php
@@ -20,6 +20,7 @@ class CompanyRelRoutingTagLifecycleServiceCollection implements LifecycleService
         "pre_persist" =>
         [
             \Ivoz\Provider\Domain\Service\CompanyRelRoutingTag\AvoidUpdates::class => 100,
+            \Ivoz\Provider\Domain\Service\CompanyRelRoutingTag\CheckCompanyType::class => 200,
         ],
     ];
 

--- a/library/phpstan-baseline.neon
+++ b/library/phpstan-baseline.neon
@@ -4171,11 +4171,6 @@ parameters:
 			path: Ivoz/Provider/Domain/Model/CompanyRelGeoIPCountry/CompanyRelGeoIPCountryRepository.php
 
 		-
-			message: "#^Cannot call method getType\\(\\) on Ivoz\\\\Provider\\\\Domain\\\\Model\\\\Company\\\\CompanyInterface\\|null\\.$#"
-			count: 1
-			path: Ivoz/Provider/Domain/Model/CompanyRelRoutingTag/CompanyRelRoutingTag.php
-
-		-
 			message: "#^Method Ivoz\\\\Provider\\\\Domain\\\\Model\\\\CompanyRelRoutingTag\\\\CompanyRelRoutingTagDtoAbstract\\:\\:getCompanyId\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: Ivoz/Provider/Domain/Model/CompanyRelRoutingTag/CompanyRelRoutingTagDtoAbstract.php


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
Fixes a Company type validation done when a Routing tag is assigned to a company.
This check can not be done in the setter or sanitize of the rel entity because company field is not yet assigned.

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
