### PR TITLE
kamusers: save Refer-to URI in dlg_var(referee)

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -1929,7 +1929,16 @@ route[WITHINDLG] {
 route[REFER] {
     if (is_present_hf("Refer-to")) {
         xinfo("[$dlg_var(cidhash)] REFER: $fU transfers call to $hdr(Refer-to)\n");
-        $dlg_var(referee) = $hdr(Refer-to);
+
+        if ($hdr(Refer-to) =~ "<.*>") {
+            # Refer-to has < >
+            $var(referee) = $(hdr(Refer-to){s.select,0,>});
+            $var(referee) = $(var(referee){s.select,1,<});
+        } else {
+            $var(referee) = $hdr(Refer-to);
+        }
+
+        $dlg_var(referee) = $(var(referee){s.select,0,?});
     } else {
         xwarn("[$dlg_var(cidhash)] REFER: No Refer-To header found, relay\n");
     }


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
Refer-to header may be too long for a 128 varchar.


#### Additional information
This PR saves into $dlg_var(referee) just the URI in Refer-to.
