### PR TITLE
Impersonate admin chain in commandlog

### DIFF
--- a/asterisk/agi/composer.lock
+++ b/asterisk/agi/composer.lock
@@ -2006,11 +2006,11 @@
         },
         {
             "name": "irontec/ivoz-provider-bundle",
-            "version": "2.6.4",
+            "version": "2.6.5",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/irontec/ivoz-provider-bundle",
-                "reference": "2adc8c39c1f6b240c77f034a3bc5d6faab230c0e"
+                "reference": "3a36f1c803087f33512fe87fb4706df7486537a8"
             },
             "require": {
                 "beberlei/doctrineextensions": "^1.2",

--- a/library/Ivoz/Provider/Domain/Model/Administrator/Administrator.php
+++ b/library/Ivoz/Provider/Domain/Model/Administrator/Administrator.php
@@ -35,6 +35,21 @@ class Administrator extends AdministratorAbstract implements AdministratorInterf
         return $this->id;
     }
 
+    public function __toString(): string
+    {
+        $userName = sprintf(
+            "%s [%s]",
+            $this->getUsername(),
+            parent::__toString(),
+        );
+
+        if ($this->getOnBehalfOf()) {
+            $userName = $this->getOnBehalfOf() . ' > ' . $userName;
+        }
+
+        return $userName;
+    }
+
     public function setOnBehalfOf(string $adminName): void
     {
         $this->onBehalfOf = $adminName;

--- a/library/Ivoz/Provider/Infrastructure/Api/Jwt/JWTCreatedListener.php
+++ b/library/Ivoz/Provider/Infrastructure/Api/Jwt/JWTCreatedListener.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Ivoz\Provider\Infrastructure\Api\Jwt;
+
+use Ivoz\Provider\Domain\Model\Administrator\AdministratorInterface;
+use Ivoz\Provider\Domain\Model\User\UserInterface;
+use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTCreatedEvent;
+
+class JWTCreatedListener
+{
+    public function __construct()
+    {
+    }
+
+    public function onJWTCreated(JWTCreatedEvent $event): void
+    {
+        $payload = $event->getData();
+        /** @var AdministratorInterface | UserInterface $user */
+        $user = $event->getUser();
+        $payload['iden'] = (string) $user;
+
+        $event->setData($payload);
+    }
+}

--- a/library/composer-packages/irontec/ivoz-provider-bundle/Resources/config/services/infraestructure/rest.yml
+++ b/library/composer-packages/irontec/ivoz-provider-bundle/Resources/config/services/infraestructure/rest.yml
@@ -21,6 +21,10 @@ services:
     tags:
       - { name: kernel.event_listener, event: kernel.request, priority: 5 }
 
+  Ivoz\Provider\Infrastructure\Api\Jwt\JWTCreatedListener:
+    tags:
+      - { name: kernel.event_listener, event: lexik_jwt_authentication.on_jwt_created, method: onJWTCreated }
+
 when@test:
   services:
     _defaults:

--- a/library/composer-packages/irontec/ivoz-provider-bundle/composer.json
+++ b/library/composer-packages/irontec/ivoz-provider-bundle/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "irontec/ivoz-provider-bundle",
-    "version": "2.6.4",
+    "version": "2.6.5",
     "type": "symfony-bundle",
     "description": "Symfony bridge for IvozProvider",
     "license": "GPL-3.0-or-later",

--- a/library/composer.lock
+++ b/library/composer.lock
@@ -2473,16 +2473,16 @@
         },
         {
             "name": "irontec/ivoz-api",
-            "version": "4.9.9",
+            "version": "4.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/irontec/ivoz-api.git",
-                "reference": "7171154b68abd8eb4044f8de2530034f9c3d1440"
+                "reference": "3daf27565e6ad493b0a2e0f36543af5d0811368a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/irontec/ivoz-api/zipball/7171154b68abd8eb4044f8de2530034f9c3d1440",
-                "reference": "7171154b68abd8eb4044f8de2530034f9c3d1440",
+                "url": "https://api.github.com/repos/irontec/ivoz-api/zipball/3daf27565e6ad493b0a2e0f36543af5d0811368a",
+                "reference": "3daf27565e6ad493b0a2e0f36543af5d0811368a",
                 "shasum": ""
             },
             "require": {
@@ -2536,27 +2536,27 @@
             "description": "Api library built on api-platform for ivozprovider",
             "support": {
                 "issues": "https://github.com/irontec/ivoz-api/issues",
-                "source": "https://github.com/irontec/ivoz-api/tree/4.9.9"
+                "source": "https://github.com/irontec/ivoz-api/tree/4.10.0"
             },
-            "time": "2023-07-03T08:30:19+00:00"
+            "time": "2023-07-12T16:57:49+00:00"
         },
         {
             "name": "irontec/ivoz-api-bundle",
-            "version": "4.8",
+            "version": "4.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/irontec/ivoz-api-bundle.git",
-                "reference": "cb215a80b804cf2221984b09e0a812ea0bd08bfe"
+                "reference": "50358dac8fa50bb3f1f0e7276d3e48a9fa5fee75"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/irontec/ivoz-api-bundle/zipball/cb215a80b804cf2221984b09e0a812ea0bd08bfe",
-                "reference": "cb215a80b804cf2221984b09e0a812ea0bd08bfe",
+                "url": "https://api.github.com/repos/irontec/ivoz-api-bundle/zipball/50358dac8fa50bb3f1f0e7276d3e48a9fa5fee75",
+                "reference": "50358dac8fa50bb3f1f0e7276d3e48a9fa5fee75",
                 "shasum": ""
             },
             "require": {
                 "gesdinet/jwt-refresh-token-bundle": "^0.12",
-                "irontec/ivoz-api": "^4.9.5",
+                "irontec/ivoz-api": "^4.10.0",
                 "irontec/ivoz-core-bundle": "^4.7",
                 "lexik/jwt-authentication-bundle": "^2.5",
                 "nelmio/cors-bundle": "^2.0",
@@ -2596,9 +2596,9 @@
             "description": "Symfony bridge for ivoz-api",
             "support": {
                 "issues": "https://github.com/irontec/ivoz-api-bundle/issues",
-                "source": "https://github.com/irontec/ivoz-api-bundle/tree/4.8"
+                "source": "https://github.com/irontec/ivoz-api-bundle/tree/4.8.1"
             },
-            "time": "2023-06-14T16:19:51+00:00"
+            "time": "2023-07-12T17:02:59+00:00"
         },
         {
             "name": "irontec/ivoz-core",
@@ -2794,11 +2794,11 @@
         },
         {
             "name": "irontec/ivoz-provider-bundle",
-            "version": "2.6.4",
+            "version": "2.6.5",
             "dist": {
                 "type": "path",
                 "url": "./composer-packages/irontec/ivoz-provider-bundle",
-                "reference": "ba4a99cadad8dd636698c16df58e8775985bbff7"
+                "reference": "2b5b4cefe29557494aeb574c07622ac302bdcb91"
             },
             "require": {
                 "beberlei/doctrineextensions": "^1.2",

--- a/microservices/balances/composer.lock
+++ b/microservices/balances/composer.lock
@@ -2006,11 +2006,11 @@
         },
         {
             "name": "irontec/ivoz-provider-bundle",
-            "version": "2.6.4",
+            "version": "2.6.5",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/irontec/ivoz-provider-bundle",
-                "reference": "2adc8c39c1f6b240c77f034a3bc5d6faab230c0e"
+                "reference": "3a36f1c803087f33512fe87fb4706df7486537a8"
             },
             "require": {
                 "beberlei/doctrineextensions": "^1.2",

--- a/microservices/provision/composer.lock
+++ b/microservices/provision/composer.lock
@@ -2006,11 +2006,11 @@
         },
         {
             "name": "irontec/ivoz-provider-bundle",
-            "version": "2.6.4",
+            "version": "2.6.5",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/irontec/ivoz-provider-bundle",
-                "reference": "2adc8c39c1f6b240c77f034a3bc5d6faab230c0e"
+                "reference": "3a36f1c803087f33512fe87fb4706df7486537a8"
             },
             "require": {
                 "beberlei/doctrineextensions": "^1.2",

--- a/microservices/realtime/composer.lock
+++ b/microservices/realtime/composer.lock
@@ -2150,11 +2150,11 @@
         },
         {
             "name": "irontec/ivoz-api",
-            "version": "4.9.9",
+            "version": "4.10.0",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/irontec/ivoz-api",
-                "reference": "7171154b68abd8eb4044f8de2530034f9c3d1440"
+                "reference": "3daf27565e6ad493b0a2e0f36543af5d0811368a"
             },
             "require": {
                 "api-platform/core": "2.6.*",
@@ -2211,15 +2211,15 @@
         },
         {
             "name": "irontec/ivoz-api-bundle",
-            "version": "4.8",
+            "version": "4.8.1",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/irontec/ivoz-api-bundle",
-                "reference": "cb215a80b804cf2221984b09e0a812ea0bd08bfe"
+                "reference": "50358dac8fa50bb3f1f0e7276d3e48a9fa5fee75"
             },
             "require": {
                 "gesdinet/jwt-refresh-token-bundle": "^0.12",
-                "irontec/ivoz-api": "^4.9.5",
+                "irontec/ivoz-api": "^4.10.0",
                 "irontec/ivoz-core-bundle": "^4.7",
                 "lexik/jwt-authentication-bundle": "^2.5",
                 "nelmio/cors-bundle": "^2.0",
@@ -2383,11 +2383,11 @@
         },
         {
             "name": "irontec/ivoz-provider-bundle",
-            "version": "2.6.4",
+            "version": "2.6.5",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/irontec/ivoz-provider-bundle",
-                "reference": "2adc8c39c1f6b240c77f034a3bc5d6faab230c0e"
+                "reference": "3a36f1c803087f33512fe87fb4706df7486537a8"
             },
             "require": {
                 "beberlei/doctrineextensions": "^1.2",

--- a/microservices/recordings/composer.lock
+++ b/microservices/recordings/composer.lock
@@ -2006,11 +2006,11 @@
         },
         {
             "name": "irontec/ivoz-provider-bundle",
-            "version": "2.6.4",
+            "version": "2.6.5",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/irontec/ivoz-provider-bundle",
-                "reference": "2adc8c39c1f6b240c77f034a3bc5d6faab230c0e"
+                "reference": "3a36f1c803087f33512fe87fb4706df7486537a8"
             },
             "require": {
                 "beberlei/doctrineextensions": "^1.2",

--- a/microservices/scheduler/composer.lock
+++ b/microservices/scheduler/composer.lock
@@ -2006,11 +2006,11 @@
         },
         {
             "name": "irontec/ivoz-provider-bundle",
-            "version": "2.6.4",
+            "version": "2.6.5",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/irontec/ivoz-provider-bundle",
-                "reference": "2adc8c39c1f6b240c77f034a3bc5d6faab230c0e"
+                "reference": "3a36f1c803087f33512fe87fb4706df7486537a8"
             },
             "require": {
                 "beberlei/doctrineextensions": "^1.2",

--- a/microservices/workers/composer.lock
+++ b/microservices/workers/composer.lock
@@ -2006,11 +2006,11 @@
         },
         {
             "name": "irontec/ivoz-provider-bundle",
-            "version": "2.6.4",
+            "version": "2.6.5",
             "dist": {
                 "type": "path",
                 "url": "../../library/vendor/irontec/ivoz-provider-bundle",
-                "reference": "2adc8c39c1f6b240c77f034a3bc5d6faab230c0e"
+                "reference": "3a36f1c803087f33512fe87fb4706df7486537a8"
             },
             "require": {
                 "beberlei/doctrineextensions": "^1.2",

--- a/schema/composer.lock
+++ b/schema/composer.lock
@@ -2108,11 +2108,11 @@
         },
         {
             "name": "irontec/ivoz-provider-bundle",
-            "version": "2.6.4",
+            "version": "2.6.5",
             "dist": {
                 "type": "path",
                 "url": "../library/vendor/irontec/ivoz-provider-bundle",
-                "reference": "2adc8c39c1f6b240c77f034a3bc5d6faab230c0e"
+                "reference": "3a36f1c803087f33512fe87fb4706df7486537a8"
             },
             "require": {
                 "beberlei/doctrineextensions": "^1.2",

--- a/web/rest/brand/composer.lock
+++ b/web/rest/brand/composer.lock
@@ -2150,11 +2150,11 @@
         },
         {
             "name": "irontec/ivoz-api",
-            "version": "4.9.9",
+            "version": "4.10.0",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/irontec/ivoz-api",
-                "reference": "7171154b68abd8eb4044f8de2530034f9c3d1440"
+                "reference": "3daf27565e6ad493b0a2e0f36543af5d0811368a"
             },
             "require": {
                 "api-platform/core": "2.6.*",
@@ -2211,15 +2211,15 @@
         },
         {
             "name": "irontec/ivoz-api-bundle",
-            "version": "4.8",
+            "version": "4.8.1",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/irontec/ivoz-api-bundle",
-                "reference": "cb215a80b804cf2221984b09e0a812ea0bd08bfe"
+                "reference": "50358dac8fa50bb3f1f0e7276d3e48a9fa5fee75"
             },
             "require": {
                 "gesdinet/jwt-refresh-token-bundle": "^0.12",
-                "irontec/ivoz-api": "^4.9.5",
+                "irontec/ivoz-api": "^4.10.0",
                 "irontec/ivoz-core-bundle": "^4.7",
                 "lexik/jwt-authentication-bundle": "^2.5",
                 "nelmio/cors-bundle": "^2.0",
@@ -2383,11 +2383,11 @@
         },
         {
             "name": "irontec/ivoz-provider-bundle",
-            "version": "2.6.4",
+            "version": "2.6.5",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/irontec/ivoz-provider-bundle",
-                "reference": "2adc8c39c1f6b240c77f034a3bc5d6faab230c0e"
+                "reference": "3a36f1c803087f33512fe87fb4706df7486537a8"
             },
             "require": {
                 "beberlei/doctrineextensions": "^1.2",

--- a/web/rest/client/composer.lock
+++ b/web/rest/client/composer.lock
@@ -2150,11 +2150,11 @@
         },
         {
             "name": "irontec/ivoz-api",
-            "version": "4.9.9",
+            "version": "4.10.0",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/irontec/ivoz-api",
-                "reference": "7171154b68abd8eb4044f8de2530034f9c3d1440"
+                "reference": "3daf27565e6ad493b0a2e0f36543af5d0811368a"
             },
             "require": {
                 "api-platform/core": "2.6.*",
@@ -2211,15 +2211,15 @@
         },
         {
             "name": "irontec/ivoz-api-bundle",
-            "version": "4.8",
+            "version": "4.8.1",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/irontec/ivoz-api-bundle",
-                "reference": "cb215a80b804cf2221984b09e0a812ea0bd08bfe"
+                "reference": "50358dac8fa50bb3f1f0e7276d3e48a9fa5fee75"
             },
             "require": {
                 "gesdinet/jwt-refresh-token-bundle": "^0.12",
-                "irontec/ivoz-api": "^4.9.5",
+                "irontec/ivoz-api": "^4.10.0",
                 "irontec/ivoz-core-bundle": "^4.7",
                 "lexik/jwt-authentication-bundle": "^2.5",
                 "nelmio/cors-bundle": "^2.0",
@@ -2383,11 +2383,11 @@
         },
         {
             "name": "irontec/ivoz-provider-bundle",
-            "version": "2.6.4",
+            "version": "2.6.5",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/irontec/ivoz-provider-bundle",
-                "reference": "2adc8c39c1f6b240c77f034a3bc5d6faab230c0e"
+                "reference": "3a36f1c803087f33512fe87fb4706df7486537a8"
             },
             "require": {
                 "beberlei/doctrineextensions": "^1.2",

--- a/web/rest/platform/composer.lock
+++ b/web/rest/platform/composer.lock
@@ -2150,11 +2150,11 @@
         },
         {
             "name": "irontec/ivoz-api",
-            "version": "4.9.9",
+            "version": "4.10.0",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/irontec/ivoz-api",
-                "reference": "7171154b68abd8eb4044f8de2530034f9c3d1440"
+                "reference": "3daf27565e6ad493b0a2e0f36543af5d0811368a"
             },
             "require": {
                 "api-platform/core": "2.6.*",
@@ -2211,15 +2211,15 @@
         },
         {
             "name": "irontec/ivoz-api-bundle",
-            "version": "4.8",
+            "version": "4.8.1",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/irontec/ivoz-api-bundle",
-                "reference": "cb215a80b804cf2221984b09e0a812ea0bd08bfe"
+                "reference": "50358dac8fa50bb3f1f0e7276d3e48a9fa5fee75"
             },
             "require": {
                 "gesdinet/jwt-refresh-token-bundle": "^0.12",
-                "irontec/ivoz-api": "^4.9.5",
+                "irontec/ivoz-api": "^4.10.0",
                 "irontec/ivoz-core-bundle": "^4.7",
                 "lexik/jwt-authentication-bundle": "^2.5",
                 "nelmio/cors-bundle": "^2.0",
@@ -2383,11 +2383,11 @@
         },
         {
             "name": "irontec/ivoz-provider-bundle",
-            "version": "2.6.4",
+            "version": "2.6.5",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/irontec/ivoz-provider-bundle",
-                "reference": "2adc8c39c1f6b240c77f034a3bc5d6faab230c0e"
+                "reference": "3a36f1c803087f33512fe87fb4706df7486537a8"
             },
             "require": {
                 "beberlei/doctrineextensions": "^1.2",

--- a/web/rest/user/composer.lock
+++ b/web/rest/user/composer.lock
@@ -2150,11 +2150,11 @@
         },
         {
             "name": "irontec/ivoz-api",
-            "version": "4.9.9",
+            "version": "4.10.0",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/irontec/ivoz-api",
-                "reference": "7171154b68abd8eb4044f8de2530034f9c3d1440"
+                "reference": "3daf27565e6ad493b0a2e0f36543af5d0811368a"
             },
             "require": {
                 "api-platform/core": "2.6.*",
@@ -2211,15 +2211,15 @@
         },
         {
             "name": "irontec/ivoz-api-bundle",
-            "version": "4.8",
+            "version": "4.8.1",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/irontec/ivoz-api-bundle",
-                "reference": "cb215a80b804cf2221984b09e0a812ea0bd08bfe"
+                "reference": "50358dac8fa50bb3f1f0e7276d3e48a9fa5fee75"
             },
             "require": {
                 "gesdinet/jwt-refresh-token-bundle": "^0.12",
-                "irontec/ivoz-api": "^4.9.5",
+                "irontec/ivoz-api": "^4.10.0",
                 "irontec/ivoz-core-bundle": "^4.7",
                 "lexik/jwt-authentication-bundle": "^2.5",
                 "nelmio/cors-bundle": "^2.0",
@@ -2383,11 +2383,11 @@
         },
         {
             "name": "irontec/ivoz-provider-bundle",
-            "version": "2.6.4",
+            "version": "2.6.5",
             "dist": {
                 "type": "path",
                 "url": "../../../library/vendor/irontec/ivoz-provider-bundle",
-                "reference": "2adc8c39c1f6b240c77f034a3bc5d6faab230c0e"
+                "reference": "3a36f1c803087f33512fe87fb4706df7486537a8"
             },
             "require": {
                 "beberlei/doctrineextensions": "^1.2",


### PR DESCRIPTION
Persist admin impersonation chain in the commandlog

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX
