### PR TITLE
Status definitions in api are not correct

### DIFF
--- a/library/Ivoz/Provider/Domain/Model/Carrier/CarrierDto.php
+++ b/library/Ivoz/Provider/Domain/Model/Carrier/CarrierDto.php
@@ -2,9 +2,19 @@
 
 namespace Ivoz\Provider\Domain\Model\Carrier;
 
+use Ivoz\Api\Core\Annotation\AttributeDefinition;
+
 class CarrierDto extends CarrierDtoAbstract
 {
-    private ?CarrierStatus $status = null;
+    /**
+     * @var ?CarrierStatus
+     * @AttributeDefinition(
+     *     type="object",
+     *     class="Ivoz\Provider\Domain\Model\Carrier\CarrierStatus",
+     *     description="Registration status"
+     * )
+     */
+    private $status = null;
 
     /**
      * @inheritdoc

--- a/library/Ivoz/Provider/Domain/Model/Carrier/CarrierStatus.php
+++ b/library/Ivoz/Provider/Domain/Model/Carrier/CarrierStatus.php
@@ -2,9 +2,15 @@
 
 namespace Ivoz\Provider\Domain\Model\Carrier;
 
+use Ivoz\Api\Core\Annotation\AttributeDefinition;
+
 class CarrierStatus
 {
-    private bool $registered;
+    /**
+     * @var bool
+     * @AttributeDefinition(type="bool")
+     */
+    private $registered;
 
     public function __construct(
         bool $registered

--- a/library/Ivoz/Provider/Domain/Model/CarrierServer/CarrierServerDto.php
+++ b/library/Ivoz/Provider/Domain/Model/CarrierServer/CarrierServerDto.php
@@ -2,12 +2,21 @@
 
 namespace Ivoz\Provider\Domain\Model\CarrierServer;
 
+use Ivoz\Api\Core\Annotation\AttributeDefinition;
+
 class CarrierServerDto extends CarrierServerDtoAbstract
 {
     public const CONTEXT_STATUS = 'status';
 
-    /** @var CarrierServerStatus[] $status */
-    private array $status = [];
+    /**
+     * @var ?CarrierServerStatus
+     * @AttributeDefinition(
+     *     type="object",
+     *     class="Ivoz\Provider\Domain\Model\CarrierServer\CarrierServerStatus",
+     *     description="Registration status"
+     * )
+     */
+    private $status;
 
     protected $sensitiveFields = [
         'authPassword',
@@ -26,7 +35,7 @@ class CarrierServerDto extends CarrierServerDtoAbstract
                 'hostname' => 'hostname',
                 'sipProxy' => 'sipProxy',
                 'authNeeded' => 'authNeeded',
-                'status' => [['registered']]
+                'status' => ['registered']
             ];
 
             if ($role === 'ROLE_BRAND_ADMIN') {
@@ -44,7 +53,7 @@ class CarrierServerDto extends CarrierServerDtoAbstract
                 'sipProxy' => 'sipProxy',
                 'authNeeded' => 'authNeeded',
                 'outboundProxy' => 'outboundProxy',
-                'status' => [['registered']]
+                'status' => ['registered']
             ];
         } else {
             $response = parent::getPropertyMap(...func_get_args());
@@ -75,7 +84,7 @@ class CarrierServerDto extends CarrierServerDtoAbstract
 
     public function addStatus(CarrierServerStatus $status): static
     {
-        $this->status[] = $status;
+        $this->status = $status;
 
         return $this;
     }
@@ -84,12 +93,9 @@ class CarrierServerDto extends CarrierServerDtoAbstract
     {
         $response = parent::toArray($hideSensitiveData);
 
-        $response['status'] = array_map(
-            function (CarrierServerStatus $registrationStatus): array {
-                return $registrationStatus->toArray();
-            },
-            $this->status
-        );
+        if (!is_null($this->status)) {
+            $response['status'] = $this->status->toArray();
+        }
 
         return $response;
     }

--- a/library/Ivoz/Provider/Domain/Model/CarrierServer/CarrierServerStatus.php
+++ b/library/Ivoz/Provider/Domain/Model/CarrierServer/CarrierServerStatus.php
@@ -2,6 +2,8 @@
 
 namespace Ivoz\Provider\Domain\Model\CarrierServer;
 
+use Ivoz\Api\Core\Annotation\AttributeDefinition;
+
 class CarrierServerStatus
 {
     /**

--- a/web/rest/brand/config/api/raw/provider.yml
+++ b/web/rest/brand/config/api/raw/provider.yml
@@ -841,6 +841,10 @@ Ivoz\Provider\Domain\Model\NotificationTemplateContent\NotificationTemplateConte
       required:
       - notificationTemplate
 
+Ivoz\Provider\Domain\Model\Carrier\CarrierStatus:
+  itemOperations: []
+  collectionOperations: []
+
 Ivoz\Provider\Domain\Model\Carrier\Carrier:
   attributes:
     access_control: '"ROLE_BRAND_ADMIN" in roles && user.hasAccessPrivileges(_api_resource_class, request.getMethod())'
@@ -859,6 +863,10 @@ Ivoz\Provider\Domain\Model\Carrier\Carrier:
       required:
       - brand
       - transformationRuleSet
+
+Ivoz\Provider\Domain\Model\CarrierServer\CarrierServerStatus:
+  itemOperations: []
+  collectionOperations: []
 
 Ivoz\Provider\Domain\Model\CarrierServer\CarrierServer:
   itemOperations:

--- a/web/rest/brand/features/provider/carrierServer/getCarrierServer.feature
+++ b/web/rest/brand/features/provider/carrierServer/getCarrierServer.feature
@@ -21,11 +21,9 @@ Feature: Retrieve carrier servers
               "sipProxy": "127.0.0.1",
               "outboundProxy": null,
               "id": 1,
-              "status": [
-                  {
-                      "registered": false
-                  }
-              ]
+              "status": {
+                  "registered": false
+              }
           },
           {
               "ip": null,
@@ -34,11 +32,10 @@ Feature: Retrieve carrier servers
               "sipProxy": "127.0.0.2",
               "outboundProxy": null,
               "id": 2,
-              "status": [
-                  {
-                      "registered": false
-                  }
-              ]
+              "status": {
+                  "registered": false
+              }
+
           }
       ]
     """

--- a/web/rest/brand/features/provider/carrierServer/getCarrierServerStatus.feature
+++ b/web/rest/brand/features/provider/carrierServer/getCarrierServerStatus.feature
@@ -67,10 +67,8 @@ Feature: Create carrier servers
           "authNeeded": "no",
           "sipProxy": "127.0.0.3",
           "id": 3,
-          "status": [
-              {
-                  "registered": false
-              }
-          ]
+          "status": {
+              "registered": false
+          }
       }
     """


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
This fix adds attribute definitions to help ivoz-api be able to expose them as documentation Models.

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
