### PR TITLE
Fixed webPortal logo load

### DIFF
--- a/library/Ivoz/Provider/Application/Service/WebPortal/GetLogoPath.php
+++ b/library/Ivoz/Provider/Application/Service/WebPortal/GetLogoPath.php
@@ -40,7 +40,9 @@ class GetLogoPath
         );
 
         $baseName = $webPortalDto->getLogoBaseName();
-        if ($logoName !== $baseName) {
+        $decodedLogoName = urldecode($logoName);
+
+        if ($decodedLogoName !== $baseName) {
             throw new \RuntimeException(
                 'Logo name missmatch',
                 404


### PR DESCRIPTION
Fixed webPortal logo load when requested logName contains character not valid in an URL

#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, portal/platform, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
<!-- Describe your changes in detail -->

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
