### PR TITLE
Fix call forward presentation in Hunt Groups users' Call Forwards

### DIFF
--- a/asterisk/agi/src/Agi/ChannelInfo.php
+++ b/asterisk/agi/src/Agi/ChannelInfo.php
@@ -69,7 +69,7 @@ class ChannelInfo
             return;
         }
 
-        $this->agi->setVariable("_ORIGIN", $agent);
+        $this->agi->setVariable("__ORIGIN", $agent);
     }
 
     /**
@@ -81,7 +81,7 @@ class ChannelInfo
             return;
         }
 
-        $this->agi->setVariable("_CALLER", $agent);
+        $this->agi->setVariable("__CALLER", $agent);
     }
 
     /**


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->

#### Description
When a user calls to a HuntGroup where some of the users have Call Forward configured, the call origin information was being lost due to wrong variable inheritance.

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
