### PR TITLE
kamusers: skip IP filter for push servers

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -402,6 +402,8 @@ modparam("rtimer", "exec", "timer=EXIT_NOW;route=EXIT_NOW")
 modparam("rtimer", "timer", "name=EXIT_WHEN_NO_CALLS;interval=3;mode=0;")
 modparam("rtimer", "exec", "timer=EXIT_WHEN_NO_CALLS;route=EXIT_WHEN_NO_CALLS")
 
+import_file "pushservers.cfg"
+
 ####### Routing Logic ########
 
 request_route {
@@ -1429,6 +1431,15 @@ route[FILTER_BY_SRC_ADDR] {
     }
 
     # Company has IP check enabled
+
+    #!ifdef WITH_PUSHSERVERS
+    if ($sht(pushservers=>$si) != $null) {
+        xnotice("[$dlg_var(cidhash)] FILTER-BY-SRC-ADDR: $si is associated with push-server $sht(pushservers=>$si), skip IP filter\n");
+        return;
+    } else {
+        xinfo("[$dlg_var(cidhash)] FILTER-BY-SRC-ADDR: $si is NOT associated with any pushserver\n");
+    }
+    #!endif
 
     #!ifdef WITH_GEOIP
     if(geoip2_match("$si", "src")) {
@@ -2968,6 +2979,10 @@ event_route[htable:mod-init] {
         xerr("Problems resolving trunks.ivozprovider.local, aborting\n");
         abort();
     }
+
+    #!ifdef WITH_PUSHSERVERS
+    route(PUSHSERVERS_TIMER);
+    #!endif
 }
 
 event_route[core:worker-one-init] {

--- a/kamailio/users/config/pushservers.cfg.in
+++ b/kamailio/users/config/pushservers.cfg.in
@@ -10,7 +10,8 @@
 #!define WITH_PUSHSERVERS
 
 modparam("htable", "htable", "pushservers=>size=8")
-modparam("timer", "declare_timer", "PUSHSERVERS_TIMER=PUSHSERVERS_TIMER,3600000,slow,enable");
+modparam("rtimer", "timer", "name=PUSHSERVERS_TIMER;interval=3600;mode=0;")
+modparam("rtimer", "exec", "timer=PUSHSERVERS_TIMER;route=PUSHSERVERS_TIMER")
 
 route[PUSHSERVERS_TIMER] {
     # Concatenate as many desired push servers adding blocks like this:

--- a/kamailio/users/config/pushservers.cfg.in
+++ b/kamailio/users/config/pushservers.cfg.in
@@ -1,0 +1,40 @@
+# Adding a file like this (without .in) and restarting kamusers
+# enables a logic that avoids source IP checking for addresses
+# matching given domains.
+#
+# This could be useful to skip source IP filter for PUSH servers of certain
+# softphones.
+#
+# Edit to include desired push server domains before restarting kamusers.
+
+#!define WITH_PUSHSERVERS
+
+modparam("htable", "htable", "pushservers=>size=8")
+modparam("timer", "declare_timer", "PUSHSERVERS_TIMER=PUSHSERVERS_TIMER,3600000,slow,enable");
+
+route[PUSHSERVERS_TIMER] {
+    # Concatenate as many desired push servers adding blocks like this:
+    #
+    # $var(pushserverdom) = 'first-pushserver.example.org';
+    # route(PUSHSERVERS_DNS);
+    #
+    # $var(pushserverdom) = 'second-pushserver.example.org';
+    # route(PUSHSERVERS_DNS);
+
+    return;
+}
+
+route[PUSHSERVERS_DNS] {
+    xnotice("PUSHSERVERS-DNS: update $var(pushserverdom) IPv4 addresses\n");
+
+    if(dns_query($var(pushserverdom), "pushserver")) {
+        $var(i) = 0;
+        while($var(i)<$dns(pushserver=>count)) {
+            if ($dns(pushserver=>type[$var(i)]) == "4") {
+                xnotice("PUSHSERVERS-DNS: saving $dns(pushserver=>addr[$var(i)]) <-> $var(pushserverdom)\n");
+                $sht(pushservers=>$dns(pushserver=>addr[$var(i)])) = $var(pushserverdom);
+            }
+            $var(i) = $var(i) + 1;
+        }
+    }
+}


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [x] Upport from existing Pull request #1971 

#### Description
Upport #1971.

#### Additional information
Cherry-pick and additional commit to use rtimer instead of timer (preferred module in 5.6).