### PR TITLE
kamusers: force selected socket for direct connectivity objects

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -1319,7 +1319,7 @@ route[STATIC_LOCATION] {
         return;
     }
 
-    sql_xquery("cb", "SELECT name, domain, directConnectivity, ip, port, transport, ruri_domain, ddiIn, trustSDP FROM $avp(endpointType) t LEFT JOIN Domains D ON t.domainId=D.id WHERE t.id='$avp(endpointId)'", "rb");
+    sql_xquery("cb", "SELECT t.name, t.directConnectivity, t.ip, t.port, t.transport, t.ruri_domain, t.ddiIn, t.trustSDP, PU.ip AS proxyusersIP FROM $avp(endpointType) t LEFT JOIN ProxyUsers PU ON PU.id=t.proxyUserId WHERE t.id='$avp(endpointId)'", "rb");
     $var(ddi_in) = $xavp(rb=>ddiIn);
 
     if ($xavp(rb=>directConnectivity) == 'no') return;
@@ -1330,9 +1330,18 @@ route[STATIC_LOCATION] {
         xinfo("[$dlg_var(cidhash)] STATIC-LOCATION: Inter-vPBX call\n");
         $rd = $fd;
         $du = "sip:users.ivozprovider.local";
+        $fs = "udp:" + $var(usersAddress) + ":5060";
         uac_replace_from("sip:" + $xavp(rb=>name) + "@" + $fd);
         $avp(intervpbx) = 'yes'; # used in SET_PAI
         return;
+    }
+
+    # From now on, logic for directConnectivity == 'yes' objects
+
+    if ($xavp(rb=>proxyusersIP) != $null && $(xavp(rb=>proxyusersIP){s.len}) > 0) {
+        $fs = "udp:" + $xavp(rb=>proxyusersIP) + ":5060";
+    } else {
+        $fs = "udp:" + $var(usersAddress) + ":5060";
     }
 
     if ($xavp(rb=>ruri_domain) == $null || $(xavp(rb=>ruri_domain){s.len}) == 0) {


### PR DESCRIPTION

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, portal/platform, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description

Use Friend/RetailAccount/ResidentialDevice proxyUsersId field added in #2671 to force proper socket in calls towards these objects.

