### PR TITLE
asterisk: disable initial unsolicited MWI notification

### DIFF
--- a/asterisk/config/pjsip.conf
+++ b/asterisk/config/pjsip.conf
@@ -5,6 +5,7 @@
 type=global
 user_agent=Irontec IvozProvider v4.0
 endpoint_identifier_order=ip,header,username,anonymous
+mwi_disable_initial_unsolicited=yes
 
 ;;
 ;; Enabled SIP Transports


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
Disable initial MWI notification during asterisk startup, otherwise it can become a problem on environments with lots of endpoints. 

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
