### PR TITLE
kamusers: fix media-relay interface for AoRs with just one contact

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -1269,33 +1269,12 @@ route[LOOKUP] {
         exit;
     }
 
-    # Save branches socket
-    route(SAVE_BRANCHES_SOCKET);
-
     # Load contact or contacts
     if (!t_next_contacts()) {
-        xinfo("[$dlg_var(cidhash)] LOOKUP: One contact found for $tu, calling $ru\n");
+        xnotice("[$dlg_var(cidhash)] LOOKUP: Just one contact found for $tu\n");
     } else {
         xnotice("[$dlg_var(cidhash)] LOOKUP: Multiple contacts found for $tu, parallel forking\n");
         $avp(parallel_forking) = 1;
-    }
-}
-
-route[SAVE_BRANCHES_SOCKET] {
-    if (!is_method("INVITE")) return;
-
-    $var(i) = 0;
-    while ($xavp(tm_contacts[$var(i)]) != $null) {
-        $avp(reversed) = $xavp(tm_contacts[$var(i)]=>sock);
-        $var(i) = $var(i) + 1;
-    }
-
-    # AVP are LIFO, reverse items
-    $var(i) = 0;
-    while ($(avp(reversed)[$var(i)]) != $null) {
-        $var(branchsock) = $(avp(reversed)[$var(i)]);
-        $avp(branchsockaddr) = $(var(branchsock){s.select,1,:});
-        $var(i) = $var(i) + 1;
     }
 }
 
@@ -2089,10 +2068,10 @@ route[RELAY] {
     if ($branch(count) == $null) {
         if ($(du{uri.host}) != $null) {
             $avp(relay_dst) = $dP + ":" + $(du{uri.host}) + ":" + $(du{uri.port});
-            xnotice("[$dlg_var(cidhash)] RELAY: Relaying to $avp(relay_dst) ($ru via $du)\n");
+            xnotice("[$dlg_var(cidhash)] RELAY: Relaying to $ru via $du - fs: $fs\n");
         } else {
             $avp(relay_dst) = $rP + ":" + $(ru{uri.host}) + ":" + $(ru{uri.port});
-            xnotice("[$dlg_var(cidhash)] RELAY: Relaying to $avp(relay_dst) ($ru)\n");
+            xnotice("[$dlg_var(cidhash)] RELAY: Relaying to $ru - fs: $fs\n");
         }
     }
 
@@ -2419,6 +2398,9 @@ route[ACCOUNTING] {
 
         # -- Set caller
         $dlg_var(callee) = $rU;
+
+        # Save external socket (used in RTPENGINE_INTERFACES)
+        $dlg_var(externalSocket) = $Ri;
     }
 
     route(CHECK_SPECIAL);
@@ -2817,9 +2799,9 @@ failure_route[MANAGE_FAILURE_AS] {
 branch_route[MANAGE_BRANCH] {
     if ($branch(count) != $null) {
         if ($(du{uri.host}) != $null) {
-            xnotice("[$dlg_var(cidhash)] MANAGE_BRANCH: new branch [$T_branch_idx] to $ru via $du (du, $dP)\n");
+            xnotice("[$dlg_var(cidhash)] MANAGE_BRANCH: new branch [$T_branch_idx] to $ru via $du (du, $dP) - fs: $fs\n");
         } else {
-            xnotice("[$dlg_var(cidhash)] MANAGE_BRANCH: new branch [$T_branch_idx] to $ru\n");
+            xnotice("[$dlg_var(cidhash)] MANAGE_BRANCH: new branch [$T_branch_idx] to $ru - fs: $fs\n");
         }
     }
 
@@ -2849,10 +2831,6 @@ event_route[dialog:start] {
     if(isbflagset(FLB_WEBSOCKETS)) {
         xnotice("[$dlg_var(cidhash)] Dialog involving WSS started\n");
         $dlg_var(ws) = 'yes';
-    }
-
-    if ($(avp(branchsockaddr)[$T_branch_idx]) != $null) {
-        $dlg_var(externalSocket) = $(avp(branchsockaddr)[$T_branch_idx]);
     }
 
     #!ifdef WITH_REALTIME
@@ -2932,7 +2910,6 @@ route[FORCE_MAIN_SOCKET] {
     if (!$var(is_from_inside) && $Ri != $var(usersAddress)) {
         # UAC talking to non-main address, force_send_socket to main address
         $fs = "udp:" + $var(usersAddress) + ":5060";
-        $dlg_var(externalSocket) = $Ri;
     }
 }
 
@@ -3033,10 +3010,14 @@ route[RTPENGINE_INTERFACES] {
     # Direction must be set only in first SDP (initial INVITE with SDP or first response with SDP to initial INVITE with no SDP)
     if ($var(is_from_inside)) {
         if ($dlg_var(externalSocket) != $null) {
+            # first response with SDP from AS to initial INVITE with no SDP from UAC
             $var(interfaces) = "direction=" + $var(usersAddress) + " direction=" + $dlg_var(externalSocket);
-        } else if ($(avp(branchsockaddr)[$T_branch_idx]) != $null) {
-            $var(interfaces) = "direction=" + $var(usersAddress) + " direction=" + $(avp(branchsockaddr)[$T_branch_idx]);
+        } else if ($fs != $null) {
+            # initial INVITE from AS with SDP
+            $var(branchsockaddr) = $(fs{s.select,1,:});
+            $var(interfaces) = "direction=" + $var(usersAddress) + " direction=" + $var(branchsockaddr);
         } else {
+            xwarn("[$dlg_var(cidhash)] RTPENGINE-INTERFACES: No dlg_var(externalSocket) and fs, this is weird, check!\n");
             $var(interfaces) = "direction=" + $var(usersAddress) + " direction=" + $var(usersAddress);
         }
     } else {


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description

Logic in 2d32c9b39 did not work for AoRs with a single contact address, causing wrong media-relay interface selection and no audio scenarios. This PR fixes this.

