### PR TITLE
[PROVIDER-2256] Update test-phpstan-update-baseline to avoid premature exit

### DIFF
--- a/library/bin/test-phpstan
+++ b/library/bin/test-phpstan
@@ -1,11 +1,9 @@
 #!/bin/bash
 
-set -e
-
 HOME=/opt/irontec/ivozprovider
 cd $HOME
 
-APPS=$(find $HOME -name composer.json ! -path '*/vendor/*' ! -path '*/composer-packages/*' ! -path "*/schema/*" -printf "%h\n")
+APPS=$(find $HOME -maxdepth 3 -name composer.json ! -path '*/vendor/*' ! -path '*/composer-packages/*' ! -path "*/schema/*" -printf "%h\n" | sort)
 
 for APP in $APPS; do
     [ -d "$APP/Ivoz" ] && TARGET="Ivoz" || TARGET="src"
@@ -20,6 +18,14 @@ for APP in $APPS; do
         --no-progress \
         --autoload-file ${APP}/vendor/autoload.php \
         --configuration ${APP}/phpstan.neon \
-        ${TARGET} $1
+        ${TARGET} $1 2>/dev/null
+
+    if [ $? -ne 0 ] && [ "$1" != "--generate-baseline" ]; then
+        echo "=========================================="
+        echo "PHPStan failed in $APP"
+        echo "=========================================="
+        exit 1
+    fi
+
     popd
 done

--- a/library/bin/test-phpstan-update-baseline
+++ b/library/bin/test-phpstan-update-baseline
@@ -3,3 +3,13 @@
 pushd /opt/irontec/ivozprovider/library/bin
   ./test-phpstan --generate-baseline
 popd
+
+pushd /opt/irontec/ivozprovider
+    if [ -n "$(git status --porcelain *phpstan-baseline.neon)" ]; then
+        echo "=============================================================================="
+        echo "Changes detected in following baselines:"
+        git status --porcelain *phpstan-baseline.neon
+        echo "=============================================================================="
+        exit 1
+    fi
+popd


### PR DESCRIPTION
<!--
  - All pull requests must be done against main branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/main/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, portal/platform, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
<!-- Describe your changes in detail -->
Before this change, test-phpstan-update-baseline stops on the first application that haves no errors in the baseline file (because having no error is considered an error when --generate-baseline flag is used). Configured phpstan version has no --allow-empty-baseline flag, so we workaround the scripts to check exit codes and generated files to properly check all symfony applications.

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
