### PR TITLE
[PROVIDER-2415] PROVIDER-2415 Fix Kamailio trunk interfaces not updating on carrier failover

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -2148,6 +2148,7 @@ failure_route[MANAGE_FAILURE_GW] {
     $var(rtEvent) = 'Terminated';
     route(REALTIME);
     #!endif
+    $dlg_var(firstRtpengineOfferDone) = $null;
     route(SELECT_NEXT_GW);
     route(RELAY);
 }


### PR DESCRIPTION
## Summary
Fixes an issue where Kamailio trunks were not updating interfaces during carrier failover.

## Jira
PROVIDER-2415