### PR TITLE
kamusers: avoid presence requests in invite logics

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -500,8 +500,8 @@ request_route {
     # Handle REGISTER
     route(REGISTER);
 
-    # Handle unsolicited NOTIFY messages (non-related to previous SUBSCRIBE)
-    route(UNSOLICITED_NOTIFY);
+    # Handle NOTIFY, SUBSCRIBE and PUBLISH
+    route(PRESENCE);
 
     # -- From now on, everything is for INVITEs --
 
@@ -1105,12 +1105,6 @@ route[REQINIT] {
         xwarn("REQINIT: Too many hops for SIP message from $si:$sp\n");
         route(ANTIFLOOD);
         send_reply("483","Too Many Hops");
-        exit;
-    }
-
-    # Avoid forwarding unsupported 'Event: as-feature-event' SUBSCRIBEs to AS
-    # (do not count in ANTIFLOOD to avoid banning wrong configured legitimate UACs)
-    if (is_method("SUBSCRIBE") && $hdr(Event) == "as-feature-event") {
         exit;
     }
 }
@@ -3030,12 +3024,41 @@ route[QUALITY] {
     }
 }
 
-route[UNSOLICITED_NOTIFY] {
-    if (!is_method("NOTIFY")) return;
-    if (!$var(is_from_inside)) return;
+route[PRESENCE] {
+    if(!is_method("PUBLISH|SUBSCRIBE|NOTIFY")) return;
 
-    route(LOOKUP);
+    if(is_method("SUBSCRIBE") && $hdr(Event)=="message-summary") {
+        send_reply("404", "No voicemail service");
+        exit;
+    }
+
+    if(is_method("SUBSCRIBE") && $hdr(Event)=="as-feature-event") {
+        send_reply("489", "Bad Event");
+        exit;
+    }
+
+    if(is_method("PUBLISH|SUBSCRIBE")) {
+        if ($var(is_from_inside)) {
+            xwarn("[$dlg_var(cidhash)] NOTIFY: Received $rm from AS, 405 Method Not Allowed\n");
+            send_reply("405", "Method Not Allowed");
+            exit;
+        }
+
+        route(DISPATCH_TO_AS);
+    } else if(is_method("NOTIFY")) {
+        # Handle unsolicited NOTIFY messages (non-related to previous SUBSCRIBE)
+        if (!$var(is_from_inside)) {
+            xwarn("[$dlg_var(cidhash)] NOTIFY: Received $rm from not AS, 405 Method Not Allowed\n");
+            send_reply("405", "Method Not Allowed");
+            exit;
+        }
+
+        # Lookup contact and relay
+        route(LOOKUP);
+    }
+
     route(RELAY);
+    exit;
 }
 
 route[EXIT_NOW] {


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description

Recover route[PRESENCE] to avoid presence requests traverse INVITE-only logics.

#### Additional information

No functional change, just avoid some error logs.