### PR TITLE
Portal platform domain list cannot show user ivozprovider local nor proxy trunks ivozprovider local

### DIFF
--- a/web/portal/platform/src/entities/MediaRelaySet/MediaRelaySet.tsx
+++ b/web/portal/platform/src/entities/MediaRelaySet/MediaRelaySet.tsx
@@ -23,7 +23,7 @@ const properties: MediaRelaySetProperties = {
   },
 };
 
-export const ChildDecorator: ChildDecoratorType = (props) => {
+const ChildDecorator: ChildDecoratorType = (props) => {
   const { routeMapItem, row } = props;
 
   if (

--- a/web/rest/platform/config/api/raw/provider.yml
+++ b/web/rest/platform/config/api/raw/provider.yml
@@ -179,6 +179,13 @@ Ivoz\Provider\Domain\Model\Domain\Domain:
     get: ~
   attributes:
     access_control: '"ROLE_SUPER_ADMIN" in roles && user.hasAccessPrivileges(_api_resource_class, request.getMethod())'
+    read_access_control:
+    - and:
+      - domain: 
+          neq: '"users.ivozprovider.local"'
+      - domain:
+          neq: '"trunks.ivozprovider.local"'
+          
 
 Ivoz\Provider\Domain\Model\Feature\Feature:
   attributes:

--- a/web/rest/platform/features/provider/domain/getDomains.feature
+++ b/web/rest/platform/features/provider/domain/getDomains.feature
@@ -15,20 +15,6 @@ Feature: Retrieve domains
       """
       [
           {
-              "domain": "users.ivozprovider.local",
-              "pointsTo": "proxyusers",
-              "id": 1,
-              "brandName": "",
-              "companyName": ""
-          },
-          {
-              "domain": "trunks.ivozprovider.local",
-              "pointsTo": "proxytrunks",
-              "id": 2,
-              "brandName": "",
-              "companyName": ""
-          },
-          {
               "domain": "127.0.0.1",
               "pointsTo": "proxyusers",
               "id": 3,
@@ -62,16 +48,16 @@ Feature: Retrieve domains
   Scenario: Retrieve certain domain json
     Given I add Authorization header
      When I add "Accept" header equal to "application/json"
-      And I send a "GET" request to "domains/1"
+      And I send a "GET" request to "domains/3"
      Then the response status code should be 200
       And the response should be in JSON
       And the header "Content-Type" should be equal to "application/json; charset=utf-8"
       And the JSON should be equal to:
       """
       {
-          "domain": "users.ivozprovider.local",
+          "domain": "127.0.0.1",
           "pointsTo": "proxyusers",
-          "description": "Minimal proxyusers global domain",
-          "id": 1
+          "description": "DemoCompany proxyusers domain",
+          "id": 3
       }
       """


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
Removed elements from domain list if domain attributes matches  *.local

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
