### PR TITLE
[PROVIDER-2482] rest/brand: order rating plan destination rates by weight

### DIFF
--- a/web/rest/brand/config/api/raw/provider.yml
+++ b/web/rest/brand/config/api/raw/provider.yml
@@ -1372,6 +1372,7 @@ Ivoz\Provider\Domain\Model\RatingPlan\RatingPlan:
   attributes:
     access_control: '"ROLE_BRAND_ADMIN" in roles && user.hasAccessPrivileges(_api_resource_class, request.getMethod())'
     order:
+      weight: DESC
       destinationRateGroup: ASC
     read_access_control:
       inherited:


### PR DESCRIPTION


<!--
  - All pull requests must be done against main branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/main/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, portal/platform, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
Destination rates linked to a rating plan group are applied from highest to lowest weight: when two prefixes collide, the one with the highest weight wins, as stated both in the field help text and in the documentation.

The collection was ordered by destinationRateGroup ASC instead, so the list followed the destination rate group ids and had nothing to do with the order in which rates are actually applied. In practice the general rate is created first and the specific ones later, so the list usually showed the exact opposite of the applied priority.

Order by weight DESC, keeping destinationRateGroup ASC as a tie breaker so rates sharing the same weight keep a stable position.
