### PR TITLE
Fix endpoints hints migration

### DIFF
--- a/schema/DoctrineMigrations/Version20220317124540.php
+++ b/schema/DoctrineMigrations/Version20220317124540.php
@@ -29,8 +29,12 @@ final class Version20220317124540 extends LoggableMigration
             INNER JOIN Terminals T ON T.id = APE.terminalId
             INNER JOIN Users U ON U.terminalId = T.id
             INNER JOIN Extensions E ON E.id = U.extensionId
-            SET APE.hint_extension = E.number,
-            APE.subscribe_context = CONCAT("company", T.companyID)
+            SET APE.hint_extension = E.number
+        ');
+
+        $this->addSql('UPDATE ast_ps_endpoints APE
+            INNER JOIN Terminals T ON T.id = APE.terminalId
+            SET APE.subscribe_context = CONCAT("company", T.companyID)
         ');
     }
 


### PR DESCRIPTION

<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description

This migration updated ast_ps_endpoints table with the appropiate
hint_extension and subscribe_context values, but it was only
considering terminals with user and extension assigned.

This is ok for hint_extension but subscribe_context must be updated
in all endpoints, no matter if there is user or not using that
terminal.

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
