### PR TITLE
Add new asterisk handler for noclient sounds

### DIFF
--- a/asterisk/config/dialplan/sounds.conf
+++ b/asterisk/config/dialplan/sounds.conf
@@ -2,6 +2,7 @@
 ;; ${EXTEN} MUST match a predefined ivozprovider locution
 [sounds]
 exten => ipnotallowed,1,Goto(playsound,${EXTEN},1)
+exten => noclient,1,Goto(playsound,${EXTEN},1)
 
 [playsound]
 exten => _[a-zA-Z].,1,NoOp(Playing requested sound ${EXTEN})


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
Added a new handler for noclient extension to reproduce a locution when a call is placed to a DDI that is not assigned to any client.

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
