### PR TITLE
Selected single proxyTrunk choice

### DIFF
--- a/web/portal/brand/src/entities/Carrier/Carrier.tsx
+++ b/web/portal/brand/src/entities/Carrier/Carrier.tsx
@@ -81,6 +81,7 @@ const properties: CarrierProperties = {
   proxyTrunk: {
     label: _('Local socket'),
     helpText: _('Local address used in SIP signalling with this carrier.'),
+    default: '__null__',
   },
 };
 

--- a/web/portal/brand/src/entities/Carrier/Form.tsx
+++ b/web/portal/brand/src/entities/Carrier/Form.tsx
@@ -4,14 +4,16 @@ import {
   FieldsetGroups,
 } from '@irontec/ivoz-ui/entities/DefaultEntityBehavior';
 import { Form as DefaultEntityForm } from '@irontec/ivoz-ui/entities/DefaultEntityBehavior/Form';
+import { useFormHandler } from '@irontec/ivoz-ui/entities/DefaultEntityBehavior/Form/useFormHandler';
 import _ from '@irontec/ivoz-ui/services/translations/translate';
 import { useStoreState } from 'store';
 
 import { ClientFeatures } from '../Company/ClientFeatures';
 import { foreignKeyGetter } from './ForeignKeyGetter';
+import { useDefaultProxyTrunk } from './hooks/useDefaultProxyTrunk';
 
 const Form = (props: EntityFormProps): JSX.Element => {
-  const { entityService, row, match } = props;
+  const { create, entityService, row, match } = props;
   const fkChoices = useFkChoices({
     foreignKeyGetter,
     entityService,
@@ -19,6 +21,12 @@ const Form = (props: EntityFormProps): JSX.Element => {
     match,
   });
 
+  const formik = useFormHandler(props);
+  useDefaultProxyTrunk({
+    create,
+    formik,
+    choices: fkChoices.proxyTrunk,
+  });
   const aboutMe = useStoreState((state) => state.clientSession.aboutMe.profile);
   const hasBillingFeature = aboutMe?.features.includes(ClientFeatures.billing);
 
@@ -42,7 +50,14 @@ const Form = (props: EntityFormProps): JSX.Element => {
     },
   ];
 
-  return <DefaultEntityForm {...props} fkChoices={fkChoices} groups={groups} />;
+  return (
+    <DefaultEntityForm
+      {...props}
+      formik={formik}
+      fkChoices={fkChoices}
+      groups={groups}
+    />
+  );
 };
 
 export default Form;

--- a/web/portal/brand/src/entities/Carrier/hooks/useDefaultProxyTrunk.tsx
+++ b/web/portal/brand/src/entities/Carrier/hooks/useDefaultProxyTrunk.tsx
@@ -1,0 +1,34 @@
+import {
+  DropdownArrayChoice,
+  NullablePropertyFkChoices,
+  useFormikType,
+} from '@irontec/ivoz-ui';
+import { useEffect } from 'react';
+
+interface useProxyTrunkProps {
+  create?: boolean;
+  formik: useFormikType;
+  choices?: NullablePropertyFkChoices;
+}
+
+export const useDefaultProxyTrunk = (props: useProxyTrunkProps): void => {
+  const { create, formik, choices } = props;
+
+  useEffect(() => {
+    if (!create) {
+      return;
+    }
+
+    const hasSingleChoice = choices?.length === 1;
+    if (!hasSingleChoice) {
+      return;
+    }
+
+    if (formik.values.proxyTrunk !== '__null__') {
+      return;
+    }
+
+    const fkId = (choices[0] as DropdownArrayChoice).id;
+    formik.setFieldValue('proxyTrunk', fkId);
+  }, [formik, choices, create]);
+};

--- a/web/portal/brand/src/entities/DdiProvider/DdiProvider.tsx
+++ b/web/portal/brand/src/entities/DdiProvider/DdiProvider.tsx
@@ -24,6 +24,7 @@ const properties: DdiProviderProperties = {
   proxyTrunk: {
     label: _('Local socket'),
     helpText: _('Local address used in SIP signalling with this DDI Provider.'),
+    default: '__null__',
   },
   mediaRelaySets: {
     label: _('Media relay Set'),

--- a/web/portal/brand/src/entities/DdiProvider/Form.tsx
+++ b/web/portal/brand/src/entities/DdiProvider/Form.tsx
@@ -4,17 +4,26 @@ import {
   FieldsetGroups,
 } from '@irontec/ivoz-ui/entities/DefaultEntityBehavior';
 import { Form as DefaultEntityForm } from '@irontec/ivoz-ui/entities/DefaultEntityBehavior/Form';
+import { useFormHandler } from '@irontec/ivoz-ui/entities/DefaultEntityBehavior/Form/useFormHandler';
 import _ from '@irontec/ivoz-ui/services/translations/translate';
 
 import { foreignKeyGetter } from './ForeignKeyGetter';
+import { useDefaultProxyTrunk } from './hooks/useDefaultProxyTrunk';
 
 const Form = (props: EntityFormProps): JSX.Element => {
-  const { entityService, row, match } = props;
+  const { entityService, row, match, create } = props;
   const fkChoices = useFkChoices({
     foreignKeyGetter,
     entityService,
     row,
     match,
+  });
+
+  const formik = useFormHandler(props);
+  useDefaultProxyTrunk({
+    create,
+    formik,
+    choices: fkChoices.proxyTrunk,
   });
 
   const groups: Array<FieldsetGroups | false> = [
@@ -33,7 +42,14 @@ const Form = (props: EntityFormProps): JSX.Element => {
     },
   ];
 
-  return <DefaultEntityForm {...props} fkChoices={fkChoices} groups={groups} />;
+  return (
+    <DefaultEntityForm
+      {...props}
+      formik={formik}
+      fkChoices={fkChoices}
+      groups={groups}
+    />
+  );
 };
 
 export default Form;

--- a/web/portal/brand/src/entities/DdiProvider/hooks/useDefaultProxyTrunk.tsx
+++ b/web/portal/brand/src/entities/DdiProvider/hooks/useDefaultProxyTrunk.tsx
@@ -1,0 +1,34 @@
+import {
+  DropdownArrayChoice,
+  NullablePropertyFkChoices,
+  useFormikType,
+} from '@irontec/ivoz-ui';
+import { useEffect } from 'react';
+
+interface useProxyTrunkProps {
+  create?: boolean;
+  formik: useFormikType;
+  choices?: NullablePropertyFkChoices;
+}
+
+export const useDefaultProxyTrunk = (props: useProxyTrunkProps): void => {
+  const { create, formik, choices } = props;
+
+  useEffect(() => {
+    if (!create) {
+      return;
+    }
+
+    const hasSingleChoice = choices?.length === 1;
+    if (!hasSingleChoice) {
+      return;
+    }
+
+    if (formik.values.proxyTrunk !== '__null__') {
+      return;
+    }
+
+    const fkId = (choices[0] as DropdownArrayChoice).id;
+    formik.setFieldValue('proxyTrunk', fkId);
+  }, [formik, choices, create]);
+};


### PR DESCRIPTION
Added logic for automatically selecting proxyTrunk in Carrier and DdiProvider when there's only one option available.

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, portal/platform, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
<!-- Describe your changes in detail -->

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
