### PR TITLE
Fix errors while sending faxes through rest API  

### DIFF
--- a/asterisk/agi/composer.json
+++ b/asterisk/agi/composer.json
@@ -60,8 +60,9 @@
         "irontec/ivoz-provider-bundle": "^2.5",
         "irontec/replacements": "^1.0",
         "php-mime-mail-parser/php-mime-mail-parser": "^7.0",
-        "symfony/proxy-manager-bridge": "^5.3",
-        "symfony/flex": "^1.9"
+        "symfony/flex": "^1.9",
+        "symfony/process": "^5.4",
+        "symfony/proxy-manager-bridge": "^5.3"
     },
     "extra": {
         "symfony-assets-install": "relative",

--- a/asterisk/agi/composer.lock
+++ b/asterisk/agi/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e44f72d71950fbe11a6cdf8ef01a99e8",
+    "content-hash": "3d1b1321c87d82c6b60263cc8d64e7e8",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -5436,6 +5436,47 @@
                 "portable",
                 "shim"
             ],
+            "transport-options": {
+                "symlink": true,
+                "relative": true
+            }
+        },
+        {
+            "name": "symfony/process",
+            "version": "v5.4.28",
+            "dist": {
+                "type": "path",
+                "url": "../../library/vendor/symfony/process",
+                "reference": "45261e1fccad1b5447a8d7a8e67aa7b4a9798b7b"
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Executes commands in sub-processes",
+            "homepage": "https://symfony.com",
             "transport-options": {
                 "symlink": true,
                 "relative": true

--- a/asterisk/agi/config/services.yaml
+++ b/asterisk/agi/config/services.yaml
@@ -147,8 +147,7 @@ services:
 
     Agi\Action\FaxReceiveStatusAction:
         lazy: true
-        arguments:
-            $mailer: '@mailer'
+        arguments: ~
 
     Agi\Action\FriendCallAction:
         lazy: true

--- a/asterisk/agi/symfony.lock
+++ b/asterisk/agi/symfony.lock
@@ -347,6 +347,9 @@
     "symfony/polyfill-php81": {
         "version": "1.23-dev"
     },
+    "symfony/process": {
+        "version": "v5.4.28"
+    },
     "symfony/property-access": {
         "version": "v3.4.44"
     },

--- a/library/Ivoz/Provider/Domain/Model/FaxesInOut/FaxesInOut.php
+++ b/library/Ivoz/Provider/Domain/Model/FaxesInOut/FaxesInOut.php
@@ -24,6 +24,16 @@ class FaxesInOut extends FaxesInOutAbstract implements FileContainerInterface, F
     }
 
     /**
+     * {@inheritDoc}
+     */
+    protected function sanitizeValues(): void
+    {
+        if (!$this->getStatus()) {
+            $this->setStatus(self::STATUS_PENDING);
+        }
+    }
+
+    /**
      * @return array
      */
     public function getFileObjects(int $filter = null): array

--- a/library/Ivoz/Provider/Domain/Model/FaxesInOut/FaxesInOutDto.php
+++ b/library/Ivoz/Provider/Domain/Model/FaxesInOut/FaxesInOutDto.php
@@ -27,6 +27,20 @@ class FaxesInOutDto extends FaxesInOutDtoAbstract
         return parent::getPropertyMap(...func_get_args());
     }
 
+    public function denormalize(array $data, string $context, string $role = ''): void
+    {
+        $contextProperties = self::getPropertyMap($context, $role);
+
+        if ($context === self::CONTEXT_SIMPLE) {
+            $contextProperties['file'][] = 'path';
+        }
+
+        $this->setByContext(
+            $contextProperties,
+            $data
+        );
+    }
+
     /**
      * @return string[]
      *

--- a/library/Ivoz/Provider/Domain/Service/FaxesInOut/FaxesInOutLifecycleServiceCollection.php
+++ b/library/Ivoz/Provider/Domain/Service/FaxesInOut/FaxesInOutLifecycleServiceCollection.php
@@ -17,9 +17,9 @@ class FaxesInOutLifecycleServiceCollection implements LifecycleServiceCollection
 
     /** @var array<array-key, array> $bindedBaseServices */
     public static $bindedBaseServices = [
-        "post_persist" =>
+        "on_commit" =>
         [
-            \Ivoz\Provider\Domain\Service\FaxesInOut\SendFaxFile::class => 10,
+            \Ivoz\Provider\Domain\Service\FaxesInOut\SendFaxFile::class => 200,
         ],
     ];
 

--- a/library/Ivoz/Provider/Domain/Service/FaxesInOut/SendFaxFile.php
+++ b/library/Ivoz/Provider/Domain/Service/FaxesInOut/SendFaxFile.php
@@ -22,7 +22,7 @@ class SendFaxFile implements FaxesInOutLifecycleEventHandlerInterface
     public static function getSubscribedEvents()
     {
         return [
-            self::EVENT_POST_PERSIST => 10
+            self::EVENT_ON_COMMIT => self::PRIORITY_NORMAL
         ];
     }
 

--- a/library/phpstan-baseline.neon
+++ b/library/phpstan-baseline.neon
@@ -2476,6 +2476,11 @@ parameters:
 			path: Ivoz/Provider/Domain/Model/FaxesInOut/FaxesInOut.php
 
 		-
+			message: "#^Cannot assign new offset to array\\<array\\<int, string\\>\\|string\\>\\|string\\.$#"
+			count: 1
+			path: Ivoz/Provider/Domain/Model/FaxesInOut/FaxesInOutDto.php
+
+		-
 			message: "#^Method Ivoz\\\\Provider\\\\Domain\\\\Model\\\\FaxesInOut\\\\FaxesInOutInterface\\:\\:getFileObjects\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: Ivoz/Provider/Domain/Model/FaxesInOut/FaxesInOutInterface.php

--- a/library/psalm-baseline.xml
+++ b/library/psalm-baseline.xml
@@ -2733,6 +2733,9 @@
     <MixedArgument occurrences="1">
       <code>func_get_args()</code>
     </MixedArgument>
+    <MixedArrayAssignment occurrences="1">
+      <code>$contextProperties['file'][]</code>
+    </MixedArrayAssignment>
   </file>
   <file src="Ivoz/Provider/Domain/Model/FaxesInOut/FaxesInOutTrait.php">
     <MixedArgument occurrences="1">

--- a/web/rest/client/features/provider/faxesInOut/postFaxesInOut.feature
+++ b/web/rest/client/features/provider/faxesInOut/postFaxesInOut.feature
@@ -37,11 +37,11 @@ This is file content
           "dst": "34688888881",
           "type": "Out",
           "pages": null,
-          "status": null,
+          "status": "pending",
           "id": 2,
           "file": {
               "fileSize": 20,
-              "mimeType": "text/plain",
+              "mimeType": "text/plain; charset=us-ascii",
               "baseName": "uploadable"
           },
           "fax": 1,
@@ -63,11 +63,11 @@ This is file content
           "dst": "34688888881",
           "type": "Out",
           "pages": null,
-          "status": null,
+          "status": "pending",
           "id": 2,
           "file": {
               "fileSize": 20,
-              "mimeType": "text/plain",
+              "mimeType": "text/plain; charset=us-ascii",
               "baseName": "uploadable"
           },
           "fax": {


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
This PR includes a group of fixes to make Faxes work again:
   - File uploaded through API was not being stored in storage path
   - Faxes configured to send emails was not working
   - PDF to TIF conversion was using a library not included as dependency
   - Send request was being sent before the entity was totally saved in database 

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
