### PR TITLE
Add yarn cache in testing Docker image

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -55,7 +55,7 @@ RUN pip install reformat-gherkin
 # Base project
 USER $UNAME
 RUN mkdir -p /opt/irontec
-RUN git clone -b halliday --depth 1 https://github.com/irontec/ivozprovider /opt/irontec/ivozprovider
+RUN git clone -b bleeding --depth 1 https://github.com/irontec/ivozprovider /opt/irontec/ivozprovider
 
 # Install phpunit 6.5.14
 RUN mkdir -p /opt/phpunit/
@@ -67,6 +67,9 @@ RUN /opt/irontec/ivozprovider/library/bin/composer-install --prefer-dist --no-pr
 
 # Store the main project vendor
 RUN cp -r /opt/irontec/ivozprovider/library/vendor/    /opt/library-vendor
+
+# Get yarn dependencies and store them in the image
+RUN yarn --cwd /opt/irontec/ivozprovider/web/portal --cache-folder /opt/web-node_modules install
 
 # We dont require project files anymore
 RUN rm -fr /opt/irontec/ivozprovider/

--- a/tests/docker/bin/prepare-and-run
+++ b/tests/docker/bin/prepare-and-run
@@ -27,11 +27,8 @@ mkdir -m 777 -p /opt/irontec/ivozprovider/web/rest/user/var/cache/test
 cp /opt/irontec/ivozprovider/schema/var/cache/test/db.sqlite.back /opt/irontec/ivozprovider/web/rest/user/var/cache/test/db.sqlite.back
 
 # Install portal dependencies
-pushd /opt/irontec/ivozprovider/web/portal/
-  [ -x $(which yarn) ] && YARN=$(which yarn) || YARN=$(which yarnpkg)
-  $YARN config set network-timeout 1000000
-  $YARN install
-popd
+yarn config set network-timeout 1000000
+yarn --cwd /opt/irontec/ivozprovider/web/portal --cache-folder /opt/web-node_modules install
 
 # Run requested command
 exec $*


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
Improve prepare times by caching node_modules in Docker image

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
