### PR TITLE
[PROVIDER-2361] fix specificUrlPattern logic

### DIFF
--- a/library/Ivoz/Provider/Domain/Service/Terminal/Provision/ProvisionSpecific.php
+++ b/library/Ivoz/Provider/Domain/Service/Terminal/Provision/ProvisionSpecific.php
@@ -152,7 +152,7 @@ class ProvisionSpecific
                 $terminalModel->getSpecificUrlPattern()
             );
             $specificUrlExtension = $this->extractFileExtension(
-                $specificUrlPattern
+                $terminalModel->getSpecificUrlPattern()
             );
             $fixedUrlSegments = explode('{mac}', strtolower($specificUrl), 2);
             $fixedSpecificUrl = str_ireplace('{mac}', (string) $candidate->getMac(), $specificUrl);
@@ -191,8 +191,12 @@ class ProvisionSpecific
         return null;
     }
 
-    protected function extractFileExtension(string $route): string
+    protected function extractFileExtension(string|null $route): string
     {
+        if (is_null($route)) {
+            return '';
+        }
+
         return pathinfo($route, PATHINFO_EXTENSION);
     }
 


### PR DESCRIPTION
<!--
  - All pull requests must be done against main branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/main/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, portal/platform, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description

#####  Problem

  When provisioning terminals via HTTPS, the system was executing specific templates regardless of the requested file extension. For example, requesting aabbccddeeff.config would execute
   the template as if aabbccddeeff.cfg was requested, even when the specificUrlPattern was set to {mac}.cfg.

#####  Root Cause

  In ProvisionSpecific::getTerminalByUrl(), the extension validation was comparing the requested URL extension against itself instead of comparing it against the extension defined in the
   terminal model's specificUrlPattern.




#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
#####  New Behavior

  • If specificUrlPattern is {mac}.cfg:
    • ✅ aabbccddeeff.cfg → Template executed
    • ❌ aabbccddeeff.other → 404 (terminal not found)
  • If specificUrlPattern is {mac} (no extension):
    • ✅ Any extension is accepted (expected behavior)
