### PR TITLE
Trust sdp ips on static location

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -1319,7 +1319,7 @@ route[STATIC_LOCATION] {
         return;
     }
 
-    sql_xquery("cb", "SELECT name, domain, directConnectivity, ip, port, transport, ruri_domain, ddiIn FROM $avp(endpointType) t LEFT JOIN Domains D ON t.domainId=D.id WHERE t.id='$avp(endpointId)'", "rb");
+    sql_xquery("cb", "SELECT name, domain, directConnectivity, ip, port, transport, ruri_domain, ddiIn, trustSDP FROM $avp(endpointType) t LEFT JOIN Domains D ON t.domainId=D.id WHERE t.id='$avp(endpointId)'", "rb");
     $var(ddi_in) = $xavp(rb=>ddiIn);
 
     if ($xavp(rb=>directConnectivity) == 'no') return;
@@ -1370,7 +1370,9 @@ route[STATIC_LOCATION] {
 
     xinfo("[$dlg_var(cidhash)] STATIC-LOCATION: Call for static endpoint, route to '$ru' via '$du'\n");
 
-    setbflag(FLB_NATB); # Assume behind NAT (port-forwarding direct connectivity)
+    if ($xavp(rb=>trustSDP) == '0') {
+        setbflag(FLB_NATB); # Assume behind NAT (port-forwarding direct connectivity)
+    }
 
     return;
 }

--- a/library/Ivoz/Provider/Domain/Model/Friend/Friend.php
+++ b/library/Ivoz/Provider/Domain/Model/Friend/Friend.php
@@ -67,6 +67,7 @@ class Friend extends FriendAbstract implements FriendInterface
                 throw new \DomainException('Invalid empty proxy_user');
             }
         } else {
+            $this->setTrustSDP(false);
             $this->setRuriDomain(null);
             $this->setIp(null);
             $this->setPort(null);

--- a/library/Ivoz/Provider/Domain/Model/Friend/FriendAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Friend/FriendAbstract.php
@@ -151,6 +151,11 @@ abstract class FriendAbstract
     protected $ruriDomain = null;
 
     /**
+     * @var bool
+     */
+    protected $trustSDP = false;
+
+    /**
      * @var CompanyInterface
      * inversedBy friends
      */
@@ -209,7 +214,8 @@ abstract class FriendAbstract
         string $t38Passthrough,
         bool $alwaysApplyTransformations,
         bool $rtpEncryption,
-        bool $multiContact
+        bool $multiContact,
+        bool $trustSDP
     ) {
         $this->setName($name);
         $this->setDescription($description);
@@ -225,6 +231,7 @@ abstract class FriendAbstract
         $this->setAlwaysApplyTransformations($alwaysApplyTransformations);
         $this->setRtpEncryption($rtpEncryption);
         $this->setMultiContact($multiContact);
+        $this->setTrustSDP($trustSDP);
     }
 
     abstract public function getId(): null|string|int;
@@ -316,6 +323,8 @@ abstract class FriendAbstract
         Assertion::notNull($rtpEncryption, 'getRtpEncryption value is null, but non null value was expected.');
         $multiContact = $dto->getMultiContact();
         Assertion::notNull($multiContact, 'getMultiContact value is null, but non null value was expected.');
+        $trustSDP = $dto->getTrustSDP();
+        Assertion::notNull($trustSDP, 'getTrustSDP value is null, but non null value was expected.');
         $company = $dto->getCompany();
         Assertion::notNull($company, 'getCompany value is null, but non null value was expected.');
 
@@ -333,7 +342,8 @@ abstract class FriendAbstract
             $t38Passthrough,
             $alwaysApplyTransformations,
             $rtpEncryption,
-            $multiContact
+            $multiContact,
+            $trustSDP
         );
 
         $self
@@ -396,6 +406,8 @@ abstract class FriendAbstract
         Assertion::notNull($rtpEncryption, 'getRtpEncryption value is null, but non null value was expected.');
         $multiContact = $dto->getMultiContact();
         Assertion::notNull($multiContact, 'getMultiContact value is null, but non null value was expected.');
+        $trustSDP = $dto->getTrustSDP();
+        Assertion::notNull($trustSDP, 'getTrustSDP value is null, but non null value was expected.');
         $company = $dto->getCompany();
         Assertion::notNull($company, 'getCompany value is null, but non null value was expected.');
 
@@ -421,6 +433,7 @@ abstract class FriendAbstract
             ->setRtpEncryption($rtpEncryption)
             ->setMultiContact($multiContact)
             ->setRuriDomain($dto->getRuriDomain())
+            ->setTrustSDP($trustSDP)
             ->setCompany($fkTransformer->transform($company))
             ->setDomain($fkTransformer->transform($dto->getDomain()))
             ->setTransformationRuleSet($fkTransformer->transform($dto->getTransformationRuleSet()))
