### PR TITLE
Fix duplicated IVR Entry success locution

### DIFF
--- a/asterisk/agi/src/Agi/Action/IvrAction.php
+++ b/asterisk/agi/src/Agi/Action/IvrAction.php
@@ -98,9 +98,6 @@ class IvrAction
             if ($entryMatched) {
                 $this->agi->notice("Entered value %d matches entry %s.", $userPressed, $entry->getEntry());
 
-                // Entered data matched one of the entries, play success (if any)
-                $this->agi->playbackLocution($ivr->getSuccessLocution());
-
                 // Play success locution (if any)
                 $successLocution = is_null($entry->getWelcomeLocution())
                     ? $ivr->getSuccessLocution()


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
Remove duplicated success locution when an ivr entry matches and have custom entry locution

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
