### PR TITLE
Fix initial generation of JWT keys

### DIFF
--- a/debian/ivozprovider-web-rest.postinst
+++ b/debian/ivozprovider-web-rest.postinst
@@ -7,11 +7,11 @@ set -e
 # Set current environment
 export APP_ENV=prod
 
-# Create jwt certificates
-[ ! -e /opt/irontec/ivozprovider/storage/jwt/private.pem ] && bin/generate-keys --initial
-
 if [ -d /opt/irontec/ivozprovider/web/rest/platform/ ]; then
     pushd /opt/irontec/ivozprovider/web/rest/platform/
+        # Create jwt certificates
+        [ ! -e /opt/irontec/ivozprovider/storage/jwt/private.pem ] && bin/generate-keys --initial
+
         # Set proper var permissions
         setfacl -dR -m u:www-data:rwX -m u:root:rwX var
         setfacl  -R -m u:www-data:rwX -m u:root:rwX var


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, portal/platform, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
Keys generation script is being invoked before changing to rest/platform directory, so the creation was failing.

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
