### PR TITLE
[PROVIDER-2473] click2call config postinstall and conffile

### DIFF
--- a/debian/ivozprovider-click2call.conffiles
+++ b/debian/ivozprovider-click2call.conffiles
@@ -1,0 +1,1 @@
+/opt/irontec/ivozprovider/microservices/click2call/configs/config.yml

--- a/debian/ivozprovider-click2call.postinst
+++ b/debian/ivozprovider-click2call.postinst
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+#DEBHELPER#
+
+# Source debconf library.
+. /usr/share/debconf/confmodule
+
+#######################################################################################################################
+#######################################################################################################################
+function setup_mysql_password()
+{
+    # Setup mysql password
+    db_get ivozprovider/mysql_password || true
+    sed -r -i "s/password:[[:space:]]*\"changeme\"/password: \"$RET\"/g" \
+        /opt/irontec/ivozprovider/microservices/click2call/configs/config.yml
+}
+
+#######################################################################################################################
+#######################################################################################################################
+function setup_digest_secret()
+{
+    local secret
+    secret=$(openssl rand -hex 32)
+    sed -i "s/secret:[[:space:]]*\"change-me-please\"/secret: \"$secret\"/" \
+        /opt/irontec/ivozprovider/microservices/click2call/configs/config.yml
+}
+
+#######################################################################################################################
+#######################################################################################################################
+setup_mysql_password
+setup_digest_secret
+
+:

--- a/microservices/click2call/.gitignore
+++ b/microservices/click2call/.gitignore
@@ -1,4 +1,2 @@
-# Real config with the digest secret and the DB password: use config.yml.dist as a template
-configs/config.yml
 # Compiled binary (anchored to the microservice root so it doesn't match cmd/originate/)
 /originate

--- a/microservices/click2call/configs/config.yml
+++ b/microservices/click2call/configs/config.yml
@@ -4,8 +4,8 @@
 server:
   listen: "0.0.0.0:9090"
   # If tls_cert and tls_key are empty, the service serves plain HTTP (to sit behind a TLS proxy).
-  tls_cert: ""
-  tls_key: ""
+  tls_cert: "/etc/ssl/certs/ivozprovider-portals.pem"
+  tls_key: "/etc/ssl/private/ivozprovider-portals.key"
   # CORS origins allowed for the browser extension. "*" = any.
   allowed_origins:
     - "*"
@@ -22,7 +22,7 @@ db:
   host: "data.ivozprovider.local"
   port: 3306
   name: "ivozprovider"
-  user: "click2call"
+  user: "root"
   password: "changeme"
 
 ami:


### PR DESCRIPTION
#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [X] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/main/doc/dev/en/commits.md)
- [X] Commits are split per component (schema, portal/platform, kamusers, agis, ..)
- [X] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
Implement packaging and postinstall configuration for `ivozprovider-click2call` aligned with `PROVIDER-2473`:

- add `debian/ivozprovider-click2call.postinst` to replace only `password: "changeme"` with the debconf mysql password in `/opt/irontec/ivozprovider/microservices/click2call/configs/config.yml`
- update `debian/ivozprovider-click2call.install` to install `config.yml.dist` directly as `config.yml` using `dh-exec`
- add `debian/ivozprovider-click2call.conffiles` so the installed click2call config is managed as a conffile
- set mysql user in `microservices/click2call/configs/config.yml.dist` to `root`

#### Additional information
Jira ticket: PROVIDER-2473
