### PR TITLE
Ignore internal admin timezones in UserTimezoneInjector

### DIFF
--- a/library/Ivoz/Provider/Domain/Model/Administrator/Administrator.php
+++ b/library/Ivoz/Provider/Domain/Model/Administrator/Administrator.php
@@ -10,6 +10,8 @@ use Symfony\Component\Security\Core\User\UserInterface;
  */
 class Administrator extends AdministratorAbstract implements AdministratorInterface, UserInterface, LegacyPasswordAuthenticatedUserInterface, \Serializable
 {
+    private null|string $onBehalfOf = null;
+
     use AdministratorTrait, AdministratorSecurityTrait {
         AdministratorTrait::getRelPublicEntities insteadof AdministratorSecurityTrait;
     }
@@ -31,6 +33,16 @@ class Administrator extends AdministratorAbstract implements AdministratorInterf
     public function getId(): ?int
     {
         return $this->id;
+    }
+
+    public function setOnBehalfOf(string $adminName): void
+    {
+        $this->onBehalfOf = $adminName;
+    }
+
+    public function getOnBehalfOf(): string|null
+    {
+        return $this->onBehalfOf;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/Administrator/AdministratorInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/Administrator/AdministratorInterface.php
@@ -31,6 +31,10 @@ interface AdministratorInterface extends LoggableEntityInterface
      */
     public function getId(): ?int;
 
+    public function setOnBehalfOf(string $adminName): void;
+
+    public function getOnBehalfOf(): ?string;
+
     /**
      * @inheritdoc
      */

--- a/library/Ivoz/Provider/Domain/Model/Administrator/AdministratorRepository.php
+++ b/library/Ivoz/Provider/Domain/Model/Administrator/AdministratorRepository.php
@@ -13,6 +13,8 @@ interface AdministratorRepository extends ObjectRepository, Selectable
      */
     public function getInnerGlobalAdmin();
 
+    public function findAdminByUsername(string $username): ?AdministratorInterface;
+
     /**
      * @param string $username
      * @return null| AdministratorInterface

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/AdministratorDoctrineRepository.php
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/AdministratorDoctrineRepository.php
@@ -52,6 +52,16 @@ class AdministratorDoctrineRepository extends ServiceEntityRepository implements
         return $privateAdmin;
     }
 
+    public function findAdminByUsername(string $username): ?AdministratorInterface
+    {
+        /** @var AdministratorInterface | null $admin */
+        $admin = $this->findOneBy([
+            'username' => $username
+        ]);
+
+        return $admin;
+    }
+
     /**
      * @param string $username
      * @return null| AdministratorInterface

--- a/schema/tests/Provider/Administrator/AdministratorRepositoryTest.php
+++ b/schema/tests/Provider/Administrator/AdministratorRepositoryTest.php
@@ -17,6 +17,7 @@ class AdministratorRepositoryTest extends KernelTestCase
     public function test_runner()
     {
         $this->it_gets_inner_global_admin();
+        $this->it_gets_admin_by_username();
         $this->it_gets_platform_admin_by_username();
         $this->it_returns_null_if_platform_admin_is_not_found();
     }
@@ -37,6 +38,32 @@ class AdministratorRepositoryTest extends KernelTestCase
         $this->assertEquals(
             $innerAdmin->getId(),
             0
+        );
+    }
+
+    public function it_gets_admin_by_username()
+    {
+        /** @var AdministratorDoctrineRepository $repository */
+        $repository = $this->em
+            ->getRepository(Administrator::class);
+
+        $targetName = 'test_brand_admin';
+        $admin = $repository->findBrandAdminByUsername(
+            $targetName
+        );
+
+        $this->assertInstanceOf(
+            Administrator::class,
+            $admin
+        );
+
+        $this->assertNotEmpty(
+            $admin->getBrand()
+        );
+
+        $this->assertEquals(
+            $targetName,
+            $admin->getUsername()
         );
     }
 


### PR DESCRIPTION
Use original admin timezone instead

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
<!-- Describe your changes in detail -->

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
