### PR TITLE
[PROVIDER-2307] kam: avoid while loops in hint validation search

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -105,7 +105,7 @@ version_table="kam_version"
 # This proxy implements gateway failover, increase branches max value to avoid "500 Forking capacity exceeded" errors
 max_branches=25
 
-max_while_loops=250
+max_while_loops=2500
 
 # Enable asynchronous framework (for delayed ACC inserts)
 async_workers=4

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -3219,16 +3219,20 @@ route[PRESENCE] {
 route[DISCARD_NONEXISTING_SUBS] {
     if (!is_method("SUBSCRIBE")) return;
 
-    sql_query("cb", "SELECT CONCAT('*', CS.code, RL.id) AS extension FROM RouteLocks RL INNER JOIN Companies C ON C.id = RL.companyId INNER JOIN CompanyServices CS ON CS.companyId = C.id WHERE C.id = '$dlg_var(companyId)' AND serviceId = 7 UNION SELECT number FROM Extensions E INNER JOIN Users U ON U.extensionId = E.id INNER JOIN Terminals T ON T.id = U.terminalId WHERE E.companyId = '$dlg_var(companyId)'", "hints");
+    $xavp(userhints) = $null;
 
-    if ($dbr(hints=>rows) > 0) {
-        $var(i) = 0;
-        while($var(i) < $dbr(hints=>rows)) {
-            if ($rU == $dbr(hints=>[$var(i),0])) {
-                return; # Hint exists, return
-            }
-            $var(i) = $var(i) + 1;
-        }
+    sql_xquery("cb", "SELECT number FROM Extensions E INNER JOIN Users U ON U.extensionId = E.id INNER JOIN Terminals T ON T.id = U.terminalId WHERE E.companyId = '$dlg_var(companyId)' AND number = '$rU'", "userhints");
+
+    if ($xavp(userhints=>number) != $null) {
+        return; # Hint exists, return
+    }
+
+    $xavp(lockhints) = $null;
+
+    sql_xquery("cb", "SELECT RL.id AS lockId FROM RouteLocks RL INNER JOIN Companies C ON C.id = RL.companyId INNER JOIN CompanyServices CS ON CS.companyId = C.id WHERE C.id = '$dlg_var(companyId)' AND serviceId = 7 AND CONCAT('*', CS.code, RL.id) = '$rU'", "lockhints");
+
+    if ($xavp(lockhints=>lockId) != $null) {
+        return; # Hint exists, return
     }
 
     #!ifdef WITH_PRESENCE_SUBBAN

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -114,7 +114,7 @@ log_stderror=no
 fork=yes
 version_table="kam_version"
 
-max_while_loops=250
+max_while_loops=2500
 
 # Enable asynchronous framework (for delayed ACC inserts)
 async_workers=4


### PR DESCRIPTION
<!--
  - All pull requests must be done against main branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/main/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, portal/platform, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description

Avoid large while loops in hint validation search, dividing the logic in 2 independent queries.

#### Additional information
`max_while_loop` has been increased from 250 to 2500 too.