### PR TITLE
core: set uacreg contact to advertised address (if any)

### DIFF
--- a/library/Ivoz/Kam/Domain/Service/TrunksUacreg/CreatedByDdiProviderRegistration.php
+++ b/library/Ivoz/Kam/Domain/Service/TrunksUacreg/CreatedByDdiProviderRegistration.php
@@ -63,9 +63,12 @@ class CreatedByDdiProviderRegistration implements DdiProviderRegistrationLifecyc
         }
 
         $trunksIp  = $trunks->getIp();
+        $contactAddr  = $trunks->getAdvertisedIp()
+            ? $trunks->getAdvertisedIp()
+            : $trunks->getIp();
 
         $socket = 'udp:' . $trunksIp . ':5060';
-        $contactAddr = $trunksIp . ':5060';
+        $contactAddr .= ':5060';
 
         $trunksUacregDto
             ->setSocket($socket)

--- a/schema/tests/Provider/DdiProviderRegistration/DdiProviderRegistrationLifeCycleTest.php
+++ b/schema/tests/Provider/DdiProviderRegistration/DdiProviderRegistrationLifeCycleTest.php
@@ -132,7 +132,7 @@ class DdiProviderRegistrationLifeCycleTest extends KernelTestCase
             'flags' => 0,
             'reg_delay' => 0,
             'socket' => 'udp:127.0.0.1:5060',
-            'contact_addr' => '127.0.0.1:5060'
+            'contact_addr' => '138.0.0.1:5060'
         ];
 
         $this->assertEquals(


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description

After #2491 kam_trunks_uacreg entries should use advertised address of DDIProvider socket (if any).
