### PR TITLE
opensips: set retail account from domain if present

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -917,8 +917,14 @@ route[SET_PAI] {
             $var(newfromuser) = $var(transformated);
         }
 
-        if ($fU != $var(newfromuser)) {
-            $var(newfromuri) = 'sip:' + $var(newfromuser) + '@' + $fd;
+        if ($(avp(retailFromDomain){s.len}) > 0 && $var(is_from_inside)) {
+            $var(newfromdomain) = $avp(retailFromDomain);
+        } else {
+            $var(newfromdomain) = $fd;
+        }
+
+        if ($fU != $var(newfromuser) || $fd != $var(newfromdomain)) {
+            $var(newfromuri) = 'sip:' + $var(newfromuser) + '@' + $var(newfromdomain);
             uac_replace_from("$var(newfromuri)");
         }
     }
@@ -1790,8 +1796,11 @@ route[GET_INFO_FROM_ENDPOINT] {
             $avp(friendFromUser) = $(xavp(endpoint=>from_user){s.trim}); # used in SET_PAI
         }
     } else {
-        sql_xquery("cb", "SELECT id, companyId, transformationRuleSetId, t38Passthrough, rtpEncryption, multiContact FROM RetailAccounts WHERE id='$avp(endpointId)'", "endpoint");
+        sql_xquery("cb", "SELECT id, companyId, transformationRuleSetId, t38Passthrough, rtpEncryption, multiContact, fromDomain FROM RetailAccounts WHERE id='$avp(endpointId)'", "endpoint");
         $avp(maxCalls) = 0; # used in GET_CALL_INFO
+        if ($xavp(endpoint=>fromDomain) != $null) {
+            $avp(retailFromDomain) = $(xavp(endpoint=>fromDomain){s.trim}); # used in SET_PAI
+        }
     }
 
     $avp(companyId) = $xavp(endpoint=>companyId); # used in CLASSIFY and FILTER_BY_SRC_ADDR


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description

Add missing logic to set from-domain of incoming external calls to retailAccounts.

#### Additional information

In remaining endpoint types (friends, residentialDevices) with fromDomain Asterisk sets from-domain properly.