### PR TITLE
kamusers: save external element Contact for Cisco phones

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -2409,7 +2409,7 @@ route[CHECK_SPECIAL] {
 
 route[SAVE_CONTACT] {
     if (!is_present_hf("Contact")) return;
-    if (!is_method("INVITE")) return;
+    if (!is_method("INVITE|SUBSCRIBE")) return;
 
     if ($ct =~ "<.*>") {
         # Contact has < >
@@ -2436,6 +2436,11 @@ route[FIX_RURI] {
 
     xwarn("[$dlg_var(cidhash)] FIX-RURI: Fix overridden contact ($ru -> $sht(dialogs=>$ci::contact::$tt))\n");
     $ru = $sht(dialogs=>$ci::contact::$tt);
+
+    if (is_method("SUBSCRIBE")) {
+        # Avoid key expiration
+        $sht(dialogs=>$ci::contact::$tt) = $sht(dialogs=>$ci::contact::$tt);
+    }
 }
 
 #!ifdef WITH_REALTIME


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
Cisco phones send in-dialog SUBSCRIBEs with wrong R-URI. This PR fixes R-URI so that it can be correctly routed to application server.