@@ -460,6 +473,7 @@ abstract class FriendAbstract
             ->setRtpEncryption(self::getRtpEncryption())
             ->setMultiContact(self::getMultiContact())
             ->setRuriDomain(self::getRuriDomain())
+            ->setTrustSDP(self::getTrustSDP())
             ->setCompany(Company::entityToDto(self::getCompany(), $depth))
             ->setDomain(Domain::entityToDto(self::getDomain(), $depth))
             ->setTransformationRuleSet(TransformationRuleSet::entityToDto(self::getTransformationRuleSet(), $depth))
@@ -497,6 +511,7 @@ abstract class FriendAbstract
             'rtpEncryption' => self::getRtpEncryption(),
             'multiContact' => self::getMultiContact(),
             'ruri_domain' => self::getRuriDomain(),
+            'trustSDP' => self::getTrustSDP(),
             'companyId' => self::getCompany()->getId(),
             'domainId' => self::getDomain()?->getId(),
             'transformationRuleSetId' => self::getTransformationRuleSet()?->getId(),
@@ -862,6 +877,18 @@ abstract class FriendAbstract
     public function getRuriDomain(): ?string
     {
         return $this->ruriDomain;
+    }
+
+    protected function setTrustSDP(bool $trustSDP): static
+    {
+        $this->trustSDP = $trustSDP;
+
+        return $this;
+    }
+
+    public function getTrustSDP(): bool
+    {
+        return $this->trustSDP;
     }
 
     public function setCompany(CompanyInterface $company): static

--- a/library/Ivoz/Provider/Domain/Model/Friend/FriendDto.php
+++ b/library/Ivoz/Provider/Domain/Model/Friend/FriendDto.php
@@ -176,6 +176,7 @@ class FriendDto extends FriendDtoAbstract
             'interCompanyId',
             'ruriDomain',
             'proxyuserId',
+            'trustSDP'
         ];
 
         return array_filter(

--- a/library/Ivoz/Provider/Domain/Model/Friend/FriendDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/Friend/FriendDtoAbstract.php
@@ -130,6 +130,11 @@ abstract class FriendDtoAbstract implements DataTransferObjectInterface
     private $ruriDomain = null;
 
     /**
+     * @var bool|null
+     */
+    private $trustSDP = false;
+
+    /**
      * @var int|null
      */
     private $id = null;
@@ -230,6 +235,7 @@ abstract class FriendDtoAbstract implements DataTransferObjectInterface
             'rtpEncryption' => 'rtpEncryption',
             'multiContact' => 'multiContact',
             'ruriDomain' => 'ruriDomain',
+            'trustSDP' => 'trustSDP',
             'id' => 'id',
             'companyId' => 'company',
             'domainId' => 'domain',
@@ -271,6 +277,7 @@ abstract class FriendDtoAbstract implements DataTransferObjectInterface
             'rtpEncryption' => $this->getRtpEncryption(),
             'multiContact' => $this->getMultiContact(),
             'ruriDomain' => $this->getRuriDomain(),
+            'trustSDP' => $this->getTrustSDP(),
             'id' => $this->getId(),
             'company' => $this->getCompany(),
             'domain' => $this->getDomain(),
@@ -550,6 +557,18 @@ abstract class FriendDtoAbstract implements DataTransferObjectInterface
     public function getRuriDomain(): ?string
     {
         return $this->ruriDomain;
+    }
+
+    public function setTrustSDP(bool $trustSDP): static
+    {
+        $this->trustSDP = $trustSDP;
+
+        return $this;
+    }
+
+    public function getTrustSDP(): ?bool
+    {
+        return $this->trustSDP;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/Friend/FriendInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/Friend/FriendInterface.php
@@ -214,6 +214,8 @@ interface FriendInterface extends LoggableEntityInterface
 
     public function getRuriDomain(): ?string;
 
+    public function getTrustSDP(): bool;
+
     public function setCompany(CompanyInterface $company): static;
 
     public function getCompany(): CompanyInterface;

--- a/library/Ivoz/Provider/Domain/Model/ResidentialDevice/ResidentialDevice.php
+++ b/library/Ivoz/Provider/Domain/Model/ResidentialDevice/ResidentialDevice.php
@@ -65,6 +65,7 @@ class ResidentialDevice extends ResidentialDeviceAbstract implements Residential
                 throw new \DomainException('Password cannot be empty for residential devices with no direct connectivity');
             }
 
+            $this->setTrustSDP(false);
             $this->setRuriDomain(null);
             $this->setIp(null);
             $this->setPort(null);

--- a/library/Ivoz/Provider/Domain/Model/ResidentialDevice/ResidentialDeviceAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/ResidentialDevice/ResidentialDeviceAbstract.php
@@ -140,6 +140,11 @@ abstract class ResidentialDeviceAbstract
     protected $ruriDomain = null;
 
     /**
+     * @var bool
+     */
+    protected $trustSDP = false;
+
+    /**
      * @var BrandInterface
      * inversedBy residentialDevices
      */
@@ -192,7 +197,8 @@ abstract class ResidentialDeviceAbstract
         int $maxCalls,
         string $t38Passthrough,
         bool $rtpEncryption,
-        bool $multiContact
+        bool $multiContact,
+        bool $trustSDP
     ) {
         $this->setName($name);
         $this->setDescription($description);
@@ -207,6 +213,7 @@ abstract class ResidentialDeviceAbstract
         $this->setT38Passthrough($t38Passthrough);
         $this->setRtpEncryption($rtpEncryption);
         $this->setMultiContact($multiContact);
+        $this->setTrustSDP($trustSDP);
     }
 
     abstract public function getId(): null|string|int;
