### PR TITLE
Remove file_get_contents from generic SNOM templates

### DIFF
--- a/microservices/provision/templates/provisioning/SnomD375/generic.cfg
+++ b/microservices/provision/templates/provisioning/SnomD375/generic.cfg
@@ -1,14 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <settings>
 <certificates>
-<?php
-$cert = file_get_contents("/etc/ssl/certs/snom.crt");
-if (preg_match_all("/-----BEGIN CERTIFICATE-----(.*?)-----END CERTIFICATE-----/s", $cert, $matches)) {
-    foreach ($matches[1] as $match) {
-        echo '<certificate type="base64">' . $match . '</certificate>';
-    }
-}
-?>
+<certificate type="base64"></certificate>
 </certificates>
 <phone-settings e="2">
 <update_policy perm="">auto_update</update_policy>

--- a/microservices/provision/templates/provisioning/SnomD717/generic.cfg
+++ b/microservices/provision/templates/provisioning/SnomD717/generic.cfg
@@ -1,14 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <settings>
 <certificates>
-<?php
-$cert = file_get_contents("/etc/ssl/certs/snom.crt");
-if (preg_match_all("/-----BEGIN CERTIFICATE-----(.*?)-----END CERTIFICATE-----/s", $cert, $matches)) {
-    foreach ($matches[1] as $match) {
-        echo '<certificate type="base64">' . $match . '</certificate>';
-    }
-}
-?>
+<certificate type="base64"></certificate>
 </certificates>
 <phone-settings e="2">
 <update_policy perm="">auto_update</update_policy>

--- a/microservices/provision/templates/provisioning/SnomD735/generic.cfg
+++ b/microservices/provision/templates/provisioning/SnomD735/generic.cfg
@@ -1,14 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <settings>
 <certificates>
-<?php
-$cert = file_get_contents("/etc/ssl/certs/snom.crt");
-if (preg_match_all("/-----BEGIN CERTIFICATE-----(.*?)-----END CERTIFICATE-----/s", $cert, $matches)) {
-    foreach ($matches[1] as $match) {
-        echo '<certificate type="base64">' . $match . '</certificate>';
-    }
-}
-?>
+<certificate type="base64"></certificate>
 </certificates>
 <phone-settings e="2">
 <update_policy perm="">auto_update</update_policy>

--- a/microservices/provision/templates/provisioning/SnomD785/generic.cfg
+++ b/microservices/provision/templates/provisioning/SnomD785/generic.cfg
@@ -1,14 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <settings>
 <certificates>
-<?php
-$cert = file_get_contents("/etc/ssl/certs/snom.crt");
-if (preg_match_all("/-----BEGIN CERTIFICATE-----(.*?)-----END CERTIFICATE-----/s", $cert, $matches)) {
-    foreach ($matches[1] as $match) {
-        echo '<certificate type="base64">' . $match . '</certificate>';
-    }
-}
-?>
+<certificate type="base64"></certificate>
 </certificates>
 <phone-settings e="2">
 <update_policy perm="">auto_update</update_policy>


### PR DESCRIPTION

<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
This function is not longer allowed to be called in provisioning templates, so if you specify a provisioning site certificate in generic provisioning, paste the whole certificate content in the template. 


#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
