### PR TITLE
kamailio: changes in fast media liberation delayer

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -1539,8 +1539,6 @@ route[GET_INFO_FROM_COMPANY] {
 
 # Handle within-dialog messages
 route[WITHINDLG] {
-    if (!$dlg_var(confirmed) && is_method("UPDATE|INVITE")) drop;
-
     # REFER not allowed
     if (is_method("REFER")) {
         xwarn("[$dlg_var(cidhash)] WITHINDLG: 'REFER' not supported\n");

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -1915,7 +1915,7 @@ route[BAD_CREDENTIALS] {
 
 # Handle within-dialog messages
 route[WITHINDLG] {
-    if (!$dlg_var(confirmed) && is_method("UPDATE|INVITE")) drop;
+    if (!$dlg_var(confirmed) && is_method("UPDATE|INVITE") && has_body("application/sdp")) drop;
 
     route(ADAPT_CALLER);
 


### PR DESCRIPTION

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, portal/platform, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description

Fast media liberation is a mechanism that drops UPDATE/reINVITE until initial transaction is acknowledged with an ACK.

#### Additional information

This PR:
- Removes this mechanism in KamTrunks as no media-liberation is done in carrier calls.
- Removes this mechanism in KamUsers when no SDP is present.