### PR TITLE
[PROVIDER-2479] kamailio: improve mediaRelaySet selection logic

### DIFF
--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -1727,6 +1727,10 @@ route[RELAY] {
         $fs = "udp:" + $var(trunksAddress) + ":" + SIP_PORT;
         $dlg_var(carrierId) = $null;
         $dlg_var(calculateCost) = "0";
+
+        # No carrier involved: use the company's set instead of the one of the
+        # carrier SELECT_NEXT_GW happened to pick
+        $dlg_var(mediaRelaySetId) = $dlg_var(companyMediaRelaySetsId);
     }
 
     if ($(du{uri.host}) != $null) {

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -240,7 +240,6 @@ modparam("ctl", "binrpc", "unix:/run/kamailio/kamailio_proxytrunks_ctl")
 # RTPENGINE
 modparam("rtpengine", "db_url", DBURL)
 modparam("rtpengine", "table_name", "kam_rtpengine")
-modparam("rtpengine", "setid_avp", "$avp(setid)")
 modparam("rtpengine", "rtp_inst_pvar", "$var(RTP_INSTANCE)")
 modparam("rtpengine", "setid_default", 0)
 modparam("rtpengine", "mos_average_pv", "$avp(mos_average)")

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -1525,7 +1525,16 @@ route[APPLY_TRANSFORMATION] {
 }
 
 route[GET_INFO_FROM_MATCHED_DDI] {
-    if ($dlg_var(type) == 'unassigned') return;
+    if ($dlg_var(type) == 'unassigned') {
+        # Unassigned DDIs have no company: honour ddiProvider's set (default one otherwise)
+        if ($dlg_var(ddiProviderMediaRelaySetsId) != $null) {
+            $dlg_var(mediaRelaySetId) = $dlg_var(ddiProviderMediaRelaySetsId);
+            xinfo("[$dlg_var(cidhash)] GET-INFO-FROM-MATCHED-DDI: unassigned DDI, use ddiProvider#$dlg_var(ddiProviderId) mediaRelaySetId ($dlg_var(mediaRelaySetId))\n");
+        } else {
+            xinfo("[$dlg_var(cidhash)] GET-INFO-FROM-MATCHED-DDI: unassigned DDI and ddiProvider#$dlg_var(ddiProviderId) has NULL mediaRelaySetId, use default set\n");
+        }
+        return;
+    }
 
     sql_xquery("cb", "SELECT c.mediaRelaySetId AS companyMediaRelaySetId, c.maxCalls AS maxCallsCompany, b.maxCalls AS maxCallsBrand, d.recordCalls, c.distributeMethod, c.applicationServerSetId, d.routeType, d.residentialDeviceId, d.retailAccountId, d.faxId FROM DDIs d JOIN Companies c ON d.companyId=c.id JOIN Brands b ON c.brandId=b.id WHERE d.id='$dlg_var(ddiId)'", "ra");
 

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -2365,12 +2365,13 @@ route[RTPENGINE] {
     if (!is_request() && !is_method("INVITE|UPDATE")) return;
     if (!is_request() && is_method("INVITE|UPDATE") && t_check_status("[12][0-9]{2}") && !has_body("application/sdp")) return;
 
-    if ($(dlg_var(mediaRelaySetId){s.len}) > 0 && $dlg_var(mediaRelaySetId) != 0) {
-        xinfo("[$dlg_var(cidhash)] RTPENGINE: call set_rtpengine_set() with $dlg_var(mediaRelaySetId)\n");
-        set_rtpengine_set("$(dlg_var(mediaRelaySetId){s.int})");
-    } else {
-        xinfo("[$dlg_var(cidhash)] RTPENGINE: do not call set_rtpengine_set() as mediaRelaySetId is '$dlg_var(mediaRelaySetId)'\n");
+    $var(mediaRelaySetId) = 0;
+    if ($(dlg_var(mediaRelaySetId){s.len}) > 0) {
+        $var(mediaRelaySetId) = $(dlg_var(mediaRelaySetId){s.int});
     }
+
+    xinfo("[$dlg_var(cidhash)] RTPENGINE: call set_rtpengine_set() with $var(mediaRelaySetId)\n");
+    set_rtpengine_set("$var(mediaRelaySetId)");
 
     $var(rtpengine_opts) = 'replace-session-connection replace-origin ICE=remove RTP/AVP asymmetric trust-address';
 

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -3009,12 +3009,13 @@ route[RTPENGINE] {
     if (!is_request() && !is_method("INVITE|UPDATE")) return;
     if (!is_request() && is_method("INVITE|UPDATE") && t_check_status("[12][0-9]{2}") && !has_body("application/sdp")) return;
 
-    if ($(dlg_var(mediaRelaySetId){s.len}) > 0 && $dlg_var(mediaRelaySetId) != 0) {
-        xinfo("[$dlg_var(cidhash)] RTPENGINE: call set_rtpengine_set() with $dlg_var(mediaRelaySetId)\n");
-        set_rtpengine_set("$(dlg_var(mediaRelaySetId){s.int})");
-    } else {
-        xinfo("[$dlg_var(cidhash)] RTPENGINE: do not call set_rtpengine_set() as mediaRelaySetId is '$dlg_var(mediaRelaySetId)'\n");
+    $var(mediaRelaySetId) = 0;
+    if ($(dlg_var(mediaRelaySetId){s.len}) > 0) {
+        $var(mediaRelaySetId) = $(dlg_var(mediaRelaySetId){s.int});
     }
+
+    xinfo("[$dlg_var(cidhash)] RTPENGINE: call set_rtpengine_set() with $var(mediaRelaySetId)\n");
+    set_rtpengine_set("$var(mediaRelaySetId)");
 
     $var(common_opts) = 'replace-session-connection replace-origin via-branch=extra';
 

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -216,7 +216,6 @@ modparam("dmq", "ping_interval", 3600)
 # RTPENGINE
 modparam("rtpengine", "db_url", DBURL)
 modparam("rtpengine", "table_name", "kam_rtpengine")
-modparam("rtpengine", "setid_avp", "$avp(setid)")
 modparam("rtpengine", "rtp_inst_pvar", "$var(RTP_INSTANCE)")
 modparam("rtpengine", "setid_default", 0)
 modparam("rtpengine", "mos_average_pv", "$avp(mos_average)")

--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -2107,6 +2107,8 @@ route[ONDEMANDRECORD] {
 
     $var(callid) = "call-id=users-" + $dlg_var(direction) + '-' + $dlg_var(callid);
 
+    route(SET_MEDIA_RELAY_SET);
+
     if ($dlg_var(recording) != 'yes') {
         xnotice("[$dlg_var(cidhash)] ONDEMANDRECORD: Start recording call\n");
         start_recording("$var(callid)");
@@ -2999,6 +3001,19 @@ route[GET_CODEC_INFO] {
     sql_result_free("rb");
 }
 
+# Select the media relay set of this call. Must be called before any rtpengine
+# command: the module keeps the selected set in per-process state and falls back
+# to the default one when it was not selected for the message being processed
+route[SET_MEDIA_RELAY_SET] {
+    $var(mediaRelaySetId) = 0;
+    if ($(dlg_var(mediaRelaySetId){s.len}) > 0) {
+        $var(mediaRelaySetId) = $(dlg_var(mediaRelaySetId){s.int});
+    }
+
+    xinfo("[$dlg_var(cidhash)] SET-MEDIA-RELAY-SET: call set_rtpengine_set() with $var(mediaRelaySetId)\n");
+    set_rtpengine_set("$var(mediaRelaySetId)");
+}
+
 route[RTPENGINE] {
     # Requests - BYE/CANCEL + INVITE/UPDATE/ACK with SDP
     if (is_request() && !is_method("INVITE|UPDATE|ACK|BYE|CANCEL")) return;
@@ -3008,13 +3023,7 @@ route[RTPENGINE] {
     if (!is_request() && !is_method("INVITE|UPDATE")) return;
     if (!is_request() && is_method("INVITE|UPDATE") && t_check_status("[12][0-9]{2}") && !has_body("application/sdp")) return;
 
-    $var(mediaRelaySetId) = 0;
-    if ($(dlg_var(mediaRelaySetId){s.len}) > 0) {
-        $var(mediaRelaySetId) = $(dlg_var(mediaRelaySetId){s.int});
-    }
-
-    xinfo("[$dlg_var(cidhash)] RTPENGINE: call set_rtpengine_set() with $var(mediaRelaySetId)\n");
-    set_rtpengine_set("$var(mediaRelaySetId)");
+    route(SET_MEDIA_RELAY_SET);
 
     $var(common_opts) = 'replace-session-connection replace-origin via-branch=extra';
 


### PR DESCRIPTION
<!--
  - All pull requests must be done against main branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/main/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, portal/platform, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description

Fixes how the media relay set (rtpengine set) is selected in both proxies.

**kamtrunks**
- Always call `set_rtpengine_set()`, default set included. The module does not fall back
  to the default set on its own — it keeps the selected one in per-process state and only
  resets it when `msg->id` changes — so on gateway failover a carrier using the default set
  kept using the set of the previous one.
- Inbound calls to unassigned DDIs never got a set assigned and were always relayed through
  the default one; they now honour the ddiProvider's.
- Bounced calls used the set of the carrier `SELECT_NEXT_GW` had picked, even though no
  carrier takes part in the call; they now use the company's.

**kamusers**
- Same explicit selection as above. Nothing is known to misroute here, as the set is read
  once from the caller's company; it just removes the trap.
- On demand recording (in-dialog INFO/MESSAGE) never selected the set, so
  `start_recording()`/`stop_recording()` were sent to the default one: for companies with a
  non-default set the command reached an rtpengine that does not know the call-id and
  recording never started. Selection now lives in its own `SET_MEDIA_RELAY_SET` route,
  called from both places.

**Both**: dropped the unused `setid_avp` modparam (`$avp(setid)` is never read nor written,
and declaring it suggested the set travels in an AVP when it does not). No behaviour change.
