### PR TITLE
[PROVIDER-1764] kamailio: make some htable tables reboot-persistent

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -312,7 +312,7 @@ modparam("pike", "remove_latency", 120)
 modparam("htable", "htable", "ipban=>size=8;autoexpire=300")
 #!endif
 modparam("htable", "htable", "cgrconn=>size=1;")
-modparam("htable", "htable", "dmq=>size=8;autoexpire=10800;dmqreplicate=1;")
+modparam("htable", "htable", "dmq=>size=8;autoexpire=10800;dmqreplicate=1;dbmode=1")
 modparam("htable", "enable_dmq", 1)
 
 # UAC

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -364,8 +364,8 @@ modparam("htable", "htable", "ipban=>size=8;autoexpire=300")
 #!endif
 
 # dialogs htable contains aleg, bleg and applicationserver per dialog
-modparam("htable", "htable", "dialogs=>size=10;autoexpire=10800")
-modparam("htable", "htable", "dmq=>size=8;autoexpire=10800;dmqreplicate=1;")
+modparam("htable", "htable", "dialogs=>size=10;autoexpire=10800;dbmode=1")
+modparam("htable", "htable", "dmq=>size=8;autoexpire=10800;dmqreplicate=1;dbmode=1")
 modparam("htable", "htable", "srcban=>size=8;autoexpire=43200")
 modparam("htable", "htable", "badauthcnt=>size=8;autoexpire=43200")
 modparam("htable", "htable", "aors=>size=10")


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description

dialogs and dmq htables should be reboot-persistent to ensure proper routing of several messages after Kamailio restart.

