### PR TITLE
asterisk: fix wrong endpoint identify in single IP standalone installs

### DIFF
--- a/asterisk/config/pjsip.conf.in
+++ b/asterisk/config/pjsip.conf.in
@@ -4,7 +4,7 @@
 [global]
 type=global
 user_agent=Irontec IvozProvider v4.1
-endpoint_identifier_order=ip,header,username,anonymous
+endpoint_identifier_order=header,ip
 mwi_disable_initial_unsolicited=yes
 
 ;;

--- a/debian/ivozprovider.postinst
+++ b/debian/ivozprovider.postinst
@@ -98,7 +98,6 @@ function setup_proxies()
         sed -i -e '/#!define SIPS_PORT/c\#!define SIPS_PORT 7061' /etc/kamailio/proxytrunks/kamailio.cfg
         sed -i -e '/modparam("dmq", "server_address"/c\modparam("dmq", "server_address", "sip:trunks.ivozprovider.local:7060")' /etc/kamailio/proxytrunks/kamailio.cfg
         sed -i -e '/contact=sip:trunks.ivozprovider.local/c\contact=sip:trunks.ivozprovider.local:7060' /etc/asterisk/pjsip.conf
-        sed -i -e '/endpoint_identifier_order=ip,contact,username,anonymous/c\endpoint_identifier_order=contact,ip,username,anonymous' /etc/asterisk/pjsip.conf
     else
         sed -i -e '/#!define TRUNKS_SIP_PORT/c\#!define TRUNKS_SIP_PORT 5060' /etc/kamailio/proxyusers/kamailio.cfg
         sed -i -e '/modparam("dmq", "notification_address"/c\modparam("dmq", "notification_address", "sip:trunks.ivozprovider.local:5060")' /etc/kamailio/proxyusers/kamailio.cfg
@@ -106,7 +105,6 @@ function setup_proxies()
         sed -i -e '/#!define SIPS_PORT/c\#!define SIPS_PORT 5061' /etc/kamailio/proxytrunks/kamailio.cfg
         sed -i -e '/modparam("dmq", "server_address"/c\modparam("dmq", "server_address", "sip:trunks.ivozprovider.local:5060")' /etc/kamailio/proxytrunks/kamailio.cfg
         sed -i -e '/contact=sip:trunks.ivozprovider.local/c\contact=sip:trunks.ivozprovider.local' /etc/asterisk/pjsip.conf
-        sed -i -e '/endpoint_identifier_order=contact,ip,username,anonymous/c\endpoint_identifier_order=ip,contact,username,anonymous' /etc/asterisk/pjsip.conf
     fi
 }
 


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, portal/platform, kamusers, agis, ..)
- [X] Changes have been tested locally
- [X] Fixes an existing issue (Fixes #1959) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
Change how endpoints are intified by asterisk. Request from kamailio proxyusers have an X-Info-Endpoint header, while requrest from kamailio proxytrunks will be identified by IP address.

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
