### PR TITLE
Update PsIdentify when owner entity changes

### DIFF
--- a/library/Ivoz/Ast/Domain/Service/PsIdentify/UpdateByFriend.php
+++ b/library/Ivoz/Ast/Domain/Service/PsIdentify/UpdateByFriend.php
@@ -2,7 +2,9 @@
 
 namespace Ivoz\Ast\Domain\Service\PsIdentify;
 
+use Ivoz\Ast\Domain\Model\PsIdentify\PsIdentify;
 use Ivoz\Ast\Domain\Model\PsIdentify\PsIdentifyDto;
+use Ivoz\Ast\Domain\Model\PsIdentify\PsIdentifyInterface;
 use Ivoz\Core\Domain\Service\EntityTools;
 use Ivoz\Provider\Domain\Model\Friend\FriendInterface;
 use Ivoz\Provider\Domain\Service\Friend\FriendLifecycleEventHandlerInterface;
@@ -27,23 +29,27 @@ class UpdateByFriend implements FriendLifecycleEventHandlerInterface
      */
     public function execute(FriendInterface $friend)
     {
-        $isNew = $friend->isNew();
-        if (!$isNew) {
-            return;
-        }
+        $identify = $friend->getPsIdentify();
+
+        /** @var PsIdentifyDto $identifyDto */
+        $identifyDto = is_null($identify)
+            ? PsIdentify::createDto()
+            : $this->entityTools->entityToDto($identify);
 
         // Get sorcery identifier
         $sorceryId = $friend->getSorcery();
 
         // Insert Identify data
-        $identifyDto = new PsIdentifyDto();
         $identifyDto
             ->setSorceryId($sorceryId)
             ->setEndpoint($sorceryId)
             ->setMatchHeader($sorceryId)
             ->setFriendId($friend->getId());
 
-        $this->entityTools
-            ->persistDto($identifyDto);
+        /** @var PsIdentifyInterface $identify */
+        $identify = $this->entityTools
+            ->persistDto($identifyDto, $identify);
+
+        $friend->setPsIdentify($identify);
     }
 }

--- a/library/Ivoz/Ast/Domain/Service/PsIdentify/UpdateByResidentialDevice.php
+++ b/library/Ivoz/Ast/Domain/Service/PsIdentify/UpdateByResidentialDevice.php
@@ -2,7 +2,9 @@
 
 namespace Ivoz\Ast\Domain\Service\PsIdentify;
 
+use Ivoz\Ast\Domain\Model\PsIdentify\PsIdentify;
 use Ivoz\Ast\Domain\Model\PsIdentify\PsIdentifyDto;
+use Ivoz\Ast\Domain\Model\PsIdentify\PsIdentifyInterface;
 use Ivoz\Core\Domain\Service\EntityTools;
 use Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDeviceInterface;
 use Ivoz\Provider\Domain\Service\ResidentialDevice\ResidentialDeviceLifecycleEventHandlerInterface;
@@ -27,23 +29,27 @@ class UpdateByResidentialDevice implements ResidentialDeviceLifecycleEventHandle
      */
     public function execute(ResidentialDeviceInterface $residentialDevice)
     {
-        $isNew = $residentialDevice->isNew();
-        if (!$isNew) {
-            return;
-        }
+        $identify = $residentialDevice->getPsIdentify();
+
+        /** @var PsIdentifyDto $identifyDto */
+        $identifyDto = is_null($identify)
+            ? PsIdentify::createDto()
+            : $this->entityTools->entityToDto($identify);
 
         // Get sorcery identifier
         $sorceryId = $residentialDevice->getSorcery();
 
         // Insert Identify data
-        $identifyDto = new PsIdentifyDto();
         $identifyDto
             ->setSorceryId($sorceryId)
             ->setEndpoint($sorceryId)
             ->setMatchHeader($sorceryId)
             ->setResidentialDeviceId($residentialDevice->getId());
 
-        $this->entityTools
-            ->persistDto($identifyDto);
+        /** @var PsIdentifyInterface $identify */
+        $identify = $this->entityTools
+            ->persistDto($identifyDto, $identify);
+
+        $residentialDevice->setPsIdentify($identify);
     }
 }

--- a/library/Ivoz/Ast/Domain/Service/PsIdentify/UpdateByRetailAccount.php
+++ b/library/Ivoz/Ast/Domain/Service/PsIdentify/UpdateByRetailAccount.php
@@ -2,7 +2,9 @@
 
 namespace Ivoz\Ast\Domain\Service\PsIdentify;
 
+use Ivoz\Ast\Domain\Model\PsIdentify\PsIdentify;
 use Ivoz\Ast\Domain\Model\PsIdentify\PsIdentifyDto;
+use Ivoz\Ast\Domain\Model\PsIdentify\PsIdentifyInterface;
 use Ivoz\Core\Domain\Service\EntityTools;
 use Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface;
 use Ivoz\Provider\Domain\Service\RetailAccount\RetailAccountLifecycleEventHandlerInterface;
