### PR TITLE
Fixed banned addresses order in platform

### DIFF
--- a/web/portal/platform/src/entities/BannedAddress/BannedAddress.tsx
+++ b/web/portal/platform/src/entities/BannedAddress/BannedAddress.tsx
@@ -33,6 +33,7 @@ const BannedAddress: EntityInterface = {
   toStr: (row: BannedAddressPropertyList<EntityValue>) => row.ip as string,
   properties,
   columns: ['ip', 'lastTimeBanned'],
+  defaultOrderBy: '',
 };
 
 export default BannedAddress;

--- a/web/rest/platform/config/api/raw/provider.yml
+++ b/web/rest/platform/config/api/raw/provider.yml
@@ -64,7 +64,7 @@ Ivoz\Provider\Domain\Model\BannedAddress\BannedAddress:
   attributes:
     access_control: '"ROLE_SUPER_ADMIN" in roles && user.hasAccessPrivileges(_api_resource_class, request.getMethod())'
     order:
-      ip: ASC
+      lastTimeBanned: DESC
     read_access_control:
       ROLE_SUPER_ADMIN:
         brand:


### PR DESCRIPTION
Fixed default order in banned addresses listing from portal plataform

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
The order is desc by lastBannedTime

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
