### PR TITLE
[PROVIDER-2484] channel usage historics by client

### DIFF
--- a/debian/ivozprovider-scheduler.install
+++ b/debian/ivozprovider-scheduler.install
@@ -3,3 +3,4 @@ debian/systemd/ivozprovider-scheduler.timer /lib/systemd/system
 debian/systemd/ivozprovider-scheduler-historic-calls.timer /lib/systemd/system
 debian/systemd/ivozprovider-cdrs.timer /lib/systemd/system
 debian/systemd/ivozprovider-users-cdrs.timer /lib/systemd/system
+debian/systemd/ivozprovider-channel-usage.timer /lib/systemd/system

--- a/debian/ivozprovider-scheduler.ivozprovider-channel-usage.service
+++ b/debian/ivozprovider-scheduler.ivozprovider-channel-usage.service
@@ -1,0 +1,1 @@
+systemd/ivozprovider-channel-usage.service

--- a/debian/ivozprovider.postinst
+++ b/debian/ivozprovider.postinst
@@ -162,6 +162,7 @@ function enable_services()
     /bin/systemctl enable ivozprovider-scheduler-historic-calls.timer
     /bin/systemctl enable ivozprovider-cdrs.timer
     /bin/systemctl enable ivozprovider-users-cdrs.timer
+    /bin/systemctl enable ivozprovider-channel-usage.timer
     /bin/systemctl enable cgrates
 }
 

--- a/debian/rules
+++ b/debian/rules
@@ -70,6 +70,7 @@ override_dh_systemd_enable:
 	dh_systemd_enable -p ivozprovider-scheduler       --name=ivozprovider-cdrs                      --no-enable
 	dh_systemd_enable -p ivozprovider-scheduler       --name=ivozprovider-scheduler-historic-calls  --no-enable
 	dh_systemd_enable -p ivozprovider-scheduler       --name=ivozprovider-users-cdrs                --no-enable
+	dh_systemd_enable -p ivozprovider-scheduler       --name=ivozprovider-channel-usage             --no-enable
 
 override_dh_systemd_start:
 	dh_systemd_start  -p ivozprovider-asterisk-agi     --name=fastagi@     fastagi@.service          --no-restart-after-upgrade --no-start
@@ -86,6 +87,7 @@ override_dh_systemd_start:
 	dh_systemd_start  -p ivozprovider-scheduler        --name=ivozprovider-cdrs                      --no-restart-after-upgrade --no-start
 	dh_systemd_start  -p ivozprovider-scheduler        --name=ivozprovider-scheduler-historic-calls  --no-restart-after-upgrade --no-start
 	dh_systemd_start  -p ivozprovider-scheduler        --name=ivozprovider-users-cdrs                --no-restart-after-upgrade --no-start
+	dh_systemd_start  -p ivozprovider-scheduler        --name=ivozprovider-channel-usage             --no-restart-after-upgrade --no-start
 
 # Install /etc/default configuration
 override_dh_installinit:

--- a/debian/systemd/ivozprovider-channel-usage.service
+++ b/debian/systemd/ivozprovider-channel-usage.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Ivozprovider Channel Usage collector
+
+[Service]
+Type=oneshot
+User=root
+ExecStart=/opt/irontec/ivozprovider/microservices/scheduler/bin/run-channel-usage

--- a/debian/systemd/ivozprovider-channel-usage.service
+++ b/debian/systemd/ivozprovider-channel-usage.service
@@ -3,5 +3,4 @@ Description=Ivozprovider Channel Usage collector
 
 [Service]
 Type=oneshot
-User=root
 ExecStart=/opt/irontec/ivozprovider/microservices/scheduler/bin/run-channel-usage

--- a/debian/systemd/ivozprovider-channel-usage.timer
+++ b/debian/systemd/ivozprovider-channel-usage.timer
@@ -3,7 +3,9 @@ Description=Ivozprovider Channel Usage collector
 
 [Timer]
 OnBootSec=3min
-OnUnitActiveSec=5min
+# Fixed 5-minute wall-clock schedule, aligned with the collector's 300s buckets.
+# OnUnitActiveSec would drift, since it counts from the end of the previous run.
+OnCalendar=*:0/5
 
 [Install]
 WantedBy=timers.target