@@ -296,6 +303,8 @@ abstract class ResidentialDeviceAbstract
         Assertion::notNull($rtpEncryption, 'getRtpEncryption value is null, but non null value was expected.');
         $multiContact = $dto->getMultiContact();
         Assertion::notNull($multiContact, 'getMultiContact value is null, but non null value was expected.');
+        $trustSDP = $dto->getTrustSDP();
+        Assertion::notNull($trustSDP, 'getTrustSDP value is null, but non null value was expected.');
         $brand = $dto->getBrand();
         Assertion::notNull($brand, 'getBrand value is null, but non null value was expected.');
         $company = $dto->getCompany();
@@ -314,7 +323,8 @@ abstract class ResidentialDeviceAbstract
             $maxCalls,
             $t38Passthrough,
             $rtpEncryption,
-            $multiContact
+            $multiContact,
+            $trustSDP
         );
 
         $self
@@ -373,6 +383,8 @@ abstract class ResidentialDeviceAbstract
         Assertion::notNull($rtpEncryption, 'getRtpEncryption value is null, but non null value was expected.');
         $multiContact = $dto->getMultiContact();
         Assertion::notNull($multiContact, 'getMultiContact value is null, but non null value was expected.');
+        $trustSDP = $dto->getTrustSDP();
+        Assertion::notNull($trustSDP, 'getTrustSDP value is null, but non null value was expected.');
         $brand = $dto->getBrand();
         Assertion::notNull($brand, 'getBrand value is null, but non null value was expected.');
         $company = $dto->getCompany();
@@ -398,6 +410,7 @@ abstract class ResidentialDeviceAbstract
             ->setRtpEncryption($rtpEncryption)
             ->setMultiContact($multiContact)
             ->setRuriDomain($dto->getRuriDomain())
+            ->setTrustSDP($trustSDP)
             ->setBrand($fkTransformer->transform($brand))
             ->setDomain($fkTransformer->transform($dto->getDomain()))
             ->setCompany($fkTransformer->transform($company))
@@ -434,6 +447,7 @@ abstract class ResidentialDeviceAbstract
             ->setRtpEncryption(self::getRtpEncryption())
             ->setMultiContact(self::getMultiContact())
             ->setRuriDomain(self::getRuriDomain())
+            ->setTrustSDP(self::getTrustSDP())
             ->setBrand(Brand::entityToDto(self::getBrand(), $depth))
             ->setDomain(Domain::entityToDto(self::getDomain(), $depth))
             ->setCompany(Company::entityToDto(self::getCompany(), $depth))
@@ -468,6 +482,7 @@ abstract class ResidentialDeviceAbstract
             'rtpEncryption' => self::getRtpEncryption(),
             'multiContact' => self::getMultiContact(),
             'ruri_domain' => self::getRuriDomain(),
+            'trustSDP' => self::getTrustSDP(),
             'brandId' => self::getBrand()->getId(),
             'domainId' => self::getDomain()?->getId(),
             'companyId' => self::getCompany()->getId(),
@@ -801,6 +816,18 @@ abstract class ResidentialDeviceAbstract
     public function getRuriDomain(): ?string
     {
         return $this->ruriDomain;
+    }
+
+    protected function setTrustSDP(bool $trustSDP): static
+    {
+        $this->trustSDP = $trustSDP;
+
+        return $this;
+    }
+
+    public function getTrustSDP(): bool
+    {
+        return $this->trustSDP;
     }
 
     public function setBrand(BrandInterface $brand): static

--- a/library/Ivoz/Provider/Domain/Model/ResidentialDevice/ResidentialDeviceDto.php
+++ b/library/Ivoz/Provider/Domain/Model/ResidentialDevice/ResidentialDeviceDto.php
@@ -219,7 +219,8 @@ class ResidentialDeviceDto extends ResidentialDeviceDtoAbstract
             'domainName',
             'status',
             'domainId',
