### PR TITLE
kamusers: fix 302 handling in wss uac

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -471,6 +471,11 @@ request_route {
     # Wholesale request?
     if(allow_trusted($si, 'any') && $avp(wholesaleId) != $null) {
         xinfo("[$dlg_var(cidhash)] Initial request from wholesale 'c$avp(wholesaleId)'\n");
+        if (nat_uac_test(64)) {
+           xwarn("[$dlg_var(cidhash)] Wholesale using WSS, reject\n");
+           send_reply("400", "Invalid transport");
+           exit;
+        }
     }
 
     # Discard unsupported methods
@@ -2232,14 +2237,9 @@ route[REGISTER] {
 
 # Detect NAT
 route[NATDETECT] {
-    # 64 - Test if the source connection of signaling is WS
-    if (nat_uac_test(64)) {
-        route(WSFIX);
-        return;
-    }
     force_rport();
 
-    if (nat_uac_test("18")) {
+    if (nat_uac_test("18") || nat_uac_test(64)) {
         xinfo("[$dlg_var(cidhash)] NATDETECT: NAT detected\n");
         setflag(FLT_NATS);
 
@@ -2257,28 +2257,6 @@ route[NATDETECT] {
             }
         }
     }
-}
-
-route[WSFIX] {
-    if ($dlg_var(type) == 'wholesale') {
-       xwarn("[$dlg_var(cidhash)] WSFIX: Wholesale using WSS\n");
-       send_reply("400", "Invalid transport");
-       exit;
-    }
-    xinfo("[$dlg_var(cidhash)] WSFIX: Websockets detected, fix contact\n");
-    # Do NAT traversal stuff for requests from a WebSocket
-    # connection - even if it is not behind a NAT!
-    # This won't be needed in the future if Kamailio and the
-    # WebSocket client support Outbound and Path.
-    force_rport();
-    if (is_method("REGISTER")) {
-        fix_nated_register();
-    } else if (is_present_hf("Contact") && !set_contact_alias()) {
-        if($dlg_var(nolog) != "1") xerr("[$dlg_var(cidhash)] WSFIX: Error aliasing contact <$ct>\n");
-        send_reply("400", "Bad Request");
-        exit;
-    }
-    return;
 }
 
 # Handle NAT
@@ -2732,16 +2710,6 @@ onreply_route[MANAGE_REPLY] {
         route(REALTIME);
     }
     #!endif
-
-    # Manage WS
-    if (nat_uac_test(64)) { # 64 - Test if the source connection of signaling is WS
-        # Do NAT traversal stuff for replies to a WebSocket connection
-        # - even if it is not behind a NAT!
-        # This won't be needed in the future if Kamailio and the
-        # WebSocket client support Outbound and Path.
-        if (is_present_hf("Contact"))
-            set_contact_alias();
-    }
 }
 
 failure_route[MANAGE_FAILURE] {


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, portal/platform, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description

302 from UACs using WSS where incorrectly mangled, causing malformed Contact header to AS.

#### Additional information

This PR avoids `set_contact_alias()` in negative responses from UACs using WSS.