### PR TITLE
pkg: remove resolv.conf symlink before setting local DNS resolution

### DIFF
--- a/debian/ivozprovider-profile-common.preinst
+++ b/debian/ivozprovider-profile-common.preinst
@@ -18,6 +18,9 @@ db_stop
 # Make resolv editable
 /usr/bin/chattr -i /etc/resolv.conf
 
+# If resolv.conf is a symlink, break it
+[ -L /etc/resolv.conf ] && rm -f /etc/resolv.conf
+
 /bin/cat > /etc/resolv.conf <<- EOM
 # THIS FILE IS AUTO-GENERATED. DO NOT EDIT MANUALLY.
 domain ivozprovider.local


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
Some setups that use cloudinit or other provisioners, resolv.conf file is a symlink to /run/ so its contents doesn't persist to reboots. This PR breaks the symlink before setting the local DNS configuration. 

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