-            'ruriDomain'
+            'ruriDomain',
+            'trustSDP'
         ];
 
         return array_filter(

--- a/library/Ivoz/Provider/Domain/Model/ResidentialDevice/ResidentialDeviceDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/ResidentialDevice/ResidentialDeviceDtoAbstract.php
@@ -120,6 +120,11 @@ abstract class ResidentialDeviceDtoAbstract implements DataTransferObjectInterfa
     private $ruriDomain = null;
 
     /**
+     * @var bool|null
+     */
+    private $trustSDP = false;
+
+    /**
      * @var int|null
      */
     private $id = null;
@@ -218,6 +223,7 @@ abstract class ResidentialDeviceDtoAbstract implements DataTransferObjectInterfa
             'rtpEncryption' => 'rtpEncryption',
             'multiContact' => 'multiContact',
             'ruriDomain' => 'ruriDomain',
+            'trustSDP' => 'trustSDP',
             'id' => 'id',
             'brandId' => 'brand',
             'domainId' => 'domain',
@@ -257,6 +263,7 @@ abstract class ResidentialDeviceDtoAbstract implements DataTransferObjectInterfa
             'rtpEncryption' => $this->getRtpEncryption(),
             'multiContact' => $this->getMultiContact(),
             'ruriDomain' => $this->getRuriDomain(),
+            'trustSDP' => $this->getTrustSDP(),
             'id' => $this->getId(),
             'brand' => $this->getBrand(),
             'domain' => $this->getDomain(),
@@ -512,6 +519,18 @@ abstract class ResidentialDeviceDtoAbstract implements DataTransferObjectInterfa
     public function getRuriDomain(): ?string
     {
         return $this->ruriDomain;
+    }
+
+    public function setTrustSDP(bool $trustSDP): static
+    {
+        $this->trustSDP = $trustSDP;
+
+        return $this;
+    }
+
+    public function getTrustSDP(): ?bool
+    {
+        return $this->trustSDP;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/ResidentialDevice/ResidentialDeviceInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/ResidentialDevice/ResidentialDeviceInterface.php
@@ -190,6 +190,8 @@ interface ResidentialDeviceInterface extends LoggableEntityInterface
 
     public function getRuriDomain(): ?string;
 
+    public function getTrustSDP(): bool;
+
     public function setBrand(BrandInterface $brand): static;
 
     public function getBrand(): BrandInterface;

--- a/library/Ivoz/Provider/Domain/Model/RetailAccount/RetailAccount.php
+++ b/library/Ivoz/Provider/Domain/Model/RetailAccount/RetailAccount.php
@@ -58,6 +58,7 @@ class RetailAccount extends RetailAccountAbstract implements RetailAccountInterf
                 throw new \DomainException('Password cannot be empty for retail accounts with no direct connectivity');
             }
 
+            $this->setTrustSDP(false);
             $this->setRuriDomain(null);
             $this->setIp(null);
             $this->setPort(null);

--- a/library/Ivoz/Provider/Domain/Model/RetailAccount/RetailAccountAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/RetailAccount/RetailAccountAbstract.php
@@ -101,6 +101,11 @@ abstract class RetailAccountAbstract
     protected $ruriDomain = null;
 
     /**
+     * @var bool
+     */
+    protected $trustSDP = false;
+
+    /**
      * @var BrandInterface
      * inversedBy residentialDevices
      */
@@ -142,7 +147,8 @@ abstract class RetailAccountAbstract
         string $ddiIn,
         string $t38Passthrough,
         bool $rtpEncryption,
-        bool $multiContact
+        bool $multiContact,
+        bool $trustSDP
     ) {
         $this->setName($name);
         $this->setDescription($description);
@@ -151,6 +157,7 @@ abstract class RetailAccountAbstract
         $this->setT38Passthrough($t38Passthrough);
         $this->setRtpEncryption($rtpEncryption);
         $this->setMultiContact($multiContact);
+        $this->setTrustSDP($trustSDP);
     }
 
     abstract public function getId(): null|string|int;
@@ -228,6 +235,8 @@ abstract class RetailAccountAbstract
         Assertion::notNull($rtpEncryption, 'getRtpEncryption value is null, but non null value was expected.');
         $multiContact = $dto->getMultiContact();
         Assertion::notNull($multiContact, 'getMultiContact value is null, but non null value was expected.');
+        $trustSDP = $dto->getTrustSDP();
+        Assertion::notNull($trustSDP, 'getTrustSDP value is null, but non null value was expected.');
         $brand = $dto->getBrand();
         Assertion::notNull($brand, 'getBrand value is null, but non null value was expected.');
         $company = $dto->getCompany();
@@ -240,7 +249,8 @@ abstract class RetailAccountAbstract
             $ddiIn,
             $t38Passthrough,
             $rtpEncryption,
