### PR TITLE
Portal brand destination rate when timing is always it fails

### DIFF
--- a/library/Ivoz/Provider/Domain/Model/RatingPlan/RatingPlanDto.php
+++ b/library/Ivoz/Provider/Domain/Model/RatingPlan/RatingPlanDto.php
@@ -31,6 +31,15 @@ class RatingPlanDto extends RatingPlanDtoAbstract
     }
 
 
+    public function setTimeIn(\DateTimeInterface|string|null $timeIn): static
+    {
+        if (is_null($timeIn)) {
+            $timeIn = new \DateTime('00:00:00');
+        }
+
+        return parent::setTimeIn($timeIn);
+    }
+
     public function setTimingType(?string $timingType = null): static
     {
         if ($timingType == RatingPlanInterface::TIMINGTYPE_ALWAYS) {

--- a/library/psalm-baseline.xml
+++ b/library/psalm-baseline.xml
@@ -6244,13 +6244,15 @@
     <UnsafeInstantiation occurrences="1"/>
   </file>
   <file src="Ivoz/Provider/Domain/Model/RatingPlan/RatingPlanDto.php">
-    <LessSpecificReturnStatement occurrences="1">
+    <LessSpecificReturnStatement occurrences="2">
+      <code>parent::setTimeIn($timeIn)</code>
       <code>parent::setTimingType($timingType)</code>
     </LessSpecificReturnStatement>
     <MixedArgument occurrences="1">
       <code>func_get_args()</code>
     </MixedArgument>
-    <MoreSpecificReturnType occurrences="1">
+    <MoreSpecificReturnType occurrences="2">
+      <code>static</code>
       <code>static</code>
     </MoreSpecificReturnType>
   </file>


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
Portal brand destination rate when fix fails when timing is always

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
