### PR TITLE
kam: avoid empty Diversion domain

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -1303,7 +1303,11 @@ route[TRANSFORMATE_IN] {
                 route(APPLY_TRANSFORMATION); # Apply $var(transformation) to $var(number)
 
                 remove_hf_value("Diversion[0]");
-                add_diversion("$avp(reason)", 'sip:' + $var(transformated) + '@' + $(di{uri.host}));
+                if ($(di{uri.host}{s.len}) > 0) {
+                    add_diversion("$avp(reason)", 'sip:' + $var(transformated) + '@' + $(di{uri.host}));
+                } else {
+                    add_diversion("$avp(reason)", 'sip:' + $var(transformated) + '@' + $fd);
+                }
                 $dlg_var(diversion) = $var(transformated); # Save for CDR
             }
         }
@@ -1440,8 +1444,10 @@ route[TRANSFORMATE_OUT] {
             remove_hf_value("Diversion[0]");
             if ($dlg_var(companyDomain) != $null) {
                 add_diversion("$avp(reason)", 'sip:' + $var(transformated) + '@' + $dlg_var(companyDomain));
-            } else {
+            } else if ($(di{uri.host}{s.len}) > 0) {
                 add_diversion("$avp(reason)", 'sip:' + $var(transformated) + '@' + $(di{uri.host}));
+            } else {
+                add_diversion("$avp(reason)", 'sip:' + $var(transformated) + '@' + $fd);
             }
         }
     }

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -975,7 +975,11 @@ route[ADAPT_DIVERSION] {
         }
     }
     remove_hf_value("Diversion[0]");
-    add_diversion("$avp(reason)", 'sip:' + $var(transformated) + '@' + $(di{uri.host}));
+    if ($(di{uri.host}{s.len}) > 0) {
+        add_diversion("$avp(reason)", 'sip:' + $var(transformated) + '@' + $(di{uri.host}));
+    } else {
+        add_diversion("$avp(reason)", 'sip:' + $var(transformated) + '@' + $fd);
+    }
     $dlg_var(diversion) = $var(transformated);
 }
 


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
Use from-domain if diversion-domain is empty, to avoid a new Diversion header with empty domain.

