### PR TITLE
microservice/provision: fix specific provisoning mac comparisson

### DIFF
--- a/library/Ivoz/Provider/Domain/Service/Terminal/Provision/ProvisionSpecific.php
+++ b/library/Ivoz/Provider/Domain/Service/Terminal/Provision/ProvisionSpecific.php
@@ -166,6 +166,10 @@ class ProvisionSpecific
                 $fixedFileName = $fixedUrlSegments[0] . $fileNameMac . $fixedUrlSegments[1];
             }
 
+            $fixedFileName = $this->extractFileName(
+                $fixedFileName
+            );
+
             if (strtolower($fixedSpecificUrl) === strtolower($fixedFileName)) {
                 $extensionMismatch = ($fileExtension !== $specificUrlExtension);
                 if (!empty($specificUrlExtension) && $extensionMismatch) {


### PR DESCRIPTION
<!--
  - All pull requests must be done against main branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/main/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, portal/platform, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
Specific provisioning pattern matching is making a comparison based on the request's last segment, comparing the specificUrl in the Terminal Model with the request sent by the terminal. This comparison was being done by removing the extension (e.g., .cfg) from the terminal model's specificUrl, but not from the terminal's request. This was preventing the terminal from being found by its MAC address.

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
