### PR TITLE
kamtrunks: reject calls to retail DDI linked to no retail account

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -1640,6 +1640,11 @@ route[SETUP_KAMUSERS_CALL] {
     # Check DDI is routed to a retail account
     $xavp(ra) = $null;
     sql_xquery("cb", "SELECT RA.name AS username, DS.domain AS domain FROM DDIs D INNER JOIN RetailAccounts RA ON D.retailAccountId=RA.id INNER JOIN Domains DS ON RA.domainId=DS.id WHERE DDIE164='$rU'", "ra");
+    if ($xavp(ra) == $null) {
+        xwarn("[$dlg_var(cidhash)] SETUP-KAMUSERS-CALL: $rU retail DDI not assigned to any retail account, reject\n");
+        send_reply("404", "No destination [SKC]");
+        exit;
+    }
 
     # Update $ru using retail account username@domain
     $ru = "sip:" + $xavp(ra=>username) + '@' + $xavp(ra=>domain);


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
Reject calls to retail DDI linked to no retail account.

#### Additional information
Prior to this PR, KamTrunks assumed retail DDIs were always linked to a retail account, but new version makes it possible to have DDIs linked to a retail client but not to a retail account.