### PR TITLE
Store user-side missed calls

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -330,11 +330,11 @@ modparam("acc", "cdr_enable", 1)
 modparam("acc", "cdr_skip", "nocdr")
 modparam("acc", "cdr_extra_nullable", 1)
 modparam("acc", "cdr_log_enable", 1)
-modparam("acc", "cdr_on_failed", 0)
+modparam("acc", "cdr_on_failed", 1)
 modparam("acc", "cdr_expired_dlg_enable", 1)
 modparam("acc", "cdr_start_on_confirmed", 1)
 modparam("acc", "cdr_facility", "LOG_LOCAL3")
-modparam("acc", "cdr_extra", "brandId=$dlg_var(brandId);companyId=$dlg_var(companyId);caller=$dlg_var(caller);callee=$dlg_var(callee);callid=$dlg_var(callid);callidHash=$dlg_var(cidhash);xcallid=$dlg_var(xcallid);diversion=$dlg_var(diversion);referrer=$dlg_var(referrer);referee=$dlg_var(referee);direction=$dlg_var(direction);userId=$dlg_var(userId);friendId=$dlg_var(friendId)")
+modparam("acc", "cdr_extra", "brandId=$dlg_var(brandId);companyId=$dlg_var(companyId);caller=$dlg_var(caller);callee=$dlg_var(callee);callid=$dlg_var(callid);callidHash=$dlg_var(cidhash);xcallid=$dlg_var(xcallid);diversion=$dlg_var(diversion);referrer=$dlg_var(referrer);referee=$dlg_var(referee);direction=$dlg_var(direction);userId=$dlg_var(userId);friendId=$dlg_var(friendId);responseCode=$dlg_var(responseCode)")
 
 # DIALOG
 modparam("dialog", "dlg_flag", DLG_FLAG)
