### PR TITLE
Add psalm baseline test to Jenkins pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -94,6 +94,7 @@ pipeline {
                     steps {
                         sh '/opt/irontec/ivozprovider/library/bin/test-phpstan'
                         sh '/opt/irontec/ivozprovider/library/bin/test-psalm'
+                        sh '/opt/irontec/ivozprovider/library/bin/test-psalm-update-baseline'
                     }
                     post {
                         success { notifySuccessGithub() }

--- a/library/bin/test-psalm-update-baseline
+++ b/library/bin/test-psalm-update-baseline
@@ -1,5 +1,16 @@
 #!/bin/bash
+# Stop on first non-zero exit code
+set -e
 
-pushd /opt/irontec/ivozprovider/library/bin
-  ./test-psalm --update-baseline
+pushd /opt/irontec/ivozprovider/library
+    # Regenerate psalm baseline
+    bin/test-psalm --set-baseline=psalm-baseline.xml
+
+    # Check baseline has changed
+    if [ -n "$(git status -s | grep psalm-baseline.xml)" ]; then
+        echo "Psalm baselines have been updated. Commit their changes!"
+        git status -s
+        exit 1
+    fi
 popd
+

--- a/library/psalm-baseline.xml
+++ b/library/psalm-baseline.xml
@@ -8472,11 +8472,6 @@
       <code>$this-&gt;services[$event][]</code>
     </MixedArrayAssignment>
   </file>
-  <file src="Ivoz/Provider/Domain/Service/RatingProfile/BillingServiceInterface.php">
-    <MissingReturnType occurrences="1">
-      <code>simulateCall</code>
-    </MissingReturnType>
-  </file>
   <file src="Ivoz/Provider/Domain/Service/RatingProfile/CheckValidCurrency.php">
     <ParamNameMismatch occurrences="1">
       <code>$ratingProfile</code>

--- a/microservices/balances/psalm-baseline.xml
+++ b/microservices/balances/psalm-baseline.xml
@@ -1,12 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="4.22.0@fc2c6ab4d5fa5d644d8617089f012f3bb84b8703">
   <file src="src/Kernel.php">
-    <DeprecatedClass occurrences="4">
-      <code>$routes-&gt;import($confDir . '/{routes}' . self::CONFIG_EXTS, '/', 'glob')</code>
-      <code>$routes-&gt;import($confDir . '/{routes}/' . $this-&gt;environment . '/*' . self::CONFIG_EXTS, '/', 'glob')</code>
-      <code>$routes-&gt;import($confDir . '/{routes}/*' . self::CONFIG_EXTS, '/', 'glob')</code>
-      <code>RouteCollectionBuilder</code>
-    </DeprecatedClass>
     <MixedArrayAccess occurrences="2">
       <code>$envs[$this-&gt;environment]</code>
       <code>$envs['all']</code>

--- a/microservices/provision/psalm-baseline.xml
+++ b/microservices/provision/psalm-baseline.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="4.22.0@fc2c6ab4d5fa5d644d8617089f012f3bb84b8703">
+  <file src="src/Behat/Context/FeatureContext.php">
+    <PossiblyInvalidCast occurrences="1">
+      <code>$container-&gt;getParameter('storagePath')</code>
+    </PossiblyInvalidCast>
+    <PropertyTypeCoercion occurrences="1"/>
+  </file>
   <file src="src/Kernel.php">
     <DeprecatedClass occurrences="4">
       <code>$routes-&gt;import($confDir . '/{routes}' . self::CONFIG_EXTS, '/', 'glob')</code>
@@ -31,8 +37,5 @@
     <MoreSpecificReturnType occurrences="1">
       <code>registerBundles</code>
     </MoreSpecificReturnType>
-    <UnresolvableInclude occurrences="1">
-      <code>require $this-&gt;getProjectDir() . '/config/bundles.php'</code>
-    </UnresolvableInclude>
   </file>
 </files>

--- a/microservices/provision/psalm.xml
+++ b/microservices/provision/psalm.xml
@@ -6,7 +6,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
-    errorBaseline="your-baseline.xml"
+    errorBaseline="psalm-baseline.xml"
 >
     <issueHandlers>
         <PossiblyNullReference errorLevel="suppress" />

--- a/web/rest/user/psalm-baseline.xml
+++ b/web/rest/user/psalm-baseline.xml
@@ -64,8 +64,6 @@
     </MixedInferredReturnType>
     <MixedMethodCall occurrences="7">
       <code>eq</code>
-      <code>eq</code>
-      <code>expr</code>
       <code>expr</code>
       <code>getEndTime</code>
       <code>getStartTime</code>


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
Unline PHPStan, Psalm does not check its baseline for exceptions that no longer apply, so this PR adds a test to the pipeline that regenerates Psalm baselines and ensures all existing exceptions still apply.

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
