### PR TITLE
asterisk: add odbc configuration to override default results order

### DIFF
--- a/asterisk/config/res_config_odbc.conf
+++ b/asterisk/config/res_config_odbc.conf
@@ -1,0 +1,14 @@
+;
+; Sample configuration for res_config_odbc
+;
+; Most configuration occurs in the system ODBC configuration files,
+; res_odbc.conf, and extconfig.conf. You only need this file in the
+; event that you want to influence default sorting behavior.
+;
+
+[general]
+; When multiple rows are requested by realtime, res_config_odbc will add an
+; explicit ORDER BY clause to the generated SELECT statement. To prevent
+; that from occuring, set order_multi_row_results_by_initial_column to 'no'.
+;
+order_multi_row_results_by_initial_column=no


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, portal/platform, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
<!-- Describe your changes in detail -->
This PR introduces a change in how data is retrieved from ODBC to fix the members dial order in Linear Queues.
Before this change, members were called ordered by interface (actually extension in ivozprovider), rather than creation time as documented.


#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
