### PR TITLE
Session & Login conflicts

### DIFF
--- a/web/portal/brand/src/App.tsx
+++ b/web/portal/brand/src/App.tsx
@@ -17,12 +17,12 @@ export default function App(): JSX.Element {
   );
   const languages = setLanguages(languagesList);
 
-  const apiSpecInitFn = useStoreActions((actions: any) => {
-    return actions.spec.init;
+  const apiSpecStore = useStoreActions((actions: any) => {
+    return actions.spec;
   });
+  const authStore = useStoreActions((actions: any) => actions.auth);
 
   const token = useStoreState((actions: any) => actions.auth.token);
-  const authInit = useStoreActions((actions: any) => actions.auth.init);
   const aboutMeResetProfile = useStoreActions(
     (actions: any) => actions.clientSession.aboutMe.resetProfile
   );
@@ -33,11 +33,14 @@ export default function App(): JSX.Element {
   useTranslation();
 
   useEffect(() => {
-    apiSpecInitFn();
-    authInit();
+    apiSpecStore.setSessionStoragePrefix('IP-brand-');
+    apiSpecStore.init();
+    authStore.setSessionStoragePrefix('IP-brand-');
+    authStore.init();
+
     aboutMeResetProfile();
     aboutMeInit();
-  }, [apiSpecInitFn, authInit, token, aboutMeInit, aboutMeResetProfile]);
+  }, [apiSpecStore, apiSpecStore, token, aboutMeInit, aboutMeResetProfile]);
 
   const apiSpec = useStoreState((state) => state.spec.spec);
   const baseUrl = process.env.BASE_URL;

--- a/web/portal/client/src/App.tsx
+++ b/web/portal/client/src/App.tsx
@@ -11,12 +11,12 @@ import { StoreContainer } from '@irontec/ivoz-ui';
 export default function App(): JSX.Element {
   StoreContainer.store = store;
 
-  const apiSpecInitFn = useStoreActions((actions: any) => {
-    return actions.spec.init;
+  const apiSpecStore = useStoreActions((actions: any) => {
+    return actions.spec;
   });
+  const authStore = useStoreActions((actions: any) => actions.auth);
 
   const token = useStoreState((actions: any) => actions.auth.token);
-  const authInit = useStoreActions((actions: any) => actions.auth.init);
   const aboutMeResetProfile = useStoreActions(
     (actions: any) => actions.clientSession.aboutMe.resetProfile
   );
@@ -25,11 +25,13 @@ export default function App(): JSX.Element {
   );
 
   useEffect(() => {
-    apiSpecInitFn();
-    authInit();
+    apiSpecStore.setSessionStoragePrefix('IP-client-');
+    apiSpecStore.init();
+    authStore.setSessionStoragePrefix('IP-client-');
+    authStore.init();
     aboutMeResetProfile();
     aboutMeInit();
-  }, [apiSpecInitFn, authInit, token, aboutMeInit, aboutMeResetProfile]);
+  }, [apiSpecStore, authStore, token, aboutMeInit, aboutMeResetProfile]);
 
   const apiSpec = useStoreState((state) => state.spec.spec);
   const baseUrl = process.env.BASE_URL;

--- a/web/portal/platform/src/App.tsx
+++ b/web/portal/platform/src/App.tsx
@@ -17,12 +17,12 @@ export default function App(): JSX.Element {
   );
   const languages = setLanguages(languagesList);
 
-  const apiSpecInitFn = useStoreActions((actions: any) => {
-    return actions.spec.init;
+  const apiSpecStore = useStoreActions((actions: any) => {
+    return actions.spec;
   });
+  const authStore = useStoreActions((actions: any) => actions.auth);
 
   const token = useStoreState((actions: any) => actions.auth.token);
-  const authInit = useStoreActions((actions: any) => actions.auth.init);
   const aboutMeResetProfile = useStoreActions(
     (actions: any) => actions.clientSession.aboutMe.resetProfile
   );
@@ -33,11 +33,13 @@ export default function App(): JSX.Element {
   useTranslation();
 
   useEffect(() => {
-    apiSpecInitFn();
-    authInit();
+    apiSpecStore.setSessionStoragePrefix('IP-platform-');
+    apiSpecStore.init();
+    authStore.setSessionStoragePrefix('IP-platform-');
+    authStore.init();
     aboutMeResetProfile();
     aboutMeInit();
-  }, [apiSpecInitFn, authInit, token, aboutMeInit, aboutMeResetProfile]);
+  }, [apiSpecStore, authStore, token, aboutMeInit, aboutMeResetProfile]);
 
   const apiSpec = useStoreState((state) => state.spec.spec);
   const baseUrl = process.env.BASE_URL;

--- a/web/portal/user/src/App.tsx
+++ b/web/portal/user/src/App.tsx
@@ -11,20 +11,23 @@ import { useEffect } from 'react';
 export default function App(): JSX.Element {
   StoreContainer.store = store;
 
-  const apiSpecInitFn = useStoreActions((actions: any) => {
-    return actions.spec.init;
+  const apiSpecStore = useStoreActions((actions: any) => {
+    return actions.spec;
   });
-  const authInit = useStoreActions((actions: any) => actions.auth.init);
+  const authStore = useStoreActions((actions: any) => actions.auth);
   const setLoginProps = useStoreActions(
     (actions: any) => actions.auth.setLoginProps
   );
+
   useEffect(() => {
-    apiSpecInitFn();
     setLoginProps({
       path: '/user_login',
     });
-    authInit();
-  }, [apiSpecInitFn, authInit, setLoginProps]);
+    apiSpecStore.setSessionStoragePrefix('IP-user-');
+    apiSpecStore.init();
+    authStore.setSessionStoragePrefix('IP-user-');
+    authStore.init();
+  }, [apiSpecStore, authStore, setLoginProps]);
 
   const apiSpec = useStoreState((state) => state.spec.spec);
   const baseUrl = process.env.BASE_URL;

--- a/web/rest/brand/public/index.php
+++ b/web/rest/brand/public/index.php
@@ -21,6 +21,15 @@ if ($trustedHosts = $_SERVER['TRUSTED_HOSTS'] ?? false) {
 
 $kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG']);
 $request = Request::createFromGlobals();
+if ($request->headers->has('cookie')) {
+    /** @var string $cookie */
+    $cookie = $request->headers->get('cookie');
+    if (str_contains($cookie, 'PHPSESSID')) {
+        //Ignore in order to avoid conflicts with klear php session
+        session_start();
+    }
+}
+
 $response = $kernel->handle($request);
 $response->send();
 $kernel->terminate($request, $response);

--- a/web/rest/client/public/index.php
+++ b/web/rest/client/public/index.php
@@ -21,6 +21,15 @@ if ($trustedHosts = $_SERVER['TRUSTED_HOSTS'] ?? false) {
 
 $kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG']);
 $request = Request::createFromGlobals();
+if ($request->headers->has('cookie')) {
+    /** @var string $cookie */
+    $cookie = $request->headers->get('cookie');
+    if (str_contains($cookie, 'PHPSESSID')) {
+        //Ignore in order to avoid conflicts with klear php session
+        session_start();
+    }
+}
+
 $response = $kernel->handle($request);
 $response->send();
 $kernel->terminate($request, $response);

--- a/web/rest/platform/public/index.php
+++ b/web/rest/platform/public/index.php
@@ -21,6 +21,15 @@ if ($trustedHosts = $_SERVER['TRUSTED_HOSTS'] ?? false) {
 
 $kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG']);
 $request = Request::createFromGlobals();
+if ($request->headers->has('cookie')) {
+    /** @var string $cookie */
+    $cookie = $request->headers->get('cookie');
+    if (str_contains($cookie, 'PHPSESSID')) {
+        //Ignore in order to avoid conflicts with klear php session
+        session_start();
+    }
+}
+
 $response = $kernel->handle($request);
 $response->send();
 $kernel->terminate($request, $response);

--- a/web/rest/user/public/index.php
+++ b/web/rest/user/public/index.php
@@ -21,6 +21,15 @@ if ($trustedHosts = $_SERVER['TRUSTED_HOSTS'] ?? false) {
 
 $kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG']);
 $request = Request::createFromGlobals();
+if ($request->headers->has('cookie')) {
+    /** @var string $cookie */
+    $cookie = $request->headers->get('cookie');
+    if (str_contains($cookie, 'PHPSESSID')) {
+        //Ignore in order to avoid conflicts with klear php session
+        session_start();
+    }
+}
+
 $response = $kernel->handle($request);
 $response->send();
 $kernel->terminate($request, $response);


### PR DESCRIPTION
- Keep klear session on new portal login
- Allow to have a tab in platform portal and another one in client/brand/user without losing the first token

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
<!-- Describe your changes in detail -->

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
