### PR TITLE
kamusers: fix URL-decode $rU

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -681,8 +681,6 @@ route[ADAPT_RURI_IN] {
 
 # Iterates through $drb, sets $var(prefix) and $var(prefixId) if R-URI matches prefix and strips it
 route[SEARCH_AND_STRIP_PREFIX] {
-    $rU = $(rU{s.urldecode.param}); # Just in case it is sent decoded (123%23 instead of 123#)
-
     $var(prefix) = "";
     if ($dbr(rb=>rows) > 0) {
         $var(i) = 0;
@@ -706,6 +704,8 @@ route[SEARCH_AND_STRIP_PREFIX] {
 
 # Detects routing tag, sets header with tag and id and strips it from r-uri
 route[GET_ROUTING_TAG] {
+    $rU = $(rU{s.replace,%23,#}); # Just in case # is sent URL-encoded (123%23 instead of 123#)
+
     sql_query("cb", "SELECT tag, RT.id FROM RoutingTags RT INNER JOIN CompaniesRelRoutingTags CRRT ON CRRT.routingTagId = RT.id WHERE CRRT.companyId = '$dlg_var(companyId)'", "rb");
     route(SEARCH_AND_STRIP_PREFIX);
 
@@ -726,6 +726,8 @@ route[GET_ROUTING_TAG] {
 
 # Detects ddi prefix, sets header with prefix and strips it from r-uri
 route[GET_DDI_PREFIX] {
+    $rU = $(rU{s.replace,%2A,*}); # Just in case * is sent URL-encoded (123%2A instead of 123*)
+
     sql_query("cb", "SELECT ODRP.prefix, ODRP.id FROM OutgoingDDIRulesPatterns ODRP INNER JOIN OutgoingDDIRules ODR ON ODR.id = ODRP.outgoingDDIRuleId INNER JOIN Companies C ON C.id = ODR.companyId INNER JOIN Users U ON U.companyId = C.id WHERE ODR.id = COALESCE(U.outgoingDDIRuleId, C.outgoingDDIRuleId) AND U.id ='$dlg_var(userId)' AND ODRP.type = 'prefix' ORDER BY priority", "rb");
     route(SEARCH_AND_STRIP_PREFIX);
 


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
URL decode replaces + in $rU with a whitespace and causes invalid URI.

#### Additional information
This PR avoids this wrong decode.