### PR TITLE
portals: hide token params from apache logs

### DIFF
--- a/profiles/portal/etc/apache2/sites-available/020-ivozprovider-portals.conf
+++ b/profiles/portal/etc/apache2/sites-available/020-ivozprovider-portals.conf
@@ -26,7 +26,7 @@
 
 # Logging Directives
 LogLevel warn
-CustomLog "|/usr/bin/logger -thttpd -plocal6.notice" combined
+CustomLog "|$/bin/sed -u -E \'s/token=[^& ]*/token=\[MASKED\]/g\' | /usr/bin/logger -thttpd -plocal6.notice" combined
 ErrorLog  "|/usr/bin/logger -thttpd -plocal6.err"
 
 # VirtualHost configuration
@@ -48,8 +48,6 @@ Alias /platform /opt/irontec/ivozprovider/web/portal/platform/dist
 
     <IfModule mod_rewrite.c>
         RewriteEngine On
-        LogLevel alert rewrite:trace6
-
         RewriteBase /platform
         RewriteRule ^/platform/index\.html$ - [L]
         RewriteCond %{REQUEST_URI} !^/(static)/
@@ -75,8 +73,6 @@ Alias /brand /opt/irontec/ivozprovider/web/portal/brand/dist
 
     <IfModule mod_rewrite.c>
         RewriteEngine On
-        LogLevel alert rewrite:trace6
-
         RewriteBase /brand
         RewriteRule ^/brand/index\.html$ - [L]
         RewriteCond %{REQUEST_URI} !^/(static)/
@@ -103,7 +99,6 @@ Alias /client /opt/irontec/ivozprovider/web/portal/client/dist
 
     <IfModule mod_rewrite.c>
         RewriteEngine On
-        LogLevel alert rewrite:trace6
 
         RewriteBase /client
         RewriteRule ^/client/index\.html$ - [L]
@@ -131,8 +126,6 @@ Alias /user /opt/irontec/ivozprovider/web/portal/user/dist
 
     <IfModule mod_rewrite.c>
         RewriteEngine On
-        LogLevel alert rewrite:trace6
-
         RewriteBase /user
         RewriteRule ^/user/index\.html$ - [L]
         RewriteCond %{REQUEST_URI} !^/(static)/


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
Replace token values in logs with [MASKED] 

```
- - [10/Feb/2023:13:36:38 +0100] "GET /client/?target=1&token=[MASKED] HTTP/2.0" 200 926 "https://1.1.1.1/brand/vPbx" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36"
- - [10/Feb/2023:13:36:38 +0100] "GET /client/assets/index.5265c558.css HTTP/2.0" 200 649 "https://1.1.1.1/client/?target=1&token=[MASKED] "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36"
- - [10/Feb/2023:13:36:38 +0100] "GET /client/assets/index.226e74ea.js HTTP/2.0" 200 390956 "https://1.1.1.1/client/?target=1&token=[MASKED] "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36"
- - [10/Feb/2023:13:36:39 +0100] "POST /api/client/token/exchange HTTP/2.0" 201 1466 "https://1.1.1.1/client/?target=1&token=[MASKED] "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36"
```



#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
