### PR TITLE
kamusers: avoid routing within dialog SUBSCRIBE to wrong AS

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -369,6 +369,8 @@ modparam("htable", "htable", "dmq=>size=8;autoexpire=10800;dmqreplicate=1;")
 modparam("htable", "htable", "srcban=>size=8;autoexpire=43200")
 modparam("htable", "htable", "badauthcnt=>size=8;autoexpire=43200")
 modparam("htable", "htable", "aors=>size=10")
+modparam("htable", "htable", "companyIdPerDomain=>size=10")
+modparam("htable", "htable", "AsPerCompanyId=>size=10")
 modparam("htable", "enable_dmq", 1)
 
 # SANITY
@@ -1224,6 +1226,12 @@ route[DISPATCH_TO_AS] {
 
     # Save CallID <-> AS relationship
     $sht(dialogs=>$ci::applicationserver) = $du;
+
+    # Cache companyId <-> AS relationship
+    $sht(AsPerCompanyId=>$dlg_var(companyId)) = $du;
+
+    # Cache domain <-> companyId relationship
+    $sht(companyIdPerDomain=>$fd) = $dlg_var(companyId);
 }
 
 route[LOOKUP] {
@@ -1920,6 +1928,8 @@ route[WITHINDLG] {
         } else if (is_method("NOTIFY")) {
             # Add Record-Route for in-dialog NOTIFY as per RFC 6665.
             record_route();
+        } else if (is_method("SUBSCRIBE")) {
+            route(CHECK_SUBSCRIBE_AS);
         }
         route(RELAY);
     } else {
@@ -1936,6 +1946,22 @@ route[WITHINDLG] {
         }
         send_reply("404","Not here");
     }
+}
+
+route[CHECK_SUBSCRIBE_AS] {
+    if ($var(is_from_inside)) return;
+
+    if ($sht(companyIdPerDomain=>$fd) == $null) return;
+    $var(companyId) = $sht(companyIdPerDomain=>$fd);
+
+    if ($sht(AsPerCompanyId=>$var(companyId)) == $null) return;
+    $var(as) = $sht(AsPerCompanyId=>$var(companyId));
+
+    if ($ru == $var(as)) return;
+
+    xwarn("[$dlg_var(cidhash)] CHECK-SUBSCRIBE-AS: companyId '$var(companyId)' now uses AS '$var(as)', not '$ru', reject\n");
+    send_reply("500", "Internal Server Error [CSA]");
+    exit;
 }
 
 route[REFER] {


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
Do not forward within dialog SUBSCRIBE to a wrong AS, reply 500 instead to force new SUBSCRIBE dialog (that will be routed to right AS).

#### Additional information

This PR prevents problems with changes in AS dispatch list, that may lead to calls being handled in a different AS to SUBSCRIBE dialogs.