### PR TITLE
Fix Content-Security-Policy for img blobs

### DIFF
--- a/profiles/portal/etc/apache2/sites-available/020-ivozprovider-portals.conf
+++ b/profiles/portal/etc/apache2/sites-available/020-ivozprovider-portals.conf
@@ -39,7 +39,7 @@ Alias /platform /opt/irontec/ivozprovider/web/portal/platform/dist
     </Limit>
 
     Header set X-Frame-Options SAMEORIGIN
-    Header set Content-Security-Policy "default-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' *.googleapis.com 'unsafe-inline'; font-src 'self' *.googleapis.com *.gstatic.com; media-src 'self' blob:;"
+    Header set Content-Security-Policy "default-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' *.googleapis.com 'unsafe-inline'; font-src 'self' *.googleapis.com *.gstatic.com; media-src 'self' blob:; img-src 'self' blob:"
 
     <IfModule mod_rewrite.c>
         RewriteEngine On
@@ -64,7 +64,7 @@ Alias /brand /opt/irontec/ivozprovider/web/portal/brand/dist
     </Limit>
 
     Header set X-Frame-Options SAMEORIGIN
-    Header set Content-Security-Policy "default-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' *.googleapis.com 'unsafe-inline'; font-src 'self' *.googleapis.com *.gstatic.com; media-src 'self' blob:;"
+    Header set Content-Security-Policy "default-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' *.googleapis.com 'unsafe-inline'; font-src 'self' *.googleapis.com *.gstatic.com; media-src 'self' blob:; img-src 'self' blob:"
 
     <IfModule mod_rewrite.c>
         RewriteEngine On
@@ -90,7 +90,7 @@ Alias /client /opt/irontec/ivozprovider/web/portal/client/dist
     </Limit>
 
     Header set X-Frame-Options SAMEORIGIN
-    Header set Content-Security-Policy "default-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' *.googleapis.com 'unsafe-inline'; font-src 'self' *.googleapis.com *.gstatic.com; media-src 'self' blob:;"
+    Header set Content-Security-Policy "default-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' *.googleapis.com 'unsafe-inline'; font-src 'self' *.googleapis.com *.gstatic.com; media-src 'self' blob:; img-src 'self' blob:"
 
     <IfModule mod_rewrite.c>
         RewriteEngine On
@@ -117,7 +117,7 @@ Alias /user /opt/irontec/ivozprovider/web/portal/user/dist
     </Limit>
 
     Header set X-Frame-Options SAMEORIGIN
-    Header set Content-Security-Policy "default-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' *.googleapis.com 'unsafe-inline'; font-src 'self' *.googleapis.com *.gstatic.com; media-src 'self' blob:;"
+    Header set Content-Security-Policy "default-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' *.googleapis.com 'unsafe-inline'; font-src 'self' *.googleapis.com *.gstatic.com; media-src 'self' blob:;  img-src 'self' blob:"
 
     <IfModule mod_rewrite.c>
         RewriteEngine On


### PR DESCRIPTION
Fixed Content-Security-Policy allowing load of images with src starting with blob:

#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, portal/platform, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
<!-- Describe your changes in detail -->

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
