### PR TITLE
Fix cgrates-reload database access for all brands reloading

### DIFF
--- a/cgrates/scripts/cgrates-reload
+++ b/cgrates/scripts/cgrates-reload
@@ -16,6 +16,10 @@ ALLBRANDS=-1
 FLUSHALL=0
 RELOADDESTINATIONS=0
 
+# Database access settings
+export MYSQL_HOST="data.ivozprovider.local"
+export MYSQL_PWD="changeme"
+
 while getopts ":Fdb:" opt; do
   case $opt in
     F)

--- a/debian/ivozprovider-profile-proxy.postinst
+++ b/debian/ivozprovider-profile-proxy.postinst
@@ -37,6 +37,7 @@ function setup_mysql_access()
 
     # Replace password in configuration files
     sed -i -r "s#(password *= *).*#\1$MYSQL_PWD#" /etc/mysql/conf.d/kamailio.cnf
+    sed -i -r "s#(MYSQL_PWD *= *).*#\1\"$MYSQL_PWD\"#" /usr/bin/cgrates-reload
     sed -i -r "s#(\"db_password\": *)\".+\"#\1\"$MYSQL_PWD\"#" /etc/cgrates/cgrates.json
 }
 


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
When this script is run with `-b all` flag, it makes a database query that must be run in data.ivozprovider.local with credentials 

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
