### PR TITLE
kamusers: discard SUBSCRIBEs to non existing hints

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -3061,17 +3061,18 @@ route[PRESENCE] {
 
     if(is_method("PUBLISH|SUBSCRIBE")) {
         if ($var(is_from_inside)) {
-            xwarn("[$dlg_var(cidhash)] NOTIFY: Received $rm from AS, 405 Method Not Allowed\n");
+            xwarn("[$dlg_var(cidhash)] PRESENCE: Received $rm from AS, 405 Method Not Allowed\n");
             send_reply("405", "Method Not Allowed");
             exit;
         }
 
+        route(DISCARD_NONEXISTING_SUBS);
         route(GET_DISTRIBUTE_METHOD);
         route(DISPATCH_TO_AS);
     } else if(is_method("NOTIFY")) {
         # Handle unsolicited NOTIFY messages (non-related to previous SUBSCRIBE)
         if (!$var(is_from_inside)) {
-            xwarn("[$dlg_var(cidhash)] NOTIFY: Received $rm from not AS, 405 Method Not Allowed\n");
+            xwarn("[$dlg_var(cidhash)] PRESENCE: Received $rm from not AS, 405 Method Not Allowed\n");
             send_reply("405", "Method Not Allowed");
             exit;
         }
@@ -3083,6 +3084,26 @@ route[PRESENCE] {
     record_route();
 
     route(RELAY);
+    exit;
+}
+
+route[DISCARD_NONEXISTING_SUBS] {
+    if (!is_method("SUBSCRIBE")) return;
+
+    sql_query("cb", "SELECT CONCAT('*', CS.code, RL.id) AS extension FROM RouteLocks RL INNER JOIN Companies C ON C.id = RL.companyId INNER JOIN CompanyServices CS ON CS.companyId = C.id WHERE C.id = '$dlg_var(companyId)' AND serviceId = 7 UNION SELECT number FROM Extensions E INNER JOIN Users U ON U.extensionId = E.id INNER JOIN Terminals T ON T.id = U.terminalId WHERE E.companyId = '$dlg_var(companyId)'", "hints");
+
+    if ($dbr(hints=>rows) > 0) {
+        $var(i) = 0;
+        while($var(i) < $dbr(hints=>rows)) {
+            if ($rU == $dbr(hints=>[$var(i),0])) {
+                return; # Hint exists, return
+            }
+            $var(i) = $var(i) + 1;
+        }
+    }
+
+    xinfo("[$dlg_var(cidhash)] DISCARD-NONEXISTING-SUBS: '$rU' is not valid subscription for company '$dlg_var(companyId)', discard\n");
+    send_reply("404", "Not Here [NES]");
     exit;
 }
 


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description

Discard in KamUsers SUBSCRIBE requests no non-existing hints.

#### Additional information

This way Asterisk is not bothered.