### PR TITLE
Enhanced tz conversion on API impersonation

### DIFF
--- a/library/DataFixtures/ORM/ProviderAdministrator.php
+++ b/library/DataFixtures/ORM/ProviderAdministrator.php
@@ -114,6 +114,7 @@ class ProviderAdministrator extends Fixture implements DependentFixtureInterface
             $this->setName("RestrictedAdmin");
             $this->setLastname("Lastname");
             $this->setBrand($fixture->getReference('_reference_ProviderBrand1'));
+            $this->setTimezone($fixture->getReference('_reference_ProviderTimezone145'));
         })->call($item6);
 
         $this->addReference('_reference_ProviderAdministrator6', $item6);

--- a/library/Ivoz/Provider/Domain/Model/Administrator/Administrator.php
+++ b/library/Ivoz/Provider/Domain/Model/Administrator/Administrator.php
@@ -188,31 +188,4 @@ class Administrator extends AdministratorAbstract implements AdministratorInterf
             $this->active
             ) = unserialize($serialized);
     }
-
-    protected function sanitizeValues(): void
-    {
-        if (!$this->getTimezone()) {
-            $this->setTimezone(
-                $this->getParentEntityTimezone()
-            );
-        }
-    }
-
-    /**
-     * @return \Ivoz\Provider\Domain\Model\Timezone\TimezoneInterface | null
-     */
-    private function getParentEntityTimezone()
-    {
-        $company = $this->getCompany();
-        if ($company) {
-            return $company->getDefaultTimezone();
-        }
-
-        $brand = $this->getBrand();
-        if ($brand) {
-            return $brand->getDefaultTimezone();
-        }
-
-        return null;
-    }
 }

--- a/library/spec/Ivoz/Provider/Domain/Model/Administrator/AdministratorSpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Model/Administrator/AdministratorSpec.php
@@ -101,28 +101,4 @@ class AdministratorSpec extends ObjectBehavior
             ->isSuperAdmin()
             ->shouldReturn(true);
     }
-
-    /**
-     * @return bool
-     */
-    public function it_gets_company_timezone_if_null(
-        TimezoneInterface $timezone
-    ) {
-        $this
-            ->dto
-            ->setTimezone(null);
-
-        $this->getterProphecy(
-            $this->company,
-            [
-                'getId' => 1,
-                'getDefaultTimezone' => $timezone,
-            ],
-            true
-        );
-
-        $this
-            ->getTimezone()
-            ->shouldReturn($timezone);
-    }
 }

--- a/schema/DoctrineMigrations/Version20240202081754.php
+++ b/schema/DoctrineMigrations/Version20240202081754.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Ivoz\Core\Infrastructure\Persistence\Doctrine\LoggableMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20240202081754 extends LoggableMigration
+{
+    public function getDescription(): string
+    {
+        return 'Remove internal admins timezone as they\'ll inherit it from now on';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('UPDATE Administrators SET timezoneId = null WHERE internal = 1');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+
+    }
+}

