### PR TITLE
kamusers: use new ruri_domain for static location (retail, residential and friends)

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -1318,7 +1318,7 @@ route[STATIC_LOCATION] {
         return;
     }
 
-    sql_xquery("cb", "SELECT name, domain, directConnectivity, ip, port, transport, ddiIn FROM $avp(endpointType) t LEFT JOIN Domains D ON t.domainId=D.id WHERE t.id='$avp(endpointId)'", "rb");
+    sql_xquery("cb", "SELECT name, domain, directConnectivity, ip, port, transport, ruri_domain, ddiIn FROM $avp(endpointType) t LEFT JOIN Domains D ON t.domainId=D.id WHERE t.id='$avp(endpointId)'", "rb");
     $var(ddi_in) = $xavp(rb=>ddiIn);
 
     if ($xavp(rb=>directConnectivity) == 'no') return;
@@ -1334,17 +1334,40 @@ route[STATIC_LOCATION] {
         return;
     }
 
-    $ru = "sip:" + $xavp(rb=>name) + '@' + $xavp(rb=>ip);
+    if ($xavp(rb=>ruri_domain) == $null || $(xavp(rb=>ruri_domain){s.len}) == 0) {
+        # ip+port without ruri_domain
+        $ru = "sip:" + $xavp(rb=>name) + '@' + $xavp(rb=>ip);
 
-    if ($(xavp(rb=>port){s.len}) > 0 && $xavp(rb=>port) != "5060") {
-        $ru = $ru + ':' + $xavp(rb=>port);
+        if ($(xavp(rb=>port){s.len}) > 0 && $xavp(rb=>port) != "5060") {
+            $ru = $ru + ':' + $xavp(rb=>port);
+        }
+
+        if ($xavp(rb=>transport) != "udp") {
+            $ru = $ru + ';transport=' + $xavp(rb=>transport);
+        }
+    } else {
+        $ru = "sip:" + $xavp(rb=>name) + '@' + $xavp(rb=>ruri_domain);
+
+        if ($xavp(rb=>ip) != $null && $(xavp(rb=>ip){s.len}) > 0) {
+            # ruri_domain and ip+port
+            $du = 'sip:' +  $xavp(rb=>ip);
+
+            if ($(xavp(rb=>port){s.len}) > 0 && $xavp(rb=>port) != "5060") {
+                $du = $du + ':' + $xavp(rb=>port);
+            }
+
+            if ($xavp(rb=>transport) != "udp") {
+                $du = $du + ';transport=' + $xavp(rb=>transport);
+            }
+        } else {
+            # ruri_domain without ip+port
+            if ($xavp(rb=>transport) != "udp") {
+                $ru = $ru + ';transport=' + $xavp(rb=>transport);
+            }
+        }
     }
 
-    if ($xavp(rb=>transport) != "udp") {
-        $ru = $ru + ';transport=' + $xavp(rb=>transport);
-    }
-
-    xinfo("[$dlg_var(cidhash)] STATIC-LOCATION: Call for static endpoint, route to '$ru'\n");
+    xinfo("[$dlg_var(cidhash)] STATIC-LOCATION: Call for static endpoint, route to '$ru' via '$du'\n");
 
     setbflag(FLB_NATB); # Assume behind NAT (port-forwarding direct connectivity)
 


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description

Static location friends, retail accounts and residential devices now have a new field ruri_domain. This PR uses this new field to route requests properly.

#### Additional information

3 kind of static location routing from now on:

- **ruri_domain + ip/port**: ip/port will act as outbound-proxy and R-URI domain will be used in R-URI header domain.
- **ruri_domain without ip/port**: no outbound-proxy, ruri_domain used in R-URI will be used to route the request.
- **ip/port without ruri_domain**: behaviour prior to this PR. ip/port will be set in R-URI.