### PR TITLE
kamusers: force min subscription expires to 1800

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -3059,6 +3059,12 @@ route[PRESENCE] {
         exit;
     }
 
+    if(is_method("SUBSCRIBE") && $hdr(Expires) < 1800) {
+        append_to_reply("Min-Expires: 1800\r\n");
+        send_reply("423", "Interval Too Brief");
+        exit;
+    }
+
     if(is_method("PUBLISH|SUBSCRIBE")) {
         if ($var(is_from_inside)) {
             xwarn("[$dlg_var(cidhash)] PRESENCE: Received $rm from AS, 405 Method Not Allowed\n");


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description

Reject SUBSCRIBE with Expires lower than 1800.

#### Additional information

Reject with "423 Intervel Too Brief" with "Min-Expires: 1800" header.