### PR TITLE
Limit fastagi service duration to 300 seconds

### DIFF
--- a/debian/systemd/fastagi@.service
+++ b/debian/systemd/fastagi@.service
@@ -5,3 +5,4 @@ User=root
 Group=root
 StandardInput=socket
 StandardOutput=socket
+RuntimeMaxSec=300


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
<!-- Describe your changes in detail -->

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
