### PR TITLE
Fix on-demand recording code on incoming calls

### DIFF
--- a/asterisk/agi/src/Dialplan/Trunks.php
+++ b/asterisk/agi/src/Dialplan/Trunks.php
@@ -94,6 +94,7 @@ class Trunks extends RouteHandlerAbstract
         $this->agi->setVariable("__COMPANYID", $company->getId());
         $this->agi->setVariable("__COMPANYTYPE", $company->getType());
         $this->agi->setVariable("__BRANDID", $brand->getId());
+        $this->agi->setVariable("__ONDEMANDCODE", $company->getOnDemandRecordCode());
         $this->agi->setVariable("CHANNEL(musicclass)", $company->getMusicClass());
         $this->agi->setVariable("CHANNEL(language)", $ddi->getLanguageCode());
 


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, portal/platform, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
On Demand recording feature code was not being set poperly on user channel during external incoming calls due to a missing channel variable.

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
