### PR TITLE
Fixed library composer autoload rules

### DIFF
--- a/library/composer.json
+++ b/library/composer.json
@@ -58,10 +58,14 @@
             "type": "git"
         }
     ],
+    "autoload": {
+        "psr-4": {
+            "Ivoz\\": "Ivoz"
+        }
+    },
     "autoload-dev": {
         "psr-4": {
-            "spec\\": "spec/",
-            "Ivoz\\": "Ivoz"
+            "spec\\": "spec/"
         }
     },
     "config": {


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
Include Ivoz namespace in library autoload
This was causing errors in terminal provisioning generated templates

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
