### PR TITLE
[PROVIDER-2477] kamtrunks: force immediate rtp session removal after early-media

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -2150,6 +2150,7 @@ failure_route[MANAGE_FAILURE_GW] {
         exit;
     } else if (t_branch_timeout() && !t_branch_replied()) {
         route(INACTIVATE_GW);
+        route(RTPENGINE);
     } else if (t_check_status("3[0-9]{2}")) {
         xwarn("[$dlg_var(cidhash)] MANAGE-FAILURE-GW: $T_reply_code: Not allowed from GW\n");
     }
@@ -2162,9 +2163,15 @@ failure_route[MANAGE_FAILURE_GW] {
     #!endif
 
     # Try next gateway
-    route(RTPENGINE); # Free rtpengine session
-    $dlg_var(firstRtpengineOfferDone) = $null; # Reset flag
     route(SELECT_NEXT_GW);
+
+    # -- ensure previous rtpengine session is destroyed before using next gateway
+    $var(forceImmediateRemoval) = 1;
+    route(RTPENGINE);
+
+    # -- reset flag for new rtpengine session
+    $dlg_var(firstRtpengineOfferDone) = $null;
+
     route(RELAY);
 }
 
@@ -2362,6 +2369,12 @@ route[RTPENGINE] {
     }
 
     $var(rtpengine_opts) = 'replace-session-connection replace-origin ICE=remove RTP/AVP asymmetric trust-address';
+
+    # Negative responses should force media-session removal asap
+    if ($var(forceImmediateRemoval)) {
+        $var(rtpengine_opts) = $var(rtpengine_opts) + ' delete-delay=0';
+        $var(forceImmediateRemoval) = 0;
+    }
 
     $var(callid) = "call-id=trunks-" + $dlg_var(direction) + '-' + $dlg_var(callid);
 


### PR DESCRIPTION
<!--
  - All pull requests must be done against main branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/main/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, portal/platform, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description

Carrier failover retries after previous session with early-media (e.g. INVITE - 183 SDP - 403) should delete rtpengine session immediately before creating a new session for next carrier.

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
