### PR TITLE
kamusers: handle proxied behind NAT UAC (transport TLS)

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -2271,14 +2271,8 @@ route[NATMANAGE] {
 
     # Set FLB_NATB? Only in within-dialog request with nat=yes on Route header initiated by us
     if (is_request() && has_totag() && check_route_param("nat=yes") && $var(is_from_inside)) {
-        $var(extparty) = $(route_uri{uri.param,extparty});
-        if ($var(extparty) != '' && $var(extparty) != $du) {
-            # Send in-dialog request to saved address:port instead of using Route addr:port
-            xwarn("[$dlg_var(cidhash)] NATMANAGE: send in-dialog $rm to $var(extparty) - instead of $du\n");
-            $du = $var(extparty);
-        }
-
         setbflag(FLB_NATB);
+        route(FIX_DU);
     }
 
     # Return unless FLT_NATS or FLB_NATB are set
@@ -2289,18 +2283,7 @@ route[NATMANAGE] {
     # Add nat=yes in record-route? Only in initial requests when called from branch_route
     if (is_request() && !has_totag() && t_is_branch_route()) {
         add_rr_param(";nat=yes");
-
-        if ($var(is_from_inside) || !is_first_hop()) {
-            if ($var(is_from_inside)) {
-                # Calling to behind NAT UAC, save real address
-                $var(extparty) = ";extparty=" + $du;
-            } else {
-                # Call from behind NAT UAC and not first hop (middle proxy), save real address
-                $var(extparty) = ";extparty=sip:" + $si + ':' + $sp;
-            }
-
-            add_rr_param("$var(extparty)");
-        }
+        route(SAVE_EXTPARTY);
     }
 
     # Add contact alias? Only to replies with NATB set and first hop
@@ -2312,6 +2295,47 @@ route[NATMANAGE] {
            exit;
         }
     }
+}
+
+route[SAVE_EXTPARTY] {
+    if ($var(is_from_inside) && $du != $null) {
+        # Calling to behind NAT UAC, save real address
+        $var(extparty) = ";extparty=sip:" + $(du{uri.host}) + ':' + $(du{uri.port});
+        xinfo("[$dlg_var(cidhash)] SAVE-EXTPARTY: add $var(extparty) to Record-Route\n");
+        add_rr_param("$var(extparty)");
+    }
+
+    if (!$var(is_from_inside) && !is_first_hop()) {
+        # Call from behind NAT UAC and not first hop (middle proxy), save real address
+        $var(extparty) = ";extparty=sip:" + $si + ':' + $sp;
+        xinfo("[$dlg_var(cidhash)] SAVE-EXTPARTY: add $var(extparty) to Record-Route\n");
+        add_rr_param("$var(extparty)");
+    }
+
+    return;
+}
+
+route[FIX_DU] {
+    if (!is_present_hf("Route")) return; # no Route header found
+
+    $var(extparty) = $(route_uri{uri.param,extparty});
+
+    if ($var(extparty) == '') return; # no ;extparty present in Route header
+
+    $var(extpartyHost) = $(var(extparty){s.select,1,:});
+    $var(extpartyPort) = $(var(extparty){s.select,2,:});
+
+    $var(duHost) = $(du{uri.host});
+    $var(duPort) = $(du{uri.port});
+
+    # If $du is equal to ;extparty, leave
+    if ($var(extpartyHost) == $var(duHost) && $var(extpartyPort) == $var(duPort)) return;
+
+    # Send in-dialog request to saved address:port instead of using Route addr:port
+    xwarn("[$dlg_var(cidhash)] FIX-DU: send in-dialog $rm to $var(extparty) - instead of $du\n");
+    $du = $var(extparty);
+
+    return;
 }
 
 # This route sets following dlg_vars: brandId, companyId, type


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description

$du may contain params (such as ;transport=tls). Strip them from extparty Record-Route param.