-            $multiContact
+            $multiContact,
+            $trustSDP
         );
 
         $self
@@ -286,6 +296,8 @@ abstract class RetailAccountAbstract
         Assertion::notNull($rtpEncryption, 'getRtpEncryption value is null, but non null value was expected.');
         $multiContact = $dto->getMultiContact();
         Assertion::notNull($multiContact, 'getMultiContact value is null, but non null value was expected.');
+        $trustSDP = $dto->getTrustSDP();
+        Assertion::notNull($trustSDP, 'getTrustSDP value is null, but non null value was expected.');
         $brand = $dto->getBrand();
         Assertion::notNull($brand, 'getBrand value is null, but non null value was expected.');
         $company = $dto->getCompany();
@@ -305,6 +317,7 @@ abstract class RetailAccountAbstract
             ->setRtpEncryption($rtpEncryption)
             ->setMultiContact($multiContact)
             ->setRuriDomain($dto->getRuriDomain())
+            ->setTrustSDP($trustSDP)
             ->setBrand($fkTransformer->transform($brand))
             ->setDomain($fkTransformer->transform($dto->getDomain()))
             ->setCompany($fkTransformer->transform($company))
@@ -334,6 +347,7 @@ abstract class RetailAccountAbstract
             ->setRtpEncryption(self::getRtpEncryption())
             ->setMultiContact(self::getMultiContact())
             ->setRuriDomain(self::getRuriDomain())
+            ->setTrustSDP(self::getTrustSDP())
             ->setBrand(Brand::entityToDto(self::getBrand(), $depth))
             ->setDomain(Domain::entityToDto(self::getDomain(), $depth))
             ->setCompany(Company::entityToDto(self::getCompany(), $depth))
@@ -361,6 +375,7 @@ abstract class RetailAccountAbstract
             'rtpEncryption' => self::getRtpEncryption(),
             'multiContact' => self::getMultiContact(),
             'ruri_domain' => self::getRuriDomain(),
+            'trustSDP' => self::getTrustSDP(),
             'brandId' => self::getBrand()->getId(),
             'domainId' => self::getDomain()?->getId(),
             'companyId' => self::getCompany()->getId(),
@@ -588,6 +603,18 @@ abstract class RetailAccountAbstract
     public function getRuriDomain(): ?string
     {
         return $this->ruriDomain;
+    }
+
+    protected function setTrustSDP(bool $trustSDP): static
+    {
+        $this->trustSDP = $trustSDP;
+
+        return $this;
+    }
+
+    public function getTrustSDP(): bool
+    {
+        return $this->trustSDP;
     }
 
     public function setBrand(BrandInterface $brand): static

--- a/library/Ivoz/Provider/Domain/Model/RetailAccount/RetailAccountDto.php
+++ b/library/Ivoz/Provider/Domain/Model/RetailAccount/RetailAccountDto.php
@@ -219,7 +219,8 @@ class RetailAccountDto extends RetailAccountDtoAbstract
             't38Passthrough',
             'rtpEncryption',
             'ddiIn',