--- a/debian/systemd/ivozprovider-channel-usage.timer
+++ b/debian/systemd/ivozprovider-channel-usage.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Ivozprovider Channel Usage collector
+
+[Timer]
+OnBootSec=3min
+OnUnitActiveSec=5min
+
+[Install]
+WantedBy=timers.target

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -2270,6 +2270,10 @@ event_route[dialog:end] {
     #!ifdef WITH_REALTIME
     $var(rtEvent) = 'Terminated';
     route(REALTIME);
+    if ($dlg_var(chUsageCounted) == "1") {
+        $var(ev) = "H:" + $Ts + ":" + $dlg_var(brandId) + ":" + $dlg_var(companyId);
+        redis_cmd("realtime", "RPUSH %s %s", "chusage:events", "$var(ev)", "r");
+    }
     #!endif
 
     if ($dlg_var(cgrid) == $null) {
@@ -2284,6 +2288,10 @@ event_route[dialog:failed] {
     #!ifdef WITH_REALTIME
     $var(rtEvent) = 'Terminated';
     route(REALTIME);
+    if ($dlg_var(chUsageCounted) == "1") {
+        $var(ev) = "H:" + $Ts + ":" + $dlg_var(brandId) + ":" + $dlg_var(companyId);
+        redis_cmd("realtime", "RPUSH %s %s", "chusage:events", "$var(ev)", "r");
+    }
     #!endif
 }
 
@@ -2506,16 +2514,28 @@ route[CONTROL_MAXCALLS] {
     if ($dlg_var(maxCallsBrand) > 0 && $avp(activeCallsBrand) >= $dlg_var(maxCallsBrand)) {
         xwarn("[$dlg_var(cidhash)] CONTROL-MAXCALLS: Call NOT allowed for brand$dlg_var(brandId) $avp(activeCallsBrand)/$dlg_var(maxCallsBrand)\n");
         $var(maxcalls_exceeded) = 1;
+        $var(maxcalls_reason) = "brand";
     } else if ($dlg_var(maxCallsCompany) > 0 && $avp(activeCallsCompany) >= $dlg_var(maxCallsCompany)) {
         xwarn("[$dlg_var(cidhash)] CONTROL-MAXCALLS: Call NOT allowed for company$dlg_var(companyId) $avp(activeCallsCompany)/$dlg_var(maxCallsCompany)\n");
         $var(maxcalls_exceeded) = 1;
+        $var(maxcalls_reason) = "company";
     } else {
         xnotice("[$dlg_var(cidhash)] CONTROL-MAXCALLS: Call ALLOWED for brand$dlg_var(brandId) $avp(activeCallsBrand)/$dlg_var(maxCallsBrand) - company$dlg_var(companyId) $avp(activeCallsCompany)/$dlg_var(maxCallsCompany)\n");
         set_dlg_profile("activeCallsCompany", "$dlg_var(companyId)");
         set_dlg_profile("activeCallsBrand", "$dlg_var(brandId)");
+        $dlg_var(chUsageCounted) = "1";
+        #!ifdef WITH_REALTIME
+        $var(chUsageOcc) = $avp(activeCallsCompany) + 1;
+        $var(ev) = "A:" + $Ts + ":" + $dlg_var(brandId) + ":" + $dlg_var(companyId) + ":" + $var(chUsageOcc);
+        redis_cmd("realtime", "RPUSH %s %s", "chusage:events", "$var(ev)", "r");
+        #!endif
     }
 
     if ($var(maxcalls_exceeded)) {
+        #!ifdef WITH_REALTIME
+        $var(ev) = "B:" + $Ts + ":" + $dlg_var(brandId) + ":" + $dlg_var(companyId) + ":" + $var(maxcalls_reason);
+        redis_cmd("realtime", "RPUSH %s %s", "chusage:events", "$var(ev)", "r");
+        #!endif
         if ($var(is_from_inside)) {
             send_reply("403", "Maxcalls exceeded");
         } else {

--- a/kamailio/trunks/config/kamailio.cfg
+++ b/kamailio/trunks/config/kamailio.cfg
@@ -2271,8 +2271,10 @@ event_route[dialog:end] {
     $var(rtEvent) = 'Terminated';
     route(REALTIME);
     if ($dlg_var(chUsageCounted) == "1") {
-        $var(ev) = "H:" + $Ts + ":" + $dlg_var(brandId) + ":" + $dlg_var(companyId);
-        redis_cmd("realtime", "RPUSH %s %s", "chusage:events", "$var(ev)", "r");
+        $var(ev) = "H:" + $TS + ":" + $dlg_var(brandId) + ":" + $dlg_var(companyId);
+        if (!redis_cmd("realtime", "RPUSH %s %s", "chusage:events", "$var(ev)", "r")) {
+            xerr("[$dlg_var(cidhash)] CHANNEL-USAGE: unable to queue event $var(ev)\n");
+        }
     }
     #!endif
 
@@ -2289,8 +2291,10 @@ event_route[dialog:failed] {
     $var(rtEvent) = 'Terminated';
     route(REALTIME);
     if ($dlg_var(chUsageCounted) == "1") {
-        $var(ev) = "H:" + $Ts + ":" + $dlg_var(brandId) + ":" + $dlg_var(companyId);
-        redis_cmd("realtime", "RPUSH %s %s", "chusage:events", "$var(ev)", "r");
+        $var(ev) = "H:" + $TS + ":" + $dlg_var(brandId) + ":" + $dlg_var(companyId);
+        if (!redis_cmd("realtime", "RPUSH %s %s", "chusage:events", "$var(ev)", "r")) {
+            xerr("[$dlg_var(cidhash)] CHANNEL-USAGE: unable to queue event $var(ev)\n");
+        }
     }
     #!endif
 }
@@ -2511,6 +2515,7 @@ route[CONTROL_MAXCALLS] {
     }
 
     $var(maxcalls_exceeded) = 0;
+    $var(maxcalls_reason) = "";
     if ($dlg_var(maxCallsBrand) > 0 && $avp(activeCallsBrand) >= $dlg_var(maxCallsBrand)) {
         xwarn("[$dlg_var(cidhash)] CONTROL-MAXCALLS: Call NOT allowed for brand$dlg_var(brandId) $avp(activeCallsBrand)/$dlg_var(maxCallsBrand)\n");
         $var(maxcalls_exceeded) = 1;
@@ -2523,18 +2528,22 @@ route[CONTROL_MAXCALLS] {
         xnotice("[$dlg_var(cidhash)] CONTROL-MAXCALLS: Call ALLOWED for brand$dlg_var(brandId) $avp(activeCallsBrand)/$dlg_var(maxCallsBrand) - company$dlg_var(companyId) $avp(activeCallsCompany)/$dlg_var(maxCallsCompany)\n");
         set_dlg_profile("activeCallsCompany", "$dlg_var(companyId)");
         set_dlg_profile("activeCallsBrand", "$dlg_var(brandId)");
-        $dlg_var(chUsageCounted) = "1";
         #!ifdef WITH_REALTIME
+        $dlg_var(chUsageCounted) = "1";
         $var(chUsageOcc) = $avp(activeCallsCompany) + 1;
-        $var(ev) = "A:" + $Ts + ":" + $dlg_var(brandId) + ":" + $dlg_var(companyId) + ":" + $var(chUsageOcc);
-        redis_cmd("realtime", "RPUSH %s %s", "chusage:events", "$var(ev)", "r");
+        $var(ev) = "A:" + $TS + ":" + $dlg_var(brandId) + ":" + $dlg_var(companyId) + ":" + $var(chUsageOcc);
+        if (!redis_cmd("realtime", "RPUSH %s %s", "chusage:events", "$var(ev)", "r")) {
+            xerr("[$dlg_var(cidhash)] CHANNEL-USAGE: unable to queue event $var(ev)\n");
+        }
         #!endif
     }
 
     if ($var(maxcalls_exceeded)) {
         #!ifdef WITH_REALTIME
-        $var(ev) = "B:" + $Ts + ":" + $dlg_var(brandId) + ":" + $dlg_var(companyId) + ":" + $var(maxcalls_reason);
-        redis_cmd("realtime", "RPUSH %s %s", "chusage:events", "$var(ev)", "r");
+        $var(ev) = "B:" + $TS + ":" + $dlg_var(brandId) + ":" + $dlg_var(companyId) + ":" + $var(maxcalls_reason);
+        if (!redis_cmd("realtime", "RPUSH %s %s", "chusage:events", "$var(ev)", "r")) {
+            xerr("[$dlg_var(cidhash)] CHANNEL-USAGE: unable to queue event $var(ev)\n");
+        }
         #!endif
         if ($var(is_from_inside)) {
             send_reply("403", "Maxcalls exceeded");

--- a/library/Ivoz/Kam/Domain/Service/TrunksClientInterface.php
+++ b/library/Ivoz/Kam/Domain/Service/TrunksClientInterface.php
@@ -46,6 +46,16 @@ interface TrunksClientInterface
      */
     public function getPlatformActiveCalls(): array;
 
+    /**
+     * Active calls of the whole platform, broken down by company.
+     *
+     * Same keyspace as getPlatformActiveCalls(), but resolved per owner in a single pass, so
+     * callers that need a per-company snapshot do not have to walk it once per company.
+     *
+     * @return array<int, array{brandId: int, occ: int}> companyId => owning brand and call count
+     */
+    public function getActiveCallsGroupedByCompany(): array;
+
     public function isCgrEnabled(): bool;
 
     public function reloadDialplan(): void;

--- a/library/Ivoz/Kam/Infrastructure/Kamailio/TrunksClient.php
+++ b/library/Ivoz/Kam/Infrastructure/Kamailio/TrunksClient.php
@@ -26,6 +26,13 @@ class TrunksClient implements TrunksClientInterface
     const INBOUND_KEY_PATTERN = 'trunks:b%s:c%s:ddi*:dp*:*';
     const OUTBOUND_KEY_PATTERN = 'trunks:b%s:c%s:ddi*:cr*:*';
 
+    /**
+     * Companion to the patterns above: extracts the owning brand and company from a matched
+     * key. Every segment is spelled out here too, for the same reason, and it lives next to
+     * them so a layout change is a single edit.
+     */
+    const KEY_OWNER_REGEXP = '/^trunks:b(\d+):c(\d+):ddi[^:]*:(?:cr|dp)[^:]*:/';
+
     public function __construct(
         RpcClient $rpcClient,
         private TrunksRpcJob $rpcJob,
@@ -244,6 +251,94 @@ class TrunksClient implements TrunksClientInterface
             $inbound,
             $outbound
         ];
+    }
+
+    /**
+     * @return array<int, array{brandId: int, occ: int}>
+     */
+    public function getActiveCallsGroupedByCompany(): array
+    {
+        $grouped = [];
+
+        foreach ([self::INBOUND_KEY_PATTERN, self::OUTBOUND_KEY_PATTERN] as $keyPattern) {
+            $filterPattern = sprintf(
+                $keyPattern,
+                '*',
+                '*'
+            );
+
+            $this->groupRedisActiveCallsByCompany($filterPattern, $grouped);
+        }
+
+        return $grouped;
+    }
+
+    /**
+     * @param array<int, array{brandId: int, occ: int}> $grouped
+     */
+    private function groupRedisActiveCallsByCompany(string $filterPattern, array &$grouped): void
+    {
+        try {
+            $redisClient = $this->redisMasterFactory->create(
+                self::REDIS_RT_CALLS_DB
+            );
+
+            /** @var int|null $redisScanIterator */
+            $redisScanIterator = null;
+
+            while (true) {
+                $keys = $redisClient->scan(
+                    $redisScanIterator,
+                    $filterPattern,
+                    self::REDIS_SCAN_COUNT
+                );
+
+                if (!is_array($keys)) {
+                    break;
+                }
+
+                foreach ($keys as $key) {
+                    $owner = [];
+                    if (!preg_match(self::KEY_OWNER_REGEXP, (string) $key, $owner)) {
+                        continue;
+                    }
+
+                    $brandId = (int) $owner[1];
+                    $companyId = (int) $owner[2];
+
+                    if (!isset($grouped[$companyId])) {
+                        $grouped[$companyId] = [
+                            'brandId' => $brandId,
+                            'occ' => 0
+                        ];
+                    }
+
+                    $grouped[$companyId]['occ']++;
+                }
+
+                if ($redisScanIterator === 0) {
+                    break;
+                }
+            }
+
+            $redisClient->close();
+        } catch (\Exception $e) {
+            $classMethod = substr(
+                __METHOD__,
+                (int) strrpos(__METHOD__, '\\') + 1
+            );
+
+            $this
+                ->logger
+                ->error(
+                    sprintf(
+                        '%s(%s): %s',
+                        $classMethod,
+                        $filterPattern,
+                        $e->getMessage()
+                    )
+                );
+        }
     }
 
     /**

--- a/library/Ivoz/Provider/Domain/Job/ChannelUsageEventQueueInterface.php
+++ b/library/Ivoz/Provider/Domain/Job/ChannelUsageEventQueueInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Ivoz\Provider\Domain\Job;
+
+interface ChannelUsageEventQueueInterface
+{
+    public const QUEUE_KEY = 'chusage:events';
+
+    /**
+     * Read up to $maxEntries raw entries from the head of the queue, without removing them.
+     *
+     * Entries are returned verbatim: parsing (and discarding malformed ones) is the caller's
+     * job, so that the number of entries actually consumed stays decoupled from the number of
+     * events successfully parsed.
+     *
+     * @return array<int, string>
+     */
+    public function readPending(int $maxEntries): array;
+
+    /**
+     * Remove exactly $entryCount raw entries from the head of the queue.
+     *
+     * Must be called only after the caller has durably processed them, and always with the
+     * count of *raw entries read*, never with a count of parsed events.
+     */
+    public function discardProcessed(int $entryCount): void;
+
+    /**
+     * Append raw entries back to the tail of the queue.
+     *
+     * Used for entries that were read but belong to a bucket that is still open, so they are
+     * re-processed on a later run. Consumers sort by timestamp, so the tail position is safe.
+     *
+     * @param array<int, string> $rawEntries
+     */
+    public function requeue(array $rawEntries): void;
+
+    /**
+     * Current active channels per company, derived from the realtime call keyspace.
+     *
+     * @return array<int, array{brandId: int, occ: int}> companyId => brand and occupancy
+     */
+    public function getActiveChannelsByCompany(): array;
+}

--- a/library/Ivoz/Provider/Domain/Job/ChannelUsageEventQueueInterface.php
+++ b/library/Ivoz/Provider/Domain/Job/ChannelUsageEventQueueInterface.php
@@ -34,11 +34,4 @@ interface ChannelUsageEventQueueInterface
      * @param array<int, string> $rawEntries
      */
     public function requeue(array $rawEntries): void;
-
-    /**
-     * Current active channels per company, derived from the realtime call keyspace.
-     *
-     * @return array<int, array{brandId: int, occ: int}> companyId => brand and occupancy
-     */
-    public function getActiveChannelsByCompany(): array;
 }

--- a/library/Ivoz/Provider/Domain/Model/ChannelUsage/ChannelUsage.php
+++ b/library/Ivoz/Provider/Domain/Model/ChannelUsage/ChannelUsage.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Ivoz\Provider\Domain\Model\ChannelUsage;
+
+/**
+ * ChannelUsage
+ */
+class ChannelUsage extends ChannelUsageAbstract implements ChannelUsageInterface
+{
+    use ChannelUsageTrait;
+
+    /**
+     * Get id
+     * @codeCoverageIgnore
+     */
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+}

--- a/library/Ivoz/Provider/Domain/Model/ChannelUsage/ChannelUsage.php
+++ b/library/Ivoz/Provider/Domain/Model/ChannelUsage/ChannelUsage.php
@@ -4,6 +4,12 @@ namespace Ivoz\Provider\Domain\Model\ChannelUsage;
 
 /**
  * ChannelUsage
+ *
+ * Note: getChangeSet() is deliberately NOT exposed here. The interface regenerator picks the
+ * parent interface by reflecting on this class, so omitting it makes ChannelUsageInterface
+ * extend EntityInterface instead of LoggableEntityInterface, which keeps this high-volume
+ * historic table out of the changelog. Do not add getChangeSet() back "for consistency" with
+ * the other entities: it would start writing an audit row per bucket per company.
  */
 class ChannelUsage extends ChannelUsageAbstract implements ChannelUsageInterface
 {
@@ -16,5 +22,33 @@ class ChannelUsage extends ChannelUsageAbstract implements ChannelUsageInterface
     public function getId(): ?int
     {
         return $this->id;
+    }
+
+    protected function sanitizeValues(): void
+    {
+        $company = $this->getCompany();
+        $brand = $this->getBrand();
+
+        $companyBrand = $company->getBrand();
+
+        if ($brand->getId() !== $companyBrand->getId()) {
+            throw new \DomainException(
+                'Company does not belong to the specified brand'
+            );
+        }
+
+        if ($this->getClosingUsage() > $this->getPeak()) {
+            throw new \DomainException(
+                'Closing usage cannot be greater than the bucket peak'
+            );
+        }
+
+        // Tolerance: avgUsage is a rounded time-weighted mean, so it can land a hair above
+        // the peak in the last decimal without the value being actually wrong.
+        if ($this->getAvgUsage() > (float) $this->getPeak() + 0.01) {
+            throw new \DomainException(
+                'Average usage cannot be greater than the bucket peak'
+            );
+        }
     }
 }

--- a/library/Ivoz/Provider/Domain/Model/ChannelUsage/ChannelUsageAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/ChannelUsage/ChannelUsageAbstract.php
@@ -1,0 +1,426 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ivoz\Provider\Domain\Model\ChannelUsage;
+
+use Assert\Assertion;
+use Ivoz\Core\Domain\DataTransferObjectInterface;
+use Ivoz\Core\Domain\Model\ChangelogTrait;
+use Ivoz\Core\Domain\Model\EntityInterface;
+use Ivoz\Core\Domain\ForeignKeyTransformerInterface;
+use Ivoz\Core\Domain\Model\Helper\DateTimeHelper;
+use Ivoz\Provider\Domain\Model\Brand\BrandInterface;
+use Ivoz\Provider\Domain\Model\Company\CompanyInterface;
+use Ivoz\Provider\Domain\Model\Brand\Brand;
+use Ivoz\Provider\Domain\Model\Company\Company;
+
+/**
+* ChannelUsageAbstract
+* @codeCoverageIgnore
+*/
+abstract class ChannelUsageAbstract
+{
+    use ChangelogTrait;
+
+    /**
+     * @var \DateTime
+     */
+    protected $timestamp;
+
+    /**
+     * @var int
+     */
+    protected $peak;
+
+    /**
+     * @var float
+     */
+    protected $avgUsage;
+
+    /**
+     * @var int
+     */
+    protected $closingUsage;
+
+    /**
+     * @var int
+     */
+    protected $maxCallsCompany;
+
+    /**
+     * @var int
+     */
+    protected $maxCallsBrand;
+
+    /**
+     * @var int
+     */
+    protected $blockedByCompanyLimit = 0;
+
+    /**
+     * @var int
+     */
+    protected $blockedByBrandLimit = 0;
+
+    /**
+     * @var BrandInterface
+     */
+    protected $brand;
+
+    /**
+     * @var CompanyInterface
+     */
+    protected $company;
+
+    /**
+     * Constructor
+     */
+    protected function __construct(
+        \DateTimeInterface|string $timestamp,
+        int $peak,
+        float $avgUsage,
+        int $closingUsage,
+        int $maxCallsCompany,
+        int $maxCallsBrand,
+        int $blockedByCompanyLimit,
+        int $blockedByBrandLimit
+    ) {
+        $this->setTimestamp($timestamp);
+        $this->setPeak($peak);
+        $this->setAvgUsage($avgUsage);
+        $this->setClosingUsage($closingUsage);
+        $this->setMaxCallsCompany($maxCallsCompany);
+        $this->setMaxCallsBrand($maxCallsBrand);
+        $this->setBlockedByCompanyLimit($blockedByCompanyLimit);
+        $this->setBlockedByBrandLimit($blockedByBrandLimit);
+    }
+
+    abstract public function getId(): null|string|int;
+
+    public function __toString(): string
+    {
+        return sprintf(
+            "%s#%s",
+            "ChannelUsage",
+            (string) $this->getId()
+        );
+    }
+
+    /**
+     * @throws \Exception
+     */
+    protected function sanitizeValues(): void
+    {
+    }
+
+    /**
+     * @param int | null $id
+     */
+    public static function createDto($id = null): ChannelUsageDto
+    {
+        return new ChannelUsageDto($id);
+    }
+
+    /**
+     * @internal use EntityTools instead
+     * @param null|ChannelUsageInterface $entity
+     */
+    public static function entityToDto(?EntityInterface $entity, int $depth = 0): ?ChannelUsageDto
+    {
+        if (!$entity) {
+            return null;
+        }
+
+        Assertion::isInstanceOf($entity, ChannelUsageInterface::class);
+
+        if ($depth < 1) {
+            return static::createDto($entity->getId());
+        }
+
+        if ($entity instanceof \Doctrine\ORM\Proxy\Proxy && !$entity->__isInitialized()) {
+            return static::createDto($entity->getId());
+        }
+
+        $dto = $entity->toDto($depth - 1);
+
+        return $dto;
+    }
+
+    /**
+     * Factory method
+     * @internal use EntityTools instead
+     * @param ChannelUsageDto $dto
+     */
+    public static function fromDto(
+        DataTransferObjectInterface $dto,
+        ForeignKeyTransformerInterface $fkTransformer
+    ): static {
+        Assertion::isInstanceOf($dto, ChannelUsageDto::class);
+        $timestamp = $dto->getTimestamp();
+        Assertion::notNull($timestamp, 'getTimestamp value is null, but non null value was expected.');
+        $peak = $dto->getPeak();
+        Assertion::notNull($peak, 'getPeak value is null, but non null value was expected.');
+        $avgUsage = $dto->getAvgUsage();
+        Assertion::notNull($avgUsage, 'getAvgUsage value is null, but non null value was expected.');
+        $closingUsage = $dto->getClosingUsage();
+        Assertion::notNull($closingUsage, 'getClosingUsage value is null, but non null value was expected.');
+        $maxCallsCompany = $dto->getMaxCallsCompany();
+        Assertion::notNull($maxCallsCompany, 'getMaxCallsCompany value is null, but non null value was expected.');
+        $maxCallsBrand = $dto->getMaxCallsBrand();
+        Assertion::notNull($maxCallsBrand, 'getMaxCallsBrand value is null, but non null value was expected.');
+        $blockedByCompanyLimit = $dto->getBlockedByCompanyLimit();
+        Assertion::notNull($blockedByCompanyLimit, 'getBlockedByCompanyLimit value is null, but non null value was expected.');
+        $blockedByBrandLimit = $dto->getBlockedByBrandLimit();
+        Assertion::notNull($blockedByBrandLimit, 'getBlockedByBrandLimit value is null, but non null value was expected.');
+        $brand = $dto->getBrand();
+        Assertion::notNull($brand, 'getBrand value is null, but non null value was expected.');
+        $company = $dto->getCompany();
+        Assertion::notNull($company, 'getCompany value is null, but non null value was expected.');
+
+        $self = new static(
+            $timestamp,
+            $peak,
+            $avgUsage,
+            $closingUsage,
+            $maxCallsCompany,
+            $maxCallsBrand,
+            $blockedByCompanyLimit,
+            $blockedByBrandLimit
+        );
+
+        $self
+            ->setBrand($fkTransformer->transform($brand))
+            ->setCompany($fkTransformer->transform($company));
+
+        $self->initChangelog();
+
+        return $self;
+    }
+
+    /**
+     * @internal use EntityTools instead
+     * @param ChannelUsageDto $dto
+     */
+    public function updateFromDto(
+        DataTransferObjectInterface $dto,
+        ForeignKeyTransformerInterface $fkTransformer
+    ): static {
+        Assertion::isInstanceOf($dto, ChannelUsageDto::class);
+
+        $timestamp = $dto->getTimestamp();
+        Assertion::notNull($timestamp, 'getTimestamp value is null, but non null value was expected.');
+        $peak = $dto->getPeak();
+        Assertion::notNull($peak, 'getPeak value is null, but non null value was expected.');
+        $avgUsage = $dto->getAvgUsage();
+        Assertion::notNull($avgUsage, 'getAvgUsage value is null, but non null value was expected.');
+        $closingUsage = $dto->getClosingUsage();
+        Assertion::notNull($closingUsage, 'getClosingUsage value is null, but non null value was expected.');
+        $maxCallsCompany = $dto->getMaxCallsCompany();
+        Assertion::notNull($maxCallsCompany, 'getMaxCallsCompany value is null, but non null value was expected.');
+        $maxCallsBrand = $dto->getMaxCallsBrand();
+        Assertion::notNull($maxCallsBrand, 'getMaxCallsBrand value is null, but non null value was expected.');
+        $blockedByCompanyLimit = $dto->getBlockedByCompanyLimit();
+        Assertion::notNull($blockedByCompanyLimit, 'getBlockedByCompanyLimit value is null, but non null value was expected.');
+        $blockedByBrandLimit = $dto->getBlockedByBrandLimit();
+        Assertion::notNull($blockedByBrandLimit, 'getBlockedByBrandLimit value is null, but non null value was expected.');
+        $brand = $dto->getBrand();
+        Assertion::notNull($brand, 'getBrand value is null, but non null value was expected.');
+        $company = $dto->getCompany();
+        Assertion::notNull($company, 'getCompany value is null, but non null value was expected.');
+
+        $this
+            ->setTimestamp($timestamp)
+            ->setPeak($peak)
+            ->setAvgUsage($avgUsage)
+            ->setClosingUsage($closingUsage)
+            ->setMaxCallsCompany($maxCallsCompany)
+            ->setMaxCallsBrand($maxCallsBrand)
+            ->setBlockedByCompanyLimit($blockedByCompanyLimit)
+            ->setBlockedByBrandLimit($blockedByBrandLimit)
+            ->setBrand($fkTransformer->transform($brand))
+            ->setCompany($fkTransformer->transform($company));
+
+        return $this;
+    }
+
+    /**
+     * @internal use EntityTools instead
+     */
+    public function toDto(int $depth = 0): ChannelUsageDto
+    {
+        return self::createDto()
+            ->setTimestamp(self::getTimestamp())
+            ->setPeak(self::getPeak())
+            ->setAvgUsage(self::getAvgUsage())
+            ->setClosingUsage(self::getClosingUsage())
+            ->setMaxCallsCompany(self::getMaxCallsCompany())
+            ->setMaxCallsBrand(self::getMaxCallsBrand())
+            ->setBlockedByCompanyLimit(self::getBlockedByCompanyLimit())
+            ->setBlockedByBrandLimit(self::getBlockedByBrandLimit())
+            ->setBrand(Brand::entityToDto(self::getBrand(), $depth))
+            ->setCompany(Company::entityToDto(self::getCompany(), $depth));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function __toArray(): array
+    {
+        return [
+            'timestamp' => self::getTimestamp(),
+            'peak' => self::getPeak(),
+            'avgUsage' => self::getAvgUsage(),
+            'closingUsage' => self::getClosingUsage(),
+            'maxCallsCompany' => self::getMaxCallsCompany(),
+            'maxCallsBrand' => self::getMaxCallsBrand(),
+            'blockedByCompanyLimit' => self::getBlockedByCompanyLimit(),
+            'blockedByBrandLimit' => self::getBlockedByBrandLimit(),
+            'brandId' => self::getBrand()->getId(),
+            'companyId' => self::getCompany()->getId()
+        ];
+    }
+
+    protected function setTimestamp(string|\DateTimeInterface $timestamp): static
+    {
+
+        /** @var \DateTime */
+        $timestamp = DateTimeHelper::createOrFix(
+            $timestamp,
+            null
+        );
+
+        if ($this->isInitialized() && $this->timestamp == $timestamp) {
+            return $this;
+        }
+
+        $this->timestamp = $timestamp;
+
+        return $this;
+    }
+
+    public function getTimestamp(): \DateTime
+    {
+        return clone $this->timestamp;
+    }
+
+    protected function setPeak(int $peak): static
+    {
+        Assertion::greaterOrEqualThan($peak, 0, 'peak provided "%s" is not greater or equal than "%s".');
+
+        $this->peak = $peak;
+
+        return $this;
+    }
+
+    public function getPeak(): int
+    {
+        return $this->peak;
+    }
+
+    protected function setAvgUsage(float $avgUsage): static
+    {
+        $this->avgUsage = $avgUsage;
+
+        return $this;
+    }
+
+    public function getAvgUsage(): float
+    {
+        return $this->avgUsage;
+    }
+
+    protected function setClosingUsage(int $closingUsage): static
+    {
+        Assertion::greaterOrEqualThan($closingUsage, 0, 'closingUsage provided "%s" is not greater or equal than "%s".');
+
+        $this->closingUsage = $closingUsage;
+
+        return $this;
+    }
+
+    public function getClosingUsage(): int
+    {
+        return $this->closingUsage;
+    }
+
+    protected function setMaxCallsCompany(int $maxCallsCompany): static
+    {
+        Assertion::greaterOrEqualThan($maxCallsCompany, 0, 'maxCallsCompany provided "%s" is not greater or equal than "%s".');
+
+        $this->maxCallsCompany = $maxCallsCompany;
+
+        return $this;
+    }
+
+    public function getMaxCallsCompany(): int
+    {
+        return $this->maxCallsCompany;
+    }
+
+    protected function setMaxCallsBrand(int $maxCallsBrand): static
+    {
+        Assertion::greaterOrEqualThan($maxCallsBrand, 0, 'maxCallsBrand provided "%s" is not greater or equal than "%s".');
+
+        $this->maxCallsBrand = $maxCallsBrand;
+
+        return $this;
+    }
+
+    public function getMaxCallsBrand(): int
+    {
+        return $this->maxCallsBrand;
+    }
+
+    protected function setBlockedByCompanyLimit(int $blockedByCompanyLimit): static
+    {
+        Assertion::greaterOrEqualThan($blockedByCompanyLimit, 0, 'blockedByCompanyLimit provided "%s" is not greater or equal than "%s".');
+
+        $this->blockedByCompanyLimit = $blockedByCompanyLimit;
+
+        return $this;
+    }
+
+    public function getBlockedByCompanyLimit(): int
+    {
+        return $this->blockedByCompanyLimit;
+    }
+
+    protected function setBlockedByBrandLimit(int $blockedByBrandLimit): static
+    {
+        Assertion::greaterOrEqualThan($blockedByBrandLimit, 0, 'blockedByBrandLimit provided "%s" is not greater or equal than "%s".');
+
+        $this->blockedByBrandLimit = $blockedByBrandLimit;
+
+        return $this;
+    }
+
+    public function getBlockedByBrandLimit(): int
+    {
+        return $this->blockedByBrandLimit;
+    }
+
+    protected function setBrand(BrandInterface $brand): static
+    {
+        $this->brand = $brand;
+
+        return $this;
+    }
+
+    public function getBrand(): BrandInterface
+    {
+        return $this->brand;
+    }
+
+    protected function setCompany(CompanyInterface $company): static
+    {
+        $this->company = $company;
+
+        return $this;
+    }
+
+    public function getCompany(): CompanyInterface
+    {
+        return $this->company;
+    }
+}

--- a/library/Ivoz/Provider/Domain/Model/ChannelUsage/ChannelUsageBucketAccumulator.php
+++ b/library/Ivoz/Provider/Domain/Model/ChannelUsage/ChannelUsageBucketAccumulator.php
@@ -102,11 +102,11 @@ final class ChannelUsageBucketAccumulator
     }
 
     /**
-     * A 'B' event: a call was rejected by a max-channel limit. Does not alter occupancy.
+     * A call was rejected by a max-channel limit. Does not alter occupancy.
      */
-    public function block(string $reason): void
+    public function block(bool $byBrandLimit): void
     {
-        if ($reason === 'brand') {
+        if ($byBrandLimit) {
             $this->blockedByBrandLimit++;
 
             return;

--- a/library/Ivoz/Provider/Domain/Model/ChannelUsage/ChannelUsageBucketAccumulator.php
+++ b/library/Ivoz/Provider/Domain/Model/ChannelUsage/ChannelUsageBucketAccumulator.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ivoz\Provider\Domain\Model\ChannelUsage;
+
+/**
+ * Mutable accumulator for a single channel usage bucket.
+ *
+ * Replaces what would otherwise be a by-reference closure over a handful of loose
+ * counters: keeping the state in typed properties is what lets the calculator stay
+ * statically analysable without suppressions.
+ */
+final class ChannelUsageBucketAccumulator
+{
+    private int $bucketEnd;
+    private int $prevTs;
+    private int $peak;
+    private float $integral = 0.0;
+    private int $blockedByCompanyLimit = 0;
+    private int $blockedByBrandLimit = 0;
+
+    public function __construct(
+        private int $bucketTs,
+        private int $bucketSize,
+        private int $occupancy
+    ) {
+        $this->bucketEnd = $bucketTs + $bucketSize;
+        $this->prevTs = $bucketTs;
+        $this->peak = $occupancy;
+    }
+
+    public function getBucketTs(): int
+    {
+        return $this->bucketTs;
+    }
+
+    public function getBucketEnd(): int
+    {
+        return $this->bucketEnd;
+    }
+
+    public function getOccupancy(): int
+    {
+        return $this->occupancy;
+    }
+
+    public function getPeak(): int
+    {
+        return $this->peak;
+    }
+
+    public function getBlockedByCompanyLimit(): int
+    {
+        return $this->blockedByCompanyLimit;
+    }
+
+    public function getBlockedByBrandLimit(): int
+    {
+        return $this->blockedByBrandLimit;
+    }
+
+    /**
+     * Time-weighted occupancy over the bucket, so a channel held for half the bucket
+     * counts as half a channel.
+     */
+    public function getAverageUsage(): float
+    {
+        return $this->integral / $this->bucketSize;
+    }
+
+    /**
+     * Accrue occupancy-time up to $ts. Timestamps must arrive in ascending order;
+     * out-of-order input would subtract time, so the caller sorts beforehand.
+     */
+    public function accrueUntil(int $ts): void
+    {
+        if ($ts <= $this->prevTs) {
+            return;
+        }
+
+        $this->integral += $this->occupancy * ($ts - $this->prevTs);
+        $this->prevTs = $ts;
+    }
+
+    /**
+     * An 'A' event: a channel was admitted. Kamailio ships the resulting occupancy,
+     * which wins over our own running count when present.
+     */
+    public function admit(?int $occupancy): void
+    {
+        $this->occupancy = $occupancy ?? ($this->occupancy + 1);
+        $this->peak = max($this->peak, $this->occupancy);
+    }
+
+    /**
+     * An 'H' event: a counted channel was released.
+     */
+    public function hangup(): void
+    {
+        $this->occupancy = max(0, $this->occupancy - 1);
+    }
+
+    /**
+     * A 'B' event: a call was rejected by a max-channel limit. Does not alter occupancy.
+     */
+    public function block(string $reason): void
+    {
+        if ($reason === 'brand') {
+            $this->blockedByBrandLimit++;
+
+            return;
+        }
+
+        $this->blockedByCompanyLimit++;
+    }
+
+    /**
+     * Complete the integral up to the bucket's end. Call before reading getAverageUsage().
+     */
+    public function seal(): void
+    {
+        $this->accrueUntil($this->bucketEnd);
+    }
+
+    /**
+     * Accumulator for the following bucket, carrying occupancy over as its opening value.
+     */
+    public function next(): self
+    {
+        return new self(
+            $this->bucketEnd,
+            $this->bucketSize,
+            $this->occupancy
+        );
+    }
+}

--- a/library/Ivoz/Provider/Domain/Model/ChannelUsage/ChannelUsageDto.php
+++ b/library/Ivoz/Provider/Domain/Model/ChannelUsage/ChannelUsageDto.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Ivoz\Provider\Domain\Model\ChannelUsage;
+
+class ChannelUsageDto extends ChannelUsageDtoAbstract
+{
+}

--- a/library/Ivoz/Provider/Domain/Model/ChannelUsage/ChannelUsageDtoAbstract.php
+++ b/library/Ivoz/Provider/Domain/Model/ChannelUsage/ChannelUsageDtoAbstract.php
@@ -1,0 +1,305 @@
+<?php
+
+namespace Ivoz\Provider\Domain\Model\ChannelUsage;
+
+use Ivoz\Core\Domain\DataTransferObjectInterface;
+use Ivoz\Core\Domain\Model\DtoNormalizer;
+use Ivoz\Provider\Domain\Model\Brand\BrandDto;
+use Ivoz\Provider\Domain\Model\Company\CompanyDto;
+
+/**
+* ChannelUsageDtoAbstract
+* @codeCoverageIgnore
+*/
+abstract class ChannelUsageDtoAbstract implements DataTransferObjectInterface
+{
+    use DtoNormalizer;
+
+    /**
+     * @var \DateTimeInterface|string|null
+     */
+    private $timestamp = null;
+
+    /**
+     * @var int|null
+     */
+    private $peak = null;
+
+    /**
+     * @var float|null
+     */
+    private $avgUsage = null;
+
+    /**
+     * @var int|null
+     */
+    private $closingUsage = null;
+
+    /**
+     * @var int|null
+     */
+    private $maxCallsCompany = null;
+
+    /**
+     * @var int|null
+     */
+    private $maxCallsBrand = null;
+
+    /**
+     * @var int|null
+     */
+    private $blockedByCompanyLimit = 0;
+
+    /**
+     * @var int|null
+     */
+    private $blockedByBrandLimit = 0;
+
+    /**
+     * @var int|null
+     */
+    private $id = null;
+
+    /**
+     * @var BrandDto | null
+     */
+    private $brand = null;
+
+    /**
+     * @var CompanyDto | null
+     */
+    private $company = null;
+
+    public function __construct(?int $id = null)
+    {
+        $this->setId($id);
+    }
+
+    /**
+    * @inheritdoc
+    */
+    public static function getPropertyMap(string $context = '', string $role = null): array
+    {
+        if ($context === self::CONTEXT_COLLECTION) {
+            return ['id' => 'id'];
+        }
+
+        return [
+            'timestamp' => 'timestamp',
+            'peak' => 'peak',
+            'avgUsage' => 'avgUsage',
+            'closingUsage' => 'closingUsage',
+            'maxCallsCompany' => 'maxCallsCompany',
+            'maxCallsBrand' => 'maxCallsBrand',
+            'blockedByCompanyLimit' => 'blockedByCompanyLimit',
+            'blockedByBrandLimit' => 'blockedByBrandLimit',
+            'id' => 'id',
+            'brandId' => 'brand',
+            'companyId' => 'company'
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(bool $hideSensitiveData = false): array
+    {
+        $response = [
+            'timestamp' => $this->getTimestamp(),
+            'peak' => $this->getPeak(),
+            'avgUsage' => $this->getAvgUsage(),
+            'closingUsage' => $this->getClosingUsage(),
+            'maxCallsCompany' => $this->getMaxCallsCompany(),
+            'maxCallsBrand' => $this->getMaxCallsBrand(),
+            'blockedByCompanyLimit' => $this->getBlockedByCompanyLimit(),
+            'blockedByBrandLimit' => $this->getBlockedByBrandLimit(),
+            'id' => $this->getId(),
+            'brand' => $this->getBrand(),
+            'company' => $this->getCompany()
+        ];
+
+        if (!$hideSensitiveData) {
+            return $response;
+        }
+
+        foreach ($this->sensitiveFields as $sensitiveField) {
+            if (!array_key_exists($sensitiveField, $response)) {
+                throw new \Exception($sensitiveField . ' field was not found');
+            }
+            $response[$sensitiveField] = '*****';
+        }
+
+        return $response;
+    }
+
+    public function setTimestamp(\DateTimeInterface|string $timestamp): static
+    {
+        $this->timestamp = $timestamp;
+
+        return $this;
+    }
+
+    public function getTimestamp(): \DateTimeInterface|string|null
+    {
+        return $this->timestamp;
+    }
+
+    public function setPeak(int $peak): static
+    {
+        $this->peak = $peak;
+
+        return $this;
+    }
+
+    public function getPeak(): ?int
+    {
+        return $this->peak;
+    }
+
+    public function setAvgUsage(float $avgUsage): static
+    {
+        $this->avgUsage = $avgUsage;
+
+        return $this;
+    }
+
+    public function getAvgUsage(): ?float
+    {
+        return $this->avgUsage;
+    }
+
+    public function setClosingUsage(int $closingUsage): static
+    {
+        $this->closingUsage = $closingUsage;
+
+        return $this;
+    }
+
+    public function getClosingUsage(): ?int
+    {
+        return $this->closingUsage;
+    }
+
+    public function setMaxCallsCompany(int $maxCallsCompany): static
+    {
+        $this->maxCallsCompany = $maxCallsCompany;
+
+        return $this;
+    }
+
+    public function getMaxCallsCompany(): ?int
+    {
+        return $this->maxCallsCompany;
+    }
+
+    public function setMaxCallsBrand(int $maxCallsBrand): static
+    {
+        $this->maxCallsBrand = $maxCallsBrand;
+
+        return $this;
+    }
+
+    public function getMaxCallsBrand(): ?int
+    {
+        return $this->maxCallsBrand;
+    }
+
+    public function setBlockedByCompanyLimit(int $blockedByCompanyLimit): static
+    {
+        $this->blockedByCompanyLimit = $blockedByCompanyLimit;
+
+        return $this;
+    }
+
+    public function getBlockedByCompanyLimit(): ?int
+    {
+        return $this->blockedByCompanyLimit;
+    }
+
+    public function setBlockedByBrandLimit(int $blockedByBrandLimit): static
+    {
+        $this->blockedByBrandLimit = $blockedByBrandLimit;
+
+        return $this;
+    }
+
+    public function getBlockedByBrandLimit(): ?int
+    {
+        return $this->blockedByBrandLimit;
+    }
+
+    /**
+     * @param int|null $id
+     */
+    public function setId($id): static
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setBrand(?BrandDto $brand): static
+    {
+        $this->brand = $brand;
+
+        return $this;
+    }
+
+    public function getBrand(): ?BrandDto
+    {
+        return $this->brand;
+    }
+
+    public function setBrandId(?int $id): static
+    {
+        $value = !is_null($id)
+            ? new BrandDto($id)
+            : null;
+
+        return $this->setBrand($value);
+    }
+
+    public function getBrandId(): ?int
+    {
+        if ($dto = $this->getBrand()) {
+            return $dto->getId();
+        }
+
+        return null;
+    }
+
+    public function setCompany(?CompanyDto $company): static
+    {
+        $this->company = $company;
+
+        return $this;
+    }
+
+    public function getCompany(): ?CompanyDto
+    {
+        return $this->company;
+    }
+
+    public function setCompanyId(?int $id): static
+    {
+        $value = !is_null($id)
+            ? new CompanyDto($id)
+            : null;
+
+        return $this->setCompany($value);
+    }
+
+    public function getCompanyId(): ?int
+    {
+        if ($dto = $this->getCompany()) {
+            return $dto->getId();
+        }
+
+        return null;
+    }
+}

--- a/library/Ivoz/Provider/Domain/Model/ChannelUsage/ChannelUsageEvent.php
+++ b/library/Ivoz/Provider/Domain/Model/ChannelUsage/ChannelUsageEvent.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ivoz\Provider\Domain\Model\ChannelUsage;
+
+/**
+ * A single channel usage event as published by kamtrunks.
+ *
+ * The wire format is:
+ *
+ *   A:<ts>:<brandId>:<companyId>:<occupancy>      a channel was admitted
+ *   H:<ts>:<brandId>:<companyId>                  a counted channel was released
+ *   B:<ts>:<brandId>:<companyId>:<brand|company>  a call was rejected by a limit
+ *
+ * The original wire string is kept: the parser drops malformed entries, so consumers
+ * cannot infer how many raw queue entries a set of events came from and need the
+ * originals to put back what they are not ready to process.
+ */
+final class ChannelUsageEvent
+{
+    public const TYPE_ADMITTED = 'A';
+    public const TYPE_HANGUP = 'H';
+    public const TYPE_BLOCKED = 'B';
+
+    public const REASON_BRAND = 'brand';
+    public const REASON_COMPANY = 'company';
+
+    private const TYPES = [
+        self::TYPE_ADMITTED,
+        self::TYPE_HANGUP,
+        self::TYPE_BLOCKED
+    ];
+
+    private function __construct(
+        private string $type,
+        private int $timestamp,
+        private int $brandId,
+        private int $companyId,
+        private ?int $occupancy,
+        private string $reason,
+        private string $wire
+    ) {
+    }
+
+    /**
+     * @return self|null null when the entry does not hold a usable event
+     */
+    public static function fromWire(string $wire): ?self
+    {
+        $parts = explode(':', $wire);
+
+        if (count($parts) < 4) {
+            return null;
+        }
+
+        $type = $parts[0];
+        $timestamp = (int) $parts[1];
+        $brandId = (int) $parts[2];
+        $companyId = (int) $parts[3];
+
+        $isValid =
+            in_array($type, self::TYPES, true)
+            && $timestamp > 0
+            && $brandId > 0
+            && $companyId > 0;
+
+        if (!$isValid) {
+            return null;
+        }
+
+        $occupancy = null;
+        if ($type === self::TYPE_ADMITTED && isset($parts[4])) {
+            $occupancy = (int) $parts[4];
+        }
+
+        $reason = '';
+        if ($type === self::TYPE_BLOCKED && isset($parts[4])) {
+            $reason = $parts[4];
+        }
+
+        return new self(
+            $type,
+            $timestamp,
+            $brandId,
+            $companyId,
+            $occupancy,
+            $reason,
+            $wire
+        );
+    }
+
+    public function getTimestamp(): int
+    {
+        return $this->timestamp;
+    }
+
+    public function getBrandId(): int
+    {
+        return $this->brandId;
+    }
+
+    public function getCompanyId(): int
+    {
+        return $this->companyId;
+    }
+
+    /**
+     * Occupancy reported by kamailio for an admission, when it shipped one.
+     */
+    public function getOccupancy(): ?int
+    {
+        return $this->occupancy;
+    }
+
+    public function getReason(): string
+    {
+        return $this->reason;
+    }
+
+    public function getWire(): string
+    {
+        return $this->wire;
+    }
+
+    public function isAdmission(): bool
+    {
+        return $this->type === self::TYPE_ADMITTED;
+    }
+
+    public function isHangup(): bool
+    {
+        return $this->type === self::TYPE_HANGUP;
+    }
+
+    public function isBlock(): bool
+    {
+        return $this->type === self::TYPE_BLOCKED;
+    }
+
+    public function isBlockedByBrand(): bool
+    {
+        return $this->isBlock()
+            && $this->reason === self::REASON_BRAND;
+    }
+
+    public function belongsTo(int $companyId): bool
+    {
+        return $this->companyId === $companyId;
+    }
+
+    public function happenedBefore(int $timestamp): bool
+    {
+        return $this->timestamp < $timestamp;
+    }
+}

--- a/library/Ivoz/Provider/Domain/Model/ChannelUsage/ChannelUsageInterface.php
+++ b/library/Ivoz/Provider/Domain/Model/ChannelUsage/ChannelUsageInterface.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Ivoz\Provider\Domain\Model\ChannelUsage;
+
+use Ivoz\Core\Domain\Model\EntityInterface;
+use Ivoz\Core\Domain\DataTransferObjectInterface;
+use Ivoz\Core\Domain\ForeignKeyTransformerInterface;
+use Ivoz\Provider\Domain\Model\Brand\BrandInterface;
+use Ivoz\Provider\Domain\Model\Company\CompanyInterface;
+
+/**
+* ChannelUsageInterface
+*/
+interface ChannelUsageInterface extends EntityInterface
+{
+    /**
+     * Get id
+     * @codeCoverageIgnore
+     */
+    public function getId(): ?int;
+
+    /**
+     * @param int | null $id
+     */
+    public static function createDto($id = null): ChannelUsageDto;
+
+    /**
+     * @internal use EntityTools instead
+     * @param null|ChannelUsageInterface $entity
+     */
+    public static function entityToDto(?EntityInterface $entity, int $depth = 0): ?ChannelUsageDto;
+
+    /**
+     * Factory method
+     * @internal use EntityTools instead
+     * @param ChannelUsageDto $dto
+     */
+    public static function fromDto(DataTransferObjectInterface $dto, ForeignKeyTransformerInterface $fkTransformer): static;
+
+    /**
+     * @internal use EntityTools instead
+     */
+    public function toDto(int $depth = 0): ChannelUsageDto;
+
+    public function getTimestamp(): \DateTime;
+
+    public function getPeak(): int;
+
+    public function getAvgUsage(): float;
+
+    public function getClosingUsage(): int;
+
+    public function getMaxCallsCompany(): int;
+
+    public function getMaxCallsBrand(): int;
+
+    public function getBlockedByCompanyLimit(): int;
+
+    public function getBlockedByBrandLimit(): int;
+
+    public function getBrand(): BrandInterface;
+
+    public function getCompany(): CompanyInterface;
+}

--- a/library/Ivoz/Provider/Domain/Model/ChannelUsage/ChannelUsageRepository.php
+++ b/library/Ivoz/Provider/Domain/Model/ChannelUsage/ChannelUsageRepository.php
@@ -16,5 +16,20 @@ interface ChannelUsageRepository extends ObjectRepository, Selectable
         \DateTimeInterface $timestamp
     ): ?ChannelUsageInterface;
 
+    /**
+     * Existing buckets for a set of companies within a timestamp window.
+     *
+     * Lets a collector resolve a whole batch of buckets with a single query instead of one
+     * lookup per row.
+     *
+     * @param array<int, int> $companyIds
+     * @return array<int, ChannelUsageInterface>
+     */
+    public function findByCompaniesAndTimestampRange(
+        array $companyIds,
+        \DateTimeInterface $from,
+        \DateTimeInterface $to
+    ): array;
+
     public function purgeOlderThan(\DateTimeInterface $cutoff, int $limit): int;
 }

--- a/library/Ivoz/Provider/Domain/Model/ChannelUsage/ChannelUsageRepository.php
+++ b/library/Ivoz/Provider/Domain/Model/ChannelUsage/ChannelUsageRepository.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Ivoz\Provider\Domain\Model\ChannelUsage;
+
+use Doctrine\Common\Collections\Selectable;
+use Doctrine\Persistence\ObjectRepository;
+
+/**
+ * @extends ObjectRepository<ChannelUsageInterface>
+ * @extends Selectable<int, ChannelUsageInterface>
+ */
+interface ChannelUsageRepository extends ObjectRepository, Selectable
+{
+    /**
+     * @param array<array{
+     *   brandId: int,
+     *   companyId: int,
+     *   timestamp: \DateTimeInterface,
+     *   peak: int,
+     *   avgUsage: float,
+     *   closingUsage: int,
+     *   maxCallsCompany: int,
+     *   maxCallsBrand: int,
+     *   blockedByCompanyLimit: int,
+     *   blockedByBrandLimit: int
+     * }> $rows
+     * @return int affected rows
+     */
+    public function upsertBatch(array $rows): int;
+
+    public function purgeOlderThan(\DateTimeInterface $cutoff, int $limit): int;
+}

--- a/library/Ivoz/Provider/Domain/Model/ChannelUsage/ChannelUsageRepository.php
+++ b/library/Ivoz/Provider/Domain/Model/ChannelUsage/ChannelUsageRepository.php
@@ -11,22 +11,10 @@ use Doctrine\Persistence\ObjectRepository;
  */
 interface ChannelUsageRepository extends ObjectRepository, Selectable
 {
-    /**
-     * @param array<array{
-     *   brandId: int,
-     *   companyId: int,
-     *   timestamp: \DateTimeInterface,
-     *   peak: int,
-     *   avgUsage: float,
-     *   closingUsage: int,
-     *   maxCallsCompany: int,
-     *   maxCallsBrand: int,
-     *   blockedByCompanyLimit: int,
-     *   blockedByBrandLimit: int
-     * }> $rows
-     * @return int affected rows
-     */
-    public function upsertBatch(array $rows): int;
+    public function findOneByCompanyAndTimestamp(
+        int $companyId,
+        \DateTimeInterface $timestamp
+    ): ?ChannelUsageInterface;
 
     public function purgeOlderThan(\DateTimeInterface $cutoff, int $limit): int;
 }

--- a/library/Ivoz/Provider/Domain/Model/ChannelUsage/ChannelUsageTrait.php
+++ b/library/Ivoz/Provider/Domain/Model/ChannelUsage/ChannelUsageTrait.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ivoz\Provider\Domain\Model\ChannelUsage;
+
+use Ivoz\Core\Domain\DataTransferObjectInterface;
+use Ivoz\Core\Domain\ForeignKeyTransformerInterface;
+
+/**
+* @codeCoverageIgnore
+*/
+trait ChannelUsageTrait
+{
+    /**
+     * @var ?int
+     */
+    protected $id = null;
+
+    /**
+     * Constructor
+     */
+    protected function __construct()
+    {
+        parent::__construct(...func_get_args());
+    }
+
+    abstract protected function sanitizeValues(): void;
+
+    /**
+     * Factory method
+     * @internal use EntityTools instead
+     * @param ChannelUsageDto $dto
+     */
+    public static function fromDto(
+        DataTransferObjectInterface $dto,
+        ForeignKeyTransformerInterface $fkTransformer
+    ): static {
+        /** @var static $self */
+        $self = parent::fromDto($dto, $fkTransformer);
+
+        $self->sanitizeValues();
+        if ($dto->getId()) {
+            $self->id = $dto->getId();
+            $self->initChangelog();
+        }
+
+        return $self;
+    }
+
+    /**
+     * @internal use EntityTools instead
+     * @param ChannelUsageDto $dto
+     */
+    public function updateFromDto(
+        DataTransferObjectInterface $dto,
+        ForeignKeyTransformerInterface $fkTransformer
+    ): static {
+        parent::updateFromDto($dto, $fkTransformer);
+
+        $this->sanitizeValues();
+
+        return $this;
+    }
+
+    /**
+     * @internal use EntityTools instead
+     */
+    public function toDto(int $depth = 0): ChannelUsageDto
+    {
+        $dto = parent::toDto($depth);
+        return $dto
+            ->setId($this->getId());
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function __toArray(): array
+    {
+        return parent::__toArray() + [
+            'id' => self::getId()
+        ];
+    }
+}

--- a/library/Ivoz/Provider/Domain/Service/ChannelUsage/ChannelUsageBucketCalculator.php
+++ b/library/Ivoz/Provider/Domain/Service/ChannelUsage/ChannelUsageBucketCalculator.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace Ivoz\Provider\Domain\Service\ChannelUsage;
 
 use Ivoz\Provider\Domain\Model\ChannelUsage\ChannelUsageBucketAccumulator;
+use Ivoz\Provider\Domain\Model\ChannelUsage\ChannelUsageEvent;
 
 /**
  * Turns a company's channel usage event stream into per-bucket metrics.
  *
  * Deliberately free of Redis, repositories and the clock: it is pure arithmetic over
- * arrays, which is what makes the interesting part of channel usage collection specable.
+ * events, which is what makes the interesting part of channel usage collection specable.
  *
- * @phpstan-type ChannelUsageEvent array{type: string, ts: int, brandId: int, companyId: int, occ: int|null, reason: string, raw: string}
  * @phpstan-type ChannelUsageBucket array{bucketTs: int, bucketEnd: int, peak: int, avgUsage: float, closingUsage: int, blockedByCompanyLimit: int, blockedByBrandLimit: int}
  */
 class ChannelUsageBucketCalculator
@@ -42,12 +42,12 @@ class ChannelUsageBucketCalculator
         $occupancy = $startOccupancy;
 
         foreach (array_reverse($events) as $event) {
-            if ($event['type'] === ChannelUsageEventParser::TYPE_ADMITTED) {
+            if ($event->isAdmission()) {
                 $occupancy = max(0, $occupancy - 1);
-            } elseif ($event['type'] === ChannelUsageEventParser::TYPE_HANGUP) {
+            } elseif ($event->isHangup()) {
                 $occupancy++;
             }
-            // 'B' events are rejections: they never changed occupancy
+            // Blocks are rejections: they never changed occupancy
         }
 
         return $occupancy;
@@ -69,7 +69,7 @@ class ChannelUsageBucketCalculator
         $events = $this->sortByTimestamp($events);
 
         $accumulator = new ChannelUsageBucketAccumulator(
-            $this->bucketStart($events[0]['ts']),
+            $this->bucketStart($events[0]->getTimestamp()),
             self::BUCKET_SIZE,
             $openingOccupancy
         );
@@ -77,7 +77,7 @@ class ChannelUsageBucketCalculator
         $buckets = [];
 
         foreach ($events as $event) {
-            $eventBucket = $this->bucketStart($event['ts']);
+            $eventBucket = $this->bucketStart($event->getTimestamp());
 
             while ($accumulator->getBucketTs() < $eventBucket) {
                 $accumulator->seal();
@@ -85,14 +85,14 @@ class ChannelUsageBucketCalculator
                 $accumulator = $accumulator->next();
             }
 
-            $accumulator->accrueUntil($event['ts']);
+            $accumulator->accrueUntil($event->getTimestamp());
 
-            if ($event['type'] === ChannelUsageEventParser::TYPE_ADMITTED) {
-                $accumulator->admit($event['occ']);
-            } elseif ($event['type'] === ChannelUsageEventParser::TYPE_HANGUP) {
+            if ($event->isAdmission()) {
+                $accumulator->admit($event->getOccupancy());
+            } elseif ($event->isHangup()) {
                 $accumulator->hangup();
-            } elseif ($event['type'] === ChannelUsageEventParser::TYPE_BLOCKED) {
-                $accumulator->block($event['reason']);
+            } elseif ($event->isBlock()) {
+                $accumulator->block($event->isBlockedByBrand());
             }
         }
 
@@ -144,7 +144,8 @@ class ChannelUsageBucketCalculator
     {
         usort(
             $events,
-            fn (array $a, array $b): int => $a['ts'] <=> $b['ts']
+            fn (ChannelUsageEvent $a, ChannelUsageEvent $b): int
+                => $a->getTimestamp() <=> $b->getTimestamp()
         );
 
         return $events;

--- a/library/Ivoz/Provider/Domain/Service/ChannelUsage/ChannelUsageBucketCalculator.php
+++ b/library/Ivoz/Provider/Domain/Service/ChannelUsage/ChannelUsageBucketCalculator.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ivoz\Provider\Domain\Service\ChannelUsage;
+
+use Ivoz\Provider\Domain\Model\ChannelUsage\ChannelUsageBucketAccumulator;
+
+/**
+ * Turns a company's channel usage event stream into per-bucket metrics.
+ *
+ * Deliberately free of Redis, repositories and the clock: it is pure arithmetic over
+ * arrays, which is what makes the interesting part of channel usage collection specable.
+ *
+ * @phpstan-type ChannelUsageEvent array{type: string, ts: int, brandId: int, companyId: int, occ: int|null, reason: string, raw: string}
+ * @phpstan-type ChannelUsageBucket array{bucketTs: int, bucketEnd: int, peak: int, avgUsage: float, closingUsage: int, blockedByCompanyLimit: int, blockedByBrandLimit: int}
+ */
+class ChannelUsageBucketCalculator
+{
+    public const BUCKET_SIZE = 300;
+
+    /**
+     * Timestamp of the bucket a given instant falls into.
+     */
+    public function bucketStart(int $timestamp): int
+    {
+        return (int) (floor($timestamp / self::BUCKET_SIZE) * self::BUCKET_SIZE);
+    }
+
+    /**
+     * Walk $events backwards from a known occupancy to recover the occupancy held before
+     * any of them happened.
+     *
+     * The clamp at zero makes the result order-dependent, so events are sorted here rather
+     * than trusting the order they were queued in.
+     *
+     * @param array<int, ChannelUsageEvent> $events
+     */
+    public function rewind(int $startOccupancy, array $events): int
+    {
+        $events = $this->sortByTimestamp($events);
+        $occupancy = $startOccupancy;
+
+        foreach (array_reverse($events) as $event) {
+            if ($event['type'] === ChannelUsageEventParser::TYPE_ADMITTED) {
+                $occupancy = max(0, $occupancy - 1);
+            } elseif ($event['type'] === ChannelUsageEventParser::TYPE_HANGUP) {
+                $occupancy++;
+            }
+            // 'B' events are rejections: they never changed occupancy
+        }
+
+        return $occupancy;
+    }
+
+    /**
+     * Replay $events forward from $openingOccupancy, emitting one entry per bucket touched.
+     * Buckets with no events in between are emitted too, carrying occupancy over.
+     *
+     * @param array<int, ChannelUsageEvent> $events
+     * @return array<int, ChannelUsageBucket>
+     */
+    public function calculate(array $events, int $openingOccupancy): array
+    {
+        if (empty($events)) {
+            return [];
+        }
+
+        $events = $this->sortByTimestamp($events);
+
+        $accumulator = new ChannelUsageBucketAccumulator(
+            $this->bucketStart($events[0]['ts']),
+            self::BUCKET_SIZE,
+            $openingOccupancy
+        );
+
+        $buckets = [];
+
+        foreach ($events as $event) {
+            $eventBucket = $this->bucketStart($event['ts']);
+
+            while ($accumulator->getBucketTs() < $eventBucket) {
+                $accumulator->seal();
+                $buckets[] = $this->toBucket($accumulator);
+                $accumulator = $accumulator->next();
+            }
+
+            $accumulator->accrueUntil($event['ts']);
+
+            if ($event['type'] === ChannelUsageEventParser::TYPE_ADMITTED) {
+                $accumulator->admit($event['occ']);
+            } elseif ($event['type'] === ChannelUsageEventParser::TYPE_HANGUP) {
+                $accumulator->hangup();
+            } elseif ($event['type'] === ChannelUsageEventParser::TYPE_BLOCKED) {
+                $accumulator->block($event['reason']);
+            }
+        }
+
+        $accumulator->seal();
+        $buckets[] = $this->toBucket($accumulator);
+
+        return $buckets;
+    }
+
+    /**
+     * A bucket in which nothing happened but $occupancy channels stayed up.
+     *
+     * @return ChannelUsageBucket
+     */
+    public function idleBucket(int $bucketTs, int $occupancy): array
+    {
+        return [
+            'bucketTs' => $bucketTs,
+            'bucketEnd' => $bucketTs + self::BUCKET_SIZE,
+            'peak' => $occupancy,
+            'avgUsage' => (float) $occupancy,
+            'closingUsage' => $occupancy,
+            'blockedByCompanyLimit' => 0,
+            'blockedByBrandLimit' => 0
+        ];
+    }
+
+    /**
+     * @return ChannelUsageBucket
+     */
+    private function toBucket(ChannelUsageBucketAccumulator $accumulator): array
+    {
+        return [
+            'bucketTs' => $accumulator->getBucketTs(),
+            'bucketEnd' => $accumulator->getBucketEnd(),
+            'peak' => $accumulator->getPeak(),
+            'avgUsage' => $accumulator->getAverageUsage(),
+            'closingUsage' => $accumulator->getOccupancy(),
+            'blockedByCompanyLimit' => $accumulator->getBlockedByCompanyLimit(),
+            'blockedByBrandLimit' => $accumulator->getBlockedByBrandLimit()
+        ];
+    }
+
+    /**
+     * @param array<int, ChannelUsageEvent> $events
+     * @return array<int, ChannelUsageEvent>
+     */
+    private function sortByTimestamp(array $events): array
+    {
+        usort(
+            $events,
+            fn (array $a, array $b): int => $a['ts'] <=> $b['ts']
+        );
+
+        return $events;
+    }
+}

--- a/library/Ivoz/Provider/Domain/Service/ChannelUsage/ChannelUsageEventParser.php
+++ b/library/Ivoz/Provider/Domain/Service/ChannelUsage/ChannelUsageEventParser.php
@@ -4,39 +4,25 @@ declare(strict_types=1);
 
 namespace Ivoz\Provider\Domain\Service\ChannelUsage;
 
+use Ivoz\Provider\Domain\Model\ChannelUsage\ChannelUsageEvent;
 use Psr\Log\LoggerInterface;
 
 /**
- * Deserializes the wire format kamtrunks pushes to the channel usage queue.
+ * Turns raw queue entries into events, reporting what could not be read.
  *
- *   A:<ts>:<brandId>:<companyId>:<occupancy>      a channel was admitted
- *   H:<ts>:<brandId>:<companyId>                  a counted channel was released
- *   B:<ts>:<brandId>:<companyId>:<brand|company>  a call was rejected by a limit
+ * The wire format itself belongs to ChannelUsageEvent::fromWire(); this only decides what
+ * to do with the entries it rejects.
  */
 class ChannelUsageEventParser
 {
-    public const TYPE_ADMITTED = 'A';
-    public const TYPE_HANGUP = 'H';
-    public const TYPE_BLOCKED = 'B';
-
-    private const TYPES = [
-        self::TYPE_ADMITTED,
-        self::TYPE_HANGUP,
-        self::TYPE_BLOCKED
-    ];
-
     public function __construct(
         private LoggerInterface $logger
     ) {
     }
 
     /**
-     * Malformed entries are dropped, but the caller still consumed them: the returned
-     * events carry no positional meaning, which is why queue trimming must always be
-     * driven by the number of raw entries read and never by the number of events parsed.
-     *
      * @param array<int, string> $rawEntries
-     * @return array<int, array{type: string, ts: int, brandId: int, companyId: int, occ: int|null, reason: string, raw: string}>
+     * @return array<int, ChannelUsageEvent>
      */
     public function parse(array $rawEntries): array
     {
@@ -44,7 +30,7 @@ class ChannelUsageEventParser
         $discarded = 0;
 
         foreach ($rawEntries as $rawEntry) {
-            $event = $this->parseEntry($rawEntry);
+            $event = ChannelUsageEvent::fromWire($rawEntry);
 
             if ($event === null) {
                 $discarded++;
@@ -64,52 +50,5 @@ class ChannelUsageEventParser
         }
 
         return $events;
-    }
-
-    /**
-     * @return array{type: string, ts: int, brandId: int, companyId: int, occ: int|null, reason: string, raw: string}|null
-     */
-    private function parseEntry(string $rawEntry): ?array
-    {
-        $parts = explode(':', $rawEntry);
-
-        if (count($parts) < 4) {
-            return null;
-        }
-
-        $type = $parts[0];
-        $ts = (int) $parts[1];
-        $brandId = (int) $parts[2];
-        $companyId = (int) $parts[3];
-
-        $isValid =
-            in_array($type, self::TYPES, true)
-            && $ts > 0
-            && $brandId > 0
-            && $companyId > 0;
-
-        if (!$isValid) {
-            return null;
-        }
-
-        $occ = null;
-        if ($type === self::TYPE_ADMITTED && isset($parts[4])) {
-            $occ = (int) $parts[4];
-        }
-
-        $reason = '';
-        if ($type === self::TYPE_BLOCKED && isset($parts[4])) {
-            $reason = $parts[4];
-        }
-
-        return [
-            'type' => $type,
-            'ts' => $ts,
-            'brandId' => $brandId,
-            'companyId' => $companyId,
-            'occ' => $occ,
-            'reason' => $reason,
-            'raw' => $rawEntry
-        ];
     }
 }

--- a/library/Ivoz/Provider/Domain/Service/ChannelUsage/ChannelUsageEventParser.php
+++ b/library/Ivoz/Provider/Domain/Service/ChannelUsage/ChannelUsageEventParser.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ivoz\Provider\Domain\Service\ChannelUsage;
+
+use Psr\Log\LoggerInterface;
+
+/**
+ * Deserializes the wire format kamtrunks pushes to the channel usage queue.
+ *
+ *   A:<ts>:<brandId>:<companyId>:<occupancy>      a channel was admitted
+ *   H:<ts>:<brandId>:<companyId>                  a counted channel was released
+ *   B:<ts>:<brandId>:<companyId>:<brand|company>  a call was rejected by a limit
+ */
+class ChannelUsageEventParser
+{
+    public const TYPE_ADMITTED = 'A';
+    public const TYPE_HANGUP = 'H';
+    public const TYPE_BLOCKED = 'B';
+
+    private const TYPES = [
+        self::TYPE_ADMITTED,
+        self::TYPE_HANGUP,
+        self::TYPE_BLOCKED
+    ];
+
+    public function __construct(
+        private LoggerInterface $logger
+    ) {
+    }
+
+    /**
+     * Malformed entries are dropped, but the caller still consumed them: the returned
+     * events carry no positional meaning, which is why queue trimming must always be
+     * driven by the number of raw entries read and never by the number of events parsed.
+     *
+     * @param array<int, string> $rawEntries
+     * @return array<int, array{type: string, ts: int, brandId: int, companyId: int, occ: int|null, reason: string, raw: string}>
+     */
+    public function parse(array $rawEntries): array
+    {
+        $events = [];
+        $discarded = 0;
+
+        foreach ($rawEntries as $rawEntry) {
+            $event = $this->parseEntry($rawEntry);
+
+            if ($event === null) {
+                $discarded++;
+                continue;
+            }
+
+            $events[] = $event;
+        }
+
+        if ($discarded > 0) {
+            $this->logger->warning(
+                sprintf(
+                    'ChannelUsage: discarded %d malformed event(s) from the queue.',
+                    $discarded
+                )
+            );
+        }
+
+        return $events;
+    }
+
+    /**
+     * @return array{type: string, ts: int, brandId: int, companyId: int, occ: int|null, reason: string, raw: string}|null
+     */
+    private function parseEntry(string $rawEntry): ?array
+    {
+        $parts = explode(':', $rawEntry);
+
+        if (count($parts) < 4) {
+            return null;
+        }
+
+        $type = $parts[0];
+        $ts = (int) $parts[1];
+        $brandId = (int) $parts[2];
+        $companyId = (int) $parts[3];
+
+        $isValid =
+            in_array($type, self::TYPES, true)
+            && $ts > 0
+            && $brandId > 0
+            && $companyId > 0;
+
+        if (!$isValid) {
+            return null;
+        }
+
+        $occ = null;
+        if ($type === self::TYPE_ADMITTED && isset($parts[4])) {
+            $occ = (int) $parts[4];
+        }
+
+        $reason = '';
+        if ($type === self::TYPE_BLOCKED && isset($parts[4])) {
+            $reason = $parts[4];
+        }
+
+        return [
+            'type' => $type,
+            'ts' => $ts,
+            'brandId' => $brandId,
+            'companyId' => $companyId,
+            'occ' => $occ,
+            'reason' => $reason,
+            'raw' => $rawEntry
+        ];
+    }
+}

--- a/library/Ivoz/Provider/Domain/Service/ChannelUsage/ChannelUsageRowBuilder.php
+++ b/library/Ivoz/Provider/Domain/Service/ChannelUsage/ChannelUsageRowBuilder.php
@@ -1,0 +1,342 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ivoz\Provider\Domain\Service\ChannelUsage;
+
+use Ivoz\Provider\Domain\Model\Brand\BrandRepository;
+use Ivoz\Provider\Domain\Model\ChannelUsage\ChannelUsageEvent;
+use Ivoz\Provider\Domain\Model\Company\CompanyRepository;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Builds the persistable channel usage rows for every company seen in a collection run.
+ *
+ * Owns the per-company bookkeeping around the pure calculator: who the buckets belong to,
+ * which limits applied, whether the live anchor can be trusted, and filling the buckets that
+ * elapsed with no events at all.
+ *
+ * @phpstan-type ChannelUsageRow array{brandId: int, companyId: int, timestamp: \DateTimeInterface, peak: int, avgUsage: float, closingUsage: int, blockedByCompanyLimit: int, blockedByBrandLimit: int, maxCallsCompany: int, maxCallsBrand: int}
+ * @phpstan-type ChannelUsageBucket array{bucketTs: int, bucketEnd: int, peak: int, avgUsage: float, closingUsage: int, blockedByCompanyLimit: int, blockedByBrandLimit: int}
+ */
+class ChannelUsageRowBuilder
+{
+    /**
+     * Ceiling on gap filling (a day's worth of buckets). Without it, a backlog whose newest
+     * event is old would emit one row per bucket for every 5 minutes elapsed since.
+     */
+    public const MAX_TRAILING_BUCKETS = 288;
+
+    /**
+     * An empty anchor is only trustworthy if no call was admitted recently: otherwise the
+     * realtime service is presumably down and its keyspace lies.
+     */
+    private const ANCHOR_COHERENCE_WINDOW = 600;
+
+    public function __construct(
+        private ChannelUsageBucketCalculator $calculator,
+        private CompanyRepository $companyRepository,
+        private BrandRepository $brandRepository,
+        private LoggerInterface $logger
+    ) {
+    }
+
+    /**
+     * @param array<int, ChannelUsageEvent> $processable events of buckets already closed
+     * @param array<int, ChannelUsageEvent> $deferred events of the bucket still open
+     * @param array<int, array{brandId: int, occ: int}> $anchor live occupancy per company
+     * @return array<int, ChannelUsageRow>
+     */
+    public function build(
+        array $processable,
+        array $deferred,
+        array $anchor,
+        int $bucketStart,
+        int $now
+    ): array {
+        $companyBrandMap = $this->buildCompanyBrandMap($processable, $anchor);
+
+        if (empty($companyBrandMap)) {
+            return [];
+        }
+
+        $anchorCoherent = $this->isAnchorCoherent($anchor, $processable, $now);
+        if (!$anchorCoherent) {
+            $this->logger->warning(
+                'ChannelUsage: anchor has 0 keys but recent A-events exist.'
+                . ' ivozprovider-realtime may be down. Skipping anchor reconciliation.'
+            );
+        }
+
+        $maxCallsCompany = $this->loadCompanyMaxCalls(
+            array_keys($companyBrandMap)
+        );
+        $maxCallsBrand = $this->loadBrandMaxCalls(
+            array_unique(array_values($companyBrandMap))
+        );
+
+        $rows = [];
+
+        foreach ($companyBrandMap as $companyId => $brandId) {
+            $limits = [
+                'maxCallsCompany' => $maxCallsCompany[$companyId] ?? 0,
+                'maxCallsBrand' => $maxCallsBrand[$brandId] ?? 0
+            ];
+
+            $rows = array_merge(
+                $rows,
+                $this->buildCompanyRows(
+                    $companyId,
+                    $brandId,
+                    $limits,
+                    $this->filterByCompany($processable, $companyId),
+                    $this->filterByCompany($deferred, $companyId),
+                    $anchor[$companyId]['occ'] ?? 0,
+                    $anchorCoherent,
+                    $bucketStart
+                )
+            );
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param array{maxCallsCompany: int, maxCallsBrand: int} $limits
+     * @param array<int, ChannelUsageEvent> $processable
+     * @param array<int, ChannelUsageEvent> $deferred
+     * @return array<int, ChannelUsageRow>
+     */
+    private function buildCompanyRows(
+        int $companyId,
+        int $brandId,
+        array $limits,
+        array $processable,
+        array $deferred,
+        int $anchorOccupancy,
+        bool $anchorCoherent,
+        int $bucketStart
+    ): array {
+        // The anchor is a *live* snapshot: rewind it past the still-open bucket first.
+        $occupancyAtBucketStart = $this->calculator->rewind(
+            $anchorOccupancy,
+            $deferred
+        );
+
+        if (empty($processable)) {
+            if (!$anchorCoherent || $occupancyAtBucketStart < 1) {
+                return [];
+            }
+
+            // Nothing happened, but channels are up: record the bucket that just closed.
+            return [
+                $this->toRow(
+                    $this->calculator->idleBucket(
+                        $bucketStart - ChannelUsageBucketCalculator::BUCKET_SIZE,
+                        $occupancyAtBucketStart
+                    ),
+                    $brandId,
+                    $companyId,
+                    $limits
+                )
+            ];
+        }
+
+        $openingOccupancy = $this->calculator->rewind(
+            $occupancyAtBucketStart,
+            $processable
+        );
+
+        $buckets = $this->calculator->calculate($processable, $openingOccupancy);
+
+        $rows = [];
+        foreach ($buckets as $bucket) {
+            $rows[] = $this->toRow($bucket, $brandId, $companyId, $limits);
+        }
+
+        return array_merge(
+            $rows,
+            $this->fillTrailingBuckets(
+                $buckets,
+                $bucketStart,
+                $anchorCoherent,
+                $brandId,
+                $companyId,
+                $limits
+            )
+        );
+    }
+
+    /**
+     * Buckets between the last event and the current open bucket got no events at all, but
+     * the channels that were up stayed up: emit them so the history has no holes.
+     *
+     * @param array<int, ChannelUsageBucket> $buckets
+     * @param array{maxCallsCompany: int, maxCallsBrand: int} $limits
+     * @return array<int, ChannelUsageRow>
+     */
+    private function fillTrailingBuckets(
+        array $buckets,
+        int $bucketStart,
+        bool $anchorCoherent,
+        int $brandId,
+        int $companyId,
+        array $limits
+    ): array {
+        $lastBucket = end($buckets);
+
+        if (!$anchorCoherent || $lastBucket === false) {
+            return [];
+        }
+
+        $occupancy = $lastBucket['closingUsage'];
+
+        if ($occupancy < 1) {
+            return [];
+        }
+
+        $rows = [];
+        for ($ts = $lastBucket['bucketEnd']; $ts < $bucketStart; $ts += ChannelUsageBucketCalculator::BUCKET_SIZE) {
+            if (count($rows) >= self::MAX_TRAILING_BUCKETS) {
+                $this->logger->warning(
+                    sprintf(
+                        'ChannelUsage: stopped filling idle buckets for company %d after %d of them.'
+                        . ' The queue backlog looks older than the gap filling is meant to cover.',
+                        $companyId,
+                        self::MAX_TRAILING_BUCKETS
+                    )
+                );
+
+                break;
+            }
+
+            $rows[] = $this->toRow(
+                $this->calculator->idleBucket($ts, $occupancy),
+                $brandId,
+                $companyId,
+                $limits
+            );
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param ChannelUsageBucket $bucket
+     * @param array{maxCallsCompany: int, maxCallsBrand: int} $limits
+     * @return ChannelUsageRow
+     */
+    private function toRow(array $bucket, int $brandId, int $companyId, array $limits): array
+    {
+        return [
+            'brandId' => $brandId,
+            'companyId' => $companyId,
+            'timestamp' => new \DateTime(
+                '@' . $bucket['bucketTs'],
+                new \DateTimeZone('UTC')
+            ),
+            'peak' => $bucket['peak'],
+            'avgUsage' => $bucket['avgUsage'],
+            'closingUsage' => $bucket['closingUsage'],
+            'blockedByCompanyLimit' => $bucket['blockedByCompanyLimit'],
+            'blockedByBrandLimit' => $bucket['blockedByBrandLimit'],
+            'maxCallsCompany' => $limits['maxCallsCompany'],
+            'maxCallsBrand' => $limits['maxCallsBrand']
+        ];
+    }
+
+    /**
+     * @param array<int, array{brandId: int, occ: int}> $anchor
+     * @param array<int, ChannelUsageEvent> $processable
+     */
+    private function isAnchorCoherent(array $anchor, array $processable, int $now): bool
+    {
+        if (!empty($anchor)) {
+            return true;
+        }
+
+        $recentThreshold = $now - self::ANCHOR_COHERENCE_WINDOW;
+
+        foreach ($processable as $event) {
+            $isRecentAdmission =
+                $event->isAdmission()
+                && $event->getTimestamp() >= $recentThreshold
+                && ($event->getOccupancy() ?? 0) > 0;
+
+            if ($isRecentAdmission) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param array<int, ChannelUsageEvent> $processable
+     * @param array<int, array{brandId: int, occ: int}> $anchor
+     * @return array<int, int> companyId => brandId
+     */
+    private function buildCompanyBrandMap(array $processable, array $anchor): array
+    {
+        $map = [];
+
+        foreach ($anchor as $companyId => $info) {
+            $map[$companyId] = $info['brandId'];
+        }
+
+        foreach ($processable as $event) {
+            if (!isset($map[$event->getCompanyId()])) {
+                $map[$event->getCompanyId()] = $event->getBrandId();
+            }
+        }
+
+        return $map;
+    }
+
+    /**
+     * @param array<int, int> $companyIds
+     * @return array<int, int> companyId => maxCalls
+     */
+    private function loadCompanyMaxCalls(array $companyIds): array
+    {
+        $result = [];
+        $companies = $this->companyRepository->findBy(['id' => $companyIds]);
+
+        foreach ($companies as $company) {
+            $result[(int) $company->getId()] = $company->getMaxCalls();
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param array<int, int> $brandIds
+     * @return array<int, int> brandId => maxCalls
+     */
+    private function loadBrandMaxCalls(array $brandIds): array
+    {
+        $result = [];
+        $brands = $this->brandRepository->findBy(['id' => $brandIds]);
+
+        foreach ($brands as $brand) {
+            /** @var \Ivoz\Provider\Domain\Model\Brand\BrandInterface $brand */
+            $result[(int) $brand->getId()] = $brand->getMaxCalls();
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param array<int, ChannelUsageEvent> $events
+     * @return array<int, ChannelUsageEvent>
+     */
+    private function filterByCompany(array $events, int $companyId): array
+    {
+        return array_values(
+            array_filter(
+                $events,
+                fn (ChannelUsageEvent $event): bool => $event->belongsTo($companyId)
+            )
+        );
+    }
+}

--- a/library/Ivoz/Provider/Domain/Service/ChannelUsage/ChannelUsageWriter.php
+++ b/library/Ivoz/Provider/Domain/Service/ChannelUsage/ChannelUsageWriter.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ivoz\Provider\Domain\Service\ChannelUsage;
+
+use Ivoz\Core\Domain\Model\Commandlog\Commandlog;
+use Ivoz\Core\Domain\Service\EntityTools;
+use Ivoz\Provider\Domain\Model\ChannelUsage\ChannelUsage;
+use Ivoz\Provider\Domain\Model\ChannelUsage\ChannelUsageDto;
+use Ivoz\Provider\Domain\Model\ChannelUsage\ChannelUsageInterface;
+use Ivoz\Provider\Domain\Model\ChannelUsage\ChannelUsageRepository;
+
+/**
+ * Writes computed channel usage buckets, creating or updating one row per company and bucket.
+ *
+ * @phpstan-type ChannelUsageRow array{brandId: int, companyId: int, timestamp: \DateTimeInterface, peak: int, avgUsage: float, closingUsage: int, blockedByCompanyLimit: int, blockedByBrandLimit: int, maxCallsCompany: int, maxCallsBrand: int}
+ */
+class ChannelUsageWriter
+{
+    public const PERSIST_BATCH_SIZE = 100;
+
+    public function __construct(
+        private ChannelUsageRepository $channelUsageRepository,
+        private EntityTools $entityTools
+    ) {
+    }
+
+    /**
+     * @param array<int, ChannelUsageRow> $rows
+     */
+    public function write(array $rows): void
+    {
+        foreach (array_chunk($rows, self::PERSIST_BATCH_SIZE) as $chunk) {
+            // One lookup for the whole chunk instead of one per row.
+            $existing = $this->loadExisting($chunk);
+
+            foreach ($chunk as $row) {
+                $this->writeRow($row, $existing);
+            }
+
+            // Let errors bubble up: the caller only drains the event queue on success, so no
+            // event is lost and the next run recomputes these buckets.
+            //
+            // Note this is at-least-once, not atomic: chunks already flushed stay committed,
+            // and the rerun rewinds from a *fresh* anchor, so a rewritten bucket can differ
+            // slightly from what a single clean run would have produced. The unique key on
+            // (companyId, timestamp) keeps the shape right - one row per company per bucket -
+            // which is what the historic is read for.
+            $this->entityTools->dispatchQueuedOperations();
+            $this->entityTools->clearExcept(
+                Commandlog::class
+            );
+        }
+    }
+
+    /**
+     * @param array<int, ChannelUsageRow> $rows
+     * @return array<string, ChannelUsageInterface> "<companyId>|<Y-m-d H:i:s>" => entity
+     */
+    private function loadExisting(array $rows): array
+    {
+        $companyIds = array_values(
+            array_unique(
+                array_column($rows, 'companyId')
+            )
+        );
+
+        $timestamps = array_column($rows, 'timestamp');
+
+        if (empty($companyIds) || empty($timestamps)) {
+            return [];
+        }
+
+        $existing = $this->channelUsageRepository->findByCompaniesAndTimestampRange(
+            $companyIds,
+            min($timestamps),
+            max($timestamps)
+        );
+
+        $indexed = [];
+        foreach ($existing as $channelUsage) {
+            $indexed[$this->rowKey(
+                (int) $channelUsage->getCompany()->getId(),
+                $channelUsage->getTimestamp()
+            )] = $channelUsage;
+        }
+
+        return $indexed;
+    }
+
+    /**
+     * @param ChannelUsageRow $row
+     * @param array<string, ChannelUsageInterface> $existing
+     */
+    private function writeRow(array $row, array $existing): void
+    {
+        $channelUsage = $existing[$this->rowKey($row['companyId'], $row['timestamp'])] ?? null;
+
+        if ($channelUsage) {
+            /** @var ChannelUsageDto $channelUsageDto */
+            $channelUsageDto = $this->entityTools->entityToDto($channelUsage);
+        } else {
+            $channelUsageDto = ChannelUsage::createDto();
+        }
+
+        $channelUsageDto
+            ->setBrandId($row['brandId'])
+            ->setCompanyId($row['companyId'])
+            ->setTimestamp($row['timestamp'])
+            ->setPeak($row['peak'])
+            ->setAvgUsage(round($row['avgUsage'], 2))
+            ->setClosingUsage($row['closingUsage'])
+            ->setMaxCallsCompany($row['maxCallsCompany'])
+            ->setMaxCallsBrand($row['maxCallsBrand'])
+            ->setBlockedByCompanyLimit($row['blockedByCompanyLimit'])
+            ->setBlockedByBrandLimit($row['blockedByBrandLimit']);
+
+        $this->entityTools->persistDto(
+            $channelUsageDto,
+            $channelUsage,
+            false
+        );
+    }
+
+    private function rowKey(int $companyId, \DateTimeInterface $timestamp): string
+    {
+        return $companyId . '|' . $timestamp->format('Y-m-d H:i:s');
+    }
+}

--- a/library/Ivoz/Provider/Domain/Service/ChannelUsage/CollectChannelUsage.php
+++ b/library/Ivoz/Provider/Domain/Service/ChannelUsage/CollectChannelUsage.php
@@ -4,20 +4,16 @@ declare(strict_types=1);
 
 namespace Ivoz\Provider\Domain\Service\ChannelUsage;
 
+use Ivoz\Kam\Domain\Service\TrunksClientInterface;
 use Ivoz\Provider\Domain\Job\ChannelUsageEventQueueInterface;
-use Ivoz\Provider\Domain\Model\Brand\BrandRepository;
-use Ivoz\Provider\Domain\Model\Company\CompanyRepository;
-use Psr\Log\LoggerInterface;
+use Ivoz\Provider\Domain\Model\ChannelUsage\ChannelUsageEvent;
 
 /**
  * Collects channel usage into closed 5-minute buckets.
  *
- * Reads the event queue through a port, reconstructs each company's occupancy by rewinding
- * from the live realtime anchor back to the start of the oldest closed bucket, then replays
- * forward to obtain peak, time-weighted average and closing occupancy per bucket.
- *
- * @phpstan-type ChannelUsageEvent array{type: string, ts: int, brandId: int, companyId: int, occ: int|null, reason: string, raw: string}
- * @phpstan-type ChannelUsageRow array{brandId: int, companyId: int, timestamp: \DateTimeInterface, peak: int, avgUsage: float, closingUsage: int, blockedByCompanyLimit: int, blockedByBrandLimit: int, maxCallsCompany: int, maxCallsBrand: int}
+ * Reads a bounded slice of the event queue, splits it into buckets that are already closed
+ * and the one still open, hands the arithmetic to the row builder and the rows to the writer,
+ * and only then consumes what it read.
  */
 class CollectChannelUsage
 {
@@ -27,26 +23,13 @@ class CollectChannelUsage
      */
     public const MAX_ENTRIES_PER_RUN = 50000;
 
-    /**
-     * Ceiling on gap filling (a day's worth of buckets). Without it, a backlog whose newest
-     * event is old would emit one row per bucket for every 5 minutes elapsed since.
-     */
-    public const MAX_TRAILING_BUCKETS = 288;
-
-    /**
-     * An empty anchor is only trustworthy if no call was admitted recently: otherwise the
-     * realtime service is presumably down and its keyspace lies.
-     */
-    private const ANCHOR_COHERENCE_WINDOW = 600;
-
     public function __construct(
         private ChannelUsageEventQueueInterface $eventQueue,
+        private TrunksClientInterface $trunksClient,
         private ChannelUsageEventParser $eventParser,
         private ChannelUsageBucketCalculator $calculator,
-        private CompanyRepository $companyRepository,
-        private BrandRepository $brandRepository,
-        private ChannelUsageWriter $channelUsageWriter,
-        private LoggerInterface $logger
+        private ChannelUsageRowBuilder $rowBuilder,
+        private ChannelUsageWriter $channelUsageWriter
     ) {
     }
 
@@ -58,13 +41,13 @@ class CollectChannelUsage
         $rawEntries = $this->eventQueue->readPending(self::MAX_ENTRIES_PER_RUN);
         $entryCount = count($rawEntries);
 
-        $anchor = $this->eventQueue->getActiveChannelsByCompany();
+        $anchor = $this->trunksClient->getActiveCallsGroupedByCompany();
         $events = $this->eventParser->parse($rawEntries);
 
         $processable = [];
         $deferred = [];
         foreach ($events as $event) {
-            if ($event['ts'] < $bucketStart) {
+            if ($event->happenedBefore($bucketStart)) {
                 $processable[] = $event;
                 continue;
             }
@@ -73,7 +56,7 @@ class CollectChannelUsage
         }
 
         if (!empty($processable) || !empty($anchor)) {
-            $rows = $this->buildRows(
+            $rows = $this->rowBuilder->build(
                 $processable,
                 $deferred,
                 $anchor,
@@ -116,278 +99,9 @@ class CollectChannelUsage
         // would trade that for double counting, which corrupts closed buckets instead.
         $this->eventQueue->discardProcessed($entryCount);
         $this->eventQueue->requeue(
-            array_column($deferred, 'raw')
-        );
-    }
-
-    /**
-     * @param array<int, ChannelUsageEvent> $processable
-     * @param array<int, ChannelUsageEvent> $deferred
-     * @param array<int, array{brandId: int, occ: int}> $anchor
-     * @return array<int, ChannelUsageRow>
-     */
-    private function buildRows(
-        array $processable,
-        array $deferred,
-        array $anchor,
-        int $bucketStart,
-        int $now
-    ): array {
-        $companyBrandMap = $this->buildCompanyBrandMap($processable, $anchor);
-
-        if (empty($companyBrandMap)) {
-            return [];
-        }
-
-        $anchorCoherent = $this->isAnchorCoherent($anchor, $processable, $now);
-        if (!$anchorCoherent) {
-            $this->logger->warning(
-                'ChannelUsage: anchor has 0 keys but recent A-events exist.'
-                . ' ivozprovider-realtime may be down. Skipping anchor reconciliation.'
-            );
-        }
-
-        $maxCallsCompany = $this->loadCompanyMaxCalls(
-            array_keys($companyBrandMap)
-        );
-        $maxCallsBrand = $this->loadBrandMaxCalls(
-            array_unique(array_values($companyBrandMap))
-        );
-
-        $rows = [];
-
-        foreach ($companyBrandMap as $companyId => $brandId) {
-            $limits = [
-                'maxCallsCompany' => $maxCallsCompany[$companyId] ?? 0,
-                'maxCallsBrand' => $maxCallsBrand[$brandId] ?? 0
-            ];
-
-            $companyDeferred = $this->filterByCompany($deferred, $companyId);
-            $companyProcessable = $this->filterByCompany($processable, $companyId);
-
-            $anchorOccupancy = $anchor[$companyId]['occ'] ?? 0;
-
-            // The anchor is a *live* snapshot: rewind it past the still-open bucket first.
-            $occupancyAtBucketStart = $this->calculator->rewind(
-                $anchorOccupancy,
-                $companyDeferred
-            );
-
-            if (empty($companyProcessable)) {
-                if ($anchorCoherent && $occupancyAtBucketStart > 0) {
-                    $rows[] = $this->toRow(
-                        $this->calculator->idleBucket(
-                            $bucketStart - ChannelUsageBucketCalculator::BUCKET_SIZE,
-                            $occupancyAtBucketStart
-                        ),
-                        $brandId,
-                        $companyId,
-                        $limits
-                    );
-                }
-
-                continue;
-            }
-
-            $openingOccupancy = $this->calculator->rewind(
-                $occupancyAtBucketStart,
-                $companyProcessable
-            );
-
-            $buckets = $this->calculator->calculate(
-                $companyProcessable,
-                $openingOccupancy
-            );
-
-            foreach ($buckets as $bucket) {
-                $rows[] = $this->toRow($bucket, $brandId, $companyId, $limits);
-            }
-
-            $rows = array_merge(
-                $rows,
-                $this->fillTrailingBuckets(
-                    $buckets,
-                    $bucketStart,
-                    $anchorCoherent,
-                    $brandId,
-                    $companyId,
-                    $limits
-                )
-            );
-        }
-
-        return $rows;
-    }
-
-    /**
-     * Buckets between the last event and the current open bucket got no events at all, but
-     * the channels that were up stayed up: emit them so the history has no holes.
-     *
-     * @param array<int, array{bucketTs: int, bucketEnd: int, peak: int, avgUsage: float, closingUsage: int, blockedByCompanyLimit: int, blockedByBrandLimit: int}> $buckets
-     * @param array{maxCallsCompany: int, maxCallsBrand: int} $limits
-     * @return array<int, ChannelUsageRow>
-     */
-    private function fillTrailingBuckets(
-        array $buckets,
-        int $bucketStart,
-        bool $anchorCoherent,
-        int $brandId,
-        int $companyId,
-        array $limits
-    ): array {
-        $lastBucket = end($buckets);
-
-        if (!$anchorCoherent || $lastBucket === false) {
-            return [];
-        }
-
-        $occupancy = $lastBucket['closingUsage'];
-
-        if ($occupancy < 1) {
-            return [];
-        }
-
-        $rows = [];
-        for ($ts = $lastBucket['bucketEnd']; $ts < $bucketStart; $ts += ChannelUsageBucketCalculator::BUCKET_SIZE) {
-            if (count($rows) >= self::MAX_TRAILING_BUCKETS) {
-                $this->logger->warning(
-                    sprintf(
-                        'ChannelUsage: stopped filling idle buckets for company %d after %d of them.'
-                        . ' The queue backlog looks older than the gap filling is meant to cover.',
-                        $companyId,
-                        self::MAX_TRAILING_BUCKETS
-                    )
-                );
-
-                break;
-            }
-
-            $rows[] = $this->toRow(
-                $this->calculator->idleBucket($ts, $occupancy),
-                $brandId,
-                $companyId,
-                $limits
-            );
-        }
-
-        return $rows;
-    }
-
-    /**
-     * @param array{bucketTs: int, bucketEnd: int, peak: int, avgUsage: float, closingUsage: int, blockedByCompanyLimit: int, blockedByBrandLimit: int} $bucket
-     * @param array{maxCallsCompany: int, maxCallsBrand: int} $limits
-     * @return ChannelUsageRow
-     */
-    private function toRow(array $bucket, int $brandId, int $companyId, array $limits): array
-    {
-        return [
-            'brandId' => $brandId,
-            'companyId' => $companyId,
-            'timestamp' => new \DateTime(
-                '@' . $bucket['bucketTs'],
-                new \DateTimeZone('UTC')
-            ),
-            'peak' => $bucket['peak'],
-            'avgUsage' => $bucket['avgUsage'],
-            'closingUsage' => $bucket['closingUsage'],
-            'blockedByCompanyLimit' => $bucket['blockedByCompanyLimit'],
-            'blockedByBrandLimit' => $bucket['blockedByBrandLimit'],
-            'maxCallsCompany' => $limits['maxCallsCompany'],
-            'maxCallsBrand' => $limits['maxCallsBrand']
-        ];
-    }
-
-    /**
-     * @param array<int, array{brandId: int, occ: int}> $anchor
-     * @param array<int, ChannelUsageEvent> $processable
-     */
-    private function isAnchorCoherent(array $anchor, array $processable, int $now): bool
-    {
-        if (!empty($anchor)) {
-            return true;
-        }
-
-        $recentThreshold = $now - self::ANCHOR_COHERENCE_WINDOW;
-
-        foreach ($processable as $event) {
-            $isRecentAdmission =
-                $event['type'] === ChannelUsageEventParser::TYPE_ADMITTED
-                && $event['ts'] >= $recentThreshold
-                && ($event['occ'] ?? 0) > 0;
-
-            if ($isRecentAdmission) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    /**
-     * @param array<int, ChannelUsageEvent> $processable
-     * @param array<int, array{brandId: int, occ: int}> $anchor
-     * @return array<int, int> companyId => brandId
-     */
-    private function buildCompanyBrandMap(array $processable, array $anchor): array
-    {
-        $map = [];
-
-        foreach ($anchor as $companyId => $info) {
-            $map[$companyId] = $info['brandId'];
-        }
-
-        foreach ($processable as $event) {
-            if (!isset($map[$event['companyId']])) {
-                $map[$event['companyId']] = $event['brandId'];
-            }
-        }
-
-        return $map;
-    }
-
-    /**
-     * @param array<int, int> $companyIds
-     * @return array<int, int> companyId => maxCalls
-     */
-    private function loadCompanyMaxCalls(array $companyIds): array
-    {
-        $result = [];
-        $companies = $this->companyRepository->findBy(['id' => $companyIds]);
-
-        foreach ($companies as $company) {
-            $result[(int) $company->getId()] = $company->getMaxCalls();
-        }
-
-        return $result;
-    }
-
-    /**
-     * @param array<int, int> $brandIds
-     * @return array<int, int> brandId => maxCalls
-     */
-    private function loadBrandMaxCalls(array $brandIds): array
-    {
-        $result = [];
-        $brands = $this->brandRepository->findBy(['id' => $brandIds]);
-
-        foreach ($brands as $brand) {
-            /** @var \Ivoz\Provider\Domain\Model\Brand\BrandInterface $brand */
-            $result[(int) $brand->getId()] = $brand->getMaxCalls();
-        }
-
-        return $result;
-    }
-
-    /**
-     * @param array<int, ChannelUsageEvent> $events
-     * @return array<int, ChannelUsageEvent>
-     */
-    private function filterByCompany(array $events, int $companyId): array
-    {
-        return array_values(
-            array_filter(
-                $events,
-                fn (array $event): bool => $event['companyId'] === $companyId
+            array_map(
+                fn (ChannelUsageEvent $event): string => $event->getWire(),
+                $deferred
             )
         );
     }

--- a/library/Ivoz/Provider/Domain/Service/ChannelUsage/CollectChannelUsage.php
+++ b/library/Ivoz/Provider/Domain/Service/ChannelUsage/CollectChannelUsage.php
@@ -1,0 +1,591 @@
+<?php
+
+namespace Ivoz\Provider\Domain\Service\ChannelUsage;
+
+use Ivoz\Core\Domain\Model\Commandlog\Commandlog;
+use Ivoz\Core\Domain\Service\EntityTools;
+use Ivoz\Core\Infrastructure\Persistence\Redis\RedisMasterFactory;
+use Ivoz\Provider\Domain\Model\Brand\BrandRepository;
+use Ivoz\Provider\Domain\Model\ChannelUsage\ChannelUsage;
+use Ivoz\Provider\Domain\Model\ChannelUsage\ChannelUsageDto;
+use Ivoz\Provider\Domain\Model\ChannelUsage\ChannelUsageRepository;
+use Ivoz\Provider\Domain\Model\Company\CompanyRepository;
+use Psr\Log\LoggerInterface;
+
+class CollectChannelUsage
+{
+    const BUCKET_SIZE = 300;
+    const RETENTION_DAYS = 30;
+    const EVENT_QUEUE_KEY = 'chusage:events';
+    const REDIS_DB = 1;
+    const REDIS_SCAN_COUNT = 1000;
+    const PERSIST_BATCH_SIZE = 100;
+    const PURGE_BATCH_SIZE = 1000;
+    const TRUNKS_KEY_PATTERN = 'trunks:*';
+
+    public function __construct(
+        private RedisMasterFactory $redisMasterFactory,
+        private CompanyRepository $companyRepository,
+        private BrandRepository $brandRepository,
+        private ChannelUsageRepository $channelUsageRepository,
+        private EntityTools $entityTools,
+        private LoggerInterface $logger
+    ) {
+    }
+
+    public function execute(): void
+    {
+        $redis = $this->redisMasterFactory->create(self::REDIS_DB);
+
+        try {
+            $anchorTime = time();
+            $bucketStart = (int) (floor($anchorTime / self::BUCKET_SIZE) * self::BUCKET_SIZE);
+
+            $anchor = $this->buildAnchor($redis);
+
+            /** @var array<string> $rawEvents */
+            $rawEvents = $redis->lrange(self::EVENT_QUEUE_KEY, 0, -1);
+            $allEvents = $this->parseEvents($rawEvents);
+
+            $processable = array_values(array_filter($allEvents, fn($e) => $e['ts'] < $bucketStart));
+            $currentBucket = array_values(array_filter($allEvents, fn($e) => $e['ts'] >= $bucketStart));
+
+            if (empty($processable) && empty($anchor)) {
+                return;
+            }
+
+            $anchorCoherent = $this->isAnchorCoherent($anchor, $processable);
+            if (!$anchorCoherent) {
+                $this->logger->warning(
+                    'ChannelUsage: anchor has 0 keys but recent A-events exist.'
+                    . ' ivozprovider-realtime may be down. Skipping anchor reconciliation.'
+                );
+            }
+
+            $companyBrandMap = $this->buildCompanyBrandMap($processable, $anchor);
+
+            if (empty($companyBrandMap)) {
+                return;
+            }
+
+            $maxCallsCompany = $this->loadCompanyMaxCalls(array_keys($companyBrandMap));
+            $maxCallsBrand = $this->loadBrandMaxCalls(array_unique(array_values($companyBrandMap)));
+
+            $rows = [];
+
+            foreach ($companyBrandMap as $companyId => $brandId) {
+                $companyCurrentEvents = $this->filterByCompany($currentBucket, $companyId);
+                $companyProcessable = $this->filterByCompany($processable, $companyId);
+
+                $anchorOcc = $anchor[$companyId]['occ'] ?? 0;
+
+                $occAtBucketStart = $this->rewind($anchorOcc, $companyCurrentEvents);
+
+                if (empty($companyProcessable)) {
+                    if ($anchorCoherent && $occAtBucketStart > 0) {
+                        $rows[] = $this->makeRow(
+                            $brandId,
+                            $companyId,
+                            $bucketStart - self::BUCKET_SIZE,
+                            $occAtBucketStart,
+                            $occAtBucketStart,
+                            $occAtBucketStart,
+                            0,
+                            0,
+                            $maxCallsCompany[$companyId] ?? 0,
+                            $maxCallsBrand[$brandId] ?? 0
+                        );
+                    }
+                    continue;
+                }
+
+                $openingOcc = $this->rewind($occAtBucketStart, $companyProcessable);
+
+                $bucketRows = $this->forwardPass(
+                    $companyProcessable,
+                    $openingOcc,
+                    $brandId,
+                    $companyId,
+                    $maxCallsCompany[$companyId] ?? 0,
+                    $maxCallsBrand[$brandId] ?? 0
+                );
+
+                $lastBucketEnd = 0;
+                foreach ($bucketRows as $bucketRow) {
+                    $lastBucketEnd = max($lastBucketEnd, $bucketRow['bucketEnd']);
+                }
+
+                // Fill empty trailing buckets up to bucketStart
+                $lastEntry = end($bucketRows);
+                if ($anchorCoherent && $lastBucketEnd > 0 && $lastBucketEnd < $bucketStart && $lastEntry !== false) {
+                    $fillOcc = $lastEntry['row']['closingUsage'];
+                    for ($ts = $lastBucketEnd; $ts < $bucketStart; $ts += self::BUCKET_SIZE) {
+                        if ($fillOcc > 0) {
+                            $rows[] = $this->makeRow(
+                                $brandId,
+                                $companyId,
+                                $ts,
+                                $fillOcc,
+                                $fillOcc,
+                                $fillOcc,
+                                0,
+                                0,
+                                $maxCallsCompany[$companyId] ?? 0,
+                                $maxCallsBrand[$brandId] ?? 0
+                            );
+                        }
+                    }
+                }
+
+                foreach ($bucketRows as $bucketRow) {
+                    $rows[] = $bucketRow['row'];
+                }
+            }
+
+            if (!empty($rows)) {
+                $this->persistRows($rows);
+            }
+
+            // LTRIM: remove processable events from queue (they are at the left/oldest end)
+            $processableCount = count($processable);
+            if ($processableCount > 0) {
+                $redis->ltrim(self::EVENT_QUEUE_KEY, $processableCount, -1);
+            }
+        } finally {
+            $redis->close();
+        }
+
+        $this->purgeOldRows();
+    }
+
+    /**
+     * @return array<int, array{brandId: int, occ: int}>
+     */
+    private function buildAnchor(\Redis $redis): array
+    {
+        $anchor = [];
+        $iterator = null;
+
+        while (true) {
+            $keys = $redis->scan($iterator, self::TRUNKS_KEY_PATTERN, self::REDIS_SCAN_COUNT);
+            if ($keys === false) {
+                break;
+            }
+
+            foreach ($keys as $key) {
+                // trunks:b<brandId>:c<companyId>:ddi<ddiId>:cr<carrierId>:<callId>
+                // trunks:b<brandId>:c<companyId>:ddi<ddiId>:dp<ddiProviderId>:<callId>
+                if (!preg_match('/^trunks:b(\d+):c(\d+):/', (string) $key, $m)) {
+                    continue;
+                }
+                $brandId = (int) $m[1];
+                $companyId = (int) $m[2];
+                if (!isset($anchor[$companyId])) {
+                    $anchor[$companyId] = ['brandId' => $brandId, 'occ' => 0];
+                }
+                $anchor[$companyId]['occ']++;
+            }
+
+            if ($iterator === 0) {
+                break;
+            }
+        }
+
+        return $anchor;
+    }
+
+    /**
+     * @param array<string> $rawEvents
+     * @return array<array{type: string, ts: int, brandId: int, companyId: int, occ?: int, reason?: string}>
+     */
+    private function parseEvents(array $rawEvents): array
+    {
+        $events = [];
+        foreach ($rawEvents as $raw) {
+            $parts = explode(':', $raw);
+            if (count($parts) < 4) {
+                continue;
+            }
+
+            $type = $parts[0];
+            $ts = (int) $parts[1];
+            $brandId = (int) $parts[2];
+            $companyId = (int) $parts[3];
+
+            if (!in_array($type, ['A', 'H', 'B'], true) || $ts <= 0 || $brandId <= 0 || $companyId <= 0) {
+                continue;
+            }
+
+            $event = ['type' => $type, 'ts' => $ts, 'brandId' => $brandId, 'companyId' => $companyId];
+
+            if ($type === 'A' && isset($parts[4])) {
+                $event['occ'] = (int) $parts[4];
+            } elseif ($type === 'B' && isset($parts[4])) {
+                $event['reason'] = $parts[4];
+            }
+
+            $events[] = $event;
+        }
+
+        return $events;
+    }
+
+    /**
+     * Check if anchor is coherent (realtime service is up).
+     * Incoherent = anchor has 0 keys but there are recent A events with occ > 0.
+     *
+     * @param array<int, array{brandId: int, occ: int}> $anchor
+     * @param array<array{type: string, ts: int, brandId: int, companyId: int, occ?: int, reason?: string}> $processable
+     */
+    private function isAnchorCoherent(array $anchor, array $processable): bool
+    {
+        if (!empty($anchor)) {
+            return true;
+        }
+
+        $recentThreshold = time() - 600;
+        foreach ($processable as $event) {
+            if ($event['type'] === 'A' && $event['ts'] >= $recentThreshold && ($event['occ'] ?? 0) > 0) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param array<array{type: string, ts: int, brandId: int, companyId: int, occ?: int, reason?: string}> $processable
+     * @param array<int, array{brandId: int, occ: int}> $anchor
+     * @return array<int, int> companyId => brandId
+     */
+    private function buildCompanyBrandMap(array $processable, array $anchor): array
+    {
+        $map = [];
+        foreach ($anchor as $companyId => $info) {
+            $map[$companyId] = $info['brandId'];
+        }
+        foreach ($processable as $event) {
+            if (!isset($map[$event['companyId']])) {
+                $map[$event['companyId']] = $event['brandId'];
+            }
+        }
+        return $map;
+    }
+
+    /**
+     * @param int[] $companyIds
+     * @return array<int, int> companyId => maxCalls
+     */
+    private function loadCompanyMaxCalls(array $companyIds): array
+    {
+        $result = [];
+        $companies = $this->companyRepository->findBy(['id' => $companyIds]);
+        foreach ($companies as $company) {
+            $result[(int) $company->getId()] = $company->getMaxCalls();
+        }
+        return $result;
+    }
+
+    /**
+     * @param int[] $brandIds
+     * @return array<int, int> brandId => maxCalls
+     */
+    private function loadBrandMaxCalls(array $brandIds): array
+    {
+        $result = [];
+        $brands = $this->brandRepository->findBy(['id' => $brandIds]);
+        foreach ($brands as $brand) {
+            /** @var \Ivoz\Provider\Domain\Model\Brand\BrandInterface $brand */
+            $result[(int) $brand->getId()] = $brand->getMaxCalls();
+        }
+        return $result;
+    }
+
+    /**
+     * @param array<array{type:string, ts:int, brandId:int, companyId:int}> $events
+     * @return array<array{type:string, ts:int, brandId:int, companyId:int}>
+     */
+    private function filterByCompany(array $events, int $companyId): array
+    {
+        return array_values(array_filter($events, fn($e) => $e['companyId'] === $companyId));
+    }
+
+    /**
+     * Rewind from startOcc through events in reverse to get the occupancy before all events.
+     * Events must be sorted oldest-first.
+     *
+     * @param array<array{type: string, ts: int, brandId: int, companyId: int, occ?: int, reason?: string}> $events
+     */
+    private function rewind(int $startOcc, array $events): int
+    {
+        $occ = $startOcc;
+        foreach (array_reverse($events) as $event) {
+            if ($event['type'] === 'A') {
+                $occ = max(0, $occ - 1);
+            } elseif ($event['type'] === 'H') {
+                $occ++;
+            }
+            // B events do not change occupancy
+        }
+        return $occ;
+    }
+
+    /**
+     * Forward pass: compute bucket records from events and opening occupancy.
+     * Each entry pairs the persistable row with the bucket's end timestamp.
+     *
+     * @param array<array{type: string, ts: int, brandId: int, companyId: int, occ?: int, reason?: string}> $events
+     * @return array<int, array{
+     *   row: array{
+     *     brandId: int,
+     *     companyId: int,
+     *     timestamp: \DateTimeInterface,
+     *     peak: int,
+     *     avgUsage: float,
+     *     closingUsage: int,
+     *     blockedByCompanyLimit: int,
+     *     blockedByBrandLimit: int,
+     *     maxCallsCompany: int,
+     *     maxCallsBrand: int
+     *   },
+     *   bucketEnd: int
+     * }>
+     */
+    private function forwardPass(
+        array $events,
+        int $openingOcc,
+        int $brandId,
+        int $companyId,
+        int $maxCallsCompany,
+        int $maxCallsBrand
+    ): array {
+        if (empty($events)) {
+            return [];
+        }
+
+        usort($events, fn(array $a, array $b): int => (int) $a['ts'] - (int) $b['ts']);
+
+        $rows = [];
+        $currentOcc = $openingOcc;
+
+        $firstBucket = (int) (floor($events[0]['ts'] / self::BUCKET_SIZE) * self::BUCKET_SIZE);
+        $currentBucketTs = $firstBucket;
+        $bucketEnd = $currentBucketTs + self::BUCKET_SIZE;
+
+        $prevTs = $currentBucketTs;
+        $peak = $currentOcc;
+        $integral = 0.0;
+        $blockedCompany = 0;
+        $blockedBrand = 0;
+
+        $finalizeAndReset = function () use (
+            &$rows,
+            &$prevTs,
+            &$peak,
+            &$integral,
+            &$blockedCompany,
+            &$blockedBrand,
+            &$currentOcc,
+            &$currentBucketTs,
+            &$bucketEnd,
+            $brandId,
+            $companyId,
+            $maxCallsCompany,
+            $maxCallsBrand
+        ): void {
+            /** @var array<int, array{row: array{brandId: int, companyId: int, timestamp: \DateTimeInterface, peak: int, avgUsage: float, closingUsage: int, blockedByCompanyLimit: int, blockedByBrandLimit: int, maxCallsCompany: int, maxCallsBrand: int}, bucketEnd: int}> $rows */
+            /** @var int $prevTs */
+            /** @var int $peak */
+            /** @var float $integral */
+            /** @var int $blockedCompany */
+            /** @var int $blockedBrand */
+            /** @var int $currentOcc */
+            /** @var int $currentBucketTs */
+            /** @var int $bucketEnd */
+            // Complete the bucket integral up to its end
+            $integral += $currentOcc * ($bucketEnd - $prevTs);
+            $avgUsage = $integral / self::BUCKET_SIZE;
+
+            $rows[] = [
+                'row' => $this->makeRow(
+                    $brandId,
+                    $companyId,
+                    $currentBucketTs,
+                    $peak,
+                    $avgUsage,
+                    $currentOcc,
+                    $blockedCompany,
+                    $blockedBrand,
+                    $maxCallsCompany,
+                    $maxCallsBrand
+                ),
+                'bucketEnd' => $bucketEnd,
+            ];
+
+            // Reset for next bucket
+            $currentBucketTs = $bucketEnd;
+            $bucketEnd = $currentBucketTs + self::BUCKET_SIZE;
+            $prevTs = $currentBucketTs;
+            $peak = $currentOcc;
+            $integral = 0.0;
+            $blockedCompany = 0;
+            $blockedBrand = 0;
+        };
+
+        foreach ($events as $event) {
+            // Advance through empty buckets before this event's bucket
+            $eventBucket = (int) (floor($event['ts'] / self::BUCKET_SIZE) * self::BUCKET_SIZE);
+            while ($currentBucketTs < $eventBucket) {
+                $finalizeAndReset();
+            }
+
+            // Accumulate time within current bucket before this event
+            /** @psalm-suppress UnusedVariable */
+            $integral += $currentOcc * ($event['ts'] - $prevTs);
+            $prevTs = $event['ts'];
+
+            // Apply event
+            if ($event['type'] === 'A') {
+                $currentOcc = $event['occ'] ?? ($currentOcc + 1);
+                $peak = max($peak, $currentOcc);
+            } elseif ($event['type'] === 'H') {
+                $currentOcc = max(0, $currentOcc - 1);
+            } elseif ($event['type'] === 'B') {
+                if (($event['reason'] ?? '') === 'brand') {
+                    $blockedBrand++;
+                } else {
+                    $blockedCompany++;
+                }
+            }
+        }
+
+        // Finalize last bucket
+        $finalizeAndReset();
+
+        return $rows;
+    }
+
+    /**
+     * @return array{brandId:int, companyId:int, timestamp:\DateTimeInterface, peak:int, avgUsage:float,
+     *              closingUsage:int, blockedByCompanyLimit:int, blockedByBrandLimit:int,
+     *              maxCallsCompany:int, maxCallsBrand:int}
+     */
+    private function makeRow(
+        int $brandId,
+        int $companyId,
+        int $bucketTs,
+        int $peak,
+        float $avgUsage,
+        int $closingUsage,
+        int $blockedByCompanyLimit,
+        int $blockedByBrandLimit,
+        int $maxCallsCompany,
+        int $maxCallsBrand
+    ): array {
+        return [
+            'brandId' => $brandId,
+            'companyId' => $companyId,
+            'timestamp' => new \DateTime('@' . $bucketTs, new \DateTimeZone('UTC')),
+            'peak' => $peak,
+            'avgUsage' => $avgUsage,
+            'closingUsage' => $closingUsage,
+            'blockedByCompanyLimit' => $blockedByCompanyLimit,
+            'blockedByBrandLimit' => $blockedByBrandLimit,
+            'maxCallsCompany' => $maxCallsCompany,
+            'maxCallsBrand' => $maxCallsBrand,
+        ];
+    }
+
+    /**
+     * @param array<array{
+     *   brandId: int,
+     *   companyId: int,
+     *   timestamp: \DateTimeInterface,
+     *   peak: int,
+     *   avgUsage: float,
+     *   closingUsage: int,
+     *   maxCallsCompany: int,
+     *   maxCallsBrand: int,
+     *   blockedByCompanyLimit: int,
+     *   blockedByBrandLimit: int
+     * }> $rows
+     */
+    private function persistRows(array $rows): void
+    {
+        foreach (array_chunk($rows, self::PERSIST_BATCH_SIZE) as $chunk) {
+            foreach ($chunk as $row) {
+                $this->persistRow($row);
+            }
+
+            // Let errors bubble up: the event queue is only trimmed on success,
+            // so the next run will reprocess and rewrite the very same buckets
+            $this->entityTools->dispatchQueuedOperations();
+            $this->entityTools->clearExcept(
+                Commandlog::class
+            );
+        }
+    }
+
+    /**
+     * @param array{
+     *   brandId: int,
+     *   companyId: int,
+     *   timestamp: \DateTimeInterface,
+     *   peak: int,
+     *   avgUsage: float,
+     *   closingUsage: int,
+     *   maxCallsCompany: int,
+     *   maxCallsBrand: int,
+     *   blockedByCompanyLimit: int,
+     *   blockedByBrandLimit: int
+     * } $row
+     */
+    private function persistRow(array $row): void
+    {
+        $channelUsage = $this
+            ->channelUsageRepository
+            ->findOneByCompanyAndTimestamp(
+                $row['companyId'],
+                $row['timestamp']
+            );
+
+        if ($channelUsage) {
+            /** @var ChannelUsageDto $channelUsageDto */
+            $channelUsageDto = $this->entityTools->entityToDto($channelUsage);
+        } else {
+            $channelUsageDto = ChannelUsage::createDto();
+        }
+
+        $channelUsageDto
+            ->setBrandId($row['brandId'])
+            ->setCompanyId($row['companyId'])
+            ->setTimestamp($row['timestamp'])
+            ->setPeak($row['peak'])
+            ->setAvgUsage(round($row['avgUsage'], 2))
+            ->setClosingUsage($row['closingUsage'])
+            ->setMaxCallsCompany($row['maxCallsCompany'])
+            ->setMaxCallsBrand($row['maxCallsBrand'])
+            ->setBlockedByCompanyLimit($row['blockedByCompanyLimit'])
+            ->setBlockedByBrandLimit($row['blockedByBrandLimit']);
+
+        $this->entityTools->persistDto(
+            $channelUsageDto,
+            $channelUsage,
+            false
+        );
+    }
+
+    private function purgeOldRows(): void
+    {
+        $utc = new \DateTimeZone('UTC');
+        $cutoff = new \DateTime('now', $utc);
+        $cutoff->modify(sprintf('-%d days', self::RETENTION_DAYS));
+
+        do {
+            $affected = $this->channelUsageRepository->purgeOlderThan($cutoff, self::PURGE_BATCH_SIZE);
+            if ($affected > 0) {
+                sleep(1);
+            }
+        } while ($affected >= self::PURGE_BATCH_SIZE);
+    }
+}

--- a/library/Ivoz/Provider/Domain/Service/ChannelUsage/CollectChannelUsage.php
+++ b/library/Ivoz/Provider/Domain/Service/ChannelUsage/CollectChannelUsage.php
@@ -1,251 +1,321 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Ivoz\Provider\Domain\Service\ChannelUsage;
 
-use Ivoz\Core\Domain\Model\Commandlog\Commandlog;
-use Ivoz\Core\Domain\Service\EntityTools;
-use Ivoz\Core\Infrastructure\Persistence\Redis\RedisMasterFactory;
+use Ivoz\Provider\Domain\Job\ChannelUsageEventQueueInterface;
 use Ivoz\Provider\Domain\Model\Brand\BrandRepository;
-use Ivoz\Provider\Domain\Model\ChannelUsage\ChannelUsage;
-use Ivoz\Provider\Domain\Model\ChannelUsage\ChannelUsageDto;
-use Ivoz\Provider\Domain\Model\ChannelUsage\ChannelUsageRepository;
 use Ivoz\Provider\Domain\Model\Company\CompanyRepository;
 use Psr\Log\LoggerInterface;
 
+/**
+ * Collects channel usage into closed 5-minute buckets.
+ *
+ * Reads the event queue through a port, reconstructs each company's occupancy by rewinding
+ * from the live realtime anchor back to the start of the oldest closed bucket, then replays
+ * forward to obtain peak, time-weighted average and closing occupancy per bucket.
+ *
+ * @phpstan-type ChannelUsageEvent array{type: string, ts: int, brandId: int, companyId: int, occ: int|null, reason: string, raw: string}
+ * @phpstan-type ChannelUsageRow array{brandId: int, companyId: int, timestamp: \DateTimeInterface, peak: int, avgUsage: float, closingUsage: int, blockedByCompanyLimit: int, blockedByBrandLimit: int, maxCallsCompany: int, maxCallsBrand: int}
+ */
 class CollectChannelUsage
 {
-    const BUCKET_SIZE = 300;
-    const RETENTION_DAYS = 30;
-    const EVENT_QUEUE_KEY = 'chusage:events';
-    const REDIS_DB = 1;
-    const REDIS_SCAN_COUNT = 1000;
-    const PERSIST_BATCH_SIZE = 100;
-    const PURGE_BATCH_SIZE = 1000;
-    const TRUNKS_KEY_PATTERN = 'trunks:*';
+    /**
+     * Upper bound on how much of the queue a single run pulls into memory. A backlog larger
+     * than this is drained over consecutive runs rather than risking the collector's memory.
+     */
+    public const MAX_ENTRIES_PER_RUN = 50000;
+
+    /**
+     * Ceiling on gap filling (a day's worth of buckets). Without it, a backlog whose newest
+     * event is old would emit one row per bucket for every 5 minutes elapsed since.
+     */
+    public const MAX_TRAILING_BUCKETS = 288;
+
+    /**
+     * An empty anchor is only trustworthy if no call was admitted recently: otherwise the
+     * realtime service is presumably down and its keyspace lies.
+     */
+    private const ANCHOR_COHERENCE_WINDOW = 600;
 
     public function __construct(
-        private RedisMasterFactory $redisMasterFactory,
+        private ChannelUsageEventQueueInterface $eventQueue,
+        private ChannelUsageEventParser $eventParser,
+        private ChannelUsageBucketCalculator $calculator,
         private CompanyRepository $companyRepository,
         private BrandRepository $brandRepository,
-        private ChannelUsageRepository $channelUsageRepository,
-        private EntityTools $entityTools,
+        private ChannelUsageWriter $channelUsageWriter,
         private LoggerInterface $logger
     ) {
     }
 
     public function execute(): void
     {
-        $redis = $this->redisMasterFactory->create(self::REDIS_DB);
+        $now = time();
+        $bucketStart = $this->calculator->bucketStart($now);
 
-        try {
-            $anchorTime = time();
-            $bucketStart = (int) (floor($anchorTime / self::BUCKET_SIZE) * self::BUCKET_SIZE);
+        $rawEntries = $this->eventQueue->readPending(self::MAX_ENTRIES_PER_RUN);
+        $entryCount = count($rawEntries);
 
-            $anchor = $this->buildAnchor($redis);
+        $anchor = $this->eventQueue->getActiveChannelsByCompany();
+        $events = $this->eventParser->parse($rawEntries);
 
-            /** @var array<string> $rawEvents */
-            $rawEvents = $redis->lrange(self::EVENT_QUEUE_KEY, 0, -1);
-            $allEvents = $this->parseEvents($rawEvents);
-
-            $processable = array_values(array_filter($allEvents, fn($e) => $e['ts'] < $bucketStart));
-            $currentBucket = array_values(array_filter($allEvents, fn($e) => $e['ts'] >= $bucketStart));
-
-            if (empty($processable) && empty($anchor)) {
-                return;
+        $processable = [];
+        $deferred = [];
+        foreach ($events as $event) {
+            if ($event['ts'] < $bucketStart) {
+                $processable[] = $event;
+                continue;
             }
 
-            $anchorCoherent = $this->isAnchorCoherent($anchor, $processable);
-            if (!$anchorCoherent) {
-                $this->logger->warning(
-                    'ChannelUsage: anchor has 0 keys but recent A-events exist.'
-                    . ' ivozprovider-realtime may be down. Skipping anchor reconciliation.'
-                );
-            }
+            $deferred[] = $event;
+        }
 
-            $companyBrandMap = $this->buildCompanyBrandMap($processable, $anchor);
-
-            if (empty($companyBrandMap)) {
-                return;
-            }
-
-            $maxCallsCompany = $this->loadCompanyMaxCalls(array_keys($companyBrandMap));
-            $maxCallsBrand = $this->loadBrandMaxCalls(array_unique(array_values($companyBrandMap)));
-
-            $rows = [];
-
-            foreach ($companyBrandMap as $companyId => $brandId) {
-                $companyCurrentEvents = $this->filterByCompany($currentBucket, $companyId);
-                $companyProcessable = $this->filterByCompany($processable, $companyId);
-
-                $anchorOcc = $anchor[$companyId]['occ'] ?? 0;
-
-                $occAtBucketStart = $this->rewind($anchorOcc, $companyCurrentEvents);
-
-                if (empty($companyProcessable)) {
-                    if ($anchorCoherent && $occAtBucketStart > 0) {
-                        $rows[] = $this->makeRow(
-                            $brandId,
-                            $companyId,
-                            $bucketStart - self::BUCKET_SIZE,
-                            $occAtBucketStart,
-                            $occAtBucketStart,
-                            $occAtBucketStart,
-                            0,
-                            0,
-                            $maxCallsCompany[$companyId] ?? 0,
-                            $maxCallsBrand[$brandId] ?? 0
-                        );
-                    }
-                    continue;
-                }
-
-                $openingOcc = $this->rewind($occAtBucketStart, $companyProcessable);
-
-                $bucketRows = $this->forwardPass(
-                    $companyProcessable,
-                    $openingOcc,
-                    $brandId,
-                    $companyId,
-                    $maxCallsCompany[$companyId] ?? 0,
-                    $maxCallsBrand[$brandId] ?? 0
-                );
-
-                $lastBucketEnd = 0;
-                foreach ($bucketRows as $bucketRow) {
-                    $lastBucketEnd = max($lastBucketEnd, $bucketRow['bucketEnd']);
-                }
-
-                // Fill empty trailing buckets up to bucketStart
-                $lastEntry = end($bucketRows);
-                if ($anchorCoherent && $lastBucketEnd > 0 && $lastBucketEnd < $bucketStart && $lastEntry !== false) {
-                    $fillOcc = $lastEntry['row']['closingUsage'];
-                    for ($ts = $lastBucketEnd; $ts < $bucketStart; $ts += self::BUCKET_SIZE) {
-                        if ($fillOcc > 0) {
-                            $rows[] = $this->makeRow(
-                                $brandId,
-                                $companyId,
-                                $ts,
-                                $fillOcc,
-                                $fillOcc,
-                                $fillOcc,
-                                0,
-                                0,
-                                $maxCallsCompany[$companyId] ?? 0,
-                                $maxCallsBrand[$brandId] ?? 0
-                            );
-                        }
-                    }
-                }
-
-                foreach ($bucketRows as $bucketRow) {
-                    $rows[] = $bucketRow['row'];
-                }
-            }
+        if (!empty($processable) || !empty($anchor)) {
+            $rows = $this->buildRows(
+                $processable,
+                $deferred,
+                $anchor,
+                $bucketStart,
+                $now
+            );
 
             if (!empty($rows)) {
-                $this->persistRows($rows);
-            }
-
-            // LTRIM: remove processable events from queue (they are at the left/oldest end)
-            $processableCount = count($processable);
-            if ($processableCount > 0) {
-                $redis->ltrim(self::EVENT_QUEUE_KEY, $processableCount, -1);
-            }
-        } finally {
-            $redis->close();
-        }
-
-        $this->purgeOldRows();
-    }
-
-    /**
-     * @return array<int, array{brandId: int, occ: int}>
-     */
-    private function buildAnchor(\Redis $redis): array
-    {
-        $anchor = [];
-        $iterator = null;
-
-        while (true) {
-            $keys = $redis->scan($iterator, self::TRUNKS_KEY_PATTERN, self::REDIS_SCAN_COUNT);
-            if ($keys === false) {
-                break;
-            }
-
-            foreach ($keys as $key) {
-                // trunks:b<brandId>:c<companyId>:ddi<ddiId>:cr<carrierId>:<callId>
-                // trunks:b<brandId>:c<companyId>:ddi<ddiId>:dp<ddiProviderId>:<callId>
-                if (!preg_match('/^trunks:b(\d+):c(\d+):/', (string) $key, $m)) {
-                    continue;
-                }
-                $brandId = (int) $m[1];
-                $companyId = (int) $m[2];
-                if (!isset($anchor[$companyId])) {
-                    $anchor[$companyId] = ['brandId' => $brandId, 'occ' => 0];
-                }
-                $anchor[$companyId]['occ']++;
-            }
-
-            if ($iterator === 0) {
-                break;
+                $this->channelUsageWriter->write($rows);
             }
         }
 
-        return $anchor;
+        // Only once the rows above are durably written: a failure leaves the queue intact so
+        // the next run recomputes the very same buckets.
+        $this->drainQueue($entryCount, $deferred);
     }
 
     /**
-     * @param array<string> $rawEvents
-     * @return array<array{type: string, ts: int, brandId: int, companyId: int, occ?: int, reason?: string}>
-     */
-    private function parseEvents(array $rawEvents): array
-    {
-        $events = [];
-        foreach ($rawEvents as $raw) {
-            $parts = explode(':', $raw);
-            if (count($parts) < 4) {
-                continue;
-            }
-
-            $type = $parts[0];
-            $ts = (int) $parts[1];
-            $brandId = (int) $parts[2];
-            $companyId = (int) $parts[3];
-
-            if (!in_array($type, ['A', 'H', 'B'], true) || $ts <= 0 || $brandId <= 0 || $companyId <= 0) {
-                continue;
-            }
-
-            $event = ['type' => $type, 'ts' => $ts, 'brandId' => $brandId, 'companyId' => $companyId];
-
-            if ($type === 'A' && isset($parts[4])) {
-                $event['occ'] = (int) $parts[4];
-            } elseif ($type === 'B' && isset($parts[4])) {
-                $event['reason'] = $parts[4];
-            }
-
-            $events[] = $event;
-        }
-
-        return $events;
-    }
-
-    /**
-     * Check if anchor is coherent (realtime service is up).
-     * Incoherent = anchor has 0 keys but there are recent A events with occ > 0.
+     * Consume the window that was read, putting back the events whose bucket is still open.
      *
-     * @param array<int, array{brandId: int, occ: int}> $anchor
-     * @param array<array{type: string, ts: int, brandId: int, companyId: int, occ?: int, reason?: string}> $processable
+     * The queue is trimmed by the number of *raw entries read*, never by the number of events
+     * parsed: malformed entries are dropped by the parser and would otherwise shift the
+     * offset permanently.
+     *
+     * @param array<int, ChannelUsageEvent> $deferred
      */
-    private function isAnchorCoherent(array $anchor, array $processable): bool
+    private function drainQueue(int $entryCount, array $deferred): void
+    {
+        if ($entryCount < 1) {
+            return;
+        }
+
+        // Everything we read still belongs to the open bucket: leave the queue untouched.
+        if (count($deferred) === $entryCount) {
+            return;
+        }
+
+        // Not atomic: a crash between the two loses the open-bucket events, which costs at
+        // most the current bucket's precision for the affected companies. The reverse order
+        // would trade that for double counting, which corrupts closed buckets instead.
+        $this->eventQueue->discardProcessed($entryCount);
+        $this->eventQueue->requeue(
+            array_column($deferred, 'raw')
+        );
+    }
+
+    /**
+     * @param array<int, ChannelUsageEvent> $processable
+     * @param array<int, ChannelUsageEvent> $deferred
+     * @param array<int, array{brandId: int, occ: int}> $anchor
+     * @return array<int, ChannelUsageRow>
+     */
+    private function buildRows(
+        array $processable,
+        array $deferred,
+        array $anchor,
+        int $bucketStart,
+        int $now
+    ): array {
+        $companyBrandMap = $this->buildCompanyBrandMap($processable, $anchor);
+
+        if (empty($companyBrandMap)) {
+            return [];
+        }
+
+        $anchorCoherent = $this->isAnchorCoherent($anchor, $processable, $now);
+        if (!$anchorCoherent) {
+            $this->logger->warning(
+                'ChannelUsage: anchor has 0 keys but recent A-events exist.'
+                . ' ivozprovider-realtime may be down. Skipping anchor reconciliation.'
+            );
+        }
+
+        $maxCallsCompany = $this->loadCompanyMaxCalls(
+            array_keys($companyBrandMap)
+        );
+        $maxCallsBrand = $this->loadBrandMaxCalls(
+            array_unique(array_values($companyBrandMap))
+        );
+
+        $rows = [];
+
+        foreach ($companyBrandMap as $companyId => $brandId) {
+            $limits = [
+                'maxCallsCompany' => $maxCallsCompany[$companyId] ?? 0,
+                'maxCallsBrand' => $maxCallsBrand[$brandId] ?? 0
+            ];
+
+            $companyDeferred = $this->filterByCompany($deferred, $companyId);
+            $companyProcessable = $this->filterByCompany($processable, $companyId);
+
+            $anchorOccupancy = $anchor[$companyId]['occ'] ?? 0;
+
+            // The anchor is a *live* snapshot: rewind it past the still-open bucket first.
+            $occupancyAtBucketStart = $this->calculator->rewind(
+                $anchorOccupancy,
+                $companyDeferred
+            );
+
+            if (empty($companyProcessable)) {
+                if ($anchorCoherent && $occupancyAtBucketStart > 0) {
+                    $rows[] = $this->toRow(
+                        $this->calculator->idleBucket(
+                            $bucketStart - ChannelUsageBucketCalculator::BUCKET_SIZE,
+                            $occupancyAtBucketStart
+                        ),
+                        $brandId,
+                        $companyId,
+                        $limits
+                    );
+                }
+
+                continue;
+            }
+
+            $openingOccupancy = $this->calculator->rewind(
+                $occupancyAtBucketStart,
+                $companyProcessable
+            );
+
+            $buckets = $this->calculator->calculate(
+                $companyProcessable,
+                $openingOccupancy
+            );
+
+            foreach ($buckets as $bucket) {
+                $rows[] = $this->toRow($bucket, $brandId, $companyId, $limits);
+            }
+
+            $rows = array_merge(
+                $rows,
+                $this->fillTrailingBuckets(
+                    $buckets,
+                    $bucketStart,
+                    $anchorCoherent,
+                    $brandId,
+                    $companyId,
+                    $limits
+                )
+            );
+        }
+
+        return $rows;
+    }
+
+    /**
+     * Buckets between the last event and the current open bucket got no events at all, but
+     * the channels that were up stayed up: emit them so the history has no holes.
+     *
+     * @param array<int, array{bucketTs: int, bucketEnd: int, peak: int, avgUsage: float, closingUsage: int, blockedByCompanyLimit: int, blockedByBrandLimit: int}> $buckets
+     * @param array{maxCallsCompany: int, maxCallsBrand: int} $limits
+     * @return array<int, ChannelUsageRow>
+     */
+    private function fillTrailingBuckets(
+        array $buckets,
+        int $bucketStart,
+        bool $anchorCoherent,
+        int $brandId,
+        int $companyId,
+        array $limits
+    ): array {
+        $lastBucket = end($buckets);
+
+        if (!$anchorCoherent || $lastBucket === false) {
+            return [];
+        }
+
+        $occupancy = $lastBucket['closingUsage'];
+
+        if ($occupancy < 1) {
+            return [];
+        }
+
+        $rows = [];
+        for ($ts = $lastBucket['bucketEnd']; $ts < $bucketStart; $ts += ChannelUsageBucketCalculator::BUCKET_SIZE) {
+            if (count($rows) >= self::MAX_TRAILING_BUCKETS) {
+                $this->logger->warning(
+                    sprintf(
+                        'ChannelUsage: stopped filling idle buckets for company %d after %d of them.'
+                        . ' The queue backlog looks older than the gap filling is meant to cover.',
+                        $companyId,
+                        self::MAX_TRAILING_BUCKETS
+                    )
+                );
+
+                break;
+            }
+
+            $rows[] = $this->toRow(
+                $this->calculator->idleBucket($ts, $occupancy),
+                $brandId,
+                $companyId,
+                $limits
+            );
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param array{bucketTs: int, bucketEnd: int, peak: int, avgUsage: float, closingUsage: int, blockedByCompanyLimit: int, blockedByBrandLimit: int} $bucket
+     * @param array{maxCallsCompany: int, maxCallsBrand: int} $limits
+     * @return ChannelUsageRow
+     */
+    private function toRow(array $bucket, int $brandId, int $companyId, array $limits): array
+    {
+        return [
+            'brandId' => $brandId,
+            'companyId' => $companyId,
+            'timestamp' => new \DateTime(
+                '@' . $bucket['bucketTs'],
+                new \DateTimeZone('UTC')
+            ),
+            'peak' => $bucket['peak'],
+            'avgUsage' => $bucket['avgUsage'],
+            'closingUsage' => $bucket['closingUsage'],
+            'blockedByCompanyLimit' => $bucket['blockedByCompanyLimit'],
+            'blockedByBrandLimit' => $bucket['blockedByBrandLimit'],
+            'maxCallsCompany' => $limits['maxCallsCompany'],
+            'maxCallsBrand' => $limits['maxCallsBrand']
+        ];
+    }
+
+    /**
+     * @param array<int, array{brandId: int, occ: int}> $anchor
+     * @param array<int, ChannelUsageEvent> $processable
+     */
+    private function isAnchorCoherent(array $anchor, array $processable, int $now): bool
     {
         if (!empty($anchor)) {
             return true;
         }
 
-        $recentThreshold = time() - 600;
+        $recentThreshold = $now - self::ANCHOR_COHERENCE_WINDOW;
+
         foreach ($processable as $event) {
-            if ($event['type'] === 'A' && $event['ts'] >= $recentThreshold && ($event['occ'] ?? 0) > 0) {
+            $isRecentAdmission =
+                $event['type'] === ChannelUsageEventParser::TYPE_ADMITTED
+                && $event['ts'] >= $recentThreshold
+                && ($event['occ'] ?? 0) > 0;
+
+            if ($isRecentAdmission) {
                 return false;
             }
         }
@@ -254,338 +324,71 @@ class CollectChannelUsage
     }
 
     /**
-     * @param array<array{type: string, ts: int, brandId: int, companyId: int, occ?: int, reason?: string}> $processable
+     * @param array<int, ChannelUsageEvent> $processable
      * @param array<int, array{brandId: int, occ: int}> $anchor
      * @return array<int, int> companyId => brandId
      */
     private function buildCompanyBrandMap(array $processable, array $anchor): array
     {
         $map = [];
+
         foreach ($anchor as $companyId => $info) {
             $map[$companyId] = $info['brandId'];
         }
+
         foreach ($processable as $event) {
             if (!isset($map[$event['companyId']])) {
                 $map[$event['companyId']] = $event['brandId'];
             }
         }
+
         return $map;
     }
 
     /**
-     * @param int[] $companyIds
+     * @param array<int, int> $companyIds
      * @return array<int, int> companyId => maxCalls
      */
     private function loadCompanyMaxCalls(array $companyIds): array
     {
         $result = [];
         $companies = $this->companyRepository->findBy(['id' => $companyIds]);
+
         foreach ($companies as $company) {
             $result[(int) $company->getId()] = $company->getMaxCalls();
         }
+
         return $result;
     }
 
     /**
-     * @param int[] $brandIds
+     * @param array<int, int> $brandIds
      * @return array<int, int> brandId => maxCalls
      */
     private function loadBrandMaxCalls(array $brandIds): array
     {
         $result = [];
         $brands = $this->brandRepository->findBy(['id' => $brandIds]);
+
         foreach ($brands as $brand) {
             /** @var \Ivoz\Provider\Domain\Model\Brand\BrandInterface $brand */
             $result[(int) $brand->getId()] = $brand->getMaxCalls();
         }
+
         return $result;
     }
 
     /**
-     * @param array<array{type:string, ts:int, brandId:int, companyId:int}> $events
-     * @return array<array{type:string, ts:int, brandId:int, companyId:int}>
+     * @param array<int, ChannelUsageEvent> $events
+     * @return array<int, ChannelUsageEvent>
      */
     private function filterByCompany(array $events, int $companyId): array
     {
-        return array_values(array_filter($events, fn($e) => $e['companyId'] === $companyId));
-    }
-
-    /**
-     * Rewind from startOcc through events in reverse to get the occupancy before all events.
-     * Events must be sorted oldest-first.
-     *
-     * @param array<array{type: string, ts: int, brandId: int, companyId: int, occ?: int, reason?: string}> $events
-     */
-    private function rewind(int $startOcc, array $events): int
-    {
-        $occ = $startOcc;
-        foreach (array_reverse($events) as $event) {
-            if ($event['type'] === 'A') {
-                $occ = max(0, $occ - 1);
-            } elseif ($event['type'] === 'H') {
-                $occ++;
-            }
-            // B events do not change occupancy
-        }
-        return $occ;
-    }
-
-    /**
-     * Forward pass: compute bucket records from events and opening occupancy.
-     * Each entry pairs the persistable row with the bucket's end timestamp.
-     *
-     * @param array<array{type: string, ts: int, brandId: int, companyId: int, occ?: int, reason?: string}> $events
-     * @return array<int, array{
-     *   row: array{
-     *     brandId: int,
-     *     companyId: int,
-     *     timestamp: \DateTimeInterface,
-     *     peak: int,
-     *     avgUsage: float,
-     *     closingUsage: int,
-     *     blockedByCompanyLimit: int,
-     *     blockedByBrandLimit: int,
-     *     maxCallsCompany: int,
-     *     maxCallsBrand: int
-     *   },
-     *   bucketEnd: int
-     * }>
-     */
-    private function forwardPass(
-        array $events,
-        int $openingOcc,
-        int $brandId,
-        int $companyId,
-        int $maxCallsCompany,
-        int $maxCallsBrand
-    ): array {
-        if (empty($events)) {
-            return [];
-        }
-
-        usort($events, fn(array $a, array $b): int => (int) $a['ts'] - (int) $b['ts']);
-
-        $rows = [];
-        $currentOcc = $openingOcc;
-
-        $firstBucket = (int) (floor($events[0]['ts'] / self::BUCKET_SIZE) * self::BUCKET_SIZE);
-        $currentBucketTs = $firstBucket;
-        $bucketEnd = $currentBucketTs + self::BUCKET_SIZE;
-
-        $prevTs = $currentBucketTs;
-        $peak = $currentOcc;
-        $integral = 0.0;
-        $blockedCompany = 0;
-        $blockedBrand = 0;
-
-        $finalizeAndReset = function () use (
-            &$rows,
-            &$prevTs,
-            &$peak,
-            &$integral,
-            &$blockedCompany,
-            &$blockedBrand,
-            &$currentOcc,
-            &$currentBucketTs,
-            &$bucketEnd,
-            $brandId,
-            $companyId,
-            $maxCallsCompany,
-            $maxCallsBrand
-        ): void {
-            /** @var array<int, array{row: array{brandId: int, companyId: int, timestamp: \DateTimeInterface, peak: int, avgUsage: float, closingUsage: int, blockedByCompanyLimit: int, blockedByBrandLimit: int, maxCallsCompany: int, maxCallsBrand: int}, bucketEnd: int}> $rows */
-            /** @var int $prevTs */
-            /** @var int $peak */
-            /** @var float $integral */
-            /** @var int $blockedCompany */
-            /** @var int $blockedBrand */
-            /** @var int $currentOcc */
-            /** @var int $currentBucketTs */
-            /** @var int $bucketEnd */
-            // Complete the bucket integral up to its end
-            $integral += $currentOcc * ($bucketEnd - $prevTs);
-            $avgUsage = $integral / self::BUCKET_SIZE;
-
-            $rows[] = [
-                'row' => $this->makeRow(
-                    $brandId,
-                    $companyId,
-                    $currentBucketTs,
-                    $peak,
-                    $avgUsage,
-                    $currentOcc,
-                    $blockedCompany,
-                    $blockedBrand,
-                    $maxCallsCompany,
-                    $maxCallsBrand
-                ),
-                'bucketEnd' => $bucketEnd,
-            ];
-
-            // Reset for next bucket
-            $currentBucketTs = $bucketEnd;
-            $bucketEnd = $currentBucketTs + self::BUCKET_SIZE;
-            $prevTs = $currentBucketTs;
-            $peak = $currentOcc;
-            $integral = 0.0;
-            $blockedCompany = 0;
-            $blockedBrand = 0;
-        };
-
-        foreach ($events as $event) {
-            // Advance through empty buckets before this event's bucket
-            $eventBucket = (int) (floor($event['ts'] / self::BUCKET_SIZE) * self::BUCKET_SIZE);
-            while ($currentBucketTs < $eventBucket) {
-                $finalizeAndReset();
-            }
-
-            // Accumulate time within current bucket before this event
-            /** @psalm-suppress UnusedVariable */
-            $integral += $currentOcc * ($event['ts'] - $prevTs);
-            $prevTs = $event['ts'];
-
-            // Apply event
-            if ($event['type'] === 'A') {
-                $currentOcc = $event['occ'] ?? ($currentOcc + 1);
-                $peak = max($peak, $currentOcc);
-            } elseif ($event['type'] === 'H') {
-                $currentOcc = max(0, $currentOcc - 1);
-            } elseif ($event['type'] === 'B') {
-                if (($event['reason'] ?? '') === 'brand') {
-                    $blockedBrand++;
-                } else {
-                    $blockedCompany++;
-                }
-            }
-        }
-
-        // Finalize last bucket
-        $finalizeAndReset();
-
-        return $rows;
-    }
-
-    /**
-     * @return array{brandId:int, companyId:int, timestamp:\DateTimeInterface, peak:int, avgUsage:float,
-     *              closingUsage:int, blockedByCompanyLimit:int, blockedByBrandLimit:int,
-     *              maxCallsCompany:int, maxCallsBrand:int}
-     */
-    private function makeRow(
-        int $brandId,
-        int $companyId,
-        int $bucketTs,
-        int $peak,
-        float $avgUsage,
-        int $closingUsage,
-        int $blockedByCompanyLimit,
-        int $blockedByBrandLimit,
-        int $maxCallsCompany,
-        int $maxCallsBrand
-    ): array {
-        return [
-            'brandId' => $brandId,
-            'companyId' => $companyId,
-            'timestamp' => new \DateTime('@' . $bucketTs, new \DateTimeZone('UTC')),
-            'peak' => $peak,
-            'avgUsage' => $avgUsage,
-            'closingUsage' => $closingUsage,
-            'blockedByCompanyLimit' => $blockedByCompanyLimit,
-            'blockedByBrandLimit' => $blockedByBrandLimit,
-            'maxCallsCompany' => $maxCallsCompany,
-            'maxCallsBrand' => $maxCallsBrand,
-        ];
-    }
-
-    /**
-     * @param array<array{
-     *   brandId: int,
-     *   companyId: int,
-     *   timestamp: \DateTimeInterface,
-     *   peak: int,
-     *   avgUsage: float,
-     *   closingUsage: int,
-     *   maxCallsCompany: int,
-     *   maxCallsBrand: int,
-     *   blockedByCompanyLimit: int,
-     *   blockedByBrandLimit: int
-     * }> $rows
-     */
-    private function persistRows(array $rows): void
-    {
-        foreach (array_chunk($rows, self::PERSIST_BATCH_SIZE) as $chunk) {
-            foreach ($chunk as $row) {
-                $this->persistRow($row);
-            }
-
-            // Let errors bubble up: the event queue is only trimmed on success,
-            // so the next run will reprocess and rewrite the very same buckets
-            $this->entityTools->dispatchQueuedOperations();
-            $this->entityTools->clearExcept(
-                Commandlog::class
-            );
-        }
-    }
-
-    /**
-     * @param array{
-     *   brandId: int,
-     *   companyId: int,
-     *   timestamp: \DateTimeInterface,
-     *   peak: int,
-     *   avgUsage: float,
-     *   closingUsage: int,
-     *   maxCallsCompany: int,
-     *   maxCallsBrand: int,
-     *   blockedByCompanyLimit: int,
-     *   blockedByBrandLimit: int
-     * } $row
-     */
-    private function persistRow(array $row): void
-    {
-        $channelUsage = $this
-            ->channelUsageRepository
-            ->findOneByCompanyAndTimestamp(
-                $row['companyId'],
-                $row['timestamp']
-            );
-
-        if ($channelUsage) {
-            /** @var ChannelUsageDto $channelUsageDto */
-            $channelUsageDto = $this->entityTools->entityToDto($channelUsage);
-        } else {
-            $channelUsageDto = ChannelUsage::createDto();
-        }
-
-        $channelUsageDto
-            ->setBrandId($row['brandId'])
-            ->setCompanyId($row['companyId'])
-            ->setTimestamp($row['timestamp'])
-            ->setPeak($row['peak'])
-            ->setAvgUsage(round($row['avgUsage'], 2))
-            ->setClosingUsage($row['closingUsage'])
-            ->setMaxCallsCompany($row['maxCallsCompany'])
-            ->setMaxCallsBrand($row['maxCallsBrand'])
-            ->setBlockedByCompanyLimit($row['blockedByCompanyLimit'])
-            ->setBlockedByBrandLimit($row['blockedByBrandLimit']);
-
-        $this->entityTools->persistDto(
-            $channelUsageDto,
-            $channelUsage,
-            false
+        return array_values(
+            array_filter(
+                $events,
+                fn (array $event): bool => $event['companyId'] === $companyId
+            )
         );
-    }
-
-    private function purgeOldRows(): void
-    {
-        $utc = new \DateTimeZone('UTC');
-        $cutoff = new \DateTime('now', $utc);
-        $cutoff->modify(sprintf('-%d days', self::RETENTION_DAYS));
-
-        do {
-            $affected = $this->channelUsageRepository->purgeOlderThan($cutoff, self::PURGE_BATCH_SIZE);
-            if ($affected > 0) {
-                sleep(1);
-            }
-        } while ($affected >= self::PURGE_BATCH_SIZE);
     }
 }

--- a/library/Ivoz/Provider/Domain/Service/ChannelUsage/PurgeOldChannelUsage.php
+++ b/library/Ivoz/Provider/Domain/Service/ChannelUsage/PurgeOldChannelUsage.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ivoz\Provider\Domain\Service\ChannelUsage;
+
+use Ivoz\Provider\Domain\Model\ChannelUsage\ChannelUsageRepository;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Channel usage retention: drops buckets older than the retention window.
+ *
+ * Split out of CollectChannelUsage because retention is a rule of its own, with its own
+ * failure mode: a purge that cannot keep up must not stop usage from being collected.
+ */
+class PurgeOldChannelUsage
+{
+    public const RETENTION_DAYS = 30;
+    public const PURGE_BATCH_SIZE = 1000;
+
+    /**
+     * Bounds a single run so a large backlog is drained over several runs instead of
+     * holding the job (and its DB load) for an unpredictable amount of time.
+     */
+    public const MAX_BATCHES_PER_RUN = 50;
+
+    public function __construct(
+        private ChannelUsageRepository $channelUsageRepository,
+        private LoggerInterface $logger
+    ) {
+    }
+
+    /**
+     * @return int rows deleted
+     */
+    public function execute(): int
+    {
+        $cutoff = new \DateTime(
+            'now',
+            new \DateTimeZone('UTC')
+        );
+        $cutoff->modify(
+            sprintf('-%d days', self::RETENTION_DAYS)
+        );
+
+        $deleted = 0;
+
+        for ($batch = 0; $batch < self::MAX_BATCHES_PER_RUN; $batch++) {
+            $affected = $this->channelUsageRepository->purgeOlderThan(
+                $cutoff,
+                self::PURGE_BATCH_SIZE
+            );
+
+            $deleted += $affected;
+
+            if ($affected < self::PURGE_BATCH_SIZE) {
+                return $deleted;
+            }
+        }
+
+        $this->logger->warning(
+            sprintf(
+                'ChannelUsage: purge hit its %d batch limit after deleting %d rows,'
+                . ' remaining rows will be dropped on the next run.',
+                self::MAX_BATCHES_PER_RUN,
+                $deleted
+            )
+        );
+
+        return $deleted;
+    }
+}

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/ChannelUsageDoctrineRepository.php
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/ChannelUsageDoctrineRepository.php
@@ -48,6 +48,38 @@ class ChannelUsageDoctrineRepository extends ServiceEntityRepository implements 
         return $response;
     }
 
+    /**
+     * @param array<int, int> $companyIds
+     * @return array<int, ChannelUsageInterface>
+     */
+    public function findByCompaniesAndTimestampRange(
+        array $companyIds,
+        \DateTimeInterface $from,
+        \DateTimeInterface $to
+    ): array {
+        if (empty($companyIds)) {
+            return [];
+        }
+
+        $qb = $this
+            ->createQueryBuilder('self');
+
+        $criteria = CriteriaHelper::fromArray([
+            ['company', 'in', $companyIds],
+            ['timestamp', 'gte', $from->format('Y-m-d H:i:s')],
+            ['timestamp', 'lte', $to->format('Y-m-d H:i:s')]
+        ]);
+
+        $qb->addCriteria($criteria);
+
+        /** @var array<int, ChannelUsageInterface> $response */
+        $response = $qb
+            ->getQuery()
+            ->getResult();
+
+        return $response;
+    }
+
     public function purgeOlderThan(\DateTimeInterface $cutoff, int $limit): int
     {
         $ids = $this->findIdsOlderThan($cutoff, $limit);

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/ChannelUsageDoctrineRepository.php
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/ChannelUsageDoctrineRepository.php
@@ -3,9 +3,10 @@
 namespace Ivoz\Provider\Infrastructure\Persistence\Doctrine;
 
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
-use Doctrine\ORM\NativeQuery;
 use Ivoz\Core\Infrastructure\Domain\Service\DoctrineQueryRunner;
+use Ivoz\Core\Infrastructure\Persistence\Doctrine\Model\Helper\CriteriaHelper;
 use Ivoz\Provider\Domain\Model\ChannelUsage\ChannelUsage;
+use Ivoz\Provider\Domain\Model\ChannelUsage\ChannelUsageInterface;
 use Ivoz\Provider\Domain\Model\ChannelUsage\ChannelUsageRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -23,63 +24,78 @@ class ChannelUsageDoctrineRepository extends ServiceEntityRepository implements 
         parent::__construct($registry, ChannelUsage::class);
     }
 
-    public function upsertBatch(array $rows): int
-    {
-        if (empty($rows)) {
-            return 0;
-        }
+    public function findOneByCompanyAndTimestamp(
+        int $companyId,
+        \DateTimeInterface $timestamp
+    ): ?ChannelUsageInterface {
+        $qb = $this
+            ->createQueryBuilder('self');
 
-        $placeholders = [];
-        $values = [];
-        foreach ($rows as $row) {
-            $placeholders[] = '(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
-            $values[] = $row['brandId'];
-            $values[] = $row['companyId'];
-            $values[] = $row['timestamp']->format('Y-m-d H:i:s');
-            $values[] = $row['peak'];
-            $values[] = round($row['avgUsage'], 2);
-            $values[] = $row['closingUsage'];
-            $values[] = $row['maxCallsCompany'];
-            $values[] = $row['maxCallsBrand'];
-            $values[] = $row['blockedByCompanyLimit'];
-            $values[] = $row['blockedByBrandLimit'];
-        }
+        $criteria = CriteriaHelper::fromArray([
+            ['company', 'eq', $companyId],
+            ['timestamp', 'eq', $timestamp->format('Y-m-d H:i:s')]
+        ]);
 
-        $sql = sprintf(
-            'INSERT INTO ChannelUsages'
-            . ' (brandId, companyId, timestamp, peak, avgUsage, closingUsage,'
-            . ' maxCallsCompany, maxCallsBrand, blockedByCompanyLimit, blockedByBrandLimit)'
-            . ' VALUES %s'
-            . ' ON DUPLICATE KEY UPDATE'
-            . ' peak = VALUES(peak),'
-            . ' avgUsage = VALUES(avgUsage),'
-            . ' closingUsage = VALUES(closingUsage),'
-            . ' maxCallsCompany = VALUES(maxCallsCompany),'
-            . ' maxCallsBrand = VALUES(maxCallsBrand),'
-            . ' blockedByCompanyLimit = VALUES(blockedByCompanyLimit),'
-            . ' blockedByBrandLimit = VALUES(blockedByBrandLimit)',
-            implode(', ', $placeholders)
-        );
+        $qb
+            ->addCriteria($criteria)
+            ->setMaxResults(1);
 
-        $query = (new NativeQuery($this->_em))->setSQL($sql);
-        foreach ($values as $idx => $value) {
-            $query->setParameter($idx + 1, $value);
-        }
+        /** @var ChannelUsageInterface | null $response */
+        $response = $qb
+            ->getQuery()
+            ->getOneOrNullResult();
 
-        return $this->queryRunner->execute(ChannelUsage::class, $query);
+        return $response;
     }
 
     public function purgeOlderThan(\DateTimeInterface $cutoff, int $limit): int
     {
-        $sql = sprintf(
-            'DELETE FROM ChannelUsages WHERE timestamp < ? LIMIT %d',
-            $limit
+        $ids = $this->findIdsOlderThan($cutoff, $limit);
+
+        if (empty($ids)) {
+            return 0;
+        }
+
+        $qb = $this
+            ->createQueryBuilder('self');
+
+        $qb
+            ->delete(
+                $this->getEntityName(),
+                'self'
+            )
+            ->where('self.id in (:ids)')
+            ->setParameter(':ids', $ids);
+
+        return $this->queryRunner->execute(
+            $this->getEntityName(),
+            $qb->getQuery()
         );
+    }
 
-        $query = (new NativeQuery($this->_em))
-            ->setSQL($sql)
-            ->setParameter(1, $cutoff->format('Y-m-d H:i:s'));
+    /**
+     * @return int[]
+     */
+    private function findIdsOlderThan(\DateTimeInterface $cutoff, int $limit): array
+    {
+        $qb = $this
+            ->createQueryBuilder('self');
 
-        return $this->queryRunner->execute(ChannelUsage::class, $query);
+        $criteria = CriteriaHelper::fromArray([
+            ['timestamp', 'lt', $cutoff->format('Y-m-d H:i:s')]
+        ]);
+
+        $qb
+            ->select('self.id')
+            ->addCriteria($criteria)
+            ->setMaxResults($limit);
+
+        return array_map(
+            'intval',
+            array_column(
+                $qb->getQuery()->getScalarResult(),
+                'id'
+            )
+        );
     }
 }

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/ChannelUsageDoctrineRepository.php
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/ChannelUsageDoctrineRepository.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Ivoz\Provider\Infrastructure\Persistence\Doctrine;
+
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\NativeQuery;
+use Ivoz\Core\Infrastructure\Domain\Service\DoctrineQueryRunner;
+use Ivoz\Provider\Domain\Model\ChannelUsage\ChannelUsage;
+use Ivoz\Provider\Domain\Model\ChannelUsage\ChannelUsageRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * ChannelUsageDoctrineRepository
+ *
+ * @template-extends ServiceEntityRepository<ChannelUsage>
+ */
+class ChannelUsageDoctrineRepository extends ServiceEntityRepository implements ChannelUsageRepository
+{
+    public function __construct(
+        ManagerRegistry $registry,
+        private DoctrineQueryRunner $queryRunner
+    ) {
+        parent::__construct($registry, ChannelUsage::class);
+    }
+
+    public function upsertBatch(array $rows): int
+    {
+        if (empty($rows)) {
+            return 0;
+        }
+
+        $placeholders = [];
+        $values = [];
+        foreach ($rows as $row) {
+            $placeholders[] = '(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
+            $values[] = $row['brandId'];
+            $values[] = $row['companyId'];
+            $values[] = $row['timestamp']->format('Y-m-d H:i:s');
+            $values[] = $row['peak'];
+            $values[] = round($row['avgUsage'], 2);
+            $values[] = $row['closingUsage'];
+            $values[] = $row['maxCallsCompany'];
+            $values[] = $row['maxCallsBrand'];
+            $values[] = $row['blockedByCompanyLimit'];
+            $values[] = $row['blockedByBrandLimit'];
+        }
+
+        $sql = sprintf(
+            'INSERT INTO ChannelUsages'
+            . ' (brandId, companyId, timestamp, peak, avgUsage, closingUsage,'
+            . ' maxCallsCompany, maxCallsBrand, blockedByCompanyLimit, blockedByBrandLimit)'
+            . ' VALUES %s'
+            . ' ON DUPLICATE KEY UPDATE'
+            . ' peak = VALUES(peak),'
+            . ' avgUsage = VALUES(avgUsage),'
+            . ' closingUsage = VALUES(closingUsage),'
+            . ' maxCallsCompany = VALUES(maxCallsCompany),'
+            . ' maxCallsBrand = VALUES(maxCallsBrand),'
+            . ' blockedByCompanyLimit = VALUES(blockedByCompanyLimit),'
+            . ' blockedByBrandLimit = VALUES(blockedByBrandLimit)',
+            implode(', ', $placeholders)
+        );
+
+        $query = (new NativeQuery($this->_em))->setSQL($sql);
+        foreach ($values as $idx => $value) {
+            $query->setParameter($idx + 1, $value);
+        }
+
+        return $this->queryRunner->execute(ChannelUsage::class, $query);
+    }
+
+    public function purgeOlderThan(\DateTimeInterface $cutoff, int $limit): int
+    {
+        $sql = sprintf(
+            'DELETE FROM ChannelUsages WHERE timestamp < ? LIMIT %d',
+            $limit
+        );
+
+        $query = (new NativeQuery($this->_em))
+            ->setSQL($sql)
+            ->setParameter(1, $cutoff->format('Y-m-d H:i:s'));
+
+        return $this->queryRunner->execute(ChannelUsage::class, $query);
+    }
+}

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/ChannelUsage.ChannelUsage.orm.xml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/ChannelUsage.ChannelUsage.orm.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+    <entity
+            repository-class="Ivoz\Provider\Infrastructure\Persistence\Doctrine\ChannelUsageDoctrineRepository"
+            name="Ivoz\Provider\Domain\Model\ChannelUsage\ChannelUsage"
+            table="ChannelUsages"
+            change-tracking-policy="DEFERRED_EXPLICIT"
+    >
+        <id name="id" type="integer" column="id">
+            <generator strategy="IDENTITY"/>
+            <options>
+                <option name="unsigned">1</option>
+            </options>
+        </id>
+    </entity>
+</doctrine-mapping>

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/ChannelUsage.ChannelUsageAbstract.orm.xml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/ChannelUsage.ChannelUsageAbstract.orm.xml
@@ -6,6 +6,7 @@
         </unique-constraints>
         <indexes>
             <index name="channelUsage_brandId_idx" columns="brandId"/>
+            <index name="channelUsage_timestamp_idx" columns="timestamp"/>
         </indexes>
         <field name="timestamp" type="datetime" column="timestamp" nullable="false"/>
         <field name="peak" type="smallint" column="peak" nullable="false">

--- a/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/ChannelUsage.ChannelUsageAbstract.orm.xml
+++ b/library/Ivoz/Provider/Infrastructure/Persistence/Doctrine/Mapping/ChannelUsage.ChannelUsageAbstract.orm.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+    <mapped-superclass name="Ivoz\Provider\Domain\Model\ChannelUsage\ChannelUsageAbstract" table="channel_usage_abstract">
+        <unique-constraints>
+            <unique-constraint name="chUsage_company_ts" columns="companyId,timestamp"/>
+        </unique-constraints>
+        <indexes>
+            <index name="channelUsage_brandId_idx" columns="brandId"/>
+        </indexes>
+        <field name="timestamp" type="datetime" column="timestamp" nullable="false"/>
+        <field name="peak" type="smallint" column="peak" nullable="false">
+            <options>
+                <option name="unsigned">1</option>
+            </options>
+        </field>
+        <field name="avgUsage" type="decimal" column="avgUsage" precision="6" scale="2" nullable="false"/>
+        <field name="closingUsage" type="smallint" column="closingUsage" nullable="false">
+            <options>
+                <option name="unsigned">1</option>
+            </options>
+        </field>
+        <field name="maxCallsCompany" type="smallint" column="maxCallsCompany" nullable="false">
+            <options>
+                <option name="unsigned">1</option>
+            </options>
+        </field>
+        <field name="maxCallsBrand" type="smallint" column="maxCallsBrand" nullable="false">
+            <options>
+                <option name="unsigned">1</option>
+            </options>
+        </field>
+        <field name="blockedByCompanyLimit" type="smallint" column="blockedByCompanyLimit" nullable="false">
+            <options>
+                <option name="unsigned">1</option>
+                <option name="default">0</option>
+            </options>
+        </field>
+        <field name="blockedByBrandLimit" type="smallint" column="blockedByBrandLimit" nullable="false">
+            <options>
+                <option name="unsigned">1</option>
+                <option name="default">0</option>
+            </options>
+        </field>
+        <many-to-one field="brand" target-entity="Ivoz\Provider\Domain\Model\Brand\BrandInterface" fetch="LAZY">
+            <join-columns>
+                <join-column name="brandId" referenced-column-name="id" on-delete="CASCADE" nullable="false"/>
+            </join-columns>
+        </many-to-one>
+        <many-to-one field="company" target-entity="Ivoz\Provider\Domain\Model\Company\CompanyInterface" fetch="LAZY">
+            <join-columns>
+                <join-column name="companyId" referenced-column-name="id" on-delete="CASCADE" nullable="false"/>
+            </join-columns>
+        </many-to-one>
+    </mapped-superclass>
+</doctrine-mapping>

--- a/library/Ivoz/Provider/Infrastructure/Redis/Job/ChannelUsageEventQueue.php
+++ b/library/Ivoz/Provider/Infrastructure/Redis/Job/ChannelUsageEventQueue.php
@@ -4,23 +4,16 @@ namespace Ivoz\Provider\Infrastructure\Redis\Job;
 
 use Ivoz\Core\Infrastructure\Persistence\Redis\RedisMasterFactory;
 use Ivoz\Provider\Domain\Job\ChannelUsageEventQueueInterface;
-use Psr\Log\LoggerInterface;
 
 class ChannelUsageEventQueue implements ChannelUsageEventQueueInterface
 {
-    public const REDIS_DB = 1;
-    public const REDIS_SCAN_COUNT = 1000;
-    public const TRUNKS_KEY_PATTERN = 'trunks:*';
-
     /**
-     * trunks:b<brandId>:c<companyId>:ddi<ddiId>:cr<carrierId>:<callId>
-     * trunks:b<brandId>:c<companyId>:ddi<ddiId>:dp<ddiProviderId>:<callId>
+     * The db kamtrunks pushes to, per its ndb_redis server config.
      */
-    private const TRUNKS_KEY_REGEXP = '/^trunks:b(\d+):c(\d+):/';
+    public const REDIS_DB = 1;
 
     public function __construct(
-        private RedisMasterFactory $redisMasterFactory,
-        private LoggerInterface $logger
+        private RedisMasterFactory $redisMasterFactory
     ) {
     }
 
@@ -88,65 +81,6 @@ class ChannelUsageEventQueue implements ChannelUsageEventQueueInterface
                     $rawEntry
                 );
             }
-        } finally {
-            $redis->close();
-        }
-    }
-
-    /**
-     * @return array<int, array{brandId: int, occ: int}>
-     */
-    public function getActiveChannelsByCompany(): array
-    {
-        $activeChannels = [];
-        $redis = $this->redisMasterFactory->create(self::REDIS_DB);
-
-        try {
-            /** @var int|null $scanIterator */
-            $scanIterator = null;
-
-            while (true) {
-                $keys = $redis->scan(
-                    $scanIterator,
-                    self::TRUNKS_KEY_PATTERN,
-                    self::REDIS_SCAN_COUNT
-                );
-
-                if (!is_array($keys)) {
-                    break;
-                }
-
-                foreach ($keys as $key) {
-                    $matches = [];
-                    if (!preg_match(self::TRUNKS_KEY_REGEXP, (string) $key, $matches)) {
-                        continue;
-                    }
-
-                    $brandId = (int) $matches[1];
-                    $companyId = (int) $matches[2];
-
-                    if (!isset($activeChannels[$companyId])) {
-                        $activeChannels[$companyId] = [
-                            'brandId' => $brandId,
-                            'occ' => 0
-                        ];
-                    }
-
-                    $activeChannels[$companyId]['occ']++;
-                }
-
-                if ($scanIterator === 0) {
-                    break;
-                }
-            }
-
-            return $activeChannels;
-        } catch (\Exception $e) {
-            $this->logger->error(
-                'ChannelUsage: unable to scan the realtime keyspace: ' . $e->getMessage()
-            );
-
-            return [];
         } finally {
             $redis->close();
         }

--- a/library/Ivoz/Provider/Infrastructure/Redis/Job/ChannelUsageEventQueue.php
+++ b/library/Ivoz/Provider/Infrastructure/Redis/Job/ChannelUsageEventQueue.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Ivoz\Provider\Infrastructure\Redis\Job;
+
+use Ivoz\Core\Infrastructure\Persistence\Redis\RedisMasterFactory;
+use Ivoz\Provider\Domain\Job\ChannelUsageEventQueueInterface;
+use Psr\Log\LoggerInterface;
+
+class ChannelUsageEventQueue implements ChannelUsageEventQueueInterface
+{
+    public const REDIS_DB = 1;
+    public const REDIS_SCAN_COUNT = 1000;
+    public const TRUNKS_KEY_PATTERN = 'trunks:*';
+
+    /**
+     * trunks:b<brandId>:c<companyId>:ddi<ddiId>:cr<carrierId>:<callId>
+     * trunks:b<brandId>:c<companyId>:ddi<ddiId>:dp<ddiProviderId>:<callId>
+     */
+    private const TRUNKS_KEY_REGEXP = '/^trunks:b(\d+):c(\d+):/';
+
+    public function __construct(
+        private RedisMasterFactory $redisMasterFactory,
+        private LoggerInterface $logger
+    ) {
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function readPending(int $maxEntries): array
+    {
+        if ($maxEntries < 1) {
+            return [];
+        }
+
+        $redis = $this->redisMasterFactory->create(self::REDIS_DB);
+
+        try {
+            /** @var array<int, string>|false $entries */
+            $entries = $redis->lrange(
+                self::QUEUE_KEY,
+                0,
+                $maxEntries - 1
+            );
+        } finally {
+            $redis->close();
+        }
+
+        return is_array($entries)
+            ? $entries
+            : [];
+    }
+
+    public function discardProcessed(int $entryCount): void
+    {
+        if ($entryCount < 1) {
+            return;
+        }
+
+        $redis = $this->redisMasterFactory->create(self::REDIS_DB);
+
+        try {
+            $redis->ltrim(
+                self::QUEUE_KEY,
+                $entryCount,
+                -1
+            );
+        } finally {
+            $redis->close();
+        }
+    }
+
+    /**
+     * @param array<int, string> $rawEntries
+     */
+    public function requeue(array $rawEntries): void
+    {
+        if (empty($rawEntries)) {
+            return;
+        }
+
+        $redis = $this->redisMasterFactory->create(self::REDIS_DB);
+
+        try {
+            foreach ($rawEntries as $rawEntry) {
+                $redis->rpush(
+                    self::QUEUE_KEY,
+                    $rawEntry
+                );
+            }
+        } finally {
+            $redis->close();
+        }
+    }
+
+    /**
+     * @return array<int, array{brandId: int, occ: int}>
+     */
+    public function getActiveChannelsByCompany(): array
+    {
+        $activeChannels = [];
+        $redis = $this->redisMasterFactory->create(self::REDIS_DB);
+
+        try {
+            /** @var int|null $scanIterator */
+            $scanIterator = null;
+
+            while (true) {
+                $keys = $redis->scan(
+                    $scanIterator,
+                    self::TRUNKS_KEY_PATTERN,
+                    self::REDIS_SCAN_COUNT
+                );
+
+                if (!is_array($keys)) {
+                    break;
+                }
+
+                foreach ($keys as $key) {
+                    $matches = [];
+                    if (!preg_match(self::TRUNKS_KEY_REGEXP, (string) $key, $matches)) {
+                        continue;
+                    }
+
+                    $brandId = (int) $matches[1];
+                    $companyId = (int) $matches[2];
+
+                    if (!isset($activeChannels[$companyId])) {
+                        $activeChannels[$companyId] = [
+                            'brandId' => $brandId,
+                            'occ' => 0
+                        ];
+                    }
+
+                    $activeChannels[$companyId]['occ']++;
+                }
+
+                if ($scanIterator === 0) {
+                    break;
+                }
+            }
+
+            return $activeChannels;
+        } catch (\Exception $e) {
+            $this->logger->error(
+                'ChannelUsage: unable to scan the realtime keyspace: ' . $e->getMessage()
+            );
+
+            return [];
+        } finally {
+            $redis->close();
+        }
+    }
+}

--- a/library/composer-packages/irontec/ivoz-provider-bundle/Resources/config/orm_target_entities.yml
+++ b/library/composer-packages/irontec/ivoz-provider-bundle/Resources/config/orm_target_entities.yml
@@ -31,6 +31,8 @@ doctrine:
         Ivoz\Provider\Domain\Model\BillableCall\BillableCall
       Ivoz\Provider\Domain\Model\BillableCallHistoric\BillableCallHistoricInterface:
         Ivoz\Provider\Domain\Model\BillableCallHistoric\BillableCallHistoric
+      Ivoz\Provider\Domain\Model\ChannelUsage\ChannelUsageInterface:
+        Ivoz\Provider\Domain\Model\ChannelUsage\ChannelUsage
       Ivoz\Provider\Domain\Model\Brand\BrandInterface:
         Ivoz\Provider\Domain\Model\Brand\Brand
       Ivoz\Provider\Domain\Model\BrandService\BrandServiceInterface:

--- a/library/composer-packages/irontec/ivoz-provider-bundle/Resources/config/services/infraestructure/jobs.yml
+++ b/library/composer-packages/irontec/ivoz-provider-bundle/Resources/config/services/infraestructure/jobs.yml
@@ -55,6 +55,12 @@ services:
   Ivoz\Provider\Domain\Job\WebhookReloadJobInterface:
     alias: Ivoz\Provider\Infrastructure\Redis\Job\WebhookReloadJob
 
+  # Channel usage event queue
+  # Note: no $redisDb argument on purpose. This queue lives in the realtime calls db
+  # (see TrunksClient::REDIS_RT_CALLS_DB), not in the jobs db.
+  Ivoz\Provider\Domain\Job\ChannelUsageEventQueueInterface:
+    alias: Ivoz\Provider\Infrastructure\Redis\Job\ChannelUsageEventQueue
+
   # Asterisk ARI calls
   Ivoz\Ast\Infrastructure\Redis\Job\DialplanReloadJob:
     arguments:

--- a/library/composer-packages/irontec/ivoz-provider-bundle/Resources/config/services/infraestructure/jobs.yml
+++ b/library/composer-packages/irontec/ivoz-provider-bundle/Resources/config/services/infraestructure/jobs.yml
@@ -58,6 +58,8 @@ services:
   # Channel usage event queue
   # Note: no $redisDb argument on purpose. This queue lives in the realtime calls db
   # (see TrunksClient::REDIS_RT_CALLS_DB), not in the jobs db.
+  Ivoz\Provider\Infrastructure\Redis\Job\ChannelUsageEventQueue: ~
+
   Ivoz\Provider\Domain\Job\ChannelUsageEventQueueInterface:
     alias: Ivoz\Provider\Infrastructure\Redis\Job\ChannelUsageEventQueue
 

--- a/library/psalm-baseline.xml
+++ b/library/psalm-baseline.xml
@@ -4813,41 +4813,6 @@
       <code>$this-&gt;services[$event][]</code>
     </MixedArrayAssignment>
   </file>
-  <file src="Ivoz/Provider/Domain/Service/ChannelUsage/CollectChannelUsage.php">
-    <MixedArgument occurrences="6">
-      <code>$avgUsage</code>
-      <code>$blockedBrand</code>
-      <code>$blockedCompany</code>
-      <code>$currentBucketTs</code>
-      <code>$currentOcc</code>
-      <code>$peak</code>
-    </MixedArgument>
-    <MixedArrayAssignment occurrences="1">
-      <code>$rows[]</code>
-    </MixedArrayAssignment>
-    <MixedOperand occurrences="11">
-      <code>$blockedBrand</code>
-      <code>$blockedCompany</code>
-      <code>$currentOcc</code>
-      <code>$currentOcc</code>
-      <code>$currentOcc</code>
-      <code>$currentOcc</code>
-      <code>$integral</code>
-      <code>$integral</code>
-      <code>$integral</code>
-      <code>$prevTs</code>
-      <code>$prevTs</code>
-    </MixedOperand>
-    <UnnecessaryVarAnnotation occurrences="1">
-      <code>int</code>
-    </UnnecessaryVarAnnotation>
-    <UnusedVariable occurrences="4">
-      <code>$blockedBrand</code>
-      <code>$blockedCompany</code>
-      <code>$integral</code>
-      <code>$prevTs</code>
-    </UnusedVariable>
-  </file>
   <file src="Ivoz/Provider/Domain/Service/Company/AbstractBalanceOperation.php">
     <MixedArgument occurrences="1">
       <code>$balance</code>

--- a/library/psalm-baseline.xml
+++ b/library/psalm-baseline.xml
@@ -1874,6 +1874,20 @@
       <code>func_get_args()</code>
     </MixedArgument>
   </file>
+  <file src="Ivoz/Provider/Domain/Model/ChannelUsage/ChannelUsageAbstract.php">
+    <MixedArgument occurrences="4">
+      <code>$fkTransformer-&gt;transform($brand)</code>
+      <code>$fkTransformer-&gt;transform($brand)</code>
+      <code>$fkTransformer-&gt;transform($company)</code>
+      <code>$fkTransformer-&gt;transform($company)</code>
+    </MixedArgument>
+    <UnsafeInstantiation occurrences="1"/>
+  </file>
+  <file src="Ivoz/Provider/Domain/Model/ChannelUsage/ChannelUsageTrait.php">
+    <MixedArgument occurrences="1">
+      <code>func_get_args()</code>
+    </MixedArgument>
+  </file>
   <file src="Ivoz/Provider/Domain/Model/Codec/CodecAbstract.php">
     <UnsafeInstantiation occurrences="1"/>
   </file>
@@ -4798,6 +4812,41 @@
     <MixedArrayAssignment occurrences="1">
       <code>$this-&gt;services[$event][]</code>
     </MixedArrayAssignment>
+  </file>
+  <file src="Ivoz/Provider/Domain/Service/ChannelUsage/CollectChannelUsage.php">
+    <MixedArgument occurrences="6">
+      <code>$avgUsage</code>
+      <code>$blockedBrand</code>
+      <code>$blockedCompany</code>
+      <code>$currentBucketTs</code>
+      <code>$currentOcc</code>
+      <code>$peak</code>
+    </MixedArgument>
+    <MixedArrayAssignment occurrences="1">
+      <code>$rows[]</code>
+    </MixedArrayAssignment>
+    <MixedOperand occurrences="11">
+      <code>$blockedBrand</code>
+      <code>$blockedCompany</code>
+      <code>$currentOcc</code>
+      <code>$currentOcc</code>
+      <code>$currentOcc</code>
+      <code>$currentOcc</code>
+      <code>$integral</code>
+      <code>$integral</code>
+      <code>$integral</code>
+      <code>$prevTs</code>
+      <code>$prevTs</code>
+    </MixedOperand>
+    <UnnecessaryVarAnnotation occurrences="1">
+      <code>int</code>
+    </UnnecessaryVarAnnotation>
+    <UnusedVariable occurrences="4">
+      <code>$blockedBrand</code>
+      <code>$blockedCompany</code>
+      <code>$integral</code>
+      <code>$prevTs</code>
+    </UnusedVariable>
   </file>
   <file src="Ivoz/Provider/Domain/Service/Company/AbstractBalanceOperation.php">
     <MixedArgument occurrences="1">

--- a/library/spec/Ivoz/Provider/Domain/Model/ChannelUsage/ChannelUsageEventSpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Model/ChannelUsage/ChannelUsageEventSpec.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace spec\Ivoz\Provider\Domain\Model\ChannelUsage;
+
+use Ivoz\Provider\Domain\Model\ChannelUsage\ChannelUsageEvent;
+use PhpSpec\ObjectBehavior;
+
+class ChannelUsageEventSpec extends ObjectBehavior
+{
+    public function let()
+    {
+        $this->beConstructedThrough('fromWire', ['A:1767225610:1:2:7']);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ChannelUsageEvent::class);
+    }
+
+    function it_reads_an_admission_off_the_wire()
+    {
+        $this->isAdmission()->shouldBe(true);
+        $this->isHangup()->shouldBe(false);
+        $this->isBlock()->shouldBe(false);
+
+        $this->getTimestamp()->shouldBe(1767225610);
+        $this->getBrandId()->shouldBe(1);
+        $this->getCompanyId()->shouldBe(2);
+        $this->getOccupancy()->shouldBe(7);
+    }
+
+    function it_keeps_the_original_wire_entry()
+    {
+        // The parser drops malformed entries, so callers cannot infer how many raw entries a
+        // set of events came from and need the originals to put back what they defer.
+        $this->getWire()->shouldBe('A:1767225610:1:2:7');
+    }
+
+    function it_reads_a_hangup_without_occupancy()
+    {
+        $event = $this::fromWire('H:1767225610:1:2');
+
+        $event->isHangup()->shouldBe(true);
+        $event->getOccupancy()->shouldBe(null);
+    }
+
+    function it_tells_which_limit_rejected_a_call()
+    {
+        $byBrand = $this::fromWire('B:1767225610:1:2:brand');
+        $byBrand->isBlock()->shouldBe(true);
+        $byBrand->isBlockedByBrand()->shouldBe(true);
+
+        $byCompany = $this::fromWire('B:1767225610:1:2:company');
+        $byCompany->isBlock()->shouldBe(true);
+        $byCompany->isBlockedByBrand()->shouldBe(false);
+    }
+
+    function it_answers_which_company_it_belongs_to()
+    {
+        $this->belongsTo(2)->shouldBe(true);
+        $this->belongsTo(3)->shouldBe(false);
+    }
+
+    function it_answers_whether_its_bucket_is_already_closed()
+    {
+        $this->happenedBefore(1767225611)->shouldBe(true);
+        $this->happenedBefore(1767225610)->shouldBe(false);
+    }
+
+    function it_rejects_entries_it_cannot_read()
+    {
+        $this::fromWire('nonsense')->shouldBeNull();
+        $this::fromWire('X:1767225610:1:2')->shouldBeNull();
+        $this::fromWire('A:0:1:2')->shouldBeNull();
+        $this::fromWire('A:1767225610:0:2')->shouldBeNull();
+        $this::fromWire('A:1767225610:1:0')->shouldBeNull();
+        $this::fromWire('A:1767225610:1')->shouldBeNull();
+    }
+}

--- a/library/spec/Ivoz/Provider/Domain/Service/ChannelUsage/ChannelUsageBucketCalculatorSpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Service/ChannelUsage/ChannelUsageBucketCalculatorSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Ivoz\Provider\Domain\Service\ChannelUsage;
 
+use Ivoz\Provider\Domain\Model\ChannelUsage\ChannelUsageEvent;
 use Ivoz\Provider\Domain\Service\ChannelUsage\ChannelUsageBucketCalculator;
 use PhpSpec\ObjectBehavior;
 
@@ -189,43 +190,18 @@ class ChannelUsageBucketCalculatorSpec extends ObjectBehavior
         ];
     }
 
-    /**
-     * @return array<string, mixed>
-     */
     private function admitted($ts, $occ)
     {
-        return $this->event('A', $ts, $occ, '');
+        return ChannelUsageEvent::fromWire('A:' . $ts . ':1:2:' . $occ);
     }
 
-    /**
-     * @return array<string, mixed>
-     */
     private function hangup($ts)
     {
-        return $this->event('H', $ts, null, '');
+        return ChannelUsageEvent::fromWire('H:' . $ts . ':1:2');
     }
 
-    /**
-     * @return array<string, mixed>
-     */
     private function blocked($ts, $reason)
     {
-        return $this->event('B', $ts, null, $reason);
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    private function event($type, $ts, $occ, $reason)
-    {
-        return [
-            'type' => $type,
-            'ts' => $ts,
-            'brandId' => 1,
-            'companyId' => 2,
-            'occ' => $occ,
-            'reason' => $reason,
-            'raw' => $type . ':' . $ts . ':1:2'
-        ];
+        return ChannelUsageEvent::fromWire('B:' . $ts . ':1:2:' . $reason);
     }
 }

--- a/library/spec/Ivoz/Provider/Domain/Service/ChannelUsage/ChannelUsageBucketCalculatorSpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Service/ChannelUsage/ChannelUsageBucketCalculatorSpec.php
@@ -1,0 +1,231 @@
+<?php
+
+namespace spec\Ivoz\Provider\Domain\Service\ChannelUsage;
+
+use Ivoz\Provider\Domain\Service\ChannelUsage\ChannelUsageBucketCalculator;
+use PhpSpec\ObjectBehavior;
+
+class ChannelUsageBucketCalculatorSpec extends ObjectBehavior
+{
+    /**
+     * 2026-01-01 00:00:00 UTC, already bucket-aligned (divisible by 300).
+     */
+    private const BUCKET = 1767225600;
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ChannelUsageBucketCalculator::class);
+    }
+
+    function it_floors_timestamps_to_their_bucket()
+    {
+        $this->bucketStart(self::BUCKET + 1)->shouldBe(self::BUCKET);
+        $this->bucketStart(self::BUCKET + 299)->shouldBe(self::BUCKET);
+        $this->bucketStart(self::BUCKET + 300)->shouldBe(self::BUCKET + 300);
+    }
+
+    function it_rewinds_admissions_and_hangups_to_the_prior_occupancy()
+    {
+        // Two calls came up and one dropped, so before all this there was 1 channel up.
+        $events = [
+            $this->admitted(self::BUCKET + 10, 2),
+            $this->admitted(self::BUCKET + 20, 3),
+            $this->hangup(self::BUCKET + 30),
+        ];
+
+        $this->rewind(2, $events)->shouldBe(1);
+    }
+
+    function it_ignores_blocked_events_when_rewinding()
+    {
+        $events = [
+            $this->blocked(self::BUCKET + 10, 'company'),
+            $this->blocked(self::BUCKET + 20, 'brand'),
+        ];
+
+        $this->rewind(5, $events)->shouldBe(5);
+    }
+
+    function it_rewinds_the_same_regardless_of_the_order_events_were_queued_in()
+    {
+        $ordered = [
+            $this->admitted(self::BUCKET + 10, 1),
+            $this->hangup(self::BUCKET + 20),
+            $this->admitted(self::BUCKET + 30, 1),
+        ];
+
+        $shuffled = [
+            $ordered[2],
+            $ordered[0],
+            $ordered[1],
+        ];
+
+        // The clamp at zero makes this order-sensitive unless the calculator sorts first,
+        // and the queue does not guarantee timestamp order.
+        $this->rewind(1, $ordered)->shouldBe(0);
+        $this->rewind(1, $shuffled)->shouldBe(0);
+    }
+
+    function it_never_rewinds_below_zero()
+    {
+        $events = [
+            $this->admitted(self::BUCKET + 10, 1),
+            $this->admitted(self::BUCKET + 20, 2),
+        ];
+
+        $this->rewind(0, $events)->shouldBe(0);
+    }
+
+    function it_returns_no_buckets_without_events()
+    {
+        $this->calculate([], 0)->shouldBe([]);
+    }
+
+    function it_computes_peak_average_and_closing_usage()
+    {
+        // One channel up for the second half of the bucket only.
+        $events = [
+            $this->admitted(self::BUCKET + 150, 1),
+        ];
+
+        $this
+            ->calculate($events, 0)
+            ->shouldBeLike([
+                $this->bucket(self::BUCKET, 1, 0.5, 1),
+            ]);
+    }
+
+    function it_carries_occupancy_into_untouched_buckets()
+    {
+        // A channel comes up in the first bucket and is still up two buckets later:
+        // the bucket in between saw no events at all but must not be a hole.
+        $events = [
+            $this->admitted(self::BUCKET, 1),
+            $this->hangup(self::BUCKET + 600),
+        ];
+
+        $this
+            ->calculate($events, 0)
+            ->shouldBeLike([
+                $this->bucket(self::BUCKET, 1, 1.0, 1),
+                $this->bucket(self::BUCKET + 300, 1, 1.0, 1),
+                $this->bucket(self::BUCKET + 600, 1, 0.0, 0),
+            ]);
+    }
+
+    function it_counts_blocked_calls_per_limit_without_touching_occupancy()
+    {
+        $events = [
+            $this->blocked(self::BUCKET + 10, 'company'),
+            $this->blocked(self::BUCKET + 20, 'brand'),
+            $this->blocked(self::BUCKET + 30, 'company'),
+        ];
+
+        $this
+            ->calculate($events, 2)
+            ->shouldBeLike([
+                $this->bucket(self::BUCKET, 2, 2.0, 2, 2, 1),
+            ]);
+    }
+
+    function it_trusts_the_occupancy_reported_by_kamailio_over_its_own_count()
+    {
+        // Kamailio ships the resulting occupancy, which wins over our running count.
+        $events = [
+            $this->admitted(self::BUCKET + 10, 7),
+        ];
+
+        $this
+            ->calculate($events, 0)
+            ->shouldBeLike([
+                $this->bucket(self::BUCKET, 7, 2030 / 300, 7),
+            ]);
+    }
+
+    function it_sorts_events_before_replaying_them()
+    {
+        $shuffled = [
+            $this->hangup(self::BUCKET + 200),
+            $this->admitted(self::BUCKET + 100, 1),
+        ];
+
+        // Replayed in the wrong order the hangup would clamp to 0 and the admission would
+        // leave the bucket closing at 1 instead of 0.
+        $this
+            ->calculate($shuffled, 0)
+            ->shouldBeLike([
+                $this->bucket(self::BUCKET, 1, 100 / 300, 0),
+            ]);
+    }
+
+    function it_builds_idle_buckets_holding_a_steady_occupancy()
+    {
+        $this
+            ->idleBucket(self::BUCKET, 3)
+            ->shouldBeLike(
+                $this->bucket(self::BUCKET, 3, 3.0, 3)
+            );
+    }
+
+    /**
+     * @return array<string, int|float>
+     */
+    private function bucket(
+        $bucketTs,
+        $peak,
+        $avgUsage,
+        $closingUsage,
+        $blockedByCompanyLimit = 0,
+        $blockedByBrandLimit = 0
+    ) {
+        return [
+            'bucketTs' => $bucketTs,
+            'bucketEnd' => $bucketTs + 300,
+            'peak' => $peak,
+            'avgUsage' => $avgUsage,
+            'closingUsage' => $closingUsage,
+            'blockedByCompanyLimit' => $blockedByCompanyLimit,
+            'blockedByBrandLimit' => $blockedByBrandLimit
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function admitted($ts, $occ)
+    {
+        return $this->event('A', $ts, $occ, '');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function hangup($ts)
+    {
+        return $this->event('H', $ts, null, '');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function blocked($ts, $reason)
+    {
+        return $this->event('B', $ts, null, $reason);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function event($type, $ts, $occ, $reason)
+    {
+        return [
+            'type' => $type,
+            'ts' => $ts,
+            'brandId' => 1,
+            'companyId' => 2,
+            'occ' => $occ,
+            'reason' => $reason,
+            'raw' => $type . ':' . $ts . ':1:2'
+        ];
+    }
+}

--- a/library/spec/Ivoz/Provider/Domain/Service/ChannelUsage/ChannelUsageEventParserSpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Service/ChannelUsage/ChannelUsageEventParserSpec.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace spec\Ivoz\Provider\Domain\Service\ChannelUsage;
+
+use Ivoz\Provider\Domain\Service\ChannelUsage\ChannelUsageEventParser;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Psr\Log\LoggerInterface;
+
+class ChannelUsageEventParserSpec extends ObjectBehavior
+{
+    protected $logger;
+
+    public function let(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+
+        $this->beConstructedWith($logger);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ChannelUsageEventParser::class);
+    }
+
+    function it_parses_an_admission_with_its_occupancy()
+    {
+        $this
+            ->parse(['A:1767225610:1:2:7'])
+            ->shouldBeLike([
+                [
+                    'type' => 'A',
+                    'ts' => 1767225610,
+                    'brandId' => 1,
+                    'companyId' => 2,
+                    'occ' => 7,
+                    'reason' => '',
+                    'raw' => 'A:1767225610:1:2:7'
+                ]
+            ]);
+    }
+
+    function it_parses_a_hangup_without_occupancy()
+    {
+        $this
+            ->parse(['H:1767225610:1:2'])
+            ->shouldBeLike([
+                [
+                    'type' => 'H',
+                    'ts' => 1767225610,
+                    'brandId' => 1,
+                    'companyId' => 2,
+                    'occ' => null,
+                    'reason' => '',
+                    'raw' => 'H:1767225610:1:2'
+                ]
+            ]);
+    }
+
+    function it_parses_the_reason_of_a_blocked_call()
+    {
+        $this
+            ->parse(['B:1767225610:1:2:brand'])
+            ->shouldBeLike([
+                [
+                    'type' => 'B',
+                    'ts' => 1767225610,
+                    'brandId' => 1,
+                    'companyId' => 2,
+                    'occ' => null,
+                    'reason' => 'brand',
+                    'raw' => 'B:1767225610:1:2:brand'
+                ]
+            ]);
+    }
+
+    function it_drops_malformed_entries_and_warns()
+    {
+        $this
+            ->logger
+            ->warning(Argument::containingString('discarded 4 malformed'))
+            ->shouldBeCalled();
+
+        $this
+            ->parse([
+                'nonsense',
+                'X:1767225610:1:2',
+                'A:0:1:2',
+                'A:1767225610:0:2',
+                'A:1767225610:1:2:3',
+            ])
+            ->shouldHaveCount(1);
+    }
+
+    function it_keeps_the_raw_entry_so_the_queue_can_be_trimmed_exactly()
+    {
+        // The parser drops entries, so the caller cannot infer how many raw entries a set
+        // of events came from: it needs the originals back.
+        $this
+            ->logger
+            ->warning(Argument::any())
+            ->shouldBeCalled();
+
+        $events = $this->parse([
+            'garbage',
+            'H:1767225610:1:2',
+        ]);
+
+        $events->shouldHaveCount(1);
+        $events[0]['raw']->shouldBe('H:1767225610:1:2');
+    }
+
+    function it_does_not_warn_when_everything_parses()
+    {
+        $this
+            ->logger
+            ->warning(Argument::any())
+            ->shouldNotBeCalled();
+
+        $this
+            ->parse(['H:1767225610:1:2'])
+            ->shouldHaveCount(1);
+    }
+}

--- a/library/spec/Ivoz/Provider/Domain/Service/ChannelUsage/ChannelUsageEventParserSpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Service/ChannelUsage/ChannelUsageEventParserSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Ivoz\Provider\Domain\Service\ChannelUsage;
 
+use Ivoz\Provider\Domain\Model\ChannelUsage\ChannelUsageEvent;
 use Ivoz\Provider\Domain\Service\ChannelUsage\ChannelUsageEventParser;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
@@ -23,62 +24,24 @@ class ChannelUsageEventParserSpec extends ObjectBehavior
         $this->shouldHaveType(ChannelUsageEventParser::class);
     }
 
-    function it_parses_an_admission_with_its_occupancy()
+    function it_turns_raw_entries_into_events()
     {
-        $this
-            ->parse(['A:1767225610:1:2:7'])
-            ->shouldBeLike([
-                [
-                    'type' => 'A',
-                    'ts' => 1767225610,
-                    'brandId' => 1,
-                    'companyId' => 2,
-                    'occ' => 7,
-                    'reason' => '',
-                    'raw' => 'A:1767225610:1:2:7'
-                ]
-            ]);
-    }
+        $events = $this->parse([
+            'A:1767225610:1:2:7',
+            'H:1767225620:1:2',
+        ]);
 
-    function it_parses_a_hangup_without_occupancy()
-    {
-        $this
-            ->parse(['H:1767225610:1:2'])
-            ->shouldBeLike([
-                [
-                    'type' => 'H',
-                    'ts' => 1767225610,
-                    'brandId' => 1,
-                    'companyId' => 2,
-                    'occ' => null,
-                    'reason' => '',
-                    'raw' => 'H:1767225610:1:2'
-                ]
-            ]);
-    }
-
-    function it_parses_the_reason_of_a_blocked_call()
-    {
-        $this
-            ->parse(['B:1767225610:1:2:brand'])
-            ->shouldBeLike([
-                [
-                    'type' => 'B',
-                    'ts' => 1767225610,
-                    'brandId' => 1,
-                    'companyId' => 2,
-                    'occ' => null,
-                    'reason' => 'brand',
-                    'raw' => 'B:1767225610:1:2:brand'
-                ]
-            ]);
+        $events->shouldHaveCount(2);
+        $events[0]->shouldBeAnInstanceOf(ChannelUsageEvent::class);
+        $events[0]->getOccupancy()->shouldBe(7);
+        $events[1]->isHangup()->shouldBe(true);
     }
 
     function it_drops_malformed_entries_and_warns()
     {
         $this
             ->logger
-            ->warning(Argument::containingString('discarded 4 malformed'))
+            ->warning(Argument::containingString('discarded 3 malformed'))
             ->shouldBeCalled();
 
         $this
@@ -86,28 +49,9 @@ class ChannelUsageEventParserSpec extends ObjectBehavior
                 'nonsense',
                 'X:1767225610:1:2',
                 'A:0:1:2',
-                'A:1767225610:0:2',
                 'A:1767225610:1:2:3',
             ])
             ->shouldHaveCount(1);
-    }
-
-    function it_keeps_the_raw_entry_so_the_queue_can_be_trimmed_exactly()
-    {
-        // The parser drops entries, so the caller cannot infer how many raw entries a set
-        // of events came from: it needs the originals back.
-        $this
-            ->logger
-            ->warning(Argument::any())
-            ->shouldBeCalled();
-
-        $events = $this->parse([
-            'garbage',
-            'H:1767225610:1:2',
-        ]);
-
-        $events->shouldHaveCount(1);
-        $events[0]['raw']->shouldBe('H:1767225610:1:2');
     }
 
     function it_does_not_warn_when_everything_parses()
@@ -120,5 +64,10 @@ class ChannelUsageEventParserSpec extends ObjectBehavior
         $this
             ->parse(['H:1767225610:1:2'])
             ->shouldHaveCount(1);
+    }
+
+    function it_returns_nothing_for_an_empty_queue()
+    {
+        $this->parse([])->shouldBe([]);
     }
 }

--- a/library/spec/Ivoz/Provider/Domain/Service/ChannelUsage/CollectChannelUsageSpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Service/ChannelUsage/CollectChannelUsageSpec.php
@@ -1,0 +1,246 @@
+<?php
+
+namespace spec\Ivoz\Provider\Domain\Service\ChannelUsage;
+
+use Ivoz\Core\Domain\Service\EntityTools;
+use Ivoz\Provider\Domain\Job\ChannelUsageEventQueueInterface;
+use Ivoz\Provider\Domain\Model\Brand\BrandRepository;
+use Ivoz\Provider\Domain\Model\ChannelUsage\ChannelUsageRepository;
+use Ivoz\Provider\Domain\Model\Company\CompanyRepository;
+use Ivoz\Provider\Domain\Service\ChannelUsage\ChannelUsageBucketCalculator;
+use Ivoz\Provider\Domain\Service\ChannelUsage\ChannelUsageEventParser;
+use Ivoz\Provider\Domain\Service\ChannelUsage\ChannelUsageWriter;
+use Ivoz\Provider\Domain\Service\ChannelUsage\CollectChannelUsage;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Psr\Log\LoggerInterface;
+
+class CollectChannelUsageSpec extends ObjectBehavior
+{
+    protected $eventQueue;
+    protected $companyRepository;
+    protected $brandRepository;
+    protected $channelUsageRepository;
+    protected $entityTools;
+    protected $logger;
+
+    public function let(
+        ChannelUsageEventQueueInterface $eventQueue,
+        CompanyRepository $companyRepository,
+        BrandRepository $brandRepository,
+        ChannelUsageRepository $channelUsageRepository,
+        EntityTools $entityTools,
+        LoggerInterface $logger
+    ) {
+        $this->eventQueue = $eventQueue;
+        $this->companyRepository = $companyRepository;
+        $this->brandRepository = $brandRepository;
+        $this->channelUsageRepository = $channelUsageRepository;
+        $this->entityTools = $entityTools;
+        $this->logger = $logger;
+
+        // The parser, the calculator and the writer are built for real: the first two are
+        // pure, and the writer is what puts the doubled repository and entityTools to work,
+        // so doubling them would only obscure the behaviour under test.
+        $this->beConstructedWith(
+            $eventQueue,
+            new ChannelUsageEventParser($logger->getWrappedObject()),
+            new ChannelUsageBucketCalculator(),
+            $companyRepository,
+            $brandRepository,
+            new ChannelUsageWriter(
+                $channelUsageRepository->getWrappedObject(),
+                $entityTools->getWrappedObject()
+            ),
+            $logger
+        );
+
+        // Permissive baseline: a double turns strict as soon as one call is expected, so
+        // every collaborator method the service may touch needs a promise up front.
+        $this->companyRepository->findBy(Argument::any())->willReturn([]);
+        $this->brandRepository->findBy(Argument::any())->willReturn([]);
+        $this
+            ->channelUsageRepository
+            ->findByCompaniesAndTimestampRange(Argument::cetera())
+            ->willReturn([]);
+
+        $this->eventQueue->readPending(Argument::any())->willReturn([]);
+        $this->eventQueue->getActiveChannelsByCompany()->willReturn([]);
+
+        // These return void, so they get an empty promise rather than willReturn(): a bare
+        // method prophecy is never registered, and the double would reject the call.
+        $noop = function () {
+        };
+
+        $this->eventQueue->discardProcessed(Argument::any())->will($noop);
+        $this->eventQueue->requeue(Argument::any())->will($noop);
+
+        $this->entityTools->persistDto(Argument::cetera())->will($noop);
+        $this->entityTools->dispatchQueuedOperations()->will($noop);
+        $this->entityTools->clearExcept(Argument::cetera())->will($noop);
+
+        $this->logger->warning(Argument::any())->will($noop);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(CollectChannelUsage::class);
+    }
+
+    function it_reads_a_bounded_slice_of_the_queue()
+    {
+        // The whole queue must never be pulled into memory: kamailio keeps pushing while
+        // the collector is down.
+        $this
+            ->eventQueue
+            ->readPending(CollectChannelUsage::MAX_ENTRIES_PER_RUN)
+            ->shouldBeCalled()
+            ->willReturn([]);
+
+        $this->eventQueue->getActiveChannelsByCompany()->willReturn([]);
+
+        $this->execute();
+    }
+
+    function it_discards_the_raw_entries_it_read_not_the_events_it_parsed()
+    {
+        // Regression: trimming by the number of parsed events leaves the malformed entry
+        // stuck at the head of the queue, shifting every later offset for good.
+        $this
+            ->eventQueue
+            ->readPending(Argument::any())
+            ->willReturn([
+                'A:100:1:2:1',
+                'this is not an event',
+                'H:200:1:2',
+            ]);
+
+        $this->eventQueue->getActiveChannelsByCompany()->willReturn([]);
+        $this->logger->warning(Argument::any())->shouldBeCalled();
+
+        $this
+            ->eventQueue
+            ->discardProcessed(3)
+            ->shouldBeCalled();
+
+        $this->eventQueue->requeue(Argument::any())->shouldBeCalled();
+
+        $this->execute();
+    }
+
+    function it_leaves_the_queue_alone_when_every_entry_belongs_to_the_open_bucket()
+    {
+        $openBucketTs = time() + 600;
+
+        $this
+            ->eventQueue
+            ->readPending(Argument::any())
+            ->willReturn(['A:' . $openBucketTs . ':1:2:1']);
+
+        $this->eventQueue->getActiveChannelsByCompany()->willReturn([]);
+
+        $this->eventQueue->discardProcessed(Argument::any())->shouldNotBeCalled();
+        $this->eventQueue->requeue(Argument::any())->shouldNotBeCalled();
+
+        $this->execute();
+    }
+
+    function it_puts_open_bucket_events_back_on_the_queue()
+    {
+        $openBucketTs = time() + 600;
+        $stillOpen = 'A:' . $openBucketTs . ':1:2:1';
+
+        $this
+            ->eventQueue
+            ->readPending(Argument::any())
+            ->willReturn([
+                'A:100:1:2:1',
+                'H:200:1:2',
+                $stillOpen,
+            ]);
+
+        $this->eventQueue->getActiveChannelsByCompany()->willReturn([]);
+
+        $this->eventQueue->discardProcessed(3)->shouldBeCalled();
+        $this
+            ->eventQueue
+            ->requeue([$stillOpen])
+            ->shouldBeCalled();
+
+        $this->execute();
+    }
+
+    function it_keeps_the_queue_intact_when_persisting_fails()
+    {
+        // At-least-once: if the buckets did not land, the events must still be there.
+        $this
+            ->eventQueue
+            ->readPending(Argument::any())
+            ->willReturn([
+                'A:100:1:2:1',
+                'H:200:1:2',
+            ]);
+
+        $this->eventQueue->getActiveChannelsByCompany()->willReturn([]);
+
+        $this
+            ->entityTools
+            ->dispatchQueuedOperations()
+            ->willThrow(new \RuntimeException('db is down'));
+
+        $this->eventQueue->discardProcessed(Argument::any())->shouldNotBeCalled();
+
+        $this
+            ->shouldThrow(\RuntimeException::class)
+            ->duringExecute();
+    }
+
+    function it_persists_one_bucket_per_closed_interval()
+    {
+        $this
+            ->eventQueue
+            ->readPending(Argument::any())
+            ->willReturn([
+                'A:100:1:2:1',
+                'H:200:1:2',
+            ]);
+
+        $this->eventQueue->getActiveChannelsByCompany()->willReturn([]);
+
+        $this
+            ->entityTools
+            ->persistDto(Argument::any(), null, false)
+            ->shouldBeCalledTimes(1);
+
+        $this->execute();
+    }
+
+    function it_resolves_a_whole_batch_of_buckets_with_a_single_lookup()
+    {
+        // One query per chunk, not one per row.
+        $this
+            ->eventQueue
+            ->readPending(Argument::any())
+            ->willReturn([
+                'A:100:1:2:1',
+                'H:200:1:2',
+                'A:400:1:3:1',
+                'H:500:1:3',
+            ]);
+
+        $this->eventQueue->getActiveChannelsByCompany()->willReturn([]);
+
+        $this
+            ->channelUsageRepository
+            ->findByCompaniesAndTimestampRange(Argument::cetera())
+            ->shouldBeCalledTimes(1)
+            ->willReturn([]);
+
+        $this
+            ->channelUsageRepository
+            ->findOneByCompanyAndTimestamp(Argument::cetera())
+            ->shouldNotBeCalled();
+
+        $this->execute();
+    }
+}

--- a/library/spec/Ivoz/Provider/Domain/Service/ChannelUsage/CollectChannelUsageSpec.php
+++ b/library/spec/Ivoz/Provider/Domain/Service/ChannelUsage/CollectChannelUsageSpec.php
@@ -3,12 +3,14 @@
 namespace spec\Ivoz\Provider\Domain\Service\ChannelUsage;
 
 use Ivoz\Core\Domain\Service\EntityTools;
+use Ivoz\Kam\Domain\Service\TrunksClientInterface;
 use Ivoz\Provider\Domain\Job\ChannelUsageEventQueueInterface;
 use Ivoz\Provider\Domain\Model\Brand\BrandRepository;
 use Ivoz\Provider\Domain\Model\ChannelUsage\ChannelUsageRepository;
 use Ivoz\Provider\Domain\Model\Company\CompanyRepository;
 use Ivoz\Provider\Domain\Service\ChannelUsage\ChannelUsageBucketCalculator;
 use Ivoz\Provider\Domain\Service\ChannelUsage\ChannelUsageEventParser;
+use Ivoz\Provider\Domain\Service\ChannelUsage\ChannelUsageRowBuilder;
 use Ivoz\Provider\Domain\Service\ChannelUsage\ChannelUsageWriter;
 use Ivoz\Provider\Domain\Service\ChannelUsage\CollectChannelUsage;
 use PhpSpec\ObjectBehavior;
@@ -18,14 +20,13 @@ use Psr\Log\LoggerInterface;
 class CollectChannelUsageSpec extends ObjectBehavior
 {
     protected $eventQueue;
-    protected $companyRepository;
-    protected $brandRepository;
+    protected $trunksClient;
     protected $channelUsageRepository;
     protected $entityTools;
-    protected $logger;
 
     public function let(
         ChannelUsageEventQueueInterface $eventQueue,
+        TrunksClientInterface $trunksClient,
         CompanyRepository $companyRepository,
         BrandRepository $brandRepository,
         ChannelUsageRepository $channelUsageRepository,
@@ -33,39 +34,41 @@ class CollectChannelUsageSpec extends ObjectBehavior
         LoggerInterface $logger
     ) {
         $this->eventQueue = $eventQueue;
-        $this->companyRepository = $companyRepository;
-        $this->brandRepository = $brandRepository;
+        $this->trunksClient = $trunksClient;
         $this->channelUsageRepository = $channelUsageRepository;
         $this->entityTools = $entityTools;
-        $this->logger = $logger;
 
-        // The parser, the calculator and the writer are built for real: the first two are
-        // pure, and the writer is what puts the doubled repository and entityTools to work,
-        // so doubling them would only obscure the behaviour under test.
+        $calculator = new ChannelUsageBucketCalculator();
+
+        // Everything pure is built for real; only the edges (queue, kamailio, db) are doubled.
         $this->beConstructedWith(
             $eventQueue,
+            $trunksClient,
             new ChannelUsageEventParser($logger->getWrappedObject()),
-            new ChannelUsageBucketCalculator(),
-            $companyRepository,
-            $brandRepository,
+            $calculator,
+            new ChannelUsageRowBuilder(
+                $calculator,
+                $companyRepository->getWrappedObject(),
+                $brandRepository->getWrappedObject(),
+                $logger->getWrappedObject()
+            ),
             new ChannelUsageWriter(
                 $channelUsageRepository->getWrappedObject(),
                 $entityTools->getWrappedObject()
-            ),
-            $logger
+            )
         );
 
         // Permissive baseline: a double turns strict as soon as one call is expected, so
         // every collaborator method the service may touch needs a promise up front.
-        $this->companyRepository->findBy(Argument::any())->willReturn([]);
-        $this->brandRepository->findBy(Argument::any())->willReturn([]);
+        $companyRepository->findBy(Argument::any())->willReturn([]);
+        $brandRepository->findBy(Argument::any())->willReturn([]);
         $this
             ->channelUsageRepository
             ->findByCompaniesAndTimestampRange(Argument::cetera())
             ->willReturn([]);
 
         $this->eventQueue->readPending(Argument::any())->willReturn([]);
-        $this->eventQueue->getActiveChannelsByCompany()->willReturn([]);
+        $this->trunksClient->getActiveCallsGroupedByCompany()->willReturn([]);
 
         // These return void, so they get an empty promise rather than willReturn(): a bare
         // method prophecy is never registered, and the double would reject the call.
@@ -79,12 +82,25 @@ class CollectChannelUsageSpec extends ObjectBehavior
         $this->entityTools->dispatchQueuedOperations()->will($noop);
         $this->entityTools->clearExcept(Argument::cetera())->will($noop);
 
-        $this->logger->warning(Argument::any())->will($noop);
+        $logger->warning(Argument::any())->will($noop);
     }
 
     function it_is_initializable()
     {
         $this->shouldHaveType(CollectChannelUsage::class);
+    }
+
+    function it_takes_the_occupancy_anchor_from_the_trunks_client()
+    {
+        // The realtime key layout belongs to TrunksClient: this service must not go looking
+        // for it in redis itself.
+        $this
+            ->trunksClient
+            ->getActiveCallsGroupedByCompany()
+            ->shouldBeCalled()
+            ->willReturn([]);
+
+        $this->execute();
     }
 
     function it_reads_a_bounded_slice_of_the_queue()
@@ -96,8 +112,6 @@ class CollectChannelUsageSpec extends ObjectBehavior
             ->readPending(CollectChannelUsage::MAX_ENTRIES_PER_RUN)
             ->shouldBeCalled()
             ->willReturn([]);
-
-        $this->eventQueue->getActiveChannelsByCompany()->willReturn([]);
 
         $this->execute();
     }
@@ -114,9 +128,6 @@ class CollectChannelUsageSpec extends ObjectBehavior
                 'this is not an event',
                 'H:200:1:2',
             ]);
-
-        $this->eventQueue->getActiveChannelsByCompany()->willReturn([]);
-        $this->logger->warning(Argument::any())->shouldBeCalled();
 
         $this
             ->eventQueue
@@ -136,8 +147,6 @@ class CollectChannelUsageSpec extends ObjectBehavior
             ->eventQueue
             ->readPending(Argument::any())
             ->willReturn(['A:' . $openBucketTs . ':1:2:1']);
-
-        $this->eventQueue->getActiveChannelsByCompany()->willReturn([]);
 
         $this->eventQueue->discardProcessed(Argument::any())->shouldNotBeCalled();
         $this->eventQueue->requeue(Argument::any())->shouldNotBeCalled();
@@ -159,8 +168,6 @@ class CollectChannelUsageSpec extends ObjectBehavior
                 $stillOpen,
             ]);
 
-        $this->eventQueue->getActiveChannelsByCompany()->willReturn([]);
-
         $this->eventQueue->discardProcessed(3)->shouldBeCalled();
         $this
             ->eventQueue
@@ -180,8 +187,6 @@ class CollectChannelUsageSpec extends ObjectBehavior
                 'A:100:1:2:1',
                 'H:200:1:2',
             ]);
-
-        $this->eventQueue->getActiveChannelsByCompany()->willReturn([]);
 
         $this
             ->entityTools
@@ -205,8 +210,6 @@ class CollectChannelUsageSpec extends ObjectBehavior
                 'H:200:1:2',
             ]);
 
-        $this->eventQueue->getActiveChannelsByCompany()->willReturn([]);
-
         $this
             ->entityTools
             ->persistDto(Argument::any(), null, false)
@@ -227,8 +230,6 @@ class CollectChannelUsageSpec extends ObjectBehavior
                 'A:400:1:3:1',
                 'H:500:1:3',
             ]);
-
-        $this->eventQueue->getActiveChannelsByCompany()->willReturn([]);
 
         $this
             ->channelUsageRepository

--- a/microservices/scheduler/bin/run-channel-usage
+++ b/microservices/scheduler/bin/run-channel-usage
@@ -1,0 +1,22 @@
+#!/usr/bin/env php
+<?php
+
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\HttpFoundation\Request;
+
+// require Composer's autoloader
+require __DIR__.'/../config/bootstrap.php';
+
+$input = new ArgvInput();
+$env = $input->getParameterOption(['--env', '-e'], getenv('APP_ENV') ?: 'dev');
+
+$kernel = new Kernel($env, false);
+$request = new Request([], [], [], [], [], ['REQUEST_URI' => '/channel-usage']);
+
+$response = $kernel->handle($request);
+$response->send();
+$kernel->terminate($request, $response);
+
+if ($response->getStatusCode() >= 300) {
+    die(1);
+}

--- a/microservices/scheduler/config/routes.yaml
+++ b/microservices/scheduler/config/routes.yaml
@@ -21,3 +21,7 @@ call-csv-to-email:
 voicemail-messages:
   path: /voicemail-messages
   controller: VoicemailMessageController:indexAction
+
+channel-usage:
+  path: /channel-usage
+  controller: ChannelUsageController:indexAction

--- a/microservices/scheduler/config/services.yaml
+++ b/microservices/scheduler/config/services.yaml
@@ -38,6 +38,9 @@ services:
     VoicemailMessageController:
         class: "VoicemailMessageController"
         public: true
+    ChannelUsageController:
+        class: "ChannelUsageController"
+        public: true
 
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones

--- a/microservices/scheduler/src/ChannelUsageController.php
+++ b/microservices/scheduler/src/ChannelUsageController.php
@@ -4,6 +4,7 @@ use Ivoz\Core\Domain\RegisterCommandTrait;
 use Ivoz\Core\Domain\RequestId;
 use Ivoz\Core\Domain\Service\DomainEventPublisher;
 use Ivoz\Provider\Domain\Service\ChannelUsage\CollectChannelUsage;
+use Ivoz\Provider\Domain\Service\ChannelUsage\PurgeOldChannelUsage;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -13,6 +14,7 @@ class ChannelUsageController
 
     public function __construct(
         private CollectChannelUsage $collectChannelUsage,
+        private PurgeOldChannelUsage $purgeOldChannelUsage,
         private LoggerInterface $logger,
         DomainEventPublisher $eventPublisher,
         RequestId $requestId
@@ -31,6 +33,16 @@ class ChannelUsageController
             return new Response(
                 $e->getMessage() . "\n",
                 500
+            );
+        }
+
+        // Retention runs after collection and never blocks it: a purge failure must not
+        // cost us the buckets we have just collected.
+        try {
+            $this->purgeOldChannelUsage->execute();
+        } catch (\Exception $e) {
+            $this->logger->error(
+                'ChannelUsage purge failed: ' . $e->getMessage()
             );
         }
 

--- a/microservices/scheduler/src/ChannelUsageController.php
+++ b/microservices/scheduler/src/ChannelUsageController.php
@@ -1,0 +1,39 @@
+<?php
+
+use Ivoz\Core\Domain\RegisterCommandTrait;
+use Ivoz\Core\Domain\RequestId;
+use Ivoz\Core\Domain\Service\DomainEventPublisher;
+use Ivoz\Provider\Domain\Service\ChannelUsage\CollectChannelUsage;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+class ChannelUsageController
+{
+    use RegisterCommandTrait;
+
+    public function __construct(
+        private CollectChannelUsage $collectChannelUsage,
+        private LoggerInterface $logger,
+        DomainEventPublisher $eventPublisher,
+        RequestId $requestId
+    ) {
+        $this->eventPublisher = $eventPublisher;
+        $this->requestId = $requestId;
+    }
+
+    public function indexAction(): Response
+    {
+        try {
+            $this->registerCommand('Scheduler', 'channelUsage');
+            $this->collectChannelUsage->execute();
+        } catch (\Exception $e) {
+            $this->logger->error($e->getMessage());
+            return new Response(
+                $e->getMessage() . "\n",
+                500
+            );
+        }
+
+        return new Response("ChannelUsage collection done!\n", 200);
+    }
+}

--- a/schema/DoctrineMigrations/Version20260826000000.php
+++ b/schema/DoctrineMigrations/Version20260826000000.php
@@ -30,6 +30,7 @@ final class Version20260826000000 extends LoggableMigration
             blockedByBrandLimit SMALLINT UNSIGNED DEFAULT 0 NOT NULL,
             UNIQUE INDEX chUsage_company_ts (companyId, timestamp),
             INDEX channelUsage_brandId_idx (brandId),
+            INDEX channelUsage_timestamp_idx (timestamp),
             PRIMARY KEY(id)
         ) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
         $this->addSql('ALTER TABLE ChannelUsages ADD CONSTRAINT FK_ChannelUsages_brandId

--- a/schema/DoctrineMigrations/Version20260826000000.php
+++ b/schema/DoctrineMigrations/Version20260826000000.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Ivoz\Core\Infrastructure\Persistence\Doctrine\LoggableMigration;
+
+final class Version20260826000000 extends LoggableMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add ChannelUsages table and PublicEntity for channel usage historics per client';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE ChannelUsages (
+            id INT UNSIGNED AUTO_INCREMENT NOT NULL,
+            brandId INT UNSIGNED NOT NULL,
+            companyId INT UNSIGNED NOT NULL,
+            timestamp DATETIME NOT NULL,
+            peak SMALLINT UNSIGNED NOT NULL,
+            avgUsage DECIMAL(6, 2) NOT NULL,
+            closingUsage SMALLINT UNSIGNED NOT NULL,
+            maxCallsCompany SMALLINT UNSIGNED NOT NULL,
+            maxCallsBrand SMALLINT UNSIGNED NOT NULL,
+            blockedByCompanyLimit SMALLINT UNSIGNED DEFAULT 0 NOT NULL,
+            blockedByBrandLimit SMALLINT UNSIGNED DEFAULT 0 NOT NULL,
+            UNIQUE INDEX chUsage_company_ts (companyId, timestamp),
+            INDEX channelUsage_brandId_idx (brandId),
+            PRIMARY KEY(id)
+        ) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE ChannelUsages ADD CONSTRAINT FK_ChannelUsages_brandId
+            FOREIGN KEY (brandId) REFERENCES Brands (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE ChannelUsages ADD CONSTRAINT FK_ChannelUsages_companyId
+            FOREIGN KEY (companyId) REFERENCES Companies (id) ON DELETE CASCADE');
+
+        $this->addSql("INSERT INTO PublicEntities (
+                            iden, fqdn, platform, brand, client,
+                            name_en, name_es, name_ca, name_it, name_eu
+                        ) VALUES (
+                            'ChannelUsages', 'Ivoz\\\\Provider\\\\Domain\\\\Model\\\\ChannelUsage\\\\ChannelUsage', 0, 0, 1,
+                            'Channel usage', 'Uso de canales', 'Uso de canales', 'Channel usage', 'Uso de canales'
+                        )"
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DELETE FROM PublicEntities WHERE iden = "ChannelUsages"');
+        $this->addSql('ALTER TABLE ChannelUsages DROP FOREIGN KEY FK_ChannelUsages_brandId');
+        $this->addSql('ALTER TABLE ChannelUsages DROP FOREIGN KEY FK_ChannelUsages_companyId');
+        $this->addSql('DROP TABLE ChannelUsages');
+    }
+}

--- a/schema/DoctrineMigrations/Version20260826000000.php
+++ b/schema/DoctrineMigrations/Version20260826000000.php
@@ -46,10 +46,28 @@ final class Version20260826000000 extends LoggableMigration
                             'Channel usage', 'Uso de canales', 'Uso de canales', 'Channel usage', 'Uso de canales'
                         )"
         );
+
+        // Restricted client admins that already exist do not go through CreateAcls, which
+        // only seeds permissions when the restricted flag itself changes. Without a row they
+        // would be stuck: the ACL resource exposes no POST, so nobody could ever grant them
+        // this entity from the portal.
+        //
+        // The row is therefore created deny-all, exactly as Version20220408095037 did for
+        // Locations/Voicemails/VoicemailMessages: the entity becomes grantable without
+        // silently widening anyone's access. Admins made restricted from now on keep getting
+        // read access automatically, since CreateAcls seeds every client = 1 entity.
+        $this->addSql(
+            'INSERT IGNORE INTO AdministratorRelPublicEntities (administratorId, publicEntityId, `create`, `read`, `update`, `delete`) '
+            . 'SELECT A.id, P.id, 0, 0, 0, 0 FROM Administrators A INNER JOIN PublicEntities P '
+            . 'WHERE A.restricted = 1 AND A.brandId IS NOT NULL AND A.companyId IS NOT NULL AND P.iden = "ChannelUsages"'
+        );
     }
 
     public function down(Schema $schema): void
     {
+        // AdministratorRelPublicEntities.publicEntityId is ON DELETE CASCADE, so dropping the
+        // public entity takes its permission rows with it. Do not add an explicit delete here:
+        // it would also remove rows created later by CreateAcls.
         $this->addSql('DELETE FROM PublicEntities WHERE iden = "ChannelUsages"');
         $this->addSql('ALTER TABLE ChannelUsages DROP FOREIGN KEY FK_ChannelUsages_brandId');
         $this->addSql('ALTER TABLE ChannelUsages DROP FOREIGN KEY FK_ChannelUsages_companyId');

--- a/schema/tests/Provider/ChannelUsage/ChannelUsageRepositoryTest.php
+++ b/schema/tests/Provider/ChannelUsage/ChannelUsageRepositoryTest.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace Tests\Provider\ChannelUsage;
+
+use Ivoz\Provider\Domain\Model\ChannelUsage\ChannelUsage;
+use Ivoz\Provider\Domain\Model\ChannelUsage\ChannelUsageDto;
+use Ivoz\Provider\Domain\Model\ChannelUsage\ChannelUsageRepository;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\DbIntegrationTestHelperTrait;
+
+class ChannelUsageRepositoryTest extends KernelTestCase
+{
+    use DbIntegrationTestHelperTrait;
+
+    /**
+     * @test
+     */
+    public function test_runner()
+    {
+        $this->it_finds_one_by_company_and_timestamp();
+        $this->it_returns_null_for_an_unknown_bucket();
+        $this->it_finds_a_whole_batch_within_a_timestamp_range();
+        $this->it_returns_nothing_without_companies();
+        $this->it_purges_rows_older_than_the_cutoff();
+        $this->it_never_deletes_more_than_the_batch_limit();
+    }
+
+    private function it_finds_one_by_company_and_timestamp()
+    {
+        $this->addChannelUsage('2026-01-01 00:00:00');
+
+        $channelUsage = $this
+            ->getRepository()
+            ->findOneByCompanyAndTimestamp(
+                1,
+                new \DateTime('2026-01-01 00:00:00', new \DateTimeZone('UTC'))
+            );
+
+        $this->assertInstanceOf(
+            ChannelUsage::class,
+            $channelUsage
+        );
+
+        $this->assertEquals(
+            2,
+            $channelUsage->getPeak()
+        );
+    }
+
+    private function it_returns_null_for_an_unknown_bucket()
+    {
+        $channelUsage = $this
+            ->getRepository()
+            ->findOneByCompanyAndTimestamp(
+                1,
+                new \DateTime('2020-06-06 06:00:00', new \DateTimeZone('UTC'))
+            );
+
+        $this->assertNull($channelUsage);
+    }
+
+    private function it_finds_a_whole_batch_within_a_timestamp_range()
+    {
+        $this->addChannelUsage('2026-01-01 00:05:00');
+        $this->addChannelUsage('2026-01-01 00:10:00');
+        // Outside the window below
+        $this->addChannelUsage('2026-01-01 01:00:00');
+
+        $channelUsages = $this
+            ->getRepository()
+            ->findByCompaniesAndTimestampRange(
+                [1],
+                new \DateTime('2026-01-01 00:00:00', new \DateTimeZone('UTC')),
+                new \DateTime('2026-01-01 00:10:00', new \DateTimeZone('UTC'))
+            );
+
+        // 00:00, 00:05 and 00:10, but not 01:00
+        $this->assertCount(
+            3,
+            $channelUsages
+        );
+    }
+
+    private function it_returns_nothing_without_companies()
+    {
+        $channelUsages = $this
+            ->getRepository()
+            ->findByCompaniesAndTimestampRange(
+                [],
+                new \DateTime('2026-01-01 00:00:00', new \DateTimeZone('UTC')),
+                new \DateTime('2026-01-01 01:00:00', new \DateTimeZone('UTC'))
+            );
+
+        $this->assertCount(
+            0,
+            $channelUsages
+        );
+    }
+
+    private function it_purges_rows_older_than_the_cutoff()
+    {
+        $this->addChannelUsage('2020-01-01 00:00:00');
+        $this->addChannelUsage('2020-01-01 00:05:00');
+
+        $deleted = $this
+            ->getRepository()
+            ->purgeOlderThan(
+                new \DateTime('2021-01-01 00:00:00', new \DateTimeZone('UTC')),
+                100
+            );
+
+        $this->assertEquals(
+            2,
+            $deleted
+        );
+
+        // The 2026 buckets are untouched
+        $this->assertNotNull(
+            $this
+                ->getRepository()
+                ->findOneByCompanyAndTimestamp(
+                    1,
+                    new \DateTime('2026-01-01 00:00:00', new \DateTimeZone('UTC'))
+                )
+        );
+    }
+
+    private function it_never_deletes_more_than_the_batch_limit()
+    {
+        $this->addChannelUsage('2019-01-01 00:00:00');
+        $this->addChannelUsage('2019-01-01 00:05:00');
+        $this->addChannelUsage('2019-01-01 00:10:00');
+
+        $deleted = $this
+            ->getRepository()
+            ->purgeOlderThan(
+                new \DateTime('2020-01-01 00:00:00', new \DateTimeZone('UTC')),
+                2
+            );
+
+        $this->assertEquals(
+            2,
+            $deleted
+        );
+
+        // The remainder is left for the next batch
+        $deleted = $this
+            ->getRepository()
+            ->purgeOlderThan(
+                new \DateTime('2020-01-01 00:00:00', new \DateTimeZone('UTC')),
+                2
+            );
+
+        $this->assertEquals(
+            1,
+            $deleted
+        );
+    }
+
+    private function getRepository(): ChannelUsageRepository
+    {
+        /** @var ChannelUsageRepository $repository */
+        $repository = $this->em->getRepository(ChannelUsage::class);
+
+        return $repository;
+    }
+
+    private function addChannelUsage(string $timestamp, int $companyId = 1): void
+    {
+        $dto = new ChannelUsageDto();
+        $dto
+            ->setBrandId(1)
+            ->setCompanyId($companyId)
+            ->setTimestamp(
+                new \DateTime($timestamp, new \DateTimeZone('UTC'))
+            )
+            ->setPeak(2)
+            ->setAvgUsage(1.5)
+            ->setClosingUsage(1)
+            ->setMaxCallsCompany(10)
+            ->setMaxCallsBrand(20)
+            ->setBlockedByCompanyLimit(0)
+            ->setBlockedByBrandLimit(0);
+
+        $this->entityTools->persistDto($dto, null, true);
+    }
+}


### PR DESCRIPTION
<!--
  - All pull requests must be done against main branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/main/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, portal/platform, kamusers, agis, ..)
- [ ] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
Adds per-company channel usage historics collected every 5 minutes and stored in a new ChannelUsages table.
  
Kamailio (`kamtrunks`) emits three event types to a Redis queue (`chusage:events`) on each call admitted (A), hung up (H), or blocked by limit (B). A scheduler job reads the queue, reconstructs occupancy via a rewind-then-forward algorithm over 5-minute buckets, and  upserts peak, weighted average, closing usage, and blocked call counts per brand/company.

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
- Rows older than 30 days are purged automatically on each run.
- No API endpoints or frontend changes — data collection only.
