### PR TITLE
kamtrunks: fix carrier/ddiprovider mediarelay selection

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -507,9 +507,6 @@ request_route {
         # Check if this call is to one of our DDIs
         route(CHECK_BOUNCE);
 
-        # Call RTPENGINE before branching (avoids call in failure routes)
-        route(RTPENGINE);
-
         # Evaluate routing logic
         route(LOAD_GWS);
         route(SELECT_NEXT_GW);
@@ -989,9 +986,6 @@ route[SELECT_NEXT_GW] {
     if (!next_gw()) {
         xwarn("[$dlg_var(cidhash)] SELECT-NEXT-GW: NO next GW, send 503 No gateways");
         send_reply("503", "No gateways");
-        # Free rtpengine session
-        $var(callid) = "call-id=trunks-outbound-" + $ci;
-        rtpengine_delete("$var(callid)");
         exit;
     }
 
@@ -2098,6 +2092,7 @@ failure_route[MANAGE_FAILURE_AS] {
 branch_route[MANAGE_BRANCH_GW] {
     route(GET_TRANSFORMATIONS_OUT);
     route(TRANSFORMATE_OUT);
+    route(RTPENGINE);
 }
 
 # Executed when dialog is confirmed with 2XX response code


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description

route(RTPENGINE) route needs dlg_var(mediaRelaySetId) to be set in order to assign proper media-relay to each call depending on which carrier/ddiprovider is involved.
    
With previous logic, it was used before being assigned, so it failed.
    
Besides, on _failure_route_ was not invoked again (to choose proper media-relay of eventual failover carrier).
    

#### Additional information

This commit tries to fix this initial RTPENGINE call, calling it after mediaRelaySetId is set.

It also re-invokes RTPENGINE route so that calls through failover carriers use proper media-relay too.
