### PR TITLE
Increase websocket idle timeout to 3600 seconds

### DIFF
--- a/profiles/portal/etc/apache2/conf-available/realtime.conf
+++ b/profiles/portal/etc/apache2/conf-available/realtime.conf
@@ -5,3 +5,4 @@ RewriteRule /wss/.* "ws:/localhost:8081/" [P,L]
 
 ProxyPass /wss ws://localhost:8081/
 ProxyPassReverse /wss ws://localhost:8081/
+ProxyTimeout 3600


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
This value is 300 seconds by default and causes Active Calls section timeouts when no call is displayed. 

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
