### PR TITLE
[PROVIDER-2377] ci: add yarn.lock to portals cache calculation in pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,10 +38,10 @@ pipeline {
         BASE_BRANCH = getBaseBranch()
         JIRA_TICKET = getJiraTicket()
         HASH_BACK = getCurrentHash("asterisk/agi doc library microservices schema web/rest")
-        HASH_FRONT_PLATFORM = getCurrentHash("web/portal/platform")
-        HASH_FRONT_BRAND = getCurrentHash("web/portal/brand")
-        HASH_FRONT_CLIENT = getCurrentHash("web/portal/client")
-        HASH_FRONT_USER = getCurrentHash("web/portal/user")
+        HASH_FRONT_PLATFORM = getCurrentHash("web/portal/platform web/portal/yarn.lock")
+        HASH_FRONT_BRAND = getCurrentHash("web/portal/brand web/portal/yarn.lock")
+        HASH_FRONT_CLIENT = getCurrentHash("web/portal/client web/portal/yarn.lock")
+        HASH_FRONT_USER = getCurrentHash("web/portal/user web/portal/yarn.lock")
         HASH_FILE = "${JENKINS_HOME}/jobs/${JOB_NAME}/../cached_pipelines.txt"
         MAX_HASHES = 400
     }


### PR DESCRIPTION
<!--
  - All pull requests must be done against main branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [X] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/main/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, portal/platform, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
<!-- Describe your changes in detail -->

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