--- a/web/portal/brand/src/components/Login.tsx
+++ b/web/portal/brand/src/components/Login.tsx
@@ -7,11 +7,12 @@ import { useStoreActions, useStoreState } from 'store';
 interface LoginProps {
   validator?: EntityValidator;
   target?: string;
+  username?: string;
   token?: string;
 }
 
 export default function Login(props: LoginProps): JSX.Element | null {
-  const { validator, target, token } = props;
+  const { validator, target, username, token } = props;
 
   const location = useLocation();
   const navigate = useNavigate();
@@ -28,11 +29,18 @@ export default function Login(props: LoginProps): JSX.Element | null {
   );
 
   useEffect(() => {
-    if (target && token) {
-      exchangeToken({
-        brandId: target,
-        token,
-      })
+    if ((target || username) && token) {
+      const payload: Record<string, string> = { token };
+
+      if (target) {
+        payload.brandId = target;
+      }
+
+      if (username) {
+        payload.username = username;
+      }
+
+      exchangeToken(payload)
         .then((success: boolean) => {
           if (!success) {
             console.error('Unable to exchange token');

--- a/web/portal/brand/src/entities/Administrator/Action/Impersonate.tsx
+++ b/web/portal/brand/src/entities/Administrator/Action/Impersonate.tsx
@@ -1,0 +1,51 @@
+import { MoreMenuItem } from '@irontec/ivoz-ui/components/List/Content/Shared/MoreChildEntityLinks';
+import {
+  StyledTableRowChildEntityLink,
+  StyledTableRowCustomCta,
+} from '@irontec/ivoz-ui/components/List/Content/Table/ContentTable.styles';
+import {
+  ActionFunctionComponent,
+  ActionItemProps,
+} from '@irontec/ivoz-ui/router/routeMapParser';
+import _ from '@irontec/ivoz-ui/services/translations/translate';
+import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
+import { Tooltip } from '@mui/material';
+import { useStoreState } from 'store';
+
+const Impersonate: ActionFunctionComponent = (props: ActionItemProps) => {
+  const { row, entityService, variant = 'icon' } = props;
+  const token = useStoreState((state) => state.auth.token);
+
+  if (!row) {
+    return null;
+  }
+
+  const { username } = row;
+  const queryString = `username=${username}&token=${token}`;
+
+  return (
+    <StyledTableRowChildEntityLink
+      to={`/client/?${queryString}`}
+      parentEntity={entityService.getEntity()}
+      parentRow={row}
+      target='_impersonate-client'
+    >
+      <>
+        {variant === 'text' && <MoreMenuItem>{_('Impersonate')}</MoreMenuItem>}
+        {variant === 'icon' && (
+          <Tooltip
+            title={_('Impersonate')}
+            placement='bottom-start'
+            enterTouchDelay={0}
+          >
+            <StyledTableRowCustomCta>
+              <AdminPanelSettingsIcon />
+            </StyledTableRowCustomCta>
+          </Tooltip>
+        )}
+      </>
+    </StyledTableRowChildEntityLink>
+  );
+};
+
+export default Impersonate;

--- a/web/portal/brand/src/entities/Administrator/Action/index.ts
+++ b/web/portal/brand/src/entities/Administrator/Action/index.ts
@@ -1,0 +1,11 @@
+import { CustomActionsType } from '@irontec/ivoz-ui/entities/EntityInterface';
+
+import Impersonate from './Impersonate';
+
+const customAction: CustomActionsType = {
+  Impersonate: {
+    action: Impersonate,
+  },
+};
+
+export default customAction;

--- a/web/portal/brand/src/entities/Administrator/Administrator.tsx
+++ b/web/portal/brand/src/entities/Administrator/Administrator.tsx
@@ -1,4 +1,5 @@
 import { EntityValues, isEntityItem } from '@irontec/ivoz-ui';
+import ChildEntityLink from '@irontec/ivoz-ui/components/List/Content/Shared/ChildEntityLink';
 import defaultEntityBehavior, {
   ChildDecorator as DefaultChildDecorator,
 } from '@irontec/ivoz-ui/entities/DefaultEntityBehavior';
@@ -9,6 +10,7 @@ import _ from '@irontec/ivoz-ui/services/translations/translate';
 import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
 
 import AdministratorRelPublicEntity from '../AdministratorRelPublicEntity/AdministratorRelPublicEntity';
+import Actions from './Action';
 import {
   AdministratorProperties,
   AdministratorPropertyList,
@@ -65,14 +67,24 @@ const properties: AdministratorProperties = {
 };
 
 export const ChildDecorator: ChildDecoratorType = (props) => {
-  const { routeMapItem, row } = props;
+  const { routeMapItem, row, variant } = props;
 
   if (
     isEntityItem(routeMapItem) &&
     routeMapItem.entity.iden === AdministratorRelPublicEntity.iden
   ) {
     if (!row.restricted) {
-      return null;
+      if (variant === 'text') {
+        return <a className='disabled'>{AdministratorRelPublicEntity.title}</a>;
+      }
+
+      return (
+        <ChildEntityLink
+          routeMapItem={routeMapItem}
+          row={row}
+          disabled={true}
+        />
+      );
     }
   }
 
@@ -94,6 +106,7 @@ const Administrator: EntityInterface = {
     iden: 'Administrators',
   },
   ChildDecorator,
+  customActions: Actions,
   selectOptions: async () => {
     const module = await import('./SelectOptions');
 

--- a/web/portal/brand/src/router/AppRoutesGuard.tsx
+++ b/web/portal/brand/src/router/AppRoutesGuard.tsx
@@ -15,13 +15,17 @@ export default function AppRoutesGuard(props: AppRoutesGuardProps) {
   const {
     target,
     token,
+    username,
   }: {
     target?: string;
     token?: string;
+    username?: string;
   } = qsArgs;
 
-  if (!loggedIn || (target && token)) {
-    return <Login target={target} token={token} />;
+  const impersonate = (target || username) && token;
+
+  if (!loggedIn || impersonate) {
+    return <Login target={target} username={username} token={token} />;
   }
 
   return <AppRoutes {...props} />;

--- a/web/portal/brand/src/router/EntityMap.ts
+++ b/web/portal/brand/src/router/EntityMap.ts
@@ -68,6 +68,7 @@ const getEntityMap = (): ExtendedRouteMap => {
               entity: entities.Administrator,
               filterBy: 'company',
               children: [
+                ...Object.values(entities.Administrator.customActions),
                 {
                   entity: entities.AdministratorRelPublicEntity,
                   filterBy: 'administrator',
@@ -103,6 +104,7 @@ const getEntityMap = (): ExtendedRouteMap => {
               entity: entities.Administrator,
               filterBy: 'company',
               children: [
+                ...Object.values(entities.Administrator.customActions),
                 {
                   entity: entities.AdministratorRelPublicEntity,
                   filterBy: 'administrator',
@@ -135,6 +137,7 @@ const getEntityMap = (): ExtendedRouteMap => {
               entity: entities.Administrator,
               filterBy: 'company',
               children: [
+                ...Object.values(entities.Administrator.customActions),
                 {
                   entity: entities.AdministratorRelPublicEntity,
                   filterBy: 'administrator',
@@ -170,6 +173,7 @@ const getEntityMap = (): ExtendedRouteMap => {
               entity: entities.Administrator,
               filterBy: 'company',
               children: [
+                ...Object.values(entities.Administrator.customActions),
                 {
                   entity: entities.AdministratorRelPublicEntity,
                   filterBy: 'administrator',

--- a/web/portal/client/src/components/Login.tsx
+++ b/web/portal/client/src/components/Login.tsx
@@ -7,11 +7,12 @@ import { useStoreActions, useStoreState } from 'store';
 interface LoginProps {
   validator?: EntityValidator;
   target?: string;
+  username?: string;
   token?: string;
 }
 
 export default function Login(props: LoginProps): JSX.Element | null {
-  const { validator, target, token } = props;
+  const { validator, target, username, token } = props;
 
   const location = useLocation();
   const navigate = useNavigate();
@@ -28,11 +29,18 @@ export default function Login(props: LoginProps): JSX.Element | null {
   );
 
   useEffect(() => {
-    if (target && token) {
-      exchangeToken({
-        clientId: target,
-        token,
-      })
+    if ((target || username) && token) {
+      const payload: Record<string, string> = { token };
+
+      if (target) {
+        payload.clientId = target;
+      }
+
+      if (username) {
+        payload.username = username;
+      }
+
+      exchangeToken(payload)
         .then((success: boolean) => {
           if (!success) {
             // eslint-disable-next-line no-console
@@ -53,7 +61,7 @@ export default function Login(props: LoginProps): JSX.Element | null {
 
       return;
     }
-  }, [target, token, exchangeToken, navigate, location.pathname]);
+  }, [target, username, token, exchangeToken, navigate, location.pathname]);
 
   useEffect(() => {
     if (target && token) {

--- a/web/portal/client/src/router/AppRoutesGuard.tsx
+++ b/web/portal/client/src/router/AppRoutesGuard.tsx
@@ -15,13 +15,17 @@ export default function AppRoutesGuard(props: AppRoutesGuardProps) {
   const {
     target,
     token,
+    username,
   }: {
     target?: string;
     token?: string;
+    username?: string;
   } = qsArgs;
 
-  if (!loggedIn || (target && token)) {
-    return <Login target={target} token={token} />;
+  const impersonate = (target || username) && token;
+
+  if (!loggedIn || impersonate) {
+    return <Login target={target} username={username} token={token} />;
   }
 
   return <AppRoutes {...props} />;

--- a/web/portal/package.json
+++ b/web/portal/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",
-    "@irontec/ivoz-ui": "^1.1.20",
+    "@irontec/ivoz-ui": "^1.1.21",
     "@mui/icons-material": "^5.11.16",
     "@mui/material": "^5.12.1",
     "@mui/styles": "^5.12.0",

--- a/web/portal/platform/src/entities/Administrator/Action/Impersonate.tsx
+++ b/web/portal/platform/src/entities/Administrator/Action/Impersonate.tsx
@@ -1,0 +1,51 @@
+import { MoreMenuItem } from '@irontec/ivoz-ui/components/List/Content/Shared/MoreChildEntityLinks';
+import {
+  StyledTableRowChildEntityLink,
+  StyledTableRowCustomCta,
+} from '@irontec/ivoz-ui/components/List/Content/Table/ContentTable.styles';
+import {
+  ActionFunctionComponent,
+  ActionItemProps,
+} from '@irontec/ivoz-ui/router/routeMapParser';
+import _ from '@irontec/ivoz-ui/services/translations/translate';
+import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
+import { Tooltip } from '@mui/material';
+import { useStoreState } from 'store';
+
+const Impersonate: ActionFunctionComponent = (props: ActionItemProps) => {
+  const { row, variant = 'icon', entityService } = props;
+  const token = useStoreState((state) => state.auth.token);
+
+  if (!row) {
+    return null;
+  }
+
+  const { username } = row;
+  const queryString = `username=${username}&token=${token}`;
+
+  return (
+    <StyledTableRowChildEntityLink
+      to={`/brand/?${queryString}`}
+      parentEntity={entityService.getEntity()}
+      parentRow={row}
+      target='_impersonate-brand'
+    >
+      <>
+        {variant === 'text' && <MoreMenuItem>{_('Impersonate')}</MoreMenuItem>}
+        {variant === 'icon' && (
+          <Tooltip
+            title={_('Impersonate')}
+            placement='bottom-start'
+            enterTouchDelay={0}
+          >
+            <StyledTableRowCustomCta>
+              <AdminPanelSettingsIcon />
+            </StyledTableRowCustomCta>
+          </Tooltip>
+        )}
+      </>
+    </StyledTableRowChildEntityLink>
+  );
+};
+
+export default Impersonate;

--- a/web/portal/platform/src/entities/Administrator/Action/index.ts
+++ b/web/portal/platform/src/entities/Administrator/Action/index.ts
@@ -1,0 +1,11 @@
+import { CustomActionsType } from '@irontec/ivoz-ui/entities/EntityInterface';
+
+import Impersonate from './Impersonate';
+
+const customAction: CustomActionsType = {
+  Impersonate: {
+    action: Impersonate,
+  },
+};
+
+export default customAction;

--- a/web/portal/platform/src/entities/Administrator/Administrator.tsx
+++ b/web/portal/platform/src/entities/Administrator/Administrator.tsx
@@ -1,4 +1,5 @@
 import { EntityValues, isEntityItem } from '@irontec/ivoz-ui';
+import ChildEntityLink from '@irontec/ivoz-ui/components/List/Content/Shared/ChildEntityLink';
 import defaultEntityBehavior, {
   ChildDecorator as DefaultChildDecorator,
   marshaller as defaultMarshaller,
@@ -10,6 +11,7 @@ import _ from '@irontec/ivoz-ui/services/translations/translate';
 import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
 
 import AdministratorRelPublicEntity from '../AdministratorRelPublicEntity/AdministratorRelPublicEntity';
+import Actions from './Action';
 import { AdministratorProperties } from './AdministratorProperties';
 
 type marshallerType = typeof defaultMarshaller;
@@ -67,14 +69,24 @@ const properties: AdministratorProperties = {
 };
 
 export const ChildDecorator: ChildDecoratorType = (props) => {
-  const { routeMapItem, row } = props;
+  const { routeMapItem, row, variant } = props;
 
   if (
     isEntityItem(routeMapItem) &&
     routeMapItem.entity.iden === AdministratorRelPublicEntity.iden
   ) {
     if (!row.restricted) {
-      return null;
+      if (variant === 'text') {
+        return <a className='disabled'>{AdministratorRelPublicEntity.title}</a>;
+      }
+
+      return (
+        <ChildEntityLink
+          routeMapItem={routeMapItem}
+          row={row}
+          disabled={true}
+        />
+      );
     }
   }
 
@@ -96,6 +108,7 @@ const Administrator: EntityInterface = {
   },
   columns: ['username', 'active', 'restricted'],
   ChildDecorator,
+  customActions: Actions,
   selectOptions: async () => {
     const module = await import('./SelectOptions');
 

--- a/web/portal/platform/src/router/EntityMap.ts
+++ b/web/portal/platform/src/router/EntityMap.ts
@@ -35,6 +35,7 @@ const getEntityMap = (): ExtendedRouteMap => {
           },
           filterBy: 'brand',
           children: [
+            ...Object.values(entities.Administrator.customActions),
             {
               entity: entities.AdministratorRelPublicEntity,
               filterBy: 'administrator',

--- a/web/portal/yarn.lock
+++ b/web/portal/yarn.lock
@@ -761,10 +761,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@irontec/ivoz-ui@^1.1.20":
-  version "1.1.20"
-  resolved "https://registry.yarnpkg.com/@irontec/ivoz-ui/-/ivoz-ui-1.1.20.tgz#3fdc88fabee064002b41b147c79c5d6c2b77071c"
-  integrity sha512-7+IN4jQfQZeJFlg/7Yh2gqOSdsSfAjpSq1DUXsXTYpvbL9lxHlyvH8h9MOQ+rtvGcmk8ZiyMiwFnxRvA0hGqeQ==
+"@irontec/ivoz-ui@^1.1.21":
+  version "1.1.21"
+  resolved "https://registry.yarnpkg.com/@irontec/ivoz-ui/-/ivoz-ui-1.1.21.tgz#24e8f6e0326e3ae136e617c0e65ec39b63120c35"
+  integrity sha512-A2IKLUiw7JMcUPz6LVVKcPGdpOVNAkgSGWqmNwjZYOiofjP+7U47h3KC1RWqqXmXsTiDwJnSFe3vTOEdeOw/Cw==
   dependencies:
     "@date-io/date-fns" "^2.10.8"
     axios "^0.21.1"

--- a/web/rest/brand/features/exchangeTimezones.feature
+++ b/web/rest/brand/features/exchangeTimezones.feature
@@ -1,0 +1,55 @@
+Feature: Authorization checking
+  In order to use the API
+  As a client software developer
+  I need to be authorized to access a given resource.
+
+  @createSchema
+  Scenario: Internal admin inherits parent admin Europe/Madrid timezone
+    When I exchange "admin" platform token for "__b1_internal" brand token
+     And I add "Accept" header equal to "application/json"
+     And I send a "GET" request to "balance_movements"
+    Then the response status code should be 200
+     And the response should be in JSON
+     And the header "Content-Type" should be equal to "application/json; charset=utf-8"
+     And the JSON should be like:
+      """
+      [
+          {
+              "createdOn": "2022-09-02 12:17:10",
+              "id": 1
+          },
+          {
+              "createdOn": "2022-09-02 12:17:11",
+              "id": 2
+          },
+          {
+              "createdOn": "2022-09-02 12:17:12",
+              "id": 3
+          }
+      ]
+      """
+
+  Scenario: Internal admin inherits parent admin UTC timezone
+    When I exchange "utcAdmin" platform token for "__b1_internal" brand token
+     And I add "Accept" header equal to "application/json"
+     And I send a "GET" request to "balance_movements"
+    Then the response status code should be 200
+     And the response should be in JSON
+     And the header "Content-Type" should be equal to "application/json; charset=utf-8"
+     And the JSON should be like:
+      """
+      [
+          {
+              "createdOn": "2022-09-02 10:17:10",
+              "id": 1
+          },
+          {
+              "createdOn": "2022-09-02 10:17:11",
+              "id": 2
+          },
+          {
+              "createdOn": "2022-09-02 10:17:12",
+              "id": 3
+          }
+      ]
+      """

--- a/web/rest/brand/src/Service/Behat/FeatureContext.php
+++ b/web/rest/brand/src/Service/Behat/FeatureContext.php
@@ -26,8 +26,6 @@ class FeatureContext extends BaseFeatureContext
 
     /**
      * @Given I add Brand Authorization header
-     *
-     * @return void
      */
     public function setBrandAuthorizationHeader(): void
     {
@@ -36,8 +34,6 @@ class FeatureContext extends BaseFeatureContext
 
     /**
      * @Given I exchange Brand Authorization header
-     *
-     * @return void
      */
     public function setBrandAuthorizationHeaderByExchange(): void
     {
@@ -46,12 +42,18 @@ class FeatureContext extends BaseFeatureContext
 
     /**
      * @Given I exchange internal Brand Authorization header
-     *
-     * @return void
      */
     public function setInternalBrandAuthorizationHeaderByExchange(): void
     {
         $this->exchangeAuthorizationHeader('admin', '__b1_internal');
+    }
+
+    /**
+     * @Given I exchange :username platform token for :username2 brand token
+     */
+    public function exchangeAuthorizationTokens(string $username, string $username2): void
+    {
+        $this->exchangeAuthorizationHeader($username, $username2);
     }
 
     /**


### PR DESCRIPTION
From now on internal admins will inherit timezone from their parent admin (the first one that is not internal in the impersonation chain). On the other hand, "real admin" impersonation will keep it's timezone.

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX
