### PR TITLE
Update PsEndpoints when User changes its Terminal or is deleted

### DIFF
--- a/library/Ivoz/Ast/Domain/Service/PsEndpoint/UpdateByUserDeleted.php
+++ b/library/Ivoz/Ast/Domain/Service/PsEndpoint/UpdateByUserDeleted.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Ivoz\Ast\Domain\Service\PsEndpoint;
+
+use Ivoz\Ast\Domain\Model\PsEndpoint\PsEndpointDto;
+use Ivoz\Core\Domain\Service\EntityTools;
+use Ivoz\Provider\Domain\Model\User\UserInterface;
+use Ivoz\Provider\Domain\Service\User\UserLifecycleEventHandlerInterface;
+
+class UpdateByUserDeleted implements UserLifecycleEventHandlerInterface
+{
+    public function __construct(
+        private EntityTools $entityTools
+    ) {
+    }
+
+    /** @return array<array-key, int> */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            self::EVENT_POST_REMOVE => self::PRIORITY_NORMAL
+        ];
+    }
+
+    /**
+     * @return void
+     */
+    public function execute(UserInterface $user)
+    {
+        $endpoint = $user->getEndpoint();
+        if (!$endpoint) {
+            return;
+        }
+
+        /** @var PsEndpointDto $endpointDto */
+        $endpointDto = $this
+            ->entityTools
+            ->entityToDto($endpoint);
+
+        $endpointDto
+            ->setCallerid(null)
+            ->setMailboxes(null)
+            ->setHintExtension(null)
+            ->setNamedPickupGroup(null)
+            ->setExtension(null);
+
+        $this
+            ->entityTools
+            ->persistDto($endpointDto, $endpoint, false);
+    }
+}

--- a/library/Ivoz/Ast/Domain/Service/PsEndpoint/UpdateByUserTerminalUnassignment.php
+++ b/library/Ivoz/Ast/Domain/Service/PsEndpoint/UpdateByUserTerminalUnassignment.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Ivoz\Ast\Domain\Service\PsEndpoint;
+
+use Ivoz\Ast\Domain\Model\PsEndpoint\PsEndpointDto;
+use Ivoz\Ast\Domain\Model\PsEndpoint\PsEndpointRepository;
+use Ivoz\Core\Domain\Service\EntityTools;
+use Ivoz\Provider\Domain\Model\User\UserInterface;
+use Ivoz\Provider\Domain\Service\User\UserLifecycleEventHandlerInterface;
+
+class UpdateByUserTerminalUnassignment implements UserLifecycleEventHandlerInterface
+{
+    public function __construct(
+        private EntityTools $entityTools,
+        private PsEndpointRepository $psEndpointRepository
+    ) {
+    }
+
+    /** @return array<array-key, int> */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            self::EVENT_POST_PERSIST => self::PRIORITY_NORMAL
+        ];
+    }
+
+    /**
+     * @return void
+     */
+    public function execute(UserInterface $user)
+    {
+        $terminalChanged = $user->hasChanged('terminalId');
+        if (!$terminalChanged) {
+            return;
+        }
+
+        $originalTerminalId = $user->getInitialValue('terminalId');
+        if (!$originalTerminalId) {
+            return;
+        }
+
+        $endpoint = $this->psEndpointRepository->findOneByTerminalId(
+            (int) $originalTerminalId
+        );
+
+        if (!$endpoint) {
+            return;
+        }
+
+        /** @var PsEndpointDto $endpointDto */
+        $endpointDto = $this
+            ->entityTools
+            ->entityToDto($endpoint);
+
+        $endpointDto
+            ->setCallerid(null)
+            ->setMailboxes(null)
+            ->setHintExtension(null)
+            ->setNamedPickupGroup(null)
+            ->setExtension(null);
+
+        $this
+            ->entityTools
+            ->persistDto($endpointDto, $endpoint, false);
+    }
+}

--- a/library/Ivoz/Provider/Domain/Service/User/UserLifecycleServiceCollection.php
+++ b/library/Ivoz/Provider/Domain/Service/User/UserLifecycleServiceCollection.php
@@ -23,12 +23,14 @@ class UserLifecycleServiceCollection implements LifecycleServiceCollectionInterf
             \Ivoz\Provider\Domain\Service\User\UnsetBossAssistant::class => 30,
             \Ivoz\Ast\Domain\Service\PsEndpoint\UpdateByUser::class => 40,
             \Ivoz\Provider\Domain\Service\Voicemail\UpdateByUser::class => 100,
+            \Ivoz\Ast\Domain\Service\PsEndpoint\UpdateByUserTerminalUnassignment::class => 200,
             \Ivoz\Ast\Domain\Service\QueueMember\UpdateByUser::class => 200,
             \Ivoz\Provider\Domain\Service\Contact\UpdateByUser::class => 200,
         ],
         "post_remove" =>
         [
             \Ivoz\Provider\Domain\Service\Extension\UpdateByUser::class => 10,
+            \Ivoz\Ast\Domain\Service\PsEndpoint\UpdateByUserDeleted::class => 200,
         ],
         "error_handler" =>
         [

--- a/library/spec/Ivoz/Ast/Domain/Service/PsEndpoint/UpdateByUserDeletedSpec.php
+++ b/library/spec/Ivoz/Ast/Domain/Service/PsEndpoint/UpdateByUserDeletedSpec.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace spec\Ivoz\Ast\Domain\Service\PsEndpoint;
+
+use Ivoz\Ast\Domain\Model\PsEndpoint\PsEndpointDto;
+use Ivoz\Ast\Domain\Model\PsEndpoint\PsEndpointInterface;
+use Ivoz\Ast\Domain\Service\PsEndpoint\UpdateByUserDeleted;
+use Ivoz\Core\Domain\Service\EntityTools;
+use Ivoz\Provider\Domain\Model\User\UserInterface;
+use Ivoz\Provider\Domain\Model\Voicemail\VoicemailInterface;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use spec\HelperTrait;
+
+class UpdateByUserDeletedSpec extends ObjectBehavior
+{
+    use HelperTrait;
+
+    /**
+     * @var EntityTools
+     */
+    protected $entityTools;
+
+    /////////////////////////////////
+    ///
+    /////////////////////////////////
+
+    /**
+     * @var UserInterface
+     */
+    protected $user;
+
+    /**
+     * @var PsEndpointInterface
+     */
+    protected $psEndpoint;
+
+    /**
+     * @var PsEndpointDto
+     */
+    protected $psEndpointDto;
+
+    public function let(
+        EntityTools $entityTools
+    ) {
+        $this->entityTools = $entityTools;
+
+        $this->beConstructedWith($entityTools);
+
+        $this->prepareExecution();
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(UpdateByUserDeleted::class);
+    }
+
+    function it_returns_on_empty_endpoint()
+    {
+        $this
+            ->user
+            ->getEndpoint()
+            ->willReturn(null)
+            ->shouldBeCalled();
+
+        $this
+            ->entityTools
+            ->entityToDto(
+                Argument::any()
+            )
+            ->shouldNotBeCalled();
+
+        $this->execute($this->user);
+    }
+
+    function it_sets_callerid()
+    {
+        $this
+            ->psEndpointDto
+            ->setCallerid(null)
+            ->willReturn($this->psEndpointDto)
+            ->shouldBeCalled();
+
+        $this->execute($this->user);
+    }
+
+    function it_sets_voicemail()
+    {
+        $this
+            ->psEndpointDto
+            ->setMailboxes(null)
+            ->willReturn($this->psEndpointDto)
+            ->shouldBeCalled();
+
+        $this->execute($this->user);
+    }
+
+    function it_sets_hint_extension()
+    {
+        $this
+            ->psEndpointDto
+            ->setHintExtension(null)
+            ->willReturn($this->psEndpointDto)
+            ->shouldBeCalled();
+
+        $this->execute($this->user);
+    }
+
+    function it_sets_named_pickup_group()
+    {
+        $this
+            ->psEndpointDto
+            ->setNamedPickupGroup(null)
+            ->willReturn($this->psEndpointDto)
+            ->shouldBeCalled();
+
+        $this->execute($this->user);
+    }
+
+    function it_sets_extension()
+    {
+        $this
+            ->psEndpointDto
+            ->setExtension(null)
+            ->willReturn($this->psEndpointDto)
+            ->shouldBeCalled();
+
+        $this->execute($this->user);
+    }
+
+    function prepareExecution()
+    {
+        $this->user = $this->getTestDouble(
+            UserInterface::class
+        );
+        $this->psEndpoint = $this->getTestDouble(
+            PsEndpointInterface::class
+        );
+        $this->psEndpointDto = $this->getTestDouble(
+            PsEndpointDto::class
+        );
+
+        $this
+            ->user
+            ->getEndpoint()
+            ->willReturn($this->psEndpoint);
+
+        $this
+            ->entityTools
+            ->entityToDto($this->psEndpoint)
+            ->willReturn($this->psEndpointDto);
+
+        $this
+            ->entityTools
+            ->persistDto(
+                $this->psEndpointDto,
+                $this->psEndpoint,
+                false
+            )
+            ->willReturn($this->psEndpoint);
+    }
+}

--- a/library/spec/Ivoz/Ast/Domain/Service/PsEndpoint/UpdateByUserTerminalUnassignmentSpec.php
+++ b/library/spec/Ivoz/Ast/Domain/Service/PsEndpoint/UpdateByUserTerminalUnassignmentSpec.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace spec\Ivoz\Ast\Domain\Service\PsEndpoint;
+
+use Ivoz\Ast\Domain\Model\PsEndpoint\PsEndpointDto;
+use Ivoz\Ast\Domain\Model\PsEndpoint\PsEndpointInterface;
+use Ivoz\Ast\Domain\Model\PsEndpoint\PsEndpointRepository;
+use Ivoz\Ast\Domain\Service\PsEndpoint\UpdateByUserTerminalUnassignment;
+use Ivoz\Core\Domain\Service\EntityTools;
+use Ivoz\Provider\Domain\Model\User\UserInterface;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use spec\HelperTrait;
+
+class UpdateByUserTerminalUnassignmentSpec extends ObjectBehavior
+{
+    use HelperTrait;
+
+    /**
+     * @var EntityTools
+     */
+    protected $entityTools;
+
+    /**
+     * @var EntityTools
+     */
+    protected $psEndpointRepository;
+
+    /////////////////////////////////
+    ///
+    /////////////////////////////////
+
+    /**
+     * @var UserInterface
+     */
+    protected $user;
+
+    /**
+     * @var PsEndpointInterface
+     */
+    protected $psEndpoint;
+
+    /**
+     * @var PsEndpointDto
+     */
+    protected $psEndpointDto;
+
+    public function let(
+        EntityTools $entityTools,
+        PsEndpointRepository $psEndpointRepository
+    ) {
+        $this->entityTools = $entityTools;
+        $this->psEndpointRepository = $psEndpointRepository;
+
+        $this->beConstructedWith(
+            $entityTools,
+            $psEndpointRepository
+        );
+
+        $this->prepareExecution();
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(UpdateByUserTerminalUnassignment::class);
+    }
+
+    function it_returns_on_unchanged_terminal()
+    {
+        $this
+            ->user
+            ->hasChanged('terminalId')
+            ->willReturn(false)
+            ->shouldBeCalled();
+
+        $this
+            ->entityTools
+            ->entityToDto(
+                Argument::any()
+            )
+            ->shouldNotBeCalled();
+
+        $this->execute($this->user);
+    }
+
+    function it_returns_on_invalid_endpoint()
+    {
+        $this
+            ->user
+            ->hasChanged('terminalId')
+            ->willReturn(true)
+            ->shouldBeCalled();
+
+        $this
+            ->user
+            ->getInitialValue('terminalId')
+            ->willReturn(null)
+            ->shouldBeCalled();
+
+        $this
+            ->entityTools
+            ->entityToDto(
+                Argument::any()
+            )
+            ->shouldNotBeCalled();
+
+        $this->execute($this->user);
+    }
+
+    function it_updates_ps_endpoint()
+    {
+        $this
+            ->user
+            ->hasChanged('terminalId')
+            ->willReturn(true)
+            ->shouldBeCalled();
+
+        $this
+            ->user
+            ->getInitialValue('terminalId')
+            ->willReturn(1)
+            ->shouldBeCalled();
+
+        $this
+            ->psEndpointRepository
+            ->findOneByTerminalId(1)
+            ->willReturn($this->psEndpoint)
+            ->shouldBeCalled();
+
+        $this
+            ->entityTools
+            ->entityToDto($this->psEndpoint)
+            ->willReturn($this->psEndpointDto);
+
+        $this
+            ->psEndpointDto
+            ->setCallerid(null)
+            ->willReturn($this->psEndpointDto)
+            ->shouldBeCalled();
+
+        $this
+            ->psEndpointDto
+            ->setMailboxes(null)
+            ->willReturn($this->psEndpointDto)
+            ->shouldBeCalled();
+
+        $this
+            ->psEndpointDto
+            ->setHintExtension(null)
+            ->willReturn($this->psEndpointDto)
+            ->shouldBeCalled();
+
+        $this
+            ->psEndpointDto
+            ->setNamedPickupGroup(null)
+            ->willReturn($this->psEndpointDto)
+            ->shouldBeCalled();
+
+        $this
+            ->entityTools
+            ->persistDto(
+                $this->psEndpointDto,
+                $this->psEndpoint,
+                false
+            )
+            ->willReturn($this->psEndpoint);
+
+        $this->execute($this->user);
+    }
+
+    function prepareExecution()
+    {
+        $this->user = $this->getTestDouble(
+            UserInterface::class
+        );
+        $this->psEndpoint = $this->getTestDouble(
+            PsEndpointInterface::class
+        );
+        $this->psEndpointDto = $this->getTestDouble(
+            PsEndpointDto::class
+        );
+
+        $this
+            ->user
+            ->getEndpoint()
+            ->willReturn($this->psEndpoint);
+
+        $this
+            ->entityTools
+            ->entityToDto($this->psEndpoint)
+            ->willReturn($this->psEndpointDto);
+
+        $this
+            ->entityTools
+            ->persistDto(
+                $this->psEndpointDto,
+                $this->psEndpoint,
+                false
+            )
+            ->willReturn($this->psEndpoint);
+    }
+}


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, portal/platform, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
PsEndpoint asterisk table is populated from Terminals, but some  fields are taken from the user (like extension, pickupgroups, etc).
When User changes its terminal or it's deleted, these fields were not being updated.
This PR should fix that setting those fields to null

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
