### PR TITLE
Change rtpengine control port to 2223

### DIFF
--- a/debian/ivozprovider-profile-proxy.postinst
+++ b/debian/ivozprovider-profile-proxy.postinst
@@ -25,7 +25,7 @@ function setup_media_relays()
 
     # Configure Media relay IPs
     sed -i -r "s/(AUDIO_SOCK *= *).*/\1$MEDIA_RELAY_ADDRESS/"  /etc/default/rtpengine
-    sed -i -r "s/(CONTROL_SOCK *= *).*/\1$MEDIA_RELAY_CONTROL:22223/"  /etc/default/rtpengine
+    sed -i -r "s/(CONTROL_SOCK *= *).*/\1$MEDIA_RELAY_CONTROL:2223/"  /etc/default/rtpengine
     sed -i -r "s/(EXTRA_OPTS *= *).*/\1\"-m $MEDIA_RELAY_MINPORT -M $MEDIA_RELAY_MAXPORT\"/"  /etc/default/rtpengine
 }
 

--- a/library/DataFixtures/ORM/KamRtpengine.php
+++ b/library/DataFixtures/ORM/KamRtpengine.php
@@ -27,7 +27,7 @@ class KamRtpengine extends Fixture implements DependentFixtureInterface
         (function () use ($fixture) {
             $this
                 ->setSetid(0)
-                ->setUrl('udp:127.0.0.1:22223')
+                ->setUrl('udp:127.0.0.1:2223')
                 ->setWeight(1)
                 ->setDisabled(false)
                 ->setDescription('rtpengine01')

--- a/schema/DoctrineMigrations/Version20221007090801.php
+++ b/schema/DoctrineMigrations/Version20221007090801.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20221007090801 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Update Media relay ports from 22223 to 2223';
+    }
+
+    public function up(Schema $schema): void
+    {
+		$this->addSql("UPDATE kam_rtpengine SET url = REPLACE(url, ':22223', ':2223');");
+    }
+
+    public function down(Schema $schema): void
+    {
+		$this->addSql("UPDATE kam_rtpengine SET url = REPLACE(url, ':2223', ':22223');");
+    }
+}

--- a/web/admin/application/configs/klear/model/KamRtpengine.yaml
+++ b/web/admin/application/configs/klear/model/KamRtpengine.yaml
@@ -7,7 +7,7 @@ production:
       trim: both
       required: true
       maxLength: 128
-      defaultValue: "udp:127.0.0.1:22223"
+      defaultValue: "udp:127.0.0.1:2223"
     weight:
       title: _('Weight')
       type: number

--- a/web/rest/platform/features/kam/rtpengine/getRtpengine.feature
+++ b/web/rest/platform/features/kam/rtpengine/getRtpengine.feature
@@ -15,7 +15,7 @@ Feature: Retrieve rtpengines
     """
       [
           {
-              "url": "udp:127.0.0.1:22223",
+              "url": "udp:127.0.0.1:2223",
               "weight": 1,
               "disabled": false,
               "description": "rtpengine01",
@@ -35,7 +35,7 @@ Feature: Retrieve rtpengines
     """
       {
           "setid": 1,
-          "url": "udp:127.0.0.1:22223",
+          "url": "udp:127.0.0.1:2223",
           "weight": 1,
           "disabled": false,
           "stamp": "2000-01-01 01:00:00",

--- a/web/rest/platform/features/kam/rtpengine/postRtpengine.feature
+++ b/web/rest/platform/features/kam/rtpengine/postRtpengine.feature
@@ -12,7 +12,7 @@ Feature: Create rtpengines
     """
       {
           "setid": 99999999,
-          "url": "udp:127.0.0.2:22223",
+          "url": "udp:127.0.0.2:2223",
           "weight": 2,
           "disabled": false,
           "stamp": "2000-01-01 01:00:00",
@@ -27,7 +27,7 @@ Feature: Create rtpengines
     """
       {
           "setid": 1,
-          "url": "udp:127.0.0.2:22223",
+          "url": "udp:127.0.0.2:2223",
           "weight": 2,
           "disabled": false,
           "stamp": "2000-01-01 01:00:00",
@@ -48,7 +48,7 @@ Feature: Create rtpengines
     """
       {
           "setid": 1,
-          "url": "udp:127.0.0.2:22223",
+          "url": "udp:127.0.0.2:2223",
           "weight": 2,
           "disabled": false,
           "stamp": "2000-01-01 01:00:00",


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
By default in ivozprovider, rtpengine uses 13000 to 19000 for media ports. Moving the control port from 22223 to 2223 allows increasing this range when required.

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
