### PR TITLE
kamusers: stop using attributes per contact (ulattrs)

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -2167,9 +2167,6 @@ route[REGISTER] {
         }
     }
 
-    # Store in kam_users_location_attrs used transport to retrieve it in lookup
-    $xavp(ulattrs=>transport) = $proto;
-
     # Store external socket if different from main users address
     if ($Ri != $var(usersAddress)) {
         $xavp(ulattrs[0]=>extrasocket) = $Ri;
@@ -2905,8 +2902,11 @@ onsend_route {
 route[TRANSPORT_DETECT] {
     if (!is_method("INVITE")) return;
 
+    $var(dstTransport) = $(nh(P){s.tolower});
+    xinfo("[$dlg_var(cidhash)] TRANSPORT_DETECT: Request transport: $proto - destination transport: $var(dstTransport)\n");
+
     if (is_request() && !has_totag()) {
-        if ($proto == 'ws' || $proto == 'wss' || $xavp(ulattrs[$T_branch_idx]=>transport) == 'ws' || $xavp(ulattrs[$T_branch_idx]=>transport) == 'wss') {
+        if ($proto == 'ws' || $proto == 'wss' || $var(dstTransport) == 'ws' || $var(dstTransport) == 'wss') {
             xnotice("[$dlg_var(cidhash)] TRANSPORT_DETECT: Mark branch as WSS\n");
             setbflag(FLB_WEBSOCKETS);
         }

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -273,7 +273,6 @@ modparam("usrloc", "nat_bflag", FLB_NATB)
 modparam("usrloc", "db_mode", 2)
 modparam("usrloc", "db_url", DBURL)
 modparam("usrloc", "timer_interval", 30)
-modparam("usrloc|tm", "xavp_contact", "ulattrs")
 
 # RR
 modparam("rr","enable_double_rr", 1)

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -1270,12 +1270,33 @@ route[LOOKUP] {
         exit;
     }
 
+    # Save branches socket
+    route(SAVE_BRANCHES_SOCKET);
+
     # Load contact or contacts
     if (!t_next_contacts()) {
         xinfo("[$dlg_var(cidhash)] LOOKUP: One contact found for $tu, calling $ru\n");
     } else {
         xnotice("[$dlg_var(cidhash)] LOOKUP: Multiple contacts found for $tu, parallel forking\n");
         $avp(parallel_forking) = 1;
+    }
+}
+
+route[SAVE_BRANCHES_SOCKET] {
+    if (!is_method("INVITE")) return;
+
+    $var(i) = 0;
+    while ($xavp(tm_contacts[$var(i)]) != $null) {
+        $avp(reversed) = $xavp(tm_contacts[$var(i)]=>sock);
+        $var(i) = $var(i) + 1;
+    }
+
+    # AVP are LIFO, reverse items
+    $var(i) = 0;
+    while ($(avp(reversed)[$var(i)]) != $null) {
+        $var(branchsock) = $(avp(reversed)[$var(i)]);
+        $avp(branchsockaddr) = $(var(branchsock){s.select,1,:});
+        $var(i) = $var(i) + 1;
     }
 }
 
@@ -2167,11 +2188,6 @@ route[REGISTER] {
         }
     }
 
-    # Store external socket if different from main users address
-    if ($Ri != $var(usersAddress)) {
-        $xavp(ulattrs[0]=>extrasocket) = $Ri;
-    }
-
     if (is_present_hf("Contact")) {
         $var(contact_uri) = @contact.uri;
     }
@@ -2836,8 +2852,8 @@ event_route[dialog:start] {
         $dlg_var(ws) = 'yes';
     }
 
-    if ($xavp(ulattrs[$T_branch_idx]=>extrasocket) != $null) {
-        $dlg_var(externalSocket) = $xavp(ulattrs[$T_branch_idx]=>extrasocket);
+    if ($(avp(branchsockaddr)[$T_branch_idx]) != $null) {
+        $dlg_var(externalSocket) = $(avp(branchsockaddr)[$T_branch_idx]);
     }
 
     #!ifdef WITH_REALTIME
@@ -3019,8 +3035,8 @@ route[RTPENGINE_INTERFACES] {
     if ($var(is_from_inside)) {
         if ($dlg_var(externalSocket) != $null) {
             $var(interfaces) = "direction=" + $var(usersAddress) + " direction=" + $dlg_var(externalSocket);
-        } else if ($xavp(ulattrs[$T_branch_idx]=>extrasocket) != $null) {
-            $var(interfaces) = "direction=" + $var(usersAddress) + " direction=" + $xavp(ulattrs[$T_branch_idx]=>extrasocket);
+        } else if ($(avp(branchsockaddr)[$T_branch_idx]) != $null) {
+            $var(interfaces) = "direction=" + $var(usersAddress) + " direction=" + $(avp(branchsockaddr)[$T_branch_idx]);
         } else {
             $var(interfaces) = "direction=" + $var(usersAddress) + " direction=" + $var(usersAddress);
         }


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description

usrloc/tm xavp_contact modparam allows storing additional attributes per contact. Prior to this PR, we use them to store registration socket and protocol.

#### Additional information

This PR adds logic to get the same info (socket and protocol) without using contact attributes. The reason behind this is to avoid inserts into this table per registration (and lots of selects).