### PR TITLE
[PROVIDER-2441] kamtrunks: add ddiId to realtime redis key

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -1969,19 +1969,19 @@ route[RT_NEWCALL] {
     if($dlg_var(direction) == 'outbound') {
         if ($dlg_var(carrierId) != $null) {
             sql_xquery("cb", "SELECT name FROM Carriers WHERE id=$dlg_var(carrierId)", "cs");
-            $dlg_var(rtChannel) = 'trunks' + ':b' + $dlg_var(brandId) + ':c' + $dlg_var(companyId) + ':cr' + $dlg_var(carrierId) + ':' + $ci;
+            $dlg_var(rtChannel) = 'trunks' + ':b' + $dlg_var(brandId) + ':c' + $dlg_var(companyId) + ':ddi' + $dlg_var(ddiId) + ':cr' + $dlg_var(carrierId) + ':' + $ci;
             jansson_set("string", "Carrier", "$xavp(cs=>name)", "$var(rtValue)");
         } else {
-            $dlg_var(rtChannel) = 'trunks' + ':b' + $dlg_var(brandId) + ':c' + $dlg_var(companyId) + ':cr0:' + $ci;
+            $dlg_var(rtChannel) = 'trunks' + ':b' + $dlg_var(brandId) + ':c' + $dlg_var(companyId) + ':ddi' + $dlg_var(ddiId) + ':cr0:' + $ci;
             jansson_set("string", "Carrier", "", "$var(rtValue)");
         }
     } else {
         if ($dlg_var(ddiProviderId) != $null) {
             sql_xquery("cb", "SELECT name FROM DDIProviders WHERE id=$dlg_var(ddiProviderId)", "dp");
-            $dlg_var(rtChannel) = 'trunks' + ':b' + $dlg_var(brandId) + ':c' + $dlg_var(companyId) + ':dp' + $dlg_var(ddiProviderId) + ':' + $ci;
+            $dlg_var(rtChannel) = 'trunks' + ':b' + $dlg_var(brandId) + ':c' + $dlg_var(companyId) + ':ddi' + $dlg_var(ddiId) + ':dp' + $dlg_var(ddiProviderId) + ':' + $ci;
             jansson_set("string", "DdiProvider", "$xavp(dp=>name)", "$var(rtValue)");
         } else {
-            $dlg_var(rtChannel) = 'trunks' + ':b' + $dlg_var(brandId) + ':c' + $dlg_var(companyId) + ':dp0:' + $ci;
+            $dlg_var(rtChannel) = 'trunks' + ':b' + $dlg_var(brandId) + ':c' + $dlg_var(companyId) + ':ddi' + $dlg_var(ddiId) + ':dp0:' + $ci;
             jansson_set("string", "DdiProvider", "", "$var(rtValue)");
         }
     }


### PR DESCRIPTION
<!--
  - All pull requests must be done against main branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/main/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, portal/platform, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description

Add ddiId to redis realtime key.

#### Additional information

This is necessary for upcoming ddi based webhooks.