-            'ruriDomain'
+            'ruriDomain',
+            'trustSDP'
         ];
 
         return array_filter(

--- a/library/Ivoz/Provider/Domain/Model/RetailAccount/RetailAccountDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/RetailAccount/RetailAccountDtoAbstract.php
@@ -88,6 +88,11 @@ abstract class RetailAccountDtoAbstract implements DataTransferObjectInterface
     private $ruriDomain = null;
 
     /**
+     * @var bool|null
+     */
+    private $trustSDP = false;
+
+    /**
      * @var int|null
      */
     private $id = null;
@@ -170,6 +175,7 @@ abstract class RetailAccountDtoAbstract implements DataTransferObjectInterface
             'rtpEncryption' => 'rtpEncryption',
             'multiContact' => 'multiContact',
             'ruriDomain' => 'ruriDomain',
+            'trustSDP' => 'trustSDP',
             'id' => 'id',
             'brandId' => 'brand',
             'domainId' => 'domain',
@@ -201,6 +207,7 @@ abstract class RetailAccountDtoAbstract implements DataTransferObjectInterface
             'rtpEncryption' => $this->getRtpEncryption(),
             'multiContact' => $this->getMultiContact(),
             'ruriDomain' => $this->getRuriDomain(),
+            'trustSDP' => $this->getTrustSDP(),
             'id' => $this->getId(),
             'brand' => $this->getBrand(),
             'domain' => $this->getDomain(),
@@ -382,6 +389,18 @@ abstract class RetailAccountDtoAbstract implements DataTransferObjectInterface
     public function getRuriDomain(): ?string
     {
         return $this->ruriDomain;
+    }
+
+    public function setTrustSDP(bool $trustSDP): static
+    {
+        $this->trustSDP = $trustSDP;
+
+        return $this;
+    }
+
+    public function getTrustSDP(): ?bool
+    {
+        return $this->trustSDP;
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Model/RetailAccount/RetailAccountInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/RetailAccount/RetailAccountInterface.php
@@ -143,6 +143,8 @@ interface RetailAccountInterface extends LoggableEntityInterface
 
     public function getRuriDomain(): ?string;
 
+    public function getTrustSDP(): bool;
+
     public function setBrand(BrandInterface $brand): static;
 
     public function getBrand(): BrandInterface;

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/Friend.FriendAbstract.orm.xml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/Friend.FriendAbstract.orm.xml
@@ -125,6 +125,11 @@
       </options>
     </field>
     <field name="ruriDomain" type="string" column="ruri_domain" length="190" nullable="true"/>
+    <field name="trustSDP" type="boolean" column="trustSDP" nullable="false">
+      <options>
+        <option name="default">0</option>
+      </options>
+    </field>
     <many-to-one field="company" target-entity="Ivoz\Provider\Domain\Model\Company\CompanyInterface" inversed-by="friends" fetch="LAZY">
       <join-columns>
         <join-column name="companyId" referenced-column-name="id" on-delete="CASCADE" nullable=""/>

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/ResidentialDevice.ResidentialDeviceAbstract.orm.xml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/ResidentialDevice.ResidentialDeviceAbstract.orm.xml
@@ -109,6 +109,11 @@
       </options>
     </field>
     <field name="ruriDomain" type="string" column="ruri_domain" length="190" nullable="true"/>
+    <field name="trustSDP" type="boolean" column="trustSDP" nullable="false">
+      <options>
+        <option name="default">0</option>
+      </options>
+    </field>
     <many-to-one field="brand" target-entity="Ivoz\Provider\Domain\Model\Brand\BrandInterface" inversed-by="residentialDevices" fetch="LAZY">
       <join-columns>
         <join-column name="brandId" referenced-column-name="id" on-delete="CASCADE" nullable=""/>

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/RetailAccount.RetailAccountAbstract.orm.xml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/RetailAccount.RetailAccountAbstract.orm.xml
@@ -70,6 +70,11 @@
       </options>
     </field>
     <field name="ruriDomain" type="string" column="ruri_domain" length="190" nullable="true"/>
+    <field name="trustSDP" type="boolean" column="trustSDP" nullable="false">
+      <options>
+        <option name="default">0</option>
+      </options>
+    </field>
     <many-to-one field="brand" target-entity="Ivoz\Provider\Domain\Model\Brand\BrandInterface" inversed-by="residentialDevices" fetch="LAZY">
       <join-columns>
         <join-column name="brandId" referenced-column-name="id" on-delete="CASCADE" nullable=""/>

--- a/schema/DoctrineMigrations/Version20240527134623.php
+++ b/schema/DoctrineMigrations/Version20240527134623.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Ivoz\Core\Infrastructure\Persistence\Doctrine\LoggableMigration;
+
+/**
+* Auto-generated Migration: Please modify to your needs!
+*/
+final class Version20240527134623 extends LoggableMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add trustSDP field to Friends ResidentialDevices and ResidentialAccounts';
+    }
+
+    public function up(Schema $schema): void
+    {
+    // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE Friends ADD trustSDP TINYINT(1) DEFAULT 0 NOT NULL');
+        $this->addSql('ALTER TABLE ResidentialDevices ADD trustSDP TINYINT(1) DEFAULT 0 NOT NULL');
+        $this->addSql('ALTER TABLE RetailAccounts ADD trustSDP TINYINT(1) DEFAULT 0 NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE Friends DROP trustSDP');
+        $this->addSql('ALTER TABLE ResidentialDevices DROP trustSDP');
+        $this->addSql('ALTER TABLE RetailAccounts DROP trustSDP');
+    }
+}

--- a/web/portal/client/src/entities/Friend/Form.tsx
+++ b/web/portal/client/src/entities/Friend/Form.tsx
@@ -64,6 +64,7 @@ const Form = (props: EntityFormProps): JSX.Element => {
         edit && 'rtpEncryption',
         'multiContact',
         'alwaysApplyTransformations',
+        'trustSDP',
       ],
     },
     {

--- a/web/portal/client/src/entities/Friend/Friend.tsx
+++ b/web/portal/client/src/entities/Friend/Friend.tsx
@@ -159,6 +159,7 @@ const properties: FriendProperties = {
           'transformationRuleSet',
           'callACL',
           'rtpEncryption',
+          'trustSDP',
         ],
         hide: ['multiContact', 'interCompany'],
       },
@@ -176,7 +177,14 @@ const properties: FriendProperties = {
           'rtpEncryption',
           'multiContact',
         ],
