### PR TITLE
kamusers: handle proxied behind NAT UAC

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -2271,7 +2271,14 @@ route[NATMANAGE] {
 
     # Set FLB_NATB? Only in within-dialog request with nat=yes on Route header initiated by us
     if (is_request() && has_totag() && check_route_param("nat=yes") && $var(is_from_inside)) {
-       setbflag(FLB_NATB);
+        $var(extparty) = $(route_uri{uri.param,extparty});
+        if ($var(extparty) != '' && $var(extparty) != $du) {
+            # Send in-dialog request to saved address:port instead of using Route addr:port
+            xwarn("[$dlg_var(cidhash)] NATMANAGE: send in-dialog $rm to $var(extparty) - instead of $du\n");
+            $du = $var(extparty);
+        }
+
+        setbflag(FLB_NATB);
     }
 
     # Return unless FLT_NATS or FLB_NATB are set
@@ -2282,6 +2289,18 @@ route[NATMANAGE] {
     # Add nat=yes in record-route? Only in initial requests when called from branch_route
     if (is_request() && !has_totag() && t_is_branch_route()) {
         add_rr_param(";nat=yes");
+
+        if ($var(is_from_inside) || !is_first_hop()) {
+            if ($var(is_from_inside)) {
+                # Calling to behind NAT UAC, save real address
+                $var(extparty) = ";extparty=" + $du;
+            } else {
+                # Call from behind NAT UAC and not first hop (middle proxy), save real address
+                $var(extparty) = ";extparty=sip:" + $si + ':' + $sp;
+            }
+
+            add_rr_param("$var(extparty)");
+        }
     }
 
     # Add contact alias? Only to replies with NATB set and first hop


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description

Before this PR UACs were supposed to reach KamUsers as first hop (no middle-proxy, no Record-Route in requests).

This PR adapts KamUsers to received proxied UAC, both of them behind NAT. On these escenarios Record-Route inserted by middle-proxy has a non-reachable address, so it needs to be handled.

#### Additional information

No functional change if no proxied UACs.