### PR TITLE
kamusers: allow unsolicited notify from asterisk for mwi

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -499,6 +499,9 @@ request_route {
     # Handle REGISTER
     route(REGISTER);
 
+    # Handle unsolicited NOTIFY messages (non-related to previous SUBSCRIBE)
+    route(UNSOLICITED_NOTIFY);
+
     # -- From now on, everything is for INVITEs --
 
     # Antiflooding for new calls establishments
@@ -2956,6 +2959,14 @@ route[QUALITY] {
         xnotice("[$dlg_var(cidhash)] QUALITY: inbound mos $avp(mos_average_B) - pl $avp(mos_average_packetloss_B) % - jt $avp(mos_average_jitter_B) ms - rtt $avp(mos_average_roundtrip_B) ms ($var(tag))");
         xnotice("[$dlg_var(cidhash)] QUALITY: outbound mos $avp(mos_average_A) - pl $avp(mos_average_packetloss_A) % - jt $avp(mos_average_jitter_A) ms - rtt $avp(mos_average_roundtrip_A) ms ($var(tag))");
     }
+}
+
+route[UNSOLICITED_NOTIFY] {
+    if (!is_method("NOTIFY")) return;
+    if (!$var(is_from_inside)) return;
+
+    route(LOOKUP);
+    route(RELAY);
 }
 
 route[EXIT_NOW] {


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description

Asterisk send out-of-dialog NOTIFY requests with MWI related info. Leave them traverse KamUsers.

#### Additional information

This was accidentally removed in eb054231f28c4e51aeb52ae6cdf5a8bce9bc7daf inside #1742