### PR TITLE
Enhanced redis blpop errors

### DIFF
--- a/microservices/workers/psalm-baseline.xml
+++ b/microservices/workers/psalm-baseline.xml
@@ -100,8 +100,7 @@
     <MissingPropertyType occurrences="1">
       <code>$retryInterval</code>
     </MissingPropertyType>
-    <MixedArgument occurrences="11">
-      <code>$data</code>
+    <MixedArgument occurrences="10">
       <code>$job['rpcEntity']</code>
       <code>$job['rpcEntity']</code>
       <code>$job['rpcMethod']</code>
@@ -113,17 +112,13 @@
       <code>$this-&gt;retryInterval</code>
       <code>$this-&gt;retryInterval</code>
     </MixedArgument>
-    <MixedAssignment occurrences="1">
-      <code>$data</code>
-    </MixedAssignment>
     <MixedInferredReturnType occurrences="1">
       <code>array</code>
     </MixedInferredReturnType>
     <MixedReturnStatement occurrences="1">
       <code>\json_decode($data, true)</code>
     </MixedReturnStatement>
-    <PossiblyNullArgument occurrences="4">
-      <code>$response</code>
+    <PossiblyNullArgument occurrences="3">
       <code>$server-&gt;getIp()</code>
       <code>$server-&gt;getIp()</code>
       <code>$server-&gt;getName()</code>

--- a/microservices/workers/src/Worker/KamRpc.php
+++ b/microservices/workers/src/Worker/KamRpc.php
@@ -183,10 +183,15 @@ class KamRpc
             );
 
         try {
+            /** @var array<string> | false $response */
             $response = $redisMaster->blPop(
                 [$channel],
                 $this->redisTimeout
             );
+
+            if (!$response) {
+                throw new \DomainException('redis blPop error on channel ' . $channel);
+            }
 
             $data = end($response);
             return \json_decode($data, true);


### PR DESCRIPTION
When redis fails on blPop it's returning false value instead of expected array. Handle this scenario in a better way.

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
<!-- Describe your changes in detail -->

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
