### PR TITLE
Modified SPA50*.cfg for firmwareVersion variable typo.

### DIFF
--- a/microservices/provision/templates/provisioning/SPA502G/generic.cfg
+++ b/microservices/provision/templates/provisioning/SPA502G/generic.cfg
@@ -35,7 +35,7 @@ echo "serv=https://" . $_SERVER['SERVER_NAME'] . ":2443/terminals/ciscolang/";
 
 preg_match("/-([0-9\.]*).*[\s,]+/", $_SERVER['HTTP_USER_AGENT'], $firmware);
 $firmwareVersion = array_key_exists("1", $firmware) ? $firmware[1] : null;
-switch(firmwareVersion){
+switch($firmwareVersion){
     case "7.5.1": echo ";d0=English;x0=spa50x_30x_en_v751.xml;d1=Spanish;x1=spa50x_30x_es_v751.xml"; break;
     case "7.5.2": echo ";d0=English;x0=spa50x_30x_en_v751.xml;d1=Spanish;x1=spa50x_30x_es_v751.xml"; break;
     case "7.5.3": echo ";d0=English;x0=spa50x_30x_en_v753.xml;d1=Spanish;x1=spa50x_30x_es_v753.xml"; break;

--- a/microservices/provision/templates/provisioning/SPA504G/generic.cfg
+++ b/microservices/provision/templates/provisioning/SPA504G/generic.cfg
@@ -35,7 +35,7 @@ echo "serv=https://" . $_SERVER['SERVER_NAME'] . ":2443/terminals/ciscolang/";
 
 preg_match("/-([0-9\.]*).*[\s,]+/", $_SERVER['HTTP_USER_AGENT'], $firmware);
 $firmwareVersion = array_key_exists("1", $firmware) ? $firmware[1] : null;
-switch(firmwareVersion){
+switch($firmwareVersion){
     case "7.5.1": echo ";d0=English;x0=spa50x_30x_en_v751.xml;d1=Spanish;x1=spa50x_30x_es_v751.xml"; break;
     case "7.5.2": echo ";d0=English;x0=spa50x_30x_en_v751.xml;d1=Spanish;x1=spa50x_30x_es_v751.xml"; break;
     case "7.5.3": echo ";d0=English;x0=spa50x_30x_en_v753.xml;d1=Spanish;x1=spa50x_30x_es_v753.xml"; break;

--- a/microservices/provision/templates/provisioning/SPA509G/generic.cfg
+++ b/microservices/provision/templates/provisioning/SPA509G/generic.cfg
@@ -35,7 +35,7 @@ echo "serv=https://" . $_SERVER['SERVER_NAME'] . ":2443/terminals/ciscolang/";
 
 preg_match("/-([0-9\.]*).*[\s,]+/", $_SERVER['HTTP_USER_AGENT'], $firmware);
 $firmwareVersion = array_key_exists("1", $firmware) ? $firmware[1] : null;
-switch(firmwareVersion){
+switch($firmwareVersion){
     case "7.5.1": echo ";d0=English;x0=spa50x_30x_en_v751.xml;d1=Spanish;x1=spa50x_30x_es_v751.xml"; break;
     case "7.5.2": echo ";d0=English;x0=spa50x_30x_en_v751.xml;d1=Spanish;x1=spa50x_30x_es_v751.xml"; break;
     case "7.5.3": echo ";d0=English;x0=spa50x_30x_en_v753.xml;d1=Spanish;x1=spa50x_30x_es_v753.xml"; break;

--- a/microservices/provision/templates/provisioning/SPA514G/generic.cfg
+++ b/microservices/provision/templates/provisioning/SPA514G/generic.cfg
@@ -35,7 +35,7 @@ echo "serv=https://" . $_SERVER['SERVER_NAME'] . ":2443/terminals/ciscolang/";
 
 preg_match("/-([0-9\.]*).*[\s,]+/", $_SERVER['HTTP_USER_AGENT'], $firmware);
 $firmwareVersion = array_key_exists("1", $firmware) ? $firmware[1] : null;
-switch(firmwareVersion){
+switch($firmwareVersion){
     case "7.5.1": echo ";d0=English;x0=spa50x_30x_en_v751.xml;d1=Spanish;x1=spa50x_30x_es_v751.xml"; break;
     case "7.5.2": echo ";d0=English;x0=spa50x_30x_en_v751.xml;d1=Spanish;x1=spa50x_30x_es_v751.xml"; break;
     case "7.5.3": echo ";d0=English;x0=spa50x_30x_en_v753.xml;d1=Spanish;x1=spa50x_30x_es_v753.xml"; break;

--- a/microservices/provision/templates/provisioning/SPA525G2/generic.cfg
+++ b/microservices/provision/templates/provisioning/SPA525G2/generic.cfg
@@ -35,7 +35,7 @@ echo "serv=https://" . $_SERVER['SERVER_NAME'] . ":2443/terminals/ciscolang/";
 
 preg_match("/-([0-9\.]*).*[\s,]+/", $_SERVER['HTTP_USER_AGENT'], $firmware);
 $firmwareVersion = array_key_exists("1", $firmware) ? $firmware[1] : null;
-switch(firmwareVersion){
+switch($firmwareVersion){
     case "7.5.1": echo ";d0=English;x0=spa525_en_v751.xml;d1=Spanish;x1=spa525_es_v751.xml"; break;
     case "7.5.2": echo ";d0=English;x0=spa525_en_v751.xml;d1=Spanish;x1=spa525_es_v751.xml"; break;
     case "7.5.3": echo ";d0=English;x0=spa525_en_v753.xml;d1=Spanish;x1=spa525_es_v753.xml"; break;

--- a/web/admin/templates/provisioning/SPA502G/generic.cfg
+++ b/web/admin/templates/provisioning/SPA502G/generic.cfg
@@ -35,7 +35,7 @@ echo "serv=https://" . $_SERVER['SERVER_NAME'] . ":2443/terminals/ciscolang/";
 
 preg_match("/-([0-9\.]*).*[\s,]+/", $_SERVER['HTTP_USER_AGENT'], $firmware);
 $firmwareVersion = array_key_exists("1", $firmware) ? $firmware[1] : null;
-switch(firmwareVersion){
+switch($firmwareVersion){
     case "7.5.1": echo ";d0=English;x0=spa50x_30x_en_v751.xml;d1=Spanish;x1=spa50x_30x_es_v751.xml"; break;
     case "7.5.2": echo ";d0=English;x0=spa50x_30x_en_v751.xml;d1=Spanish;x1=spa50x_30x_es_v751.xml"; break;
     case "7.5.3": echo ";d0=English;x0=spa50x_30x_en_v753.xml;d1=Spanish;x1=spa50x_30x_es_v753.xml"; break;

--- a/web/admin/templates/provisioning/SPA504G/generic.cfg
+++ b/web/admin/templates/provisioning/SPA504G/generic.cfg
@@ -35,7 +35,7 @@ echo "serv=https://" . $_SERVER['SERVER_NAME'] . ":2443/terminals/ciscolang/";
 
 preg_match("/-([0-9\.]*).*[\s,]+/", $_SERVER['HTTP_USER_AGENT'], $firmware);
 $firmwareVersion = array_key_exists("1", $firmware) ? $firmware[1] : null;
-switch(firmwareVersion){
+switch($firmwareVersion){
     case "7.5.1": echo ";d0=English;x0=spa50x_30x_en_v751.xml;d1=Spanish;x1=spa50x_30x_es_v751.xml"; break;
     case "7.5.2": echo ";d0=English;x0=spa50x_30x_en_v751.xml;d1=Spanish;x1=spa50x_30x_es_v751.xml"; break;
     case "7.5.3": echo ";d0=English;x0=spa50x_30x_en_v753.xml;d1=Spanish;x1=spa50x_30x_es_v753.xml"; break;

--- a/web/admin/templates/provisioning/SPA509G/generic.cfg
+++ b/web/admin/templates/provisioning/SPA509G/generic.cfg
@@ -35,7 +35,7 @@ echo "serv=https://" . $_SERVER['SERVER_NAME'] . ":2443/terminals/ciscolang/";
 
 preg_match("/-([0-9\.]*).*[\s,]+/", $_SERVER['HTTP_USER_AGENT'], $firmware);
 $firmwareVersion = array_key_exists("1", $firmware) ? $firmware[1] : null;
-switch(firmwareVersion){
+switch($firmwareVersion){
     case "7.5.1": echo ";d0=English;x0=spa50x_30x_en_v751.xml;d1=Spanish;x1=spa50x_30x_es_v751.xml"; break;
     case "7.5.2": echo ";d0=English;x0=spa50x_30x_en_v751.xml;d1=Spanish;x1=spa50x_30x_es_v751.xml"; break;
     case "7.5.3": echo ";d0=English;x0=spa50x_30x_en_v753.xml;d1=Spanish;x1=spa50x_30x_es_v753.xml"; break;

--- a/web/admin/templates/provisioning/SPA514G/generic.cfg
+++ b/web/admin/templates/provisioning/SPA514G/generic.cfg
@@ -35,7 +35,7 @@ echo "serv=https://" . $_SERVER['SERVER_NAME'] . ":2443/terminals/ciscolang/";
 
 preg_match("/-([0-9\.]*).*[\s,]+/", $_SERVER['HTTP_USER_AGENT'], $firmware);
 $firmwareVersion = array_key_exists("1", $firmware) ? $firmware[1] : null;
-switch(firmwareVersion){
+switch($firmwareVersion){
     case "7.5.1": echo ";d0=English;x0=spa50x_30x_en_v751.xml;d1=Spanish;x1=spa50x_30x_es_v751.xml"; break;
     case "7.5.2": echo ";d0=English;x0=spa50x_30x_en_v751.xml;d1=Spanish;x1=spa50x_30x_es_v751.xml"; break;
     case "7.5.3": echo ";d0=English;x0=spa50x_30x_en_v753.xml;d1=Spanish;x1=spa50x_30x_es_v753.xml"; break;

--- a/web/admin/templates/provisioning/SPA525G2/generic.cfg
+++ b/web/admin/templates/provisioning/SPA525G2/generic.cfg
@@ -35,7 +35,7 @@ echo "serv=https://" . $_SERVER['SERVER_NAME'] . ":2443/terminals/ciscolang/";
 
 preg_match("/-([0-9\.]*).*[\s,]+/", $_SERVER['HTTP_USER_AGENT'], $firmware);
 $firmwareVersion = array_key_exists("1", $firmware) ? $firmware[1] : null;
-switch(firmwareVersion){
+switch($firmwareVersion){
     case "7.5.1": echo ";d0=English;x0=spa525_en_v751.xml;d1=Spanish;x1=spa525_es_v751.xml"; break;
     case "7.5.2": echo ";d0=English;x0=spa525_en_v751.xml;d1=Spanish;x1=spa525_es_v751.xml"; break;
     case "7.5.3": echo ";d0=English;x0=spa525_en_v753.xml;d1=Spanish;x1=spa525_es_v753.xml"; break;


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
This changes fix a typo in generic config provision files.

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
