### PR TITLE
kamusers: drop as-feature-event to avoid pike

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -1107,6 +1107,12 @@ route[REQINIT] {
         send_reply("483","Too Many Hops");
         exit;
     }
+
+    # Avoid forwarding unsupported 'Event: as-feature-event' SUBSCRIBEs to AS
+    # (do not count in ANTIFLOOD to avoid banning wrong configured legitimate UACs)
+    if (is_method("SUBSCRIBE") && $hdr(Event) == "as-feature-event") {
+        exit;
+    }
 }
 
 route[MAXCALLS_USER] {


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description

In version 4 presence is handled in AS nodes. Prior versions handled presence in Kamailio users proxy.

_Event: as-feature-event_ SUBSCRIBEs are rejected by Asterisk and causes UACs to retry a lot. After a while, legitimate UACs get banned by PIKE.

This PR drops this kind of unsupported SUBSCRIBE messages to avoid this pike ban.
