### PR TITLE
kamusers: SUBSCRIBE Event dialog only

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -3075,12 +3075,7 @@ route[QUALITY] {
 route[PRESENCE] {
     if(!is_method("PUBLISH|SUBSCRIBE|NOTIFY")) return;
 
-    if(is_method("SUBSCRIBE") && $hdr(Event)=="message-summary") {
-        send_reply("404", "No voicemail service");
-        exit;
-    }
-
-    if(is_method("SUBSCRIBE") && $hdr(Event)=="as-feature-event") {
+    if(is_method("SUBSCRIBE") && $hdr(Event) != "dialog") {
         send_reply("489", "Bad Event");
         exit;
     }


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description

Discard with "489 Bad Event" all SUBSCRIBE messages except "Event: dialog"

