### PR TITLE
Use default startsecs for supervisord workers

### DIFF
--- a/profiles/portal/etc/supervisor/conf.d/asterisk-dialplan.conf
+++ b/profiles/portal/etc/supervisor/conf.d/asterisk-dialplan.conf
@@ -3,6 +3,5 @@ command=/usr/bin/php /opt/irontec/ivozprovider/microservices/workers/bin/asteris
 autorestart=true
 autostart=true
 user=www-data
-startsecs=0
 process_name=%(program_name)s-%(process_num)s
 stopsignal=KILL

--- a/profiles/portal/etc/supervisor/conf.d/asterisk-hints.conf
+++ b/profiles/portal/etc/supervisor/conf.d/asterisk-hints.conf
@@ -3,6 +3,5 @@ command=/usr/bin/php /opt/irontec/ivozprovider/microservices/workers/bin/asteris
 autorestart=true
 autostart=true
 user=www-data
-startsecs=0
 process_name=%(program_name)s-%(process_num)s
 stopsignal=KILL

--- a/profiles/portal/etc/supervisor/conf.d/kamrpc-daemon.conf
+++ b/profiles/portal/etc/supervisor/conf.d/kamrpc-daemon.conf
@@ -3,6 +3,5 @@ command=/usr/bin/php /opt/irontec/ivozprovider/microservices/workers/bin/kam-rpc
 autorestart=true
 autostart=true
 user=www-data
-startsecs=0
 process_name=%(program_name)s-%(process_num)s
 stopsignal=KILL

--- a/profiles/portal/etc/supervisor/conf.d/kamrpc-delayed-daemon.conf
+++ b/profiles/portal/etc/supervisor/conf.d/kamrpc-delayed-daemon.conf
@@ -3,6 +3,5 @@ command=/usr/bin/php /opt/irontec/ivozprovider/microservices/workers/bin/kam-rpc
 autorestart=true
 autostart=true
 user=www-data
-startsecs=0
 process_name=%(program_name)s-%(process_num)s
 stopsignal=KILL


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
Use default startsecs to detect when a worker is not running

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
