### PR TITLE
[PROVIDER-2296] kamtrunks: fix socket for bounced calls

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -1710,6 +1710,7 @@ route[RELAY] {
         xinfo("[$dlg_var(cidhash)] RELAY: Bounce call to myself\n");
         $du = "sip:trunks.ivozprovider.local:" + SIP_PORT;
         $rd = "trunks.ivozprovider.local";
+        $fs = "udp:" + $var(trunksAddress) + ":" + SIP_PORT;
         $dlg_var(carrierId) = $null;
         $dlg_var(calculateCost) = "0";
     }
@@ -2371,7 +2372,9 @@ route[RTPENGINE_INTERFACES] {
     # first SDP of the initial INVITE transaction, rtpengine_offer() will be called (direction= is only needed in first rtpengine_offer)
     $dlg_var(firstRtpengineOfferDone) = 'yes';
 
-    if ($var(is_from_inside)) {
+    if ($dlg_var(bounced) == '1') {
+        $var(interfaces) = "direction=" + $var(trunksAddress) + " direction=" + $var(trunksAddress);
+    } else if ($var(is_from_inside)) {
         $var(interfaces) = "direction=" + $var(trunksAddress) + " direction=" + $dlg_var(externalSocket);
     } else {
         $var(interfaces) = "direction=" + $dlg_var(externalSocket) + " direction=" + $var(trunksAddress);


### PR DESCRIPTION
<!--
  - All pull requests must be done against main branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/main/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, portal/platform, kamusers, agis, ..)
- [x] Changes have been tested locally
- [x] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description

Use internal socket for bounced calls, instead of carrier external socket.

#### Additional information

This PR fixes one-way-audio in bounced calls depending on networking of given environment.