### PR TITLE
kamtrunks: skip sql-injector detector for within-dialog reqs

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -613,17 +613,26 @@ route[REQINIT] {
     }
     #!endif
 
+    # Malformed SIP message?
+    if(!sanity_check("5607", "7")) {
+        xwarn("REQINIT: Dropping malformed SIP message from $si:$sp\n");
+        exit;
+    }
+
+    # Max forwards?
+    if (!mf_process_maxfwd_header("10")) {
+        xwarn("REQINIT: Too many hops for SIP message from $si:$sp\n");
+        send_reply("483","Too Many Hops");
+        exit;
+    }
+
     # Easy dropping for scanners
     if($ua =~ "friendly-scanner|sipcli|VaxSIPUserAgent|pplsip" || search("sipvicious")) {
         xwarn("REQINIT: Dropping scanner request ----> $rm from $si\n");
         exit;
     }
 
-    # Malformed SIP message?
-    if(!sanity_check("5607", "7")) {
-        xwarn("REQINIT: Dropping malformed SIP message from $si:$sp\n");
-        exit;
-    }
+    if (has_totag()) return; # Skip sql-injector detector for within dialog requests
 
     # SQL injection control
     if($fd != $null && $fd =~ "(\=)|(\-\-)|(')|(\#)|(\%27)|(\%24)") {
@@ -658,13 +667,6 @@ route[REQINIT] {
 
     if($au != $null && $au =~ "(\=)|(\-\-)|(')|(\#)|(\%27)|(\%24)") {
         xwarn("REQINIT: Someone from $si is doing an sql injection attack, drop");
-        exit;
-    }
-
-    # Max forwards?
-    if (!mf_process_maxfwd_header("10")) {
-        xwarn("REQINIT: Too many hops for SIP message from $si:$sp\n");
-        send_reply("483","Too Many Hops");
         exit;
     }
 }


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description

Some carriers use username params in URIs of within-dialog requests. Example:
    
```
From: <sip:XXXYYYZZZ;phone-context=+34@A.B.C.D;user=phone>;correlation-id=56752665;tag=l9quzgg4-267aw
```
    
These params makes SQL-injection fail, so this mechanism will be skipped for within-dialog requests.
