### PR TITLE
[PROVIDER-2336] Fix asterisk sorcery configuration to avoid memory leaks

### DIFF
--- a/asterisk/config/sorcery.conf
+++ b/asterisk/config/sorcery.conf
@@ -3,15 +3,15 @@
 ;
 
 [res_pjsip]
-endpoint/cache = memory_cache,object_lifetime_maximum=120,expire_on_reload=yes,full_backend_cache=yes
+endpoint/cache = memory_cache,object_lifetime_stale=600,object_lifetime_maximum=1800,expire_on_reload=yes
 endpoint = config,pjsip.conf,criteria=type=endpoint
 endpoint = realtime,ps_endpoints
-aor/cache = memory_cache,object_lifetime_maximum=120,expire_on_reload=yes,full_backend_cache=yes
+aor/cache = memory_cache,expire_on_reload=yes,object_lifetime_maximum=1800,full_backend_cache=yes
 aor = config,pjsip.conf,criteria=type=aor
 aor = realtime,ps_aors
 voicemail = realtime,voicemail
 
 [res_pjsip_endpoint_identifier_ip]
-identify/cache = memory_cache,object_lifetime_maximum=120,expire_on_reload=yes,full_backend_cache=yes
+identify/cache = memory_cache,expire_on_reload=yes,object_lifetime_maximum=1800,full_backend_cache=yes
 identify = config,pjsip.conf,criteria=type=identify
 identify = realtime,ps_identify


### PR DESCRIPTION
Updated cache settings for endpoint and aor in sorcery.conf to increase object lifetime.

<!--
  - All pull requests must be done against main branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/main/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, portal/platform, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
<!-- Describe your changes in detail -->

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
