### PR TITLE
kamailio: do not forward within-dlg INFO to AS-es (except DTMFs)

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -1546,6 +1546,12 @@ route[GET_INFO_FROM_COMPANY] {
 
 # Handle within-dialog messages
 route[WITHINDLG] {
+    # No INFO to AS-es (except DTMFs)
+    if (is_method("INFO") && !$var(is_from_inside) && $hdr(Content-Type) != "application/dtmf-relay") {
+        send_reply("200", "OK");
+        exit;
+    }
+
     # REFER not allowed
     if (is_method("REFER")) {
         xwarn("[$dlg_var(cidhash)] WITHINDLG: 'REFER' not supported\n");

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -1937,6 +1937,12 @@ route[WITHINDLG] {
         route(FIX_RURI);
     }
 
+    # No INFO to AS-es (except DTMFs)
+    if (is_method("INFO") && !$var(is_from_inside) && $hdr(Content-Type) != "application/dtmf-relay") {
+        send_reply("200", "OK");
+        exit;
+    }
+
     # sequential request withing a dialog should
     # take the path determined by record-routing
     if (loose_route()) {


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, portal/platform, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description

Asterisk does not reply to within dialog INFOs (except DTMFs). With this PR, these INFO will be answered in proxies.

