### PR TITLE
pkg: configure click2call password in postinstall

### DIFF
--- a/debian/ivozprovider-click2call.install
+++ b/debian/ivozprovider-click2call.install
@@ -1,2 +1,4 @@
-microservices/click2call/originate  /opt/irontec/ivozprovider/microservices/click2call/
-microservices/click2call/configs /opt/irontec/ivozprovider/microservices/click2call/
+#!/usr/bin/dh-exec
+
+microservices/click2call/originate /opt/irontec/ivozprovider/microservices/click2call/
+microservices/click2call/configs/config.yml.dist => /opt/irontec/ivozprovider/microservices/click2call/configs/config.yml

--- a/debian/ivozprovider-click2call.postinst
+++ b/debian/ivozprovider-click2call.postinst
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+#DEBHELPER#
+
+# Source debconf library.
+. /usr/share/debconf/confmodule
+
+#######################################################################################################################
+#######################################################################################################################
+function setup_mysql_password()
+{
+    # Setup mysql password
+    db_get ivozprovider/mysql_password || true
+    sed -r -i "s/password:[[:space:]]*\"changeme\"/password: \"$RET\"/g" \
+        /opt/irontec/ivozprovider/microservices/click2call/configs/config.yml
+}
+
+#######################################################################################################################
+#######################################################################################################################
+setup_mysql_password
+
+:


### PR DESCRIPTION
## Summary
- add `debian/ivozprovider-click2call.postinst` to replace `password: "changeme"` with the configured debconf mysql password
- update `debian/ivozprovider-click2call.install` to use `dh-exec` rename syntax
- install `microservices/click2call/configs/config.yml.dist` as `/opt/irontec/ivozprovider/microservices/click2call/configs/config.yml`

## Notes
- follows the same packaging pattern used in other microservices postinst scripts
