### PR TITLE
Readonly client on brand retail residential and friend

### DIFF
--- a/library/Ivoz/Provider/Domain/Service/Friend/AvoidUpdateCompany.php
+++ b/library/Ivoz/Provider/Domain/Service/Friend/AvoidUpdateCompany.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Ivoz\Provider\Domain\Service\Friend;
+
+use Ivoz\Core\Domain\Assert\Assertion;
+use Ivoz\Core\Domain\Service\AvoidEntityUpdatesAbstract;
+use Ivoz\Provider\Domain\Model\Friend\FriendDto;
+use Ivoz\Provider\Domain\Model\Friend\FriendInterface;
+use Ivoz\Provider\Domain\Service\Friend\FriendLifecycleEventHandlerInterface;
+
+class AvoidUpdateCompany implements FriendLifecycleEventHandlerInterface
+{
+    public const PRE_PERSIST_PRIORITY = self::PRIORITY_NORMAL;
+
+    /**
+     * @return array<string,int>
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            self::EVENT_PRE_PERSIST => self::PRE_PERSIST_PRIORITY,
+        ];
+    }
+
+    public function execute(FriendInterface $friend): void
+    {
+        if ($friend->isNew()) {
+            return;
+        }
+
+        Assertion::false(
+            $friend->hasChanged('companyId')
+        );
+    }
+}

--- a/library/Ivoz/Provider/Domain/Service/Friend/FriendLifecycleServiceCollection.php
+++ b/library/Ivoz/Provider/Domain/Service/Friend/FriendLifecycleServiceCollection.php
@@ -19,6 +19,7 @@ class FriendLifecycleServiceCollection implements LifecycleServiceCollectionInte
     public static $bindedBaseServices = [
         "pre_persist" =>
         [
+            \Ivoz\Provider\Domain\Service\Friend\AvoidUpdateCompany::class => 200,
             \Ivoz\Provider\Domain\Service\Friend\CheckUniqueness::class => 200,
             \Ivoz\Provider\Domain\Service\Friend\SanitizeInterVpbxPriority::class => 200,
         ],

--- a/library/Ivoz/Provider/Domain/Service/ResidentialDevice/AvoidUpdateCompany.php
+++ b/library/Ivoz/Provider/Domain/Service/ResidentialDevice/AvoidUpdateCompany.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Ivoz\Provider\Domain\Service\ResidentialDevice;
+
+use Ivoz\Core\Domain\Assert\Assertion;
+use Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDeviceInterface;
+use Ivoz\Provider\Domain\Service\ResidentialDevice\ResidentialDeviceLifecycleEventHandlerInterface;
+
+class AvoidUpdateCompany implements ResidentialDeviceLifecycleEventHandlerInterface
+{
+    public const PRE_PERSIST_PRIORITY = self::PRIORITY_NORMAL;
+
+    /**
+     * @return array<string,int>
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            self::EVENT_PRE_PERSIST => self::PRE_PERSIST_PRIORITY,
+        ];
+    }
+
+    public function execute(ResidentialDeviceInterface $residentialDevice): void
+    {
+        if ($residentialDevice->isNew()) {
+            return;
+        }
+
+        Assertion::false(
+            $residentialDevice->hasChanged('companyId')
+        );
+    }
+}

--- a/library/Ivoz/Provider/Domain/Service/ResidentialDevice/ResidentialDeviceLifecycleServiceCollection.php
+++ b/library/Ivoz/Provider/Domain/Service/ResidentialDevice/ResidentialDeviceLifecycleServiceCollection.php
@@ -19,6 +19,7 @@ class ResidentialDeviceLifecycleServiceCollection implements LifecycleServiceCol
     public static $bindedBaseServices = [
         "pre_persist" =>
         [
+            \Ivoz\Provider\Domain\Service\ResidentialDevice\AvoidUpdateCompany::class => 200,
             \Ivoz\Provider\Domain\Service\ResidentialDevice\CheckUniqueness::class => 200,
         ],
         "post_persist" =>

--- a/library/Ivoz/Provider/Domain/Service/RetailAccount/AvoidUpdateCompany.php
+++ b/library/Ivoz/Provider/Domain/Service/RetailAccount/AvoidUpdateCompany.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Ivoz\Provider\Domain\Service\RetailAccount;
+
+use Ivoz\Core\Domain\Assert\Assertion;
+use Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface;
+use Ivoz\Provider\Domain\Service\RetailAccount\RetailAccountLifecycleEventHandlerInterface;
+
+class AvoidUpdateCompany implements RetailAccountLifecycleEventHandlerInterface
+{
+    public const PRE_PERSIST_PRIORITY = self::PRIORITY_NORMAL;
+
+    /**
+     * @return array<string,int>
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            self::EVENT_PRE_PERSIST => self::PRE_PERSIST_PRIORITY,
+        ];
+    }
+
+    public function execute(RetailAccountInterface $retailAccount): void
+    {
+        if ($retailAccount->isNew()) {
+            return;
+        }
+
+        Assertion::false(
+            $retailAccount->hasChanged('companyId')
+        );
+    }
+}

--- a/library/Ivoz/Provider/Domain/Service/RetailAccount/RetailAccountLifecycleServiceCollection.php
+++ b/library/Ivoz/Provider/Domain/Service/RetailAccount/RetailAccountLifecycleServiceCollection.php
@@ -19,6 +19,7 @@ class RetailAccountLifecycleServiceCollection implements LifecycleServiceCollect
     public static $bindedBaseServices = [
         "pre_persist" =>
         [
+            \Ivoz\Provider\Domain\Service\RetailAccount\AvoidUpdateCompany::class => 200,
             \Ivoz\Provider\Domain\Service\RetailAccount\CheckUniqueness::class => 200,
         ],
         "post_persist" =>

--- a/library/spec/Ivoz/Provider/Domain/Service/Friend/AvoidUpdateCompanySpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Service/Friend/AvoidUpdateCompanySpec.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace spec\Ivoz\Provider\Domain\Service\Friend;
+
+use Assert\InvalidArgumentException;
+use Ivoz\Provider\Domain\Model\Friend\FriendInterface;
+use Ivoz\Provider\Domain\Service\Friend\AvoidUpdateCompany;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class AvoidUpdateCompanySpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(AvoidUpdateCompany::class);
+    }
+
+    function its_does_nothing_on_new_entities(
+        FriendInterface $entity
+    ) {
+        $entity
+            ->isNew()
+            ->willReturn(true)
+            ->shouldBeCalled();
+
+        $this->execute($entity);
+    }
+
+    function its_does_now_allow_updated(
+        FriendInterface $entity
+    ) {
+        $entity
+            ->isNew()
+            ->willReturn(false)
+            ->shouldBeCalled();
+
+        $entity
+            ->hasChanged('companyId')
+            ->willReturn(true)
+            ->shouldBeCalled();
+
+        $this
+            ->shouldThrow(InvalidArgumentException::class)
+            ->during('execute', [$entity]);
+    }
+}

--- a/library/spec/Ivoz/Provider/Domain/Service/ResidentialDevice/AvoidUpdateCompanySpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Service/ResidentialDevice/AvoidUpdateCompanySpec.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace spec\Ivoz\Provider\Domain\Service\ResidentialDevice;
+
+use Assert\InvalidArgumentException;
+use Ivoz\Provider\Domain\Model\ResidentialDevice\ResidentialDeviceInterface;
+use Ivoz\Provider\Domain\Service\ResidentialDevice\AvoidUpdateCompany;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class AvoidUpdateCompanySpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(AvoidUpdateCompany::class);
+    }
+
+    function its_does_nothing_on_new_entities(
+        ResidentialDeviceInterface $entity
+    ) {
+        $entity
+            ->isNew()
+            ->willReturn(true)
+            ->shouldBeCalled();
+
+        $this->execute($entity);
+    }
+
+    function its_does_now_allow_updated(
+        ResidentialDeviceInterface $entity
+    ) {
+        $entity
+            ->isNew()
+            ->willReturn(false)
+            ->shouldBeCalled();
+
+        $entity
+            ->hasChanged('companyId')
+            ->willReturn(true)
+            ->shouldBeCalled();
+
+        $this
+            ->shouldThrow(InvalidArgumentException::class)
+            ->during('execute', [$entity]);
+    }
+}

--- a/library/spec/Ivoz/Provider/Domain/Service/RetailAccount/AvoidUpdateCompanySpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Service/RetailAccount/AvoidUpdateCompanySpec.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace spec\Ivoz\Provider\Domain\Service\RetailAccount;
+
+use Assert\InvalidArgumentException;
+use Ivoz\Provider\Domain\Model\RetailAccount\RetailAccountInterface;
+use Ivoz\Provider\Domain\Service\RetailAccount\AvoidUpdateCompany;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class AvoidUpdateCompanySpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(AvoidUpdateCompany::class);
+    }
+
+    function its_does_nothing_on_new_entities(
+        RetailAccountInterface $entity
+    ) {
+        $entity
+            ->isNew()
+            ->willReturn(true)
+            ->shouldBeCalled();
+
+        $this->execute($entity);
+    }
+
+    function its_does_now_allow_updated(
+        RetailAccountInterface $entity
+    ) {
+        $entity
+            ->isNew()
+            ->willReturn(false)
+            ->shouldBeCalled();
+
+        $entity
+            ->hasChanged('companyId')
+            ->willReturn(true)
+            ->shouldBeCalled();
+
+        $this
+            ->shouldThrow(InvalidArgumentException::class)
+            ->during('execute', [$entity]);
+    }
+}

--- a/web/portal/brand/src/entities/ResidentialDevice/Form.tsx
+++ b/web/portal/brand/src/entities/ResidentialDevice/Form.tsx
@@ -8,7 +8,7 @@ import { Form as DefaultEntityForm } from '@irontec/ivoz-ui/entities/DefaultEnti
 import { foreignKeyGetter } from './ForeignKeyGetter';
 
 const Form = (props: EntityFormProps): JSX.Element => {
-  const { entityService, row, match } = props;
+  const { entityService, row, match, edit } = props;
   const fkChoices = useFkChoices({
     foreignKeyGetter,
     entityService,
@@ -34,7 +34,18 @@ const Form = (props: EntityFormProps): JSX.Element => {
     },
   ];
 
-  return <DefaultEntityForm {...props} fkChoices={fkChoices} groups={groups} />;
+  const readOnlyProperties = {
+    company: edit,
+  };
+
+  return (
+    <DefaultEntityForm
+      {...props}
+      fkChoices={fkChoices}
+      groups={groups}
+      readOnlyProperties={readOnlyProperties}
+    />
+  );
 };
 
 export default Form;

--- a/web/portal/brand/src/entities/RetailAccount/Form.tsx
+++ b/web/portal/brand/src/entities/RetailAccount/Form.tsx
@@ -8,7 +8,7 @@ import { Form as DefaultEntityForm } from '@irontec/ivoz-ui/entities/DefaultEnti
 import { foreignKeyGetter } from './ForeignKeyGetter';
 
 const Form = (props: EntityFormProps): JSX.Element => {
-  const { entityService, row, match } = props;
+  const { entityService, row, match, edit } = props;
   const fkChoices = useFkChoices({
     foreignKeyGetter,
     entityService,
@@ -34,7 +34,18 @@ const Form = (props: EntityFormProps): JSX.Element => {
     },
   ];
 
-  return <DefaultEntityForm {...props} fkChoices={fkChoices} groups={groups} />;
+  const readOnlyProperties = {
+    company: edit,
+  };
+
+  return (
+    <DefaultEntityForm
+      {...props}
+      fkChoices={fkChoices}
+      groups={groups}
+      readOnlyProperties={readOnlyProperties}
+    />
+  );
 };
 
 export default Form;

--- a/web/rest/brand/features/provider/friend/putFriend.feature
+++ b/web/rest/brand/features/provider/friend/putFriend.feature
@@ -26,7 +26,6 @@ Feature: Update friends
           "fromDomain": "",
           "directConnectivity": "yes",
           "id": 1,
-          "company": 1,
           "callAcl": null,
           "outgoingDdi": null,
           "language": null
@@ -101,3 +100,16 @@ Feature: Update friends
           "interCompany": 1
       }
       """
+
+  @createSchema
+  Scenario: Update a friend company must fail
+    Given I add Brand Authorization header
+     When I add "Content-Type" header equal to "application/json"
+      And I add "Accept" header equal to "application/json"
+      And I send a "PUT" request to "/friends/1" with body:
+      """
+      {
+          "company": 2
+      }
+      """
+     Then the response status code should be 400

--- a/web/rest/brand/features/provider/residentialDevice/putResidentialDevice.feature
+++ b/web/rest/brand/features/provider/residentialDevice/putResidentialDevice.feature
@@ -24,7 +24,6 @@ Feature: Update residential device
           "maxCalls": 1,
           "t38Passthrough": "no",
           "id": 1,
-          "company": 1,
           "transformationRuleSet": null,
           "outgoingDdi": null,
           "language": null,
@@ -53,10 +52,23 @@ Feature: Update residential device
           "multiContact": true,
           "ruriDomain": null,
           "id": 1,
-          "company": 1,
+          "company": 4,
           "transformationRuleSet": null,
           "outgoingDdi": null,
           "language": null,
           "proxyUser": 1
       }
       """
+
+  @createSchema
+  Scenario: Update a ddi company must fail
+    Given I add Brand Authorization header
+     When I add "Content-Type" header equal to "application/json"
+      And I add "Accept" header equal to "application/json"
+      And I send a "PUT" request to "/residential_devices/1" with body:
+      """
+      {
+        "company": 1,
+      }
+      """
+     Then the response status code should be 400

--- a/web/rest/brand/features/provider/retailAccount/putRetailAccount.feature
+++ b/web/rest/brand/features/provider/retailAccount/putRetailAccount.feature
@@ -21,7 +21,6 @@ Feature: Update ddi
           "directConnectivity": "no",
           "ddiIn": "yes",
           "t38Passthrough": "no",
-          "company": 1,
           "transformationRuleSet": null,
           "outgoingDdi": null,
           "proxyUser": 1
@@ -47,10 +46,23 @@ Feature: Update ddi
           "multiContact": true,
           "ruriDomain": null,
           "id": 1,
-          "company": 1,
+          "company": 3,
           "transformationRuleSet": null,
           "outgoingDdi": null,
           "proxyUser": null,
           "status": []
       }
       """
+
+  @createSchema
+  Scenario: Update a retail account company must fail
+    Given I add Brand Authorization header
+     When I add "Content-Type" header equal to "application/json"
+      And I add "Accept" header equal to "application/json"
+      And I send a "PUT" request to "/retail_accounts/1" with body:
+      """
+      {
+        "company": 1
+      }
+      """
+     Then the response status code should be 400


### PR DESCRIPTION
Modified back and front to make client readonly on Friends, RetailAccounts and ResidentialDevices edition

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, portal/platform, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
<!-- Describe your changes in detail -->

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
