### PR TITLE
Set all realtime keys TTL to 3 hours

### DIFF
--- a/microservices/realtime/pkg/services/redis_helper.go
+++ b/microservices/realtime/pkg/services/redis_helper.go
@@ -27,8 +27,7 @@ type EventData struct {
 	DdiProvider string `json:"DdiProvider,omitempty"`
 }
 
-const REDIS_KEYS_IN_CALL_TTL = 3*time.Hour + 30*time.Minute
-const REDIS_KEYS_TTL = 2 * time.Minute
+const REDIS_KEYS_TTL = 3 * time.Hour
 
 // Constants
 const (
@@ -129,18 +128,11 @@ func updateCurrentCallsStatus(msg *redis.Message, redisClient *redis.Client) {
 		return
 	}
 
-	ttl := func() time.Duration {
-		if event == "IN_CALL" {
-			return REDIS_KEYS_IN_CALL_TTL
-		}
-		return REDIS_KEYS_TTL
-	}()
-
 	redisClient.SetEx(
 		context.Background(),
 		channel,
 		string(dataBytes),
-		ttl,
+		REDIS_KEYS_TTL,
 	)
 
 }


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
TTL of keys stored with SETEX can not be overwritten by another SETEX with a different TTL. This was causing all keys to be stored only during 2 minutes (initial TTL when a call wasn't been answered).

The easiest approach here is to create keys with 3 hours TTL (the one intended to be used when a call was answered) instead of mixing two different types of TTL based on call status. 

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
