### PR TITLE
kamusers: 500 as default responseCode for internal errors

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -2838,7 +2838,11 @@ event_route[dialog:end] {
 
 # Executed when dialog is not established
 event_route[dialog:failed] {
-    $dlg_var(responseCode) = $rs;
+    if ($rs == $null) {
+        $dlg_var(responseCode) = '500'; # Default response code for internal errors
+    } else {
+        $dlg_var(responseCode) = $rs;
+    }
 
     sht_rm_name_re("dialogs=>$ci::.*");
 


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description

KamUsers generated errors (e.g. 486 due to maxcalls) get responseCode null ($rs is null in dialog:failed event route) and cdr fails as it cannot be null.

This PR adds 500 default response code for KamUsers generated errors.

#### Additional information
