### PR TITLE
Fixed brand.proxyTrunks foreign key resolver

### DIFF
--- a/web/portal/platform/src/entities/Brand/Brand.tsx
+++ b/web/portal/platform/src/entities/Brand/Brand.tsx
@@ -64,6 +64,7 @@ const properties: BrandProperties = {
   proxyTrunks: {
     label: _('Proxy Trunks', { count: 20 }),
     null: _('There are not associated elements'),
+    $ref: '#/definitions/ProxyTrunk',
   },
 };
 

--- a/web/portal/platform/src/entities/Brand/ForeignKeyResolver.tsx
+++ b/web/portal/platform/src/entities/Brand/ForeignKeyResolver.tsx
@@ -20,7 +20,7 @@ const foreignKeyResolver: foreignKeyResolverType = async function ({
     data,
     cancelToken,
     entityService,
-    skip: ['features', 'proxyTrunks'],
+    skip: ['features'],
   });
 
   promises.push(
@@ -35,19 +35,6 @@ const foreignKeyResolver: foreignKeyResolverType = async function ({
           const name = row.name as Record<string, string>;
           return name[language];
         },
-      },
-      cancelToken,
-    })
-  );
-
-  promises.push(
-    genericForeignKeyResolver({
-      data,
-      fkFld: 'proxyTrunks',
-      addLink: false,
-      entity: {
-        ...entities.ProxyTrunk,
-        toStr: (row: ProxyTrunkPropertyList<EntityValue>) => row.ip as string,
       },
       cancelToken,
     })


### PR DESCRIPTION
It was showing the id instead of a string value

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
<!-- Describe your changes in detail -->

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
