### PR TITLE
Added width and empty content to specific and generic templates

### DIFF
--- a/web/portal/package.json
+++ b/web/portal/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",
-    "@irontec/ivoz-ui": "^1.1.0",
+    "@irontec/ivoz-ui": "^1.1.1",
     "@mui/icons-material": "^5.11.16",
     "@mui/material": "^5.12.1",
     "@mui/styles": "^5.12.0",

--- a/web/portal/platform/src/entities/TerminalModel/Form.tsx
+++ b/web/portal/platform/src/entities/TerminalModel/Form.tsx
@@ -24,7 +24,12 @@ const Form = (props: EntityFormProps): JSX.Element => {
     },
     {
       legend: '',
-      fields: ['genericTemplate'],
+      fields: [
+        {
+          name: 'genericTemplate',
+          size: { md: 12, lg: 12, xl: 12 },
+        },
+      ],
     },
     {
       legend: '',
@@ -32,7 +37,12 @@ const Form = (props: EntityFormProps): JSX.Element => {
     },
     {
       legend: '',
-      fields: ['specificTemplate'],
+      fields: [
+        {
+          name: 'specificTemplate',
+          size: { md: 12, lg: 12, xl: 12 },
+        },
+      ],
     },
   ];
 

--- a/web/portal/yarn.lock
+++ b/web/portal/yarn.lock
@@ -689,10 +689,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@irontec/ivoz-ui@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@irontec/ivoz-ui/-/ivoz-ui-1.1.0.tgz#f8611d1f9b1d85ddfe4ef8cef9d54db0bfb69d7f"
-  integrity sha512-9P7aDFV+yffd1rlUEZkkDQQqsU8AuHFydjY/mWcMrVJeQ/plVvtcwyX0MmiK4F7NHIhfikxVkpyQbx8oDs+KOQ==
+"@irontec/ivoz-ui@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@irontec/ivoz-ui/-/ivoz-ui-1.1.1.tgz#67c1c9f9ef59b2e92e13e4294976168cc4d18343"
+  integrity sha512-7a7ALHn467J5QJVJfAulVdQEvhjODk6OrgxbNWY1JdpiU3gCtnATmHftnfgEaEf7XT1bEaW/bgaKCAl4Lez60A==
   dependencies:
     "@date-io/date-fns" "^2.10.8"
     axios "^0.21.1"


### PR DESCRIPTION
Added width and empty content to specific and generic templates

<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
Added width and empty content to specific and generic templates

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
