### PR TITLE
kamusers: fix X-Info-Endpoint for retail call-forward

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -1191,7 +1191,7 @@ route[DISPATCH_TO_AS] {
         send_reply("500", "Internal Server Error [DTA]");
         exit;
     }
-    $var(sorcery) = $var(sorcery) + "_" + $fU;
+    $var(sorcery) = $var(sorcery) + "_" + $avp(endpointName);
     append_hf("X-Info-Endpoint: $var(sorcery)\r\n");
 
     # Static routing to specific AS?
@@ -1777,7 +1777,7 @@ route[GET_ENDPOINT] {
         # cached?
         if ($sht(aors=>$var(aor)) != $null) {
             $xavp(endpoint) = $null;
-            sql_xquery("cb", "SELECT T.id, T.password FROM $sht(aors=>$var(aor)) T JOIN Domains D ON D.id=T.domainId WHERE T.name='$var(username)' AND D.domain='$var(domain)'", "endpoint");
+            sql_xquery("cb", "SELECT T.id, T.password, T.name FROM $sht(aors=>$var(aor)) T JOIN Domains D ON D.id=T.domainId WHERE T.name='$var(username)' AND D.domain='$var(domain)'", "endpoint");
             if ($xavp(endpoint=>id) != $null) {
                 $var(found) = 1;
                 break;
@@ -1787,7 +1787,7 @@ route[GET_ENDPOINT] {
 
         # terminal
         $xavp(endpoint) = $null;
-        sql_xquery("cb", "SELECT T.id, T.password FROM Terminals T JOIN Domains D ON D.id=T.domainId WHERE T.name='$var(username)' AND D.domain='$var(domain)'", "endpoint");
+        sql_xquery("cb", "SELECT T.id, T.password, T.name FROM Terminals T JOIN Domains D ON D.id=T.domainId WHERE T.name='$var(username)' AND D.domain='$var(domain)'", "endpoint");
         if ($xavp(endpoint=>id) != $null) {
             $sht(aors=>$var(aor)) = "Terminals";
             $var(found) = 1;
@@ -1796,7 +1796,7 @@ route[GET_ENDPOINT] {
 
         # retail
         $xavp(endpoint) = $null;
-        sql_xquery("cb", "SELECT T.id, T.password FROM RetailAccounts T JOIN Domains D ON D.id=T.domainId WHERE T.name='$var(username)' AND D.domain='$var(domain)'", "endpoint");
+        sql_xquery("cb", "SELECT T.id, T.password, T.name FROM RetailAccounts T JOIN Domains D ON D.id=T.domainId WHERE T.name='$var(username)' AND D.domain='$var(domain)'", "endpoint");
         if ($xavp(endpoint=>id) != $null) {
             $sht(aors=>$var(aor)) = "RetailAccounts";
             $var(found) = 1;
@@ -1805,7 +1805,7 @@ route[GET_ENDPOINT] {
 
         # friend
         $xavp(endpoint) = $null;
-        sql_xquery("cb", "SELECT T.id, T.password FROM Friends T JOIN Domains D ON D.id=T.domainId WHERE T.name='$var(username)' AND D.domain='$var(domain)'", "endpoint");
+        sql_xquery("cb", "SELECT T.id, T.password, T.name FROM Friends T JOIN Domains D ON D.id=T.domainId WHERE T.name='$var(username)' AND D.domain='$var(domain)'", "endpoint");
         if ($xavp(endpoint=>id) != $null) {
             $sht(aors=>$var(aor)) = "Friends";
             $var(found) = 1;
@@ -1814,7 +1814,7 @@ route[GET_ENDPOINT] {
 
         # residential
         $xavp(endpoint) = $null;
-        sql_xquery("cb", "SELECT T.id, T.password FROM ResidentialDevices T JOIN Domains D ON D.id=T.domainId WHERE T.name='$var(username)' AND D.domain='$var(domain)'", "endpoint");
+        sql_xquery("cb", "SELECT T.id, T.password, T.name FROM ResidentialDevices T JOIN Domains D ON D.id=T.domainId WHERE T.name='$var(username)' AND D.domain='$var(domain)'", "endpoint");
         if ($xavp(endpoint=>id) != $null) {
             $sht(aors=>$var(aor)) = "ResidentialDevices";
             $var(found) = 1;
@@ -1832,9 +1832,10 @@ route[GET_ENDPOINT] {
 
     $avp(endpointType) = $sht(aors=>$var(aor));
     $avp(endpointId) = $xavp(endpoint=>id);
+    $avp(endpointName) = $xavp(endpoint=>name);
     $avp(password) = $xavp(endpoint=>password);
 
-    xinfo("[$dlg_var(cidhash)] GET-ENDPOINT: $avp(endpointType)#$avp(endpointId)");
+    xinfo("[$dlg_var(cidhash)] GET-ENDPOINT: $avp(endpointType)#$avp(endpointId)#$avp(endpointName)");
 }
 
 route[BAD_CREDENTIALS] {


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description

X-Info-Endpoint header is used in Asterisk to identify calling peer. This header is added by KamUsers and was added wrong for retail call forwards.

This PR fixes this minor bug.
