### PR TITLE
kamusers: handle parallel-forking media-sessions properly

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -240,6 +240,7 @@ modparam("rtpengine", "mos_average_B_pv", "$avp(mos_average_B)")
 modparam("rtpengine", "mos_average_packetloss_B_pv", "$avp(mos_average_packetloss_B)")
 modparam("rtpengine", "mos_average_jitter_B_pv", "$avp(mos_average_jitter_B)")
 modparam("rtpengine", "mos_average_roundtrip_B_pv", "$avp(mos_average_roundtrip_B)")
+modparam("rtpengine", "extra_id_pv", "$avp(extra_id)")
 
 # DEBUGGER
 modparam("debugger", "mod_hash_size", 5)
@@ -1250,6 +1251,7 @@ route[LOOKUP] {
         xinfo("[$dlg_var(cidhash)] LOOKUP: One contact found for $tu, calling $ru\n");
     } else {
         xnotice("[$dlg_var(cidhash)] LOOKUP: Multiple contacts found for $tu, parallel forking\n");
+        $avp(parallel_forking) = 1;
     }
 }
 
@@ -2540,6 +2542,8 @@ onreply_route[MANAGE_REPLY] {
     # Manage NAT
     if (t_check_status("[12][0-9]{2}")) {
         route(NATMANAGE);
+    } else if ($avp(parallel_forking)) {
+        route(RTPENGINE); # Free failing branch media-session
     }
 
     #!ifdef WITH_REALTIME
@@ -2796,7 +2800,14 @@ route[RTPENGINE] {
         set_rtpengine_set("$(dlg_var(mediaRelaySetsId){s.int})");
     }
 
-    $var(common_opts) = 'replace-session-connection replace-origin';
+    $var(common_opts) = 'replace-session-connection replace-origin via-branch=extra';
+
+    if ($avp(parallel_forking)) {
+        # Initial transaction to parallel-forking UAC
+        #  - request: create different media-session per branch
+        #  - negative response: free failing branch media-session
+        $avp(extra_id) = $T_branch_idx;
+    }
 
     if (nat_uac_test("18") && !$var(is_from_inside)) {
         # NAT detected, do not trust SDP addresses


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description

Create different media-session for different branches of the same call (due to parallel-forking enabled UAC). This way, each of them can be configured independently.

#### Additional information

This PR fixes this known situations as no audio in calls where a branch replies 183 with SDP but the call is answered by a different branch.