### PR TITLE
kamailio: avoid short callid collisions

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -284,7 +284,7 @@ modparam("acc", "cdr_on_failed", 0)
 modparam("acc", "cdr_expired_dlg_enable", 1)
 modparam("acc", "cdr_start_on_confirmed", 1)
 modparam("acc", "cdr_facility", "LOG_LOCAL3")
-modparam("acc", "cdr_extra", "brandId=$dlg_var(brandId);companyId=$dlg_var(companyId);caller=$dlg_var(caller);callee=$dlg_var(callee);callid=$dlg_var(callid);callidHash=$dlg_var(cidhash);xcallid=$dlg_var(xcallid);diversion=$dlg_var(diversion);carrierId=$dlg_var(carrierId);direction=$dlg_var(direction);bounced=$dlg_var(bounced);cgrid=$dlg_var(cgrid);retailAccountId=$dlg_var(retailAccountId);residentialDeviceId=$dlg_var(residentialDeviceId);parsed=$dlg_var(parsed);userId=$dlg_var(userId);friendId=$dlg_var(friendId);faxId=$dlg_var(faxId);ddiId=$dlg_var(ddiId);ddiProviderId=$dlg_var(ddiProviderId)")
+modparam("acc", "cdr_extra", "brandId=$dlg_var(brandId);companyId=$dlg_var(companyId);caller=$dlg_var(caller);callee=$dlg_var(callee);callid=$dlg_var(callidLong);callidHash=$dlg_var(cidhash);xcallid=$dlg_var(xcallid);diversion=$dlg_var(diversion);carrierId=$dlg_var(carrierId);direction=$dlg_var(direction);bounced=$dlg_var(bounced);cgrid=$dlg_var(cgrid);retailAccountId=$dlg_var(retailAccountId);residentialDeviceId=$dlg_var(residentialDeviceId);parsed=$dlg_var(parsed);userId=$dlg_var(userId);friendId=$dlg_var(friendId);faxId=$dlg_var(faxId);ddiId=$dlg_var(ddiId);ddiProviderId=$dlg_var(ddiProviderId)")
 modparam("acc", "cdr_extra_nullable", 1)
 
 # DIALOG
@@ -1804,6 +1804,12 @@ route[ACCOUNTING] {
     }
 
     $dlg_var(callid) = $ci;
+    if ($(ci{s.len}) < 20) {
+        $dlg_var(callidLong) = $ci + '-lengthen-' + $RANDOM + '.' + $RANDOM;
+        xwarn("[$dlg_var(cidhash)] ACCOUNTING: '$ci' is too short, save '$dlg_var(callidLong)' instead");
+    } else {
+        $dlg_var(callidLong) = $ci;
+    }
     $dlg_var(callee) = $rU;
 }
 

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -327,7 +327,7 @@ modparam("acc", "cdr_on_failed", 1)
 modparam("acc", "cdr_expired_dlg_enable", 1)
 modparam("acc", "cdr_start_on_confirmed", 1)
 modparam("acc", "cdr_facility", "LOG_LOCAL3")
-modparam("acc", "cdr_extra", "brandId=$dlg_var(brandId);companyId=$dlg_var(companyId);caller=$dlg_var(caller);callee=$dlg_var(callee);callid=$dlg_var(callid);callidHash=$dlg_var(cidhash);xcallid=$dlg_var(xcallid);diversion=$dlg_var(diversion);referrer=$dlg_var(referrer);referee=$dlg_var(referee);direction=$dlg_var(direction);userId=$dlg_var(userId);friendId=$dlg_var(friendId);responseCode=$dlg_var(responseCode)")
+modparam("acc", "cdr_extra", "brandId=$dlg_var(brandId);companyId=$dlg_var(companyId);caller=$dlg_var(caller);callee=$dlg_var(callee);callid=$dlg_var(callidLong);callidHash=$dlg_var(cidhash);xcallid=$dlg_var(xcallid);diversion=$dlg_var(diversion);referrer=$dlg_var(referrer);referee=$dlg_var(referee);direction=$dlg_var(direction);userId=$dlg_var(userId);friendId=$dlg_var(friendId);responseCode=$dlg_var(responseCode)")
 
 # DIALOG
 modparam("dialog", "dlg_flag", DLG_FLAG)
@@ -2436,6 +2436,12 @@ route[ACCOUNTING] {
     route(CHECK_SPECIAL);
 
     $dlg_var(callid) = $ci;
+    if ($(ci{s.len}) < 20) {
+        $dlg_var(callidLong) = $ci + '-lengthen-' + $RANDOM + '.' + $RANDOM;
+        xwarn("[$dlg_var(cidhash)] ACCOUNTING: '$ci' is too short, save '$dlg_var(callidLong)' instead");
+    } else {
+        $dlg_var(callidLong) = $ci;
+    }
 
     if (is_present_hf("Referred-by")) {
         $dlg_var(referrer) = $(hdr(Referred-by){nameaddr.uri}{uri.user});


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, portal/platform, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description

SIP callid header should be long and random enough to be globally unique over time. However, some poor SIP implementators generate too short callid (e.g. numeric 5 digits callids).


#### Additional information
This PR lengthen the callid saved in CDR fields whenever original callid is shorter than 20 characters, adding some random content.
