### PR TITLE
Fix Voicemail rest API delete ACLs

### DIFF
--- a/library/DataFixtures/ORM/ProviderVoicemail.php
+++ b/library/DataFixtures/ORM/ProviderVoicemail.php
@@ -77,6 +77,18 @@ class ProviderVoicemail extends Fixture implements DependentFixtureInterface
         $this->sanitizeEntityValues($item4);
         $manager->persist($item4);
 
+        $item5 = $this->createEntityInstance(Voicemail::class);
+        (function () use ($fixture) {
+            $this->setName("Voicemail For Other Company");
+            $this->setEmail("other@voicemail.com");
+            $this->setSendMail(true);
+            $this->setAttachSound(false);
+            $this->setCompany($fixture->getReference('_reference_ProviderCompany2'));
+        })->call($item5);
+
+        $this->addReference('_reference_ProviderVoicemail5', $item5);
+        $this->sanitizeEntityValues($item5);
+        $manager->persist($item5);
 
         $manager->flush();
     }

--- a/web/rest/client/config/api/raw/provider.yml
+++ b/web/rest/client/config/api/raw/provider.yml
@@ -1972,6 +1972,13 @@ Ivoz\Provider\Domain\Model\Voicemail\Voicemail:
       - or:
         - inheritedOrNull:
             locution: 'Ivoz\Provider\Domain\Model\Locution\Locution'
+    delete_access_control:
+      ROLE_COMPANY_ADMIN:
+        - and:
+          - user:
+              isNull: ~
+          - residentialDevice:
+              isNull: ~
     swagger_context:
       required:
       - company

--- a/web/rest/client/features/provider/voicemail/postVoicemail.feature
+++ b/web/rest/client/features/provider/voicemail/postVoicemail.feature
@@ -28,7 +28,7 @@ Feature: Create voicemails
           "email": "generic@voicemail.com",
           "sendMail": true,
           "attachSound": true,
-          "id": 5,
+          "id": 6,
           "user": null,
           "residentialDevice": null,
           "company": 1,
@@ -39,7 +39,7 @@ Feature: Create voicemails
   Scenario: Retrieve created voicemail
     Given I add Company Authorization header
     When I add "Accept" header equal to "application/json"
-    And I send a "GET" request to "/voicemails/2"
+    And I send a "GET" request to "/voicemails/6"
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/json; charset=utf-8"
@@ -47,18 +47,13 @@ Feature: Create voicemails
     """
       {
           "enabled": true,
-          "name": "Voicemail For Residential 1",
-          "email": "",
-          "sendMail": false,
-          "attachSound": false,
-          "id": 2,
+          "name": "newGenericVoicemail",
+          "email": "generic@voicemail.com",
+          "sendMail": true,
+          "attachSound": true,
+          "id": 6,
           "user": null,
-          "residentialDevice": {
-              "name": "residentialDevice",
-              "description": "",
-              "directConnectivity": "no",
-              "id": 1
-          },
+          "residentialDevice": null,
           "company": {
               "type": "vpbx",
               "name": "DemoCompany",

--- a/web/rest/client/features/provider/voicemail/removeVoicemail.feature
+++ b/web/rest/client/features/provider/voicemail/removeVoicemail.feature
@@ -8,5 +8,26 @@ Feature: Manage voicemails
     Given I add Company Authorization header
      When I add "Content-Type" header equal to "application/json"
       And I add "Accept" header equal to "application/json"
-      And I send a "DELETE" request to "/voicemails/4"
+      And I send a "DELETE" request to "/voicemails/3"
      Then the response status code should be 204
+
+  Scenario: Remove a voicemail from a user
+    Given I add Company Authorization header
+    When I add "Content-Type" header equal to "application/json"
+    And I add "Accept" header equal to "application/json"
+    And I send a "DELETE" request to "/voicemails/1"
+    Then the response status code should be 403
+
+  Scenario: Remove a voicemail from a residential device
+    Given I add Company Authorization header
+    When I add "Content-Type" header equal to "application/json"
+    And I add "Accept" header equal to "application/json"
+    And I send a "DELETE" request to "/voicemails/2"
+    Then the response status code should be 403
+
+  Scenario: Remove a voicemail from another company
+    Given I add Company Authorization header
+    When I add "Content-Type" header equal to "application/json"
+    And I add "Accept" header equal to "application/json"
+    And I send a "DELETE" request to "/voicemails/5"
+    Then the response status code should be 404


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
Current API ACLs allows deletion of Voicemails associated to Users and Residential Devices. This PR fixes that to only permit generic voicemails removal.

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
