### PR TITLE
Portal platform not found snackbar when inital load at list

### DIFF
--- a/web/portal/platform/src/entities/BillableCall/BillableCall.tsx
+++ b/web/portal/platform/src/entities/BillableCall/BillableCall.tsx
@@ -121,6 +121,11 @@ const BillableCall: EntityInterface = {
     delete: false,
   },
   customActions: Actions,
+  foreignKeyResolver: async () => {
+    const module = await import('./ForeignKeyResolver');
+
+    return module.default;
+  },
   View: async () => {
     const module = await import('./View');
 

--- a/web/portal/platform/src/entities/BillableCall/ForeignKeyResolver.tsx
+++ b/web/portal/platform/src/entities/BillableCall/ForeignKeyResolver.tsx
@@ -1,0 +1,23 @@
+import { autoForeignKeyResolver } from '@irontec/ivoz-ui/entities/DefaultEntityBehavior';
+import { foreignKeyResolverType } from '@irontec/ivoz-ui/entities/EntityInterface';
+
+import { BillableCallPropertiesList } from './BillableCallProperties';
+
+const foreignKeyResolver: foreignKeyResolverType = async function ({
+  data,
+  cancelToken,
+  entityService,
+}): Promise<BillableCallPropertiesList> {
+  const promises = autoForeignKeyResolver({
+    data,
+    cancelToken,
+    entityService,
+    skip: ['ddi', 'ddiProvider'],
+  });
+
+  await Promise.all(promises);
+
+  return data;
+};
+
+export default foreignKeyResolver;

--- a/web/portal/platform/src/entities/Ddi/Ddi.tsx
+++ b/web/portal/platform/src/entities/Ddi/Ddi.tsx
@@ -14,7 +14,7 @@ const Ddi: EntityInterface = {
   link: '/doc/en/administration_portal/client/vpbx/ddis.html',
   iden: 'Ddi',
   title: _('DDI', { count: 2 }),
-  path: '/Ddis',
+  path: '/ddis',
   toStr: (row: DdiPropertyList<EntityValue>) => row.ddie164 as string,
   properties,
 };

--- a/web/portal/platform/src/entities/DdiProvider/DdiProvider.tsx
+++ b/web/portal/platform/src/entities/DdiProvider/DdiProvider.tsx
@@ -36,7 +36,7 @@ const DdiProvider: EntityInterface = {
   link: '/doc/en/administration_portal/brand/providers/ddi_providers.html',
   iden: 'DdiProvider',
   title: _('DDI Provider', { count: 2 }),
-  path: '/DdiProviders',
+  path: '/ddi_providers',
   toStr: (row: DdiProviderPropertyList<EntityValue>) => row.name as string,
   properties,
 };


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
Fixed path literal in DDi entity from platform portal, and exposed its collection in the API.

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
