### PR TITLE
asterisk: decrease sorcery cache lifetime to 120 secs

### DIFF
--- a/asterisk/config/sorcery.conf
+++ b/asterisk/config/sorcery.conf
@@ -3,15 +3,15 @@
 ;
 
 [res_pjsip]
-endpoint/cache = memory_cache,object_lifetime_stale=600,object_lifetime_maximum=1800,expire_on_reload=yes,full_backend_cache=yes
+endpoint/cache = memory_cache,object_lifetime_maximum=120,expire_on_reload=yes,full_backend_cache=yes
 endpoint = config,pjsip.conf,criteria=type=endpoint
 endpoint = realtime,ps_endpoints
-aor/cache = memory_cache,object_lifetime_stale=1500,object_lifetime_maximum=1800,expire_on_reload=yes,full_backend_cache=yes
+aor/cache = memory_cache,object_lifetime_maximum=120,expire_on_reload=yes,full_backend_cache=yes
 aor = config,pjsip.conf,criteria=type=aor
 aor = realtime,ps_aors
 voicemail = realtime,voicemail
 
 [res_pjsip_endpoint_identifier_ip]
-identify/cache = memory_cache,object_lifetime_stale=600,object_lifetime_maximum=1800,expire_on_reload=yes,full_backend_cache=yes
+identify/cache = memory_cache,object_lifetime_maximum=120,expire_on_reload=yes,full_backend_cache=yes
 identify = config,pjsip.conf,criteria=type=identify
 identify = realtime,ps_identify


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
Decrease asterisk sorcery cache lifetime from 1800 secs to 120

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
