### PR TITLE
core: return array as defined in function header

### DIFF
--- a/library/Ivoz/Kam/Infrastructure/Kamailio/TrunksClient.php
+++ b/library/Ivoz/Kam/Infrastructure/Kamailio/TrunksClient.php
@@ -101,6 +101,9 @@ class TrunksClient implements TrunksClientInterface
         return (array) $response->result;
     }
 
+    /**
+     * @param int $gw_id
+     */
     public function getLcrGatewayInfo($gw_id): array
     {
         $response = $this->sendRequest(
@@ -116,29 +119,36 @@ class TrunksClient implements TrunksClientInterface
         /** @var  \stdClass $result */
         $result = $response->result;
 
+        if (
+            !isset($result->gw)
+            || !is_array($result->gw)
+        ) {
+            return [];
+        }
+
         /**
-         * Expected response format
-         * {
-         *   lcr_id: 1
-         *   gw_id: 21
-         *   gw_index: 2
-         *   gw_name: b1c1s14
-         *   scheme: sip:
-         *   ip_addr: 0.0.0.0
-         *   hostname: example.com
-         *   port: 5060
-         *   params:
-         *   transport: ;transport=udp
-         *   strip: 0
-         *   prefix:
-         *   tag:
-         *   flags: 14
-         *   state: 0
-         *   defunct_until: 0
+         * @var array{
+         *   lcr_id: int,
+         *   gw_id: int,
+         *   gw_index: int,
+         *   gw_name: string,
+         *   scheme: string,
+         *   ip_addr: string,
+         *   hostname: string,
+         *   port: int,
+         *   params: string,
+         *   transport: string,
+         *   strip: int,
+         *   prefix: string,
+         *   tag: string,
+         *   flags: int,
+         *   state: int,
+         *   defunct_until: int,
          * }
          */
+        $response = (array) $result->gw[0];
 
-        return $result->gw[0] ?? [];
+        return $response;
     }
 
     public function reloadRtpengine(): void

--- a/library/phpstan-baseline.neon
+++ b/library/phpstan-baseline.neon
@@ -1726,11 +1726,6 @@ parameters:
 			path: Ivoz/Kam/Infrastructure/Kamailio/RpcClient.php
 
 		-
-			message: "#^Method Ivoz\\\\Kam\\\\Infrastructure\\\\Kamailio\\\\TrunksClient\\:\\:getLcrGatewayInfo\\(\\) has parameter \\$gw_id with no typehint specified\\.$#"
-			count: 1
-			path: Ivoz/Kam/Infrastructure/Kamailio/TrunksClient.php
-
-		-
 			message: "#^Method Ivoz\\\\Kam\\\\Infrastructure\\\\Kamailio\\\\TrunksClient\\:\\:getLcrGatewayInfo\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: Ivoz/Kam/Infrastructure/Kamailio/TrunksClient.php


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description

This PR prevents this exception when accessing Carriers section using Klear web portal:

`
klear[1550304]: Exception captured [500]: Ivoz\Kam\Infrastructure\Kamailio\TrunksClient::getLcrGatewayInfo(): Return value must be of type array, stdClass returned (0) # /opt/irontec/ivozprovider/library/Ivoz/Kam/Infrastructure/Kamailio/TrunksClient.php (141)
`
