### PR TITLE
portal: add apache /doc alias for documentation

### DIFF
--- a/profiles/portal/etc/apache2/sites-available/020-ivozprovider-portals.conf
+++ b/profiles/portal/etc/apache2/sites-available/020-ivozprovider-portals.conf
@@ -149,6 +149,16 @@ Alias /user /opt/irontec/ivozprovider/web/portal/user/dist
 
 </Directory>
 
+Alias /doc /opt/irontec/ivozprovider/doc/html/
+<Directory /opt/irontec/ivozprovider/doc/html/>
+    Options -Indexes +FollowSymLinks -MultiViews
+    AllowOverride All
+     <Limit GET HEAD POST PUT DELETE OPTIONS PATCH>
+        Order allow,deny
+        allow from all
+        Require all granted
+    </Limit>
+</Directory>
 
 
 ################################################################################


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
This was broken when we added /classic path support. Before this commit the doc was available at /classic/doc, not it can also be accessed in /doc

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
