### PR TITLE
Fixed audio players

### DIFF
--- a/profiles/portal/etc/apache2/sites-available/020-ivozprovider-portals.conf
+++ b/profiles/portal/etc/apache2/sites-available/020-ivozprovider-portals.conf
@@ -42,7 +42,7 @@ Alias /klearMatrix /opt/irontec/ivozprovider/web/admin/public
     </Limit>
 
     Header set X-Frame-Options SAMEORIGIN
-    Header set Content-Security-Policy "default-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'"
+    Header set Content-Security-Policy "default-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline';"
 </Directory>
 
 # Platform Administartion portal
@@ -57,7 +57,7 @@ Alias /platform /opt/irontec/ivozprovider/web/portal/platform/dist
     </Limit>
 
     Header set X-Frame-Options SAMEORIGIN
-    Header set Content-Security-Policy "default-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' *.googleapis.com 'unsafe-inline'; font-src 'self' *.googleapis.com *.gstatic.com;"
+    Header set Content-Security-Policy "default-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' *.googleapis.com 'unsafe-inline'; font-src 'self' *.googleapis.com *.gstatic.com; media-src 'self' blob:;"
 
     <IfModule mod_rewrite.c>
         RewriteEngine On
@@ -82,7 +82,7 @@ Alias /brand /opt/irontec/ivozprovider/web/portal/brand/dist
     </Limit>
 
     Header set X-Frame-Options SAMEORIGIN
-    Header set Content-Security-Policy "default-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' *.googleapis.com 'unsafe-inline'; font-src 'self' *.googleapis.com *.gstatic.com;"
+    Header set Content-Security-Policy "default-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' *.googleapis.com 'unsafe-inline'; font-src 'self' *.googleapis.com *.gstatic.com; media-src 'self' blob:;"
 
     <IfModule mod_rewrite.c>
         RewriteEngine On
@@ -108,7 +108,7 @@ Alias /client /opt/irontec/ivozprovider/web/portal/client/dist
     </Limit>
 
     Header set X-Frame-Options SAMEORIGIN
-    Header set Content-Security-Policy "default-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' *.googleapis.com 'unsafe-inline'; font-src 'self' *.googleapis.com *.gstatic.com;"
+    Header set Content-Security-Policy "default-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' *.googleapis.com 'unsafe-inline'; font-src 'self' *.googleapis.com *.gstatic.com; media-src 'self' blob:;"
 
     <IfModule mod_rewrite.c>
         RewriteEngine On
@@ -135,7 +135,7 @@ Alias /user /opt/irontec/ivozprovider/web/portal/user/dist
     </Limit>
 
     Header set X-Frame-Options SAMEORIGIN
-    Header set Content-Security-Policy "default-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' *.googleapis.com 'unsafe-inline'; font-src 'self' *.googleapis.com *.gstatic.com;"
+    Header set Content-Security-Policy "default-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' *.googleapis.com 'unsafe-inline'; font-src 'self' *.googleapis.com *.gstatic.com; media-src 'self' blob:;"
 
     <IfModule mod_rewrite.c>
         RewriteEngine On


### PR DESCRIPTION
Allow blob as media-src in Content-Security-Policy so that web audio player does not complain about security rules

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [X] Fixes an existing issue (Fixes #2405) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX
