### PR TITLE
kamusers: avoid nat_uac_test(18) for responses

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -1890,6 +1890,7 @@ route[WITHINDLG] {
         } else if (is_method("ACK")) {
             # ACK is forwarded statelessly
             route(NATMANAGE);
+            route(RTPENGINE);
         } else if (is_method("REFER")) {
             setflag(FLT_ACC);       # do accounting
             setflag(FLT_ACCFAILED); # even if the transaction fails
@@ -2211,9 +2212,6 @@ route[WSFIX] {
 
 # Handle NAT
 route[NATMANAGE] {
-    # RTP handling is always enforced
-    route(RTPENGINE);
-
     # Set FLB_NATB? Only in within-dialog request with nat=yes on Route header initiated by us
     if (is_request() && has_totag() && check_route_param("nat=yes") && $var(is_from_inside)) {
         setbflag(FLB_NATB);
@@ -2634,6 +2632,7 @@ onreply_route[MANAGE_REPLY] {
     # Manage NAT
     if (t_check_status("[12][0-9]{2}")) {
         route(NATMANAGE);
+        route(RTPENGINE);
     } else if ($avp(parallel_forking)) {
         route(RTPENGINE); # Free failing branch media-session
     }
@@ -2676,6 +2675,7 @@ failure_route[MANAGE_FAILURE] {
 
     route(IS_FROM_INSIDE);
     route(NATMANAGE);
+    route(RTPENGINE);
 }
 
 failure_route[MANAGE_FAILURE_RETAIL] {
@@ -2694,6 +2694,7 @@ failure_route[MANAGE_FAILURE_RETAIL] {
 
     route(IS_FROM_INSIDE);
     route(NATMANAGE);
+    route(RTPENGINE);
 
     # Handle 408 to retail accounts and apply call-forward if necessary
     if (t_branch_timeout() && !t_branch_replied()) {
@@ -2723,6 +2724,7 @@ failure_route[MANAGE_FAILURE_AS] {
 
     route(IS_FROM_INSIDE);
     route(NATMANAGE);
+    route(RTPENGINE);
 
     # next DST - only for 404 or local timeout
     if (t_check_status("404") or (t_branch_timeout() and !t_branch_replied())) {
@@ -2774,6 +2776,7 @@ branch_route[MANAGE_BRANCH] {
     #!endif
 
     route(NATMANAGE);
+    route(RTPENGINE);
 }
 
 # Executed when dialog is confirmed with 2XX response code
@@ -2911,7 +2914,7 @@ route[RTPENGINE] {
         $avp(extra_id) = $T_branch_idx;
     }
 
-    if (nat_uac_test("18") && !$var(is_from_inside)) {
+    if ( (is_request() && isflagset(FLT_NATS)) || (is_reply() && isbflagset(FLB_NATB)) ) {
         # NAT detected, do not trust SDP addresses
         $var(symmetry) = 'SIP-source-address';
     } else {


### PR DESCRIPTION

<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
<!-- Describe your changes in detail -->
nat_uac_test(18) is always true for responses due to Via tests (thanks @manwe :)

Use NAT flags instead calling nat_uac_test(18) inside RTPENGINE route, that is also used in responses.

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
RTPENGINE was called inside NATMANAGE route. Now it is called afterwards, to ensure that NAT flags are correctly set for both initial and within-dialog requests and responses.
