### PR TITLE
kamtrunks: use carrier server from_domain in Diversion (if any)

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -1445,7 +1445,9 @@ route[TRANSFORMATE_OUT] {
             route(APPLY_TRANSFORMATION); # Apply $var(transformation) to $var(number)
 
             remove_hf_value("Diversion[0]");
-            if ($dlg_var(companyDomain) != $null) {
+            if ($avp(from_domain) != $null) {
+                add_diversion("$avp(reason)", 'sip:' + $var(transformated) + '@' + $avp(from_domain));
+            } else if ($dlg_var(companyDomain) != $null) {
                 add_diversion("$avp(reason)", 'sip:' + $var(transformated) + '@' + $dlg_var(companyDomain));
             } else if ($(di{uri.host}{s.len}) > 0) {
                 add_diversion("$avp(reason)", 'sip:' + $var(transformated) + '@' + $(di{uri.host}));


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description

If selected carrier server has from-domain setting, use it in Diversion header URI domain too.

