### PR TITLE
kamusers: fix behind nat proxied SUBSCRIBEs

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -2186,8 +2186,6 @@ route[NATDETECT] {
 
         if (is_method("REGISTER")) {
             fix_nated_register();
-        } else if (is_method("SUBSCRIBE")) {
-            fix_nated_contact();
         } else {
             if(is_first_hop()) {
                 # Sets ;alias only if received ip and port differ from those in contact URI


### PR DESCRIPTION

#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description

Behind NAT UACs routing their requests through a intermediate external SIP proxy are not being handled correctly (only SUBSCRIBEs). Prior to version 4 presence messaged where handled in Kamailio, but since version 4 they are routed to application server.


#### Additional information

This PR avoids Contact handling for non-first-hop SUBSCRIBE requests so that they are routed properly (equal to remaining non-first-hop requests).