### PR TITLE
Filter platform web portals properly

### DIFF
--- a/web/portal/platform/src/router/EntityMap.ts
+++ b/web/portal/platform/src/router/EntityMap.ts
@@ -63,6 +63,9 @@ const getEntityMap = (): ExtendedRouteMap => {
     },
     {
       entity: entities.WebPortal,
+      filterValues: {
+        urlType: 'god',
+      },
       divider: true,
     },
     {


### PR DESCRIPTION
It was showing both god and brand portals

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
<!-- Describe your changes in detail -->

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
