### PR TITLE
agis: fix on demand record code on simple huntgroups

### DIFF
--- a/asterisk/agi/src/Agi/Action/HuntGroupCallAction.php
+++ b/asterisk/agi/src/Agi/Action/HuntGroupCallAction.php
@@ -64,6 +64,11 @@ class HuntGroupCallAction
             $options .= "c";
         }
 
+        // For record asterisk builtin feature code (FIXME Dont use both X's)
+        if ($huntGroup->getCompany()->getOnDemandRecord() == 2) {
+            $options .= "xX";
+        }
+
         // Call the PSJIP endpoint
         $this->agi->setVariable("DIAL_DST", $endpointName);
         $this->agi->setVariable("DIAL_TIMEOUT", $timeout);

--- a/asterisk/agi/src/Dialplan/Trunks.php
+++ b/asterisk/agi/src/Dialplan/Trunks.php
@@ -94,14 +94,9 @@ class Trunks extends RouteHandlerAbstract
         $this->agi->setVariable("__COMPANYID", $company->getId());
         $this->agi->setVariable("__COMPANYTYPE", $company->getType());
         $this->agi->setVariable("__BRANDID", $brand->getId());
-        $this->agi->setVariable("__ONDEMANDCODE", $company->getOnDemandRecordCode());
+        $this->agi->setVariable("__ONDEMANDCODE", $company->getOnDemandRecordDTMFs());
         $this->agi->setVariable("CHANNEL(musicclass)", $company->getMusicClass());
         $this->agi->setVariable("CHANNEL(language)", $ddi->getLanguageCode());
-
-        // Check company On demand record code
-        if ($company->getOnDemandRecord()) {
-            $this->agi->setVariable("FEATUREMAP(automixmon)", $company->getOnDemandRecordDTMFs());
-        }
 
         // Set DDI as the caller
         $this->channelInfo->setChannelCaller(new DdiAgent($this->agi, $ddi));

--- a/asterisk/agi/src/Dialplan/Users.php
+++ b/asterisk/agi/src/Dialplan/Users.php
@@ -160,7 +160,7 @@ class Users extends RouteHandlerAbstract
         $this->agi->setVariable("__COMPANYID", $company->getId());
         $this->agi->setVariable("__COMPANYTYPE", $company->getType());
         $this->agi->setVariable("__BRANDID", $brand->getId());
-        $this->agi->setVariable("__ONDEMANDCODE", $company->getOnDemandRecordCode());
+        $this->agi->setVariable("__ONDEMANDCODE", $company->getOnDemandRecordDTMFs());
 
         // Mark this call as generated from user
         $this->agi->setVariable("__CALL_TYPE", "internal");


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, portal/platform, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
To enable builtin automixmon features, Dial application require xX flags (most probably only x is required) and also setting the DTMF code including * in "FEATUREMAP(automixmon)" variable.

This PR add the missing options to Dial used by simple HuntGroups and fixes the code not having the * prefix proprely defined in feature map variable.


#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
