### PR TITLE
Hide "Route Labels" if brand has not retail or wholesale features

### DIFF
--- a/web/portal/brand/src/router/EntityMap.ts
+++ b/web/portal/brand/src/router/EntityMap.ts
@@ -278,6 +278,12 @@ const getEntityMap = (): ExtendedRouteMap => {
         },
         {
           entity: entities.RoutingTag,
+          isAccessible: (aboutMe) => {
+            return (
+              aboutMe.features.includes('wholesale') ||
+              aboutMe.features.includes('retail')
+            );
+          },
         },
       ],
     },


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
The "Route Labels" section does not have to be displayed in the brand portal without retail/wholesale features

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
