### PR TITLE
kamusers+kamtrunks: avoid AS failover on 404

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -2083,13 +2083,11 @@ failure_route[MANAGE_FAILURE_AS] {
 
     route(IS_FROM_INSIDE);
 
-    # next DST - only for 404 or local timeout
-    if (t_check_status("404") or (t_branch_timeout() and !t_branch_replied())) {
-        # Invalidate AS only if no response received
-        if (t_branch_timeout() and !t_branch_replied()) {
-            xerr("[$dlg_var(cidhash)] MANAGE-FAILURE-AS: Mark AS '$xavp(_dsdst_=>uri)' as inactive\n");
-            ds_mark_dst("ip");
-        }
+    # next DST - only for local timeout
+    if (t_branch_timeout() and !t_branch_replied()) {
+        # Invalidate AS as no response received
+        xerr("[$dlg_var(cidhash)] MANAGE-FAILURE-AS: Mark AS '$xavp(_dsdst_=>uri)' as inactive\n");
+        ds_mark_dst("ip");
 
         if($dlg_var(distributeMethod) != 'static' && ds_next_dst()) {
             xinfo("[$dlg_var(cidhash)] MANAGE-FAILURE-AS: going to <$ru> via <$du>\n");

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -2731,13 +2731,11 @@ failure_route[MANAGE_FAILURE_AS] {
     route(NATMANAGE);
     route(RTPENGINE);
 
-    # next DST - only for 404 or local timeout
-    if (t_check_status("404") or (t_branch_timeout() and !t_branch_replied())) {
-        # Invalidate AS only if no response received
-        if (t_branch_timeout() and !t_branch_replied()) {
-            xerr("[$dlg_var(cidhash)] MANAGE-FAILURE-AS: Mark AS '$xavp(_dsdst_=>uri)' as inactive\n");
-            ds_mark_dst("ip");
-        }
+    # next DST - only for local timeout
+    if (t_branch_timeout() and !t_branch_replied()) {
+        # Invalidate AS as no response received
+        xerr("[$dlg_var(cidhash)] MANAGE-FAILURE-AS: Mark AS '$xavp(_dsdst_=>uri)' as inactive\n");
+        ds_mark_dst("ip");
 
         if(ds_next_dst()) {
             xinfo("[$dlg_var(cidhash)] MANAGE-FAILURE-AS: going to <$ru> via <$du>\n");


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description

No failover is needed when AS replies 404.