@@ -438,6 +438,9 @@ request_route {
         if (t_check_trans()) {
             setflag(FLT_ACC);       # do accounting
             setflag(FLT_ACCFAILED); # even if the transaction fails
+            if (is_present_hf("Reason") && $hdr(Reason) == 'SIP;cause=200;text="Call completed elsewhere"') {
+                $dlg_var(nocdr) = "1";
+            }
             route(RTPENGINE);
             route(RELAY);
         }
@@ -2781,6 +2784,8 @@ branch_route[MANAGE_BRANCH] {
 
 # Executed when dialog is confirmed with 2XX response code
 event_route[dialog:start] {
+    $dlg_var(responseCode) = '200';
+
     if(isbflagset(FLB_WEBSOCKETS)) {
         xnotice("[$dlg_var(cidhash)] Dialog involving WSS started\n");
         $dlg_var(ws) = 'yes';
@@ -2833,6 +2838,8 @@ event_route[dialog:end] {
 
 # Executed when dialog is not established
 event_route[dialog:failed] {
+    $dlg_var(responseCode) = $rs;
+
     sht_rm_name_re("dialogs=>$ci::.*");
 
     #!ifdef WITH_REALTIME

--- a/library/Ivoz/Kam/Domain/Model/UsersCdr/UsersCdrAbstract.php
+++ b/library/Ivoz/Kam/Domain/Model/UsersCdr/UsersCdrAbstract.php
@@ -90,6 +90,11 @@ abstract class UsersCdrAbstract
     protected $xcallid = null;
 
     /**
+     * @var string
+     */
+    protected $responseCode = '200';
+
+    /**
      * @var ?BrandInterface
      */
     protected $brand = null;
@@ -115,11 +120,13 @@ abstract class UsersCdrAbstract
     protected function __construct(
         \DateTimeInterface|string $startTime,
         \DateTimeInterface|string $endTime,
-        float $duration
+        float $duration,
+        string $responseCode
     ) {
         $this->setStartTime($startTime);
         $this->setEndTime($endTime);
         $this->setDuration($duration);
+        $this->setResponseCode($responseCode);
     }
 
     abstract public function getId(): null|string|int;
@@ -189,11 +196,14 @@ abstract class UsersCdrAbstract
         Assertion::notNull($endTime, 'getEndTime value is null, but non null value was expected.');
         $duration = $dto->getDuration();
         Assertion::notNull($duration, 'getDuration value is null, but non null value was expected.');
+        $responseCode = $dto->getResponseCode();
+        Assertion::notNull($responseCode, 'getResponseCode value is null, but non null value was expected.');
 
         $self = new static(
             $startTime,
             $endTime,
-            $duration
+            $duration,
+            $responseCode
         );
 
         $self
@@ -232,6 +242,8 @@ abstract class UsersCdrAbstract
         Assertion::notNull($endTime, 'getEndTime value is null, but non null value was expected.');
         $duration = $dto->getDuration();
         Assertion::notNull($duration, 'getDuration value is null, but non null value was expected.');
+        $responseCode = $dto->getResponseCode();
+        Assertion::notNull($responseCode, 'getResponseCode value is null, but non null value was expected.');
 
         $this
             ->setStartTime($startTime)
@@ -246,6 +258,7 @@ abstract class UsersCdrAbstract
             ->setCallid($dto->getCallid())
             ->setCallidHash($dto->getCallidHash())
             ->setXcallid($dto->getXcallid())
+            ->setResponseCode($responseCode)
             ->setBrand($fkTransformer->transform($dto->getBrand()))
             ->setCompany($fkTransformer->transform($dto->getCompany()))
             ->setUser($fkTransformer->transform($dto->getUser()))
@@ -272,6 +285,7 @@ abstract class UsersCdrAbstract
             ->setCallid(self::getCallid())
             ->setCallidHash(self::getCallidHash())
             ->setXcallid(self::getXcallid())
+            ->setResponseCode(self::getResponseCode())
             ->setBrand(Brand::entityToDto(self::getBrand(), $depth))
             ->setCompany(Company::entityToDto(self::getCompany(), $depth))
             ->setUser(User::entityToDto(self::getUser(), $depth))
@@ -296,6 +310,7 @@ abstract class UsersCdrAbstract
             'callid' => self::getCallid(),
             'callidHash' => self::getCallidHash(),
             'xcallid' => self::getXcallid(),
+            'responseCode' => self::getResponseCode(),
             'brandId' => self::getBrand()?->getId(),
             'companyId' => self::getCompany()?->getId(),
             'userId' => self::getUser()?->getId(),
@@ -499,6 +514,20 @@ abstract class UsersCdrAbstract
     public function getXcallid(): ?string
     {
         return $this->xcallid;
+    }
+
+    protected function setResponseCode(string $responseCode): static
+    {
+        Assertion::maxLength($responseCode, 64, 'responseCode value "%s" is too long, it should have no more than %d characters, but has %d characters.');
+
+        $this->responseCode = $responseCode;
+
+        return $this;
+    }
+
+    public function getResponseCode(): string
+    {
+        return $this->responseCode;
     }
 
     protected function setBrand(?BrandInterface $brand = null): static

--- a/library/Ivoz/Kam/Domain/Model/UsersCdr/UsersCdrDtoAbstract.php
+++ b/library/Ivoz/Kam/Domain/Model/UsersCdr/UsersCdrDtoAbstract.php
@@ -78,6 +78,11 @@ abstract class UsersCdrDtoAbstract implements DataTransferObjectInterface
     private $xcallid = null;
 
     /**
+     * @var string|null
+     */
+    private $responseCode = '200';
+
+    /**
      * @var int|null
      */
     private $id = null;
@@ -129,6 +134,7 @@ abstract class UsersCdrDtoAbstract implements DataTransferObjectInterface
             'callid' => 'callid',
             'callidHash' => 'callidHash',
             'xcallid' => 'xcallid',
+            'responseCode' => 'responseCode',
             'id' => 'id',
             'brandId' => 'brand',
             'companyId' => 'company',
@@ -155,6 +161,7 @@ abstract class UsersCdrDtoAbstract implements DataTransferObjectInterface
             'callid' => $this->getCallid(),
             'callidHash' => $this->getCallidHash(),
             'xcallid' => $this->getXcallid(),
+            'responseCode' => $this->getResponseCode(),
             'id' => $this->getId(),
             'brand' => $this->getBrand(),
             'company' => $this->getCompany(),
@@ -318,6 +325,18 @@ abstract class UsersCdrDtoAbstract implements DataTransferObjectInterface
     public function getXcallid(): ?string
     {
         return $this->xcallid;
+    }
+
+    public function setResponseCode(string $responseCode): static
+    {
+        $this->responseCode = $responseCode;
+
+        return $this;
+    }
+
+    public function getResponseCode(): ?string
+    {
+        return $this->responseCode;
     }
 
     /**

--- a/library/Ivoz/Kam/Domain/Model/UsersCdr/UsersCdrInterface.php
+++ b/library/Ivoz/Kam/Domain/Model/UsersCdr/UsersCdrInterface.php
@@ -79,6 +79,8 @@ interface UsersCdrInterface extends EntityInterface
 
     public function getXcallid(): ?string;
 
+    public function getResponseCode(): string;
+
     public function getBrand(): ?BrandInterface;
 
     public function getCompany(): ?CompanyInterface;

--- a/library/Ivoz/Kam/Infrastructure/Persistence/Doctrine/Mapping/UsersCdr.UsersCdrAbstract.orm.xml
+++ b/library/Ivoz/Kam/Infrastructure/Persistence/Doctrine/Mapping/UsersCdr.UsersCdrAbstract.orm.xml
@@ -71,6 +71,11 @@
         <option name="fixed"/>
       </options>
     </field>
+    <field name="responseCode" type="string" column="responseCode" length="64" nullable="false">
+      <options>
+        <option name="default">200</option>
+      </options>
+    </field>
     <many-to-one field="brand" target-entity="Ivoz\Provider\Domain\Model\Brand\BrandInterface" fetch="LAZY">
       <join-columns>
         <join-column name="brandId" referenced-column-name="id" on-delete="set null"/>

--- a/schema/DoctrineMigrations/Version20231124114023.php
+++ b/schema/DoctrineMigrations/Version20231124114023.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Ivoz\Core\Infrastructure\Persistence\Doctrine\LoggableMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20231124114023 extends LoggableMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add responseCode to kam_users_cdrs';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE kam_users_cdrs ADD responseCode VARCHAR(64) DEFAULT \'200\' NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE kam_users_cdrs DROP responseCode');
+    }
+}


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
kam_users_cdrs will store non-established calls (failed calls, missed calls). This PR adds a new field responseCode that will be non-200 for these calls.

#### Additional information

Upcoming PRs will show these calls on both vpbx client portal and user portal.