### PR TITLE
kamailio: avoid hardcoded SIP ports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,18 +19,3 @@ web/portal/client/.history
 
 doc/html/*
 doc/doctrees/
-
-kamailio/users/config/kamailio-selfsigned.key
-kamailio/trunks/config/kamailio-selfsigned.key
-
-kamailio/users/config/listeners.cfg
-kamailio/trunks/config/listeners.cfg
-
-kamailio/users/config/pushservers.cfg
-kamailio/users/config/geoip.cfg
-kamailio/users/config/multisocket.cfg
-kamailio/users/config/apiban.cfg
-kamailio/users/config/siptrace.cfg
-kamailio/trunks/config/custom_settings.cfg
-kamailio/trunks/config/apiban.cfg
-kamailio/trunks/config/siptrace.cfg

--- a/kamailio/.gitignore
+++ b/kamailio/.gitignore
@@ -1,4 +1,13 @@
+*.crt
+*.key
+apiban.cfg
 custom-defines.cfg
 custom-global-params.cfg
-*.key
-*.crt
+custom_settings.cfg
+geoip.cfg
+listeners.cfg
+multisocket.cfg
+ports.cfg
+ports.cfg.dev
+pushservers.cfg
+siptrace.cfg

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -9,10 +9,7 @@
 
 ####### Defines #########
 
-#!define SIP_PORT 5060
-#!define SIPS_PORT 5061
-#!define RPC_PORT 8001
-#!define XMLRPC_PORT 8002
+include_file "ports.cfg"
 
 # - flags
 #   FLT_ - per transaction (message) flags
@@ -201,8 +198,8 @@ modparam("ndb_redis", "init_without_redis", 1)
 #!endif
 
 # DMQ
-modparam("dmq", "server_address", "sip:trunks.ivozprovider.local:5060")
-modparam("dmq", "notification_address", "sip:users.ivozprovider.local:5060")
+modparam("dmq", "server_address", TRUNKS_DMQ_SERVER)
+modparam("dmq", "notification_address", USERS_DMQ_SERVER)
 modparam("dmq", "ping_interval", 3600)
 
 # HTTP_CLIENT
@@ -1590,7 +1587,7 @@ route[WITHINDLG] {
 route[DISPATCH] {
     if ($Ri != $var(trunksAddress)) {
         # force_send_socket to main address
-        $fs = "udp:" + $var(trunksAddress) + ":5060";
+        $fs = "udp:" + $var(trunksAddress) + ":" + SIP_PORT;
     }
 
     if ($dlg_var(type) == 'retail') {
@@ -2109,7 +2106,7 @@ failure_route[MANAGE_FAILURE_AS] {
             xinfo("[$dlg_var(cidhash)] MANAGE-FAILURE-AS: going to <$ru> via <$du>\n");
 
             # Reset force_socket again
-            $fs = "udp:" + $var(trunksAddress) + ":5060";
+            $fs = "udp:" + $var(trunksAddress) + ":" + SIP_PORT;
 
             t_on_failure("MANAGE_FAILURE_AS");
             route(RELAY);
@@ -2424,13 +2421,13 @@ route[IS_WITHIN_COUNTRY] {
 route[FORCE_CARRIER_SOCKET] {
     if ($var(carrierSocketTransport) == '2') {
         $avp(carrierSocketTransport) = 'tcp';
-        $avp(carrierSocketPort) = '5060';
+        $avp(carrierSocketPort) = SIP_PORT;
     } else if ($var(carrierSocketTransport) == '3') {
         $avp(carrierSocketTransport) = 'tls';
-        $avp(carrierSocketPort) = '5061';
+        $avp(carrierSocketPort) = SIPS_PORT;
     } else {
         $avp(carrierSocketTransport) = 'udp';
-        $avp(carrierSocketPort) = '5060';
+        $avp(carrierSocketPort) = SIP_PORT;
     }
 
     $fs = $avp(carrierSocketTransport) + ":" + $avp(carrierSocketIp) + ":" + $avp(carrierSocketPort);

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -2212,6 +2212,19 @@ event_route[tm:local-request] {
             $ru = $dlg_var(contact);
         }
     }
+
+    # REGISTER: fix Contact and socket port if wrong (for mono-IP environments)
+    if (is_method("REGISTER") && SIP_PORT != 5060) {
+        $var(contactUsername) = $(ct{s.rm,<}{s.rm,>}{uri.user}); # Extract Contact Username
+
+        sql_xquery("cb", "SELECT socket FROM kam_trunks_uacreg WHERE l_uuid='$var(contactUsername)'", "uacreg");
+        if ($xavp(uacreg=>socket) != $null && $(xavp(uacreg=>socket){s.len}) > 0) {
+            $var(socketIP) = $(xavp(uacreg=>socket){s.select,1,:});
+            $fs = "udp:" + $var(socketIP) + ":" + SIP_PORT;
+        }
+
+        subst_hf("Contact", "/:5060/:" + SIP_PORT + "/", "a");
+    }
 }
 
 onsend_route {

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -9,12 +9,7 @@
 
 ####### Defines #########
 
-#!define TRUNKS_SIP_PORT 5060
-#!define SIP_PORT 5060
-#!define SIPS_PORT 5061
-#!define RPC_PORT 8000
-#!define WS_PORT 10080
-#!define WSS_PORT 10081
+include_file "ports.cfg"
 
 #
 # - flags
@@ -214,8 +209,8 @@ import_file "geoip.cfg"
 import_file "siptrace.cfg"
 
 # DMQ
-modparam("dmq", "server_address", "sip:users.ivozprovider.local:5060")
-modparam("dmq", "notification_address", "sip:trunks.ivozprovider.local:5060")
+modparam("dmq", "server_address", USERS_DMQ_SERVER)
+modparam("dmq", "notification_address", TRUNKS_DMQ_SERVER)
 modparam("dmq", "ping_interval", 3600)
 
 # RTPENGINE
@@ -1330,7 +1325,7 @@ route[STATIC_LOCATION] {
         xinfo("[$dlg_var(cidhash)] STATIC-LOCATION: Inter-vPBX call\n");
         $rd = $fd;
         $du = "sip:users.ivozprovider.local";
-        $fs = "udp:" + $var(usersAddress) + ":5060";
+        $fs = "udp:" + $var(usersAddress) + ":" + SIP_PORT;
         uac_replace_from("sip:" + $xavp(rb=>name) + "@" + $fd);
         $avp(intervpbx) = 'yes'; # used in SET_PAI
         return;
@@ -1339,9 +1334,9 @@ route[STATIC_LOCATION] {
     # From now on, logic for directConnectivity == 'yes' objects
 
     if ($xavp(rb=>proxyusersIP) != $null && $(xavp(rb=>proxyusersIP){s.len}) > 0) {
-        $fs = "udp:" + $xavp(rb=>proxyusersIP) + ":5060";
+        $fs = "udp:" + $xavp(rb=>proxyusersIP) + ":" + SIP_PORT;
     } else {
-        $fs = "udp:" + $var(usersAddress) + ":5060";
+        $fs = "udp:" + $var(usersAddress) + ":" + SIP_PORT;
     }
 
     if ($xavp(rb=>ruri_domain) == $null || $(xavp(rb=>ruri_domain){s.len}) == 0) {
@@ -2944,7 +2939,7 @@ route[TRANSPORT_DETECT] {
 route[FORCE_MAIN_SOCKET] {
     if (!$var(is_from_inside) && $Ri != $var(usersAddress)) {
         # UAC talking to non-main address, force_send_socket to main address
-        $fs = "udp:" + $var(usersAddress) + ":5060";
+        $fs = "udp:" + $var(usersAddress) + ":" + SIP_PORT;
     }
 }
 

--- a/profiles/proxy/etc/kamailio/autoconf
+++ b/profiles/proxy/etc/kamailio/autoconf
@@ -3,6 +3,7 @@
 use v5.10;
 use strict;
 use DBI;
+use File::Copy;
 
 my $MYSQL_FILE = "/etc/mysql/conf.d/kamailio.cnf";
 my $database = 'ivozprovider';
@@ -12,6 +13,7 @@ my $data_source = "dbi:mysql:$database" .
 
 my $PROXY;
 my $LISTENERS_FILE;
+my $PORTS_FILE;
 
 sub printListeners() {
     my %listeners;
@@ -43,6 +45,34 @@ sub printListeners() {
     $dbh->disconnect();
 
     return \%listeners;
+}
+
+sub printPorts() {
+    unlink $PORTS_FILE;
+
+    open my $FILE, ">>", $PORTS_FILE;
+
+    say $FILE '#!define TRUNKS_DMQ_SERVER "sip:trunks.ivozprovider.local:5060"';
+    say $FILE '#!define USERS_DMQ_SERVER "sip:users.ivozprovider.local:5060"';
+    if ($PROXY eq "users") {
+        say $FILE '#!define TRUNKS_SIP_PORT 5060';
+    }
+
+    say $FILE "";
+    say $FILE "#!define SIP_PORT 5060";
+    say $FILE "#!define SIPS_PORT 5061";
+
+    if ($PROXY eq "users") {
+        say $FILE "#!define RPC_PORT 8000";
+        say $FILE "#!define WS_PORT 10080";
+        say $FILE "#!define WSS_PORT 10081";
+    } else {
+        say $FILE "#!define RPC_PORT 8001";
+        say $FILE "#!define XMLRPC_PORT 8002";
+    }
+
+    say $FILE "";
+    close $FILE;
 }
 
 sub printListener() {
@@ -95,7 +125,14 @@ if (@ARGV != 1 || ($ARGV[0] ne "users" && $ARGV[0] ne "trunks")) {
 }
 
 $PROXY = shift @ARGV;
+$PORTS_FILE = "/etc/kamailio/proxy$PROXY/ports.cfg";
 $LISTENERS_FILE = "/etc/kamailio/proxy$PROXY/listeners.cfg";
+
+if (-f "$PORTS_FILE.dev") {
+    copy "$PORTS_FILE.dev", $PORTS_FILE;
+} else {
+    &printPorts();
+}
 
 &printListeners();
 


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, portal/platform, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description

Standalone installations sharing a unique IP address where broken as long as 5060 port for proxytrunks was hardcoded in some points of logic.

This PR avoids this hardcoding and fixes standalone mono-IP environments using 7060 in proxytrunks.
