### PR TITLE
kamtrunks: unassigned DDIs handling

### DIFF
--- a/asterisk/config/dialplan/default.conf
+++ b/asterisk/config/dialplan/default.conf
@@ -6,6 +6,8 @@
 [trunks]
 exten => _[+*0-9]!,1,NoOp(Incoming external call from ${CALLERID(all)} to ${EXTEN})
     same => n,AGI(agi://${FASTAGI_SERVER}/fastagi-runner.php?command=Dialplan/Trunks)
+; Playback specific sounds and leave
+include => sounds
 
 ;; Context for user calls (from proxyUsers)
 ;; ${EXTEN} may match a Company Extension, Company Service or External number

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -1476,6 +1476,8 @@ route[APPLY_TRANSFORMATION] {
 }
 
 route[GET_INFO_FROM_MATCHED_DDI] {
+    if ($dlg_var(type) == 'unassigned') return;
+
     sql_xquery("cb", "SELECT c.mediaRelaySetsId, c.maxCalls AS maxCallsCompany, b.maxCalls AS maxCallsBrand, d.recordCalls, c.distributeMethod, AppS.ip AS asAddress, d.routeType, d.residentialDeviceId, d.retailAccountId, d.faxId FROM DDIs d JOIN Companies c ON d.companyId=c.id LEFT JOIN ApplicationServers AppS ON AppS.id=c.applicationServerId JOIN Brands b ON c.brandId=b.id WHERE d.DDIE164='$rU'", "ra");
 
     # Matched DDI
@@ -1741,9 +1743,18 @@ route[CLASSIFY] {
         set_dlg_profile("outboundCallsCompany", "$dlg_var(companyId)");
         set_dlg_profile("outboundCallsBrand", "$dlg_var(brandId)");
     } else {
-        sql_xquery("cb", "SELECT C.brandId, C.id AS companyId, C.type FROM DDIs D JOIN Companies C ON D.companyId=C.id WHERE DDIE164='$rU'", "rp");
+        sql_xquery("cb", "SELECT B.id AS brandId, C.id AS companyId, C.type FROM DDIs D JOIN Brands B ON B.id=D.brandId LEFT JOIN Companies C ON D.companyId=C.id WHERE DDIE164='$rU'", "rp");
         $dlg_var(brandId) = $xavp(rp=>brandId);
         $dlg_var(companyId) = $xavp(rp=>companyId);
+
+        if ($dlg_var(brandId) != $null && $dlg_var(companyId) == $null) {
+            xnotice("[$dlg_var(cidhash)] CLASSIFY: inbound call to unassigned DDI $rU (b$dlg_var(brandId))");
+            $dlg_var(skipRealtime) = 'yes'; # Skip this call in realtime
+            $dlg_var(type) = 'unassigned';
+            $rU = 'noclient';
+            return;
+        }
+
         $dlg_var(type) = $xavp(rp=>type);
 
         if ($dlg_var(type) == 'wholesale') {
@@ -2340,6 +2351,8 @@ route[RECORD] {
 }
 
 route[CONTROL_MAXCALLS] {
+    if ($dlg_var(type) == 'unassigned') return;
+
     if (!get_profile_size("activeCallsCompany", "$dlg_var(companyId)", "$avp(activeCallsCompany)")) {
         xerr("[$dlg_var(cidhash)] CONTROL-MAXCALLS: company$dlg_var(companyId) $avp(activeCallsCompany)/$dlg_var(maxCallsCompany) calls (error obtaining value)\n");
         if ($dlg_var(maxCallsCompany) > 0) {


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description

Now it is not compulsory to assign a DDI to a company, it can be left unassigned.

This PR adds logic to send inbound external calls to these DDIs to Asterisk to play a locution to calling party.


