### PR TITLE
[PROVIDER-2218] core: fix hasUniqueName (only for client CallCsvSchedulers)

### DIFF
--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/CallCsvSchedulerDoctrineRepository.php
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/CallCsvSchedulerDoctrineRepository.php
@@ -97,6 +97,7 @@ class CallCsvSchedulerDoctrineRepository extends ServiceEntityRepository impleme
         $criteria = CriteriaHelper::fromArray([
             ['id', 'neq', $callCsvScheduler->getId()],
             ['company', 'eq', $callCsvScheduler->getCompany()->getId()],
+            ['brand', 'isNull'],
             ['name', 'eq', $callCsvScheduler->getName()]
         ]);
 


### PR DESCRIPTION
<!--
  - All pull requests must be done against main branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/main/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, portal/platform, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description

Modified logic should only apply for client created CallCsvSchedulers. Its goal is to avoid duplicate names.

#### Additional information

Before this fix a collision between brand generated CallCsvSchedulers and client generated ones happened. With this fix, each level can have same names without causing any trouble.