### PR TITLE
Fix ISO image Debian dependencies

### DIFF
--- a/debian/ivozprovider-profile-as.links
+++ b/debian/ivozprovider-profile-as.links
@@ -1,2 +1,1 @@
-/etc/odbcinst.ini.ivozprovider  /etc/odbcinst.ini
 /etc/odbc.ini.ivozprovider      /etc/odbc.ini

--- a/debian/ivozprovider-profile-as.postinst
+++ b/debian/ivozprovider-profile-as.postinst
@@ -44,11 +44,19 @@ function setup_default_dial_opts()
     sed -i -r "s/(DIAL_DEF_OPTS *= *).*/\1$DIAL_DEF_OPTS/"  /etc/asterisk/extensions.conf
 }
 
+function setup_odbcinst()
+{
+    if ! odbcinst -q -d -n "MYSQL" >/dev/null 2>&1; then
+        odbcinst -i -d -f /etc/odbcinst.ini.ivozprovider
+    fi
+}
+
 #######################################################################################################################
 #######################################################################################################################
 setup_php
 setup_mysql_access
 setup_fastagi_server
 setup_default_dial_opts
+setup_odbcinst
 
 :

--- a/doc/dev/AcceptedCommitTagsList.txt
+++ b/doc/dev/AcceptedCommitTagsList.txt
@@ -8,6 +8,7 @@ data
 doc
 docker
 feature
+iso
 kamailio
 kamtrunks
 kamusers

--- a/extra/simple-cdd/profiles/ivozprovider.downloads
+++ b/extra/simple-cdd/profiles/ivozprovider.downloads
@@ -4,6 +4,7 @@
 # libgnutls-openssl27
 # libgnutls30
 perl-openssl-defaults
+zstd
 
 # Main iso package
 ivozprovider


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, portal/platform, kamusers, agis, ..)
- [X] Changes have been tested locally
- [X] Fixes an existing issue (Fixes #2841) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
<!-- Describe your changes in detail -->
- Add zstd to extra explict Debian download packages 
- Fix ivozprovider-profile-as not installing because it required user confirmation to overwrite odbcinst.ini 

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