-        hide: ['ip', 'port', 'transport', 'interCompany', 'ruriDomain'],
+        hide: [
+          'ip',
+          'port',
+          'transport',
+          'interCompany',
+          'ruriDomain',
+          'trustSDP',
+        ],
       },
       intervpbx: {
         show: [],
@@ -198,6 +206,7 @@ const properties: FriendProperties = {
           'multiContact',
           'outgoingDdi',
           'alwaysApplyTransformations',
+          'trustSDP',
         ],
       },
     },
@@ -272,6 +281,14 @@ const properties: FriendProperties = {
   ruriDomain: {
     label: _('R-URI domain'),
     type: 'string',
+  },
+  trustSDP: {
+    label: _('Trust SDP'),
+    enum: {
+      '0': _('No'),
+      '1': _('Yes'),
+    },
+    default: '0',
   },
 };
 

--- a/web/portal/client/src/entities/Friend/FriendProperties.tsx
+++ b/web/portal/client/src/entities/Friend/FriendProperties.tsx
@@ -33,6 +33,7 @@ export type FriendPropertyList<T> = {
   statusIcon?: T;
   interCompany?: T;
   ruriDomain?: T;
+  trustSDP?: T;
 };
 
 export type FriendProperties = FriendPropertyList<Partial<PropertySpec>>;

--- a/web/portal/client/src/entities/ResidentialDevice/Form.tsx
+++ b/web/portal/client/src/entities/ResidentialDevice/Form.tsx
@@ -48,6 +48,7 @@ const Form = (props: EntityFormProps): JSX.Element => {
         'maxCalls',
         'rtpEncryption',
         'multiContact',
+        'trustSDP',
       ],
     },
     {

--- a/web/portal/client/src/entities/ResidentialDevice/ResidentialDevice.tsx
+++ b/web/portal/client/src/entities/ResidentialDevice/ResidentialDevice.tsx
@@ -172,12 +172,19 @@ const properties: ResidentialDeviceProperties = {
     },
     visualToggle: {
       yes: {
-        show: ['ip', 'port', 'transport', 'auth_needed'],
+        show: ['ip', 'port', 'transport', 'auth_needed', 'trustSDP'],
         hide: ['multiContact'],
       },
       no: {
         show: ['multiContact'],
-        hide: ['ip', 'port', 'transport', 'auth_needed', 'ruriDomain'],
+        hide: [
+          'ip',
+          'port',
+          'transport',
+          'auth_needed',
+          'ruriDomain',
+          'trustSDP',
+        ],
       },
     },
   },
@@ -250,6 +257,14 @@ const properties: ResidentialDeviceProperties = {
   ruriDomain: {
     label: _('R-URI domain'),
     type: 'string',
+  },
+  trustSDP: {
+    label: _('Trust SDP'),
+    enum: {
+      '0': _('No'),
+      '1': _('Yes'),
+    },
+    default: '0',
   },
 };
 

--- a/web/portal/client/src/entities/ResidentialDevice/ResidentialDeviceProperties.tsx
+++ b/web/portal/client/src/entities/ResidentialDevice/ResidentialDeviceProperties.tsx
@@ -30,6 +30,7 @@ export type ResidentialDevicePropertyList<T> = {
   statusIcon: T;
   directConnectivity: T;
   ruriDomain: T;
+  trustSDP: T;
 };
 
 export type ResidentialDeviceStatus = {

--- a/web/portal/client/src/entities/RetailAccount/Form.tsx
+++ b/web/portal/client/src/entities/RetailAccount/Form.tsx
@@ -47,6 +47,7 @@ const Form = (props: EntityFormProps): JSX.Element => {
         't38Passthrough',
         'rtpEncryption',
         'multiContact',
+        'trustSDP',
       ],
     },
     {

--- a/web/portal/client/src/entities/RetailAccount/RetailAccount.tsx
+++ b/web/portal/client/src/entities/RetailAccount/RetailAccount.tsx
@@ -78,11 +78,11 @@ const properties: RetailAccountProperties = {
     },
     visualToggle: {
       yes: {
-        show: ['ip', 'port', 'transport', 'ruriDomain'],
+        show: ['ip', 'port', 'transport', 'ruriDomain', 'trustSDP'],
         hide: ['multiContact'],
       },
       no: {
-        hide: ['ip', 'port', 'transport', 'ruriDomain'],
+        hide: ['ip', 'port', 'transport', 'ruriDomain', 'trustSDP'],
         show: ['multiContact'],
       },
     },
@@ -142,6 +142,14 @@ const properties: RetailAccountProperties = {
   },
   ruriDomain: {
     label: _('R-URI domain'),
+  },
+  trustSDP: {
+    label: _('Trust SDP'),
+    enum: {
+      '0': _('No'),
+      '1': _('Yes'),
+    },
+    default: '0',
   },
 };
 

