### PR TITLE
Fixed object error in TrunksClient.

### DIFF
--- a/library/Ivoz/Kam/Infrastructure/Kamailio/TrunksClient.php
+++ b/library/Ivoz/Kam/Infrastructure/Kamailio/TrunksClient.php
@@ -113,6 +113,9 @@ class TrunksClient implements TrunksClientInterface
             return [];
         }
 
+        /** @var  \stdClass $result */
+        $result = $response->result;
+
         /**
          * Expected response format
          * {
@@ -134,7 +137,8 @@ class TrunksClient implements TrunksClientInterface
          *   defunct_until: 0
          * }
          */
-        return (array) $response->result;
+
+        return $result->gw[0];
     }
 
     public function reloadRtpengine(): void


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
<!-- Describe your changes in detail -->
This error happens when retrieving LcrGatewayInfo and the object composition changes between versions 5.1 and 5.4 of Kamailio.

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
