### PR TITLE
web/admin: fixed residential client forced values

### DIFF
--- a/web/admin/application/configs/klear/ResidentialClientsList.yaml
+++ b/web/admin/application/configs/klear/ResidentialClientsList.yaml
@@ -43,11 +43,11 @@ production:
           typeIcon: true
           domainUsers: true
           transformationRuleSet: true
-          postalAddress: true
-          postalCode: true
-          town: true
-          province: true
-          countryName: true
+          invoicing.postalAddress: true
+          invoicing.postalCode: true
+          invoicing.town: true
+          invoicing.province: true
+          invoicing.countryName: true
           country: true
           outgoingDdiRule: true
           registryData: true
@@ -182,11 +182,11 @@ production:
         type: "residential"
         <<: *forcedBrand
         invoicing.nif: '12345678-Z'
-        postalAddress: 'Postal address'
-        postalCode: 'PC'
-        town: 'Town'
-        countryName: 'Country'
-        province: 'Province'
+        invoicing.postalAddress: 'Postal address'
+        invoicing.postalCode: 'PC'
+        invoicing.town: 'Town'
+        invoicing.countryName: 'Country'
+        invoicing.province: 'Province'
 
     residentialClientsEdit_screen: &residentialClientsEdit_screenLink
       <<: *ResidentialClients


### PR DESCRIPTION
Fix `Call to undefined method Ivoz\Provider\Domain\Model\Company\CompanyDto::setPostalAddress() (0) # /opt/irontec/klear/modules/klearMatrix/controllers/helpers/Column2Model.php` error on residential client creation

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX
