### PR TITLE
Get Migration bundle back

### DIFF
--- a/library/composer.json
+++ b/library/composer.json
@@ -87,7 +87,7 @@
         "doctrine/persistence": "^2.1",
         "irontec/ivoz-api-bundle": "^4.8.5",
         "irontec/ivoz-core": "^4.18.0",
-        "irontec/ivoz-dev-tools": "^5.12.1",
+        "irontec/ivoz-dev-tools": "^5.13.0",
         "irontec/ivoz-provider-bundle": "^2.6.7",
         "irontec/prophecy": "^1.13",
         "irontec/replacements": "^1.0",

--- a/library/composer.lock
+++ b/library/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eb558dbc7496082b606c9f0e150d0f97",
+    "content-hash": "8f5fcadd3bb3ea8c903fbb39a6f2ccbc",
     "packages": [
         {
             "name": "api-platform/core",
@@ -2745,16 +2745,16 @@
         },
         {
             "name": "irontec/ivoz-dev-tools",
-            "version": "5.12.1",
+            "version": "5.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/irontec/ivoz-dev-tools.git",
-                "reference": "6c89cc256f14ae80ed5b40c5e4c84916c5f5f8a6"
+                "reference": "9a9f237a4645f9d5878a2df1e3a6c12464c4b71f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/irontec/ivoz-dev-tools/zipball/6c89cc256f14ae80ed5b40c5e4c84916c5f5f8a6",
-                "reference": "6c89cc256f14ae80ed5b40c5e4c84916c5f5f8a6",
+                "url": "https://api.github.com/repos/irontec/ivoz-dev-tools/zipball/9a9f237a4645f9d5878a2df1e3a6c12464c4b71f",
+                "reference": "9a9f237a4645f9d5878a2df1e3a6c12464c4b71f",
                 "shasum": ""
             },
             "require": {
@@ -2795,9 +2795,9 @@
             "description": "DevTools for ivozprovider",
             "support": {
                 "issues": "https://github.com/irontec/ivoz-dev-tools/issues",
-                "source": "https://github.com/irontec/ivoz-dev-tools/tree/5.12.1"
+                "source": "https://github.com/irontec/ivoz-dev-tools/tree/5.13.0"
             },
-            "time": "2024-01-23T12:25:26+00:00"
+            "time": "2024-04-18T10:39:00+00:00"
         },
         {
             "name": "irontec/ivoz-provider-bundle",

--- a/schema/composer.lock
+++ b/schema/composer.lock
@@ -2064,11 +2064,11 @@
         },
         {
             "name": "irontec/ivoz-dev-tools",
-            "version": "5.12.1",
+            "version": "5.13.0",
             "dist": {
                 "type": "path",
                 "url": "../library/vendor/irontec/ivoz-dev-tools",
-                "reference": "6c89cc256f14ae80ed5b40c5e4c84916c5f5f8a6"
+                "reference": "9a9f237a4645f9d5878a2df1e3a6c12464c4b71f"
             },
             "require": {
                 "doctrine/doctrine-bundle": "^2.0",

--- a/schema/config/bundles.php
+++ b/schema/config/bundles.php
@@ -14,4 +14,5 @@ return [
     IvozDevTools\CommandlogBundle\CommandlogBundle::class => ['all' => true],
     Symfony\Bundle\MakerBundle\MakerBundle::class => ['all' => true],
     IvozDevTools\EntityGeneratorBundle\EntityGeneratorBundle::class => ['all' => true],
+    IvozDevTools\MigrationsBundle\MigrationsBundle::class => ['all' => true],
 ];

--- a/schema/config/services.yaml
+++ b/schema/config/services.yaml
@@ -1,7 +1,7 @@
 imports:
     - { resource: "@ProviderBundle/Resources/config/config.yml" }
     - { resource: "@CommandlogBundle/Resources/config/services.yml" }
-#    - { resource: "@MigrationsBundle/Resources/config/services.yml" }
+    - { resource: "@MigrationsBundle/Resources/config/services.yml" }
 
 # This file is the entry point to configure your own services.
 # Files in the packages/ subdirectory configure your dependencies.


### PR DESCRIPTION
So that migrations come with LoggableMigrations by default

Updates ivoz-dev-tools to include https://github.com/irontec/ivoz-dev-tools/commit/9a9f237a4645f9d5878a2df1e3a6c12464c4b71f

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
<!-- Describe your changes in detail -->

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
