### PR TITLE
Remove default notification templates crud from rest platform

### DIFF
--- a/web/rest/platform/config/api/raw/provider.yml
+++ b/web/rest/platform/config/api/raw/provider.yml
@@ -302,6 +302,10 @@ Ivoz\Provider\Domain\Model\InvoiceTemplate\InvoiceTemplate:
           isNull: ~
 
 Ivoz\Provider\Domain\Model\NotificationTemplate\NotificationTemplate:
+  itemOperations:
+    get: ~
+  collectionOperations:
+    get: ~
   attributes:
     access_control: '"ROLE_SUPER_ADMIN" in roles && user.hasAccessPrivileges(_api_resource_class, request.getMethod())'
     read_access_control:

--- a/web/rest/platform/features/provider/notificationTemplate/postNotificationTemplate.feature
+++ b/web/rest/platform/features/provider/notificationTemplate/postNotificationTemplate.feature
@@ -4,7 +4,7 @@ Feature: Create notification templates
   I need to be able to create them through the API.
 
   @createSchema
-  Scenario: Create an notification template
+  Scenario: Can't create a notification template
     Given I add Authorization header
      When I add "Content-Type" header equal to "application/json"
       And I add "Accept" header equal to "application/json"
@@ -15,31 +15,4 @@ Feature: Create notification templates
           "type": "fax"
       }
       """
-     Then the response status code should be 201
-      And the response should be in JSON
-      And the header "Content-Type" should be equal to "application/json; charset=utf-8"
-      And the JSON should be equal to:
-      """
-      {
-          "name": "New fax notification",
-          "type": "fax",
-          "id": 5,
-          "brand": null
-      }
-      """
-
-  Scenario: Retrieve created notification template
-    Given I add Authorization header
-     When I add "Accept" header equal to "application/json"
-      And I send a "GET" request to "notification_templates/5"
-     Then the response status code should be 200
-      And the response should be in JSON
-      And the header "Content-Type" should be equal to "application/json; charset=utf-8"
-      And the JSON should be like:
-      """
-      {
-          "name": "New fax notification",
-          "type": "fax",
-          "id": 5
-      }
-      """
+     Then the response status code should be 405

--- a/web/rest/platform/features/provider/notificationTemplate/putNotificationTemplate.feature
+++ b/web/rest/platform/features/provider/notificationTemplate/putNotificationTemplate.feature
@@ -4,7 +4,7 @@ Feature: Update notification templates
   I need to be able to update them through the API.
 
   @createSchema
-  Scenario: Update an notification template
+  Scenario: Can't update a notification template
     Given I add Authorization header
      When I add "Content-Type" header equal to "application/json"
       And I add "Accept" header equal to "application/json"
@@ -15,14 +15,4 @@ Feature: Update notification templates
           "type": "voicemail"
       }
       """
-     Then the response status code should be 200
-      And the response should be in JSON
-      And the header "Content-Type" should be equal to "application/json; charset=utf-8"
-      And the JSON should be like:
-      """
-      {
-          "name": "New fax notification",
-          "type": "voicemail",
-          "id": 2
-      }
-      """
+     Then the response status code should be 405

--- a/web/rest/platform/features/provider/notificationTemplate/removeNotificationTemplate.feature
+++ b/web/rest/platform/features/provider/notificationTemplate/removeNotificationTemplate.feature
@@ -4,9 +4,9 @@ Feature: Manage notification templates
   I need to be able to delete them through the API.
 
   @createSchema
-  Scenario: Remove a notification templates
+  Scenario: Can't remove a notification templates
     Given I add Authorization header
      When I add "Content-Type" header equal to "application/json"
       And I add "Accept" header equal to "application/json"
       And I send a "DELETE" request to "/notification_templates/2"
-     Then the response status code should be 204
+     Then the response status code should be 405


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
Only read Notification Templates entity.

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