@@ -27,23 +29,27 @@ class UpdateByRetailAccount implements RetailAccountLifecycleEventHandlerInterfa
      */
     public function execute(RetailAccountInterface $retailAccount)
     {
-        $isNew = $retailAccount->isNew();
-        if (!$isNew) {
-            return;
-        }
+        $identify = $retailAccount->getPsIdentify();
+
+        /** @var PsIdentifyDto $identifyDto */
+        $identifyDto = is_null($identify)
+            ? PsIdentify::createDto()
+            : $this->entityTools->entityToDto($identify);
 
         // Get sorcery identifier
         $sorceryId = $retailAccount->getSorcery();
 
         // Insert Identify data
-        $identifyDto = new PsIdentifyDto();
         $identifyDto
             ->setSorceryId($sorceryId)
             ->setEndpoint($sorceryId)
             ->setMatchHeader($sorceryId)
             ->setRetailAccountId($retailAccount->getId());
 
-        $this->entityTools
-            ->persistDto($identifyDto);
+        /** @var PsIdentifyInterface $identify */
+        $identify = $this->entityTools
+            ->persistDto($identifyDto, $identify);
+
+        $retailAccount->setPsIdentify($identify);
     }
 }

--- a/library/Ivoz/Ast/Domain/Service/PsIdentify/UpdateByTerminal.php
+++ b/library/Ivoz/Ast/Domain/Service/PsIdentify/UpdateByTerminal.php
@@ -2,7 +2,9 @@
 
 namespace Ivoz\Ast\Domain\Service\PsIdentify;
 
+use Ivoz\Ast\Domain\Model\PsIdentify\PsIdentify;
 use Ivoz\Ast\Domain\Model\PsIdentify\PsIdentifyDto;
+use Ivoz\Ast\Domain\Model\PsIdentify\PsIdentifyInterface;
 use Ivoz\Core\Domain\Service\EntityTools;
 use Ivoz\Provider\Domain\Model\Terminal\TerminalInterface;
 use Ivoz\Provider\Domain\Service\Terminal\TerminalLifecycleEventHandlerInterface;
@@ -27,23 +29,27 @@ class UpdateByTerminal implements TerminalLifecycleEventHandlerInterface
      */
     public function execute(TerminalInterface $terminal)
     {
-        $isNew = $terminal->isNew();
-        if (!$isNew) {
-            return;
-        }
+        $identify = $terminal->getPsIdentify();
+
+        /** @var PsIdentifyDto $identifyDto */
+        $identifyDto = is_null($identify)
+            ? PsIdentify::createDto()
+            : $this->entityTools->entityToDto($identify);
 
         // Get sorcery identifier
         $sorceryId = $terminal->getSorcery();
 
         // Insert Identify data
-        $identifyDto = new PsIdentifyDto();
         $identifyDto
             ->setSorceryId($sorceryId)
             ->setEndpoint($sorceryId)
             ->setMatchHeader($sorceryId)
             ->setTerminalId($terminal->getId());
 
-        $this->entityTools
-            ->persistDto($identifyDto);
+        /** @var PsIdentifyInterface $identify */
+        $identify = $this->entityTools
+            ->persistDto($identifyDto, $identify);
+
+        $terminal->setPsIdentify($identify);
     }
 }

--- a/schema/tests/Provider/Friend/FriendLifeCycleTest.php
+++ b/schema/tests/Provider/Friend/FriendLifeCycleTest.php
@@ -119,6 +119,7 @@ class FriendLifeCycleTest extends KernelTestCase
         $this->assetChangedEntities([
             Friend::class,
             PsEndpoint::class,
+            PsIdentify::class,
         ]);
     }
 

--- a/schema/tests/Provider/ResidentialDevice/ResidentialDeviceLifeCycleTest.php
+++ b/schema/tests/Provider/ResidentialDevice/ResidentialDeviceLifeCycleTest.php
@@ -165,6 +165,7 @@ class ResidentialDeviceLifeCycleTest extends KernelTestCase
             ResidentialDevice::class,
             Voicemail::class,
             PsEndpoint::class,
+            PsIdentify::class,
             AstVoicemail::class,
         ]);
     }

--- a/schema/tests/Provider/RetailAccount/RetailAccountLifeCycleTest.php
+++ b/schema/tests/Provider/RetailAccount/RetailAccountLifeCycleTest.php
@@ -116,6 +116,7 @@ class RetailAccountLifeCycleTest extends KernelTestCase
         $this->assetChangedEntities([
             RetailAccount::class,
             PsEndpoint::class,
+            PsIdentify::class,
         ]);
     }
 

--- a/schema/tests/Provider/Terminal/TerminalLifeCycleTest.php
+++ b/schema/tests/Provider/Terminal/TerminalLifeCycleTest.php
@@ -113,6 +113,7 @@ class TerminalLifeCycleTest extends KernelTestCase
         $this->assetChangedEntities([
             Terminal::class,
             PsEndpoint::class,
+            PsIdentify::class,
             QueueMember::class,
         ]);
     }


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
PsIdentify entities must be updated when its owner entity (Terminal, Friend, Residential Device or Retail Account) changes. Otherwise, some data like endpoint name is not properly synced.


#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
