### PR TITLE
Default empty email in CallCsvScheduler

### DIFF
--- a/library/Ivoz/Provider/Domain/Model/CallCsvScheduler/CallCsvSchedulerAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/CallCsvScheduler/CallCsvSchedulerAbstract.php
@@ -66,7 +66,7 @@ abstract class CallCsvSchedulerAbstract
     /**
      * @var string
      */
-    protected $email;
+    protected $email = '';
 
     /**
      * @var ?\DateTime

--- a/library/Ivoz/Provider/Domain/Model/CallCsvScheduler/CallCsvSchedulerDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/CallCsvScheduler/CallCsvSchedulerDtoAbstract.php
@@ -47,7 +47,7 @@ abstract class CallCsvSchedulerDtoAbstract implements DataTransferObjectInterfac
     /**
      * @var string|null
      */
-    private $email = null;
+    private $email = '';
 
     /**
      * @var \DateTimeInterface|string|null

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/CallCsvScheduler.CallCsvSchedulerAbstract.orm.xml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/CallCsvScheduler.CallCsvSchedulerAbstract.orm.xml
@@ -31,6 +31,7 @@
     <field name="email" type="string" column="email" length="140" nullable="false">
       <options>
         <option name="fixed"/>
+        <option name="default"/>
       </options>
     </field>
     <field name="lastExecution" type="datetime" column="lastExecution" nullable="true"/>

--- a/schema/DoctrineMigrations/Version20241114091020.php
+++ b/schema/DoctrineMigrations/Version20241114091020.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Ivoz\Core\Infrastructure\Persistence\Doctrine\LoggableMigration;
+
+/**
+* Auto-generated Migration: Please modify to your needs!
+*/
+final class Version20241114091020 extends LoggableMigration
+{
+    public function getDescription(): string
+    {
+        return 'Added default empty string to email in CallCsvSchedulers';
+    }
+
+    public function up(Schema $schema): void
+    {
+    // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE CallCsvSchedulers CHANGE email email VARCHAR(140) DEFAULT \'\' NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE CallCsvSchedulers CHANGE email email VARCHAR(140) NOT NULL');
+    }
+}


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [X] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, portal/platform, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
Added default empty value for email in CallCsvScheduler

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