--- a/web/portal/client/src/entities/RetailAccount/RetailAccountProperties.tsx
+++ b/web/portal/client/src/entities/RetailAccount/RetailAccountProperties.tsx
@@ -24,6 +24,7 @@ export type RetailAccountPropertyList<T> = {
   rtpEncryption?: T;
   multiContact?: T;
   ruriDomain?: T;
+  trustSDP?: T;
 };
 
 export type RetailAccountStatus = {

--- a/web/portal/client/src/translations/ca.json
+++ b/web/portal/client/src/translations/ca.json
@@ -553,6 +553,7 @@
   "Transformation RuleSet_one": "Transformació numèrica",
   "Transformation RuleSet_other": "Transformacions numèriques",
   "Transport": "Transport",
+  "Trust SDP": "Confiar en SDP",
   "Tuesday": "Dimarts",
   "Type": "Tipus",
   "Unassigned": "No adscrit",

--- a/web/portal/client/src/translations/en.json
+++ b/web/portal/client/src/translations/en.json
@@ -492,6 +492,7 @@
   "Transformation RuleSet_one": "Transformation RuleSet",
   "Transformation RuleSet_other": "Transformation RuleSets",
   "Transport": "Transport",
+  "Trust SDP": "Trust SDP",
   "Tuesday": "Tuesday",
   "Type": "Type",
   "Unassigned": "Unassigned",

--- a/web/portal/client/src/translations/es.json
+++ b/web/portal/client/src/translations/es.json
@@ -553,6 +553,7 @@
   "Transformation RuleSet_one": "Transformación numérica",
   "Transformation RuleSet_other": "Transformaciones numéricas",
   "Transport": "Transporte",
+  "Trust SDP": "Confiar en SDP",
   "Tuesday": "Martes",
   "Type": "Tipo",
   "Unassigned": "Sin asignar",

--- a/web/portal/client/src/translations/it.json
+++ b/web/portal/client/src/translations/it.json
@@ -553,6 +553,7 @@
   "Transformation RuleSet_one": "Regola di trasformazione",
   "Transformation RuleSet_other": "Regole di trasformazione",
   "Transport": "Trasporto",
+  "Trust SDP": "Fidarsi di SDP",
   "Tuesday": "Martedì",
   "Type": "Tipo",
   "Unassigned": "Non assegnato",

--- a/web/rest/client/features/provider/friend/getFriend.feature
+++ b/web/rest/client/features/provider/friend/getFriend.feature
@@ -64,6 +64,7 @@ Feature: Retrieve friends
           "rtpEncryption": false,
           "multiContact": true,
           "ruriDomain": null,
+          "trustSDP": false,
           "id": 1,
           "transformationRuleSet": null,
           "callAcl": null,

--- a/web/rest/client/features/provider/residentialDevices/getResidentialDevice.feature
+++ b/web/rest/client/features/provider/residentialDevices/getResidentialDevice.feature
@@ -73,6 +73,7 @@ Feature: Retrieve residential devices
           "rtpEncryption": false,
           "multiContact": true,
           "ruriDomain": null,
+          "trustSDP": false,
           "id": 1,
           "transformationRuleSet": null,
           "outgoingDdi": null,
@@ -93,6 +94,5 @@ Feature: Retrieve residential devices
                   "userAgent": "Yealink SIP-T23G 44.80.0.130"
               }
           ]
-
       }
       """

--- a/web/rest/client/features/provider/residentialDevices/putResidentialDevice.feature
+++ b/web/rest/client/features/provider/residentialDevices/putResidentialDevice.feature
@@ -49,6 +49,7 @@ Feature: Update residential devices
           "rtpEncryption": false,
           "multiContact": true,
           "ruriDomain": null,
+          "trustSDP": false,
           "id": 1,
           "transformationRuleSet": null,
           "outgoingDdi": 2,
@@ -89,11 +90,11 @@ Feature: Update residential devices
           "rtpEncryption": false,
           "multiContact": true,
           "ruriDomain": null,
+          "trustSDP": false,
           "id": 1,
           "transformationRuleSet": null,
           "outgoingDdi": null,
           "language": null
-
       }
       """
 

--- a/web/rest/client/features/provider/retailAccount/getRetailAccount.feature
+++ b/web/rest/client/features/provider/retailAccount/getRetailAccount.feature
@@ -66,6 +66,7 @@ Feature: Retrieve retail accounts
           "rtpEncryption": false,
           "multiContact": true,
           "ruriDomain": null,
+          "trustSDP": false,
           "id": 1,
           "transformationRuleSet": null,
           "outgoingDdi": null,


### PR DESCRIPTION
Added field in portal/client for ResidentialDevices, RetailAccounts and Friends for trusting SPD

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, portal/platform, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
<!-- Describe your changes in detail -->

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
