### PR TITLE
kamusers: record-route initial presence requests

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -3055,6 +3055,8 @@ route[PRESENCE] {
         route(LOOKUP);
     }
 
+    record_route();
+
     route(RELAY);
     exit;
 }


### PR DESCRIPTION

#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description

Presence initial requests should be record_routed.

#### Additional information

This bug was introduced in https://github.com/irontec/ivozprovider/pull/2561/commits/cd6afb566535da55ec86217b8e9fea41ecee054c