### PR TITLE
[PROVIDER-2488] Add release tooling, documentation and skill

### DIFF
--- a/.claude/skills/release-ivozprovider/SKILL.md
+++ b/.claude/skills/release-ivozprovider/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: release-ivozprovider
+description: Cut an IvozProvider release - bump versions, write the ChangeLog and the API changelogs, open the release pull request and, once merged, tag tempest and publish the GitHub release. Use when the user asks to prepare or publish a release, "sacar la release", "prepara la 4.8.0", or says "/release-ivozprovider".
+---
+
+# Release
+
+Prepare and publish an IvozProvider release. The human procedure this automates
+is documented in `doc/dev/RELEASE.md`; keep both in sync when changing either.
+
+Releases go from `main` to `tempest`, the maintained release branch. The work is
+split in a pull request (phases 1 to 5) and a set of post-merge steps (phase 6).
+
+## Rules
+
+- **Never write to Jira.** Reading a ticket is required; creating, commenting,
+  transitioning or releasing versions is not this skill's job.
+- **Never run the ISO or documentation Jenkins jobs.** They are listed as a
+  reminder at the end.
+- Commits carry no `Co-Authored-By` trailer, as stated in `AGENTS.md`.
+- Stop for review before committing anything the model wrote (phases 3 and 4).
+  Everything else is mechanical and self-checked.
+
+## Resuming
+
+The skill has no state of its own: on every run, work out where the release
+stands and continue from there.
+
+```bash
+git rev-parse --abbrev-ref HEAD
+git log --oneline origin/main..HEAD
+gh pr view --json number,state,mergedAt,url 2>/dev/null
+git tag --list "v<X.Y.Z>"
+```
+
+| Situation | Phase to continue from |
+| --- | --- |
+| No release branch | 0 |
+| Branch without version commit | 2 |
+| Version commit present, no package version commit | 2, from the package step |
+| Package version commit present, no ChangeLog commit | 3 |
+| ChangeLog commit present, no API changelog commit | 4 |
+| Commits ready, no pull request | 5 |
+| Pull request merged, tag missing | 6 |
+| Tag present, GitHub release missing | 6, from the release step |
+
+## Phase 0 - Ticket and version
+
+Ask the user which Jira ticket the release belongs to. Read it (read only) to
+get its key and its fix version:
+
+- Branch prefix: the ticket key, for example `PROVIDER-2467`.
+- Version: the ticket fix version, for example `4.7.0`.
+
+If Jira cannot be reached, ask the user for the ticket key and the version.
+**Without a ticket, stop**: the branch name is what links the pull request to
+Jira in Jenkins.
+
+Then work out the release type and confirm it with the user before touching
+anything:
+
+```bash
+git describe --tags --abbrev=0 main      # previous release, e.g. v4.7.0
+git merge-base main tempest              # release range starts here
+```
+
+- `MAJOR.MINOR` changed since the previous tag: **minor** release.
+- Only `PATCH` changed: **patch** release.
+
+Show which files each type touches and ask for confirmation. If the user's
+answer contradicts the version numbers, stop and explain the conflict; never
+mix both flows.
+
+Refuse to continue if `main` is not clean and up to date.
+
+## Phase 1 - Branch
+
+```bash
+git fetch origin main
+git checkout -b <TICKET>-changelog-<X.Y.Z> origin/main
+```
+
+## Phase 2 - Versions
+
+```bash
+scripts/update-version.sh <X.Y.Z>
+git status --short
+```
+
+Expected on a **minor** release, nothing else:
+
+```
+README.md  asterisk/config/pjsip.conf.in  doc/sphinx/conf.py
+kamailio/trunks/config/kamailio.cfg  kamailio/users/config/kamailio.cfg
+web/portal/{platform,brand,client,user}/package.json
+```
+
+On a **patch** release only `README.md` and the four `package.json` change; the
+other substitutions rewrite the same `MAJOR.MINOR` value.
+
+Verify no commit or tag appeared on its own (`git log --oneline -1`,
+`git tag --points-at HEAD`), then commit:
+
+- Minor: `doc: update all versions to <X.Y.Z>`
+- Patch: `portal: update portals versions to <X.Y.Z>` for the four
+  `package.json`, then `doc: update README for <X.Y.Z> release`
+
+Then bump the Debian package version, which marks the current
+`debian/changelog` entry as stable and opens a new `UNRELEASED` one:
+
+```bash
+scripts/update-package-version.sh <X.Y.Z>
+```
+
+Only `debian/changelog` changes. Commit it as `pkg: version bump to <X.Y.Z>`.
+
+## Phase 3 - ChangeLog
+
+```bash
+scripts/release-commits.sh
+```
+
+Read `reference/changelog-format.md` before writing. Turn its output into a new
+entry at the top of `ChangeLog`:
+
+- Group by section, merge related pull requests into one entry, and rewrite
+  each one for users rather than for developers.
+- Drop internal work: CI, tests, refactors, local development environment,
+  packaging plumbing. Collapse dependency updates into a single entry.
+- Keep every discarded pull request in a list and **show it to the user** along
+  with the draft, so nothing disappears silently.
+
+Stop, show the draft entry and the discarded list, and apply the user's
+corrections. Then commit `doc: update ChangeLog for <X.Y.Z> release`.
+
+## Phase 4 - API changelog
+
+```bash
+for APP in platform brand client user; do scripts/apispec-diff.sh $APP; done
+```
+
+An application exiting with 1 has no API changes and gets no entry. For the
+rest, add a `## <X.Y.Z>` section on top of `web/rest/<app>/CHANGELOG.md`
+following `reference/changelog-format.md`.
+
+Stop for review, then commit `doc: update API Changelog for <X.Y.Z> release`.
+
+## Phase 5 - ISO packages and pull request
+
+```bash
+scripts/check-iso-packages.sh
+```
+
+If it reports missing packages, add them to `extra/simple-cdd/package.list` in
+alphabetical order and commit `iso: add missing ivozprovider packages for ISO
+generation`, listing them in the commit body.
+
+Check the commit tags and open the pull request:
+
+```bash
+library/bin/test-commit-tags origin/main
+git push -u origin <TICKET>-changelog-<X.Y.Z>
+gh pr create --base main --title "Update ChangeLog for <X.Y.Z> release" --body-file <body>
+```
+
+Title and body in English. Body is `.github/PULL_REQUEST_TEMPLATE.md` with
+`New feature or enhancement` and the two commit checklist boxes ticked.
+
+Then wait for the checks and merge it after the user confirms:
+
+```bash
+gh pr view --json statusCheckRollup,reviewDecision,mergeable
+gh pr merge --merge
+```
+
+Warn the user if Jenkins is red or the review is missing, and do not merge
+until they explicitly say so.
+
+## Phase 6 - After the merge
+
+Only once the pull request is merged (`gh pr view --json mergedAt`). Otherwise
+stop and say so.
+
+```bash
+git checkout main && git pull --ff-only
+git checkout tempest && git pull --ff-only
+git merge main -m "Merge commit for <X.Y.Z>"
+git tag v<X.Y.Z>
+
+git checkout main
+git merge --ff-only tempest
+
+git push origin main tempest
+git push origin v<X.Y.Z>
+```
+
+`--ff-only` on `main` is deliberate: it fails instead of discarding commits
+someone else merged meanwhile. If it fails, stop and report it.
+
+Publish the GitHub release with the body format from
+`reference/changelog-format.md`:
+
+```bash
+gh release create v<X.Y.Z> --title "IvozProvider v<X.Y.Z>" --notes-file <body>
+```
+
+Finally print, without doing any of it:
+
+```
+Release v<X.Y.Z> published. Left to do by hand:
+
+1. Wait for the package build to finish (announced in Mattermost / Jenkins).
+2. Run the ivozprovider-install-cd job to build the ISO image:
+   https://jenkins.irontec.com/view/VoIP/job/ivozprovider/view/Other/job/ivozprovider-install-cd/
+3. Run the ivozprovider-github-pages job to regenerate the documentation:
+   https://jenkins.irontec.com/view/VoIP/job/ivozprovider/view/Other/job/ivozprovider-github-pages/
+4. Check that the ISO link written in the README resolves.
+```

--- a/.claude/skills/release-ivozprovider/reference/changelog-format.md
+++ b/.claude/skills/release-ivozprovider/reference/changelog-format.md
@@ -1,0 +1,146 @@
+# Changelog formats
+
+Exact formats of the three documents written during a release, with real
+examples taken from previous ones.
+
+## ChangeLog
+
+A new entry goes on top of `ChangeLog`, separated from the previous one by two
+blank lines.
+
+```
+Tue, 16 Jun 2026 10:00:00 +0200 IvozProvider Team <vozip+ivozprovider@irontec.com>
+
+    * IvozProvider 4.7.0 released
+
+    * Portals:
+        - Added webhook management to brand and client portals
+        - Added per-DDI webhook configuration to brand portal
+        - Added on-demand recording email and notification template
+          configuration
+        - Fixed brand invoice select options showing id instead of number
+
+    * Core:
+        - Added webhooks (entity, access control and dispatcher microservice)
+        - Added DDI and user webhook events (call start, ring, answer, end and
+          updateClid)
+        - Removed PDF basename sanitization
+
+    * Misc:
+        - Updated ivoz-api to 5.6 and ivoz-ui to 1.8.2
+        - Several dependency updates
+```
+
+- Header: `date -R` style timestamp, then always
+  `IvozProvider Team <vozip+ivozprovider@irontec.com>`.
+- Sections are indented four spaces, entries eight, and continuation lines ten.
+  Lines wrap at 76 columns.
+- Section order: `Portals`, `Core`, `Kamailio`, `Asterisk`, `Provisioning`,
+  `Schema`, `Misc`. Only the ones with entries.
+- Entries start with a verb in past tense: `Added`, `Fixed`, `Improved`,
+  `Removed`, `Updated`.
+- Pull request references go at the end of the entry, `(#3082)`, listing all of
+  them when the entry merges several: `(#3074, #3070, #3114)`.
+
+### Mapping commit tags to sections
+
+| Commit tags | Section |
+| --- | --- |
+| `portal`, `portal/*` | Portals |
+| `core`, `rest`, `rest/*` | Core |
+| `kamailio`, `kamusers`, `kamtrunks`, `proxy` | Kamailio |
+| `asterisk`, `agi`, `as` | Asterisk |
+| `microservices/provision` | Provisioning |
+| `schema`, `data` | Schema |
+| anything else | Misc |
+
+The mapping is a hint, not a rule: a change that users experience in the portal
+belongs in `Portals` even if it also touched schema and core.
+
+### What is left out
+
+CI, packaging plumbing, tests, fixtures, refactors, static analysis baselines,
+local development environment, documentation of internals. Dependency updates
+collapse into a single `Several dependency updates` entry; library upgrades
+that matter to users are named, as in `Updated ivoz-api to 5.6 and ivoz-ui to
+1.8.2`.
+
+### Patch releases
+
+Same format, usually a single section:
+
+```
+Tue, 14 Nov 2025 10:37:00 +0200 IvozProvider Team <vozip+ivozprovider@irontec.com>
+
+    * IvozProvider 4.5.1 released
+
+    * Portals:
+        - Fixed AccountStatus display in Daily Usage screen (#3036)
+
+    * Core:
+        - Added dedicated endpoints for balances and dailyUsage for better performance (#3030)
+```
+
+## API changelog
+
+One `web/rest/<app>/CHANGELOG.md` per REST application, newest version first,
+right below the `# Changelog` header.
+
+```
+## 4.7.0
+* Endpoints:
+    - /webhooks:
+      - Added [GET] endpoint to list webhook resources.
+      - Added [POST] endpoint to create webhook resources.
+    - /webhooks/{id}:
+      - Added [GET], [PUT] and [DELETE] endpoints to retrieve, update and
+        delete a webhook resource.
+    - /match_list_patterns:
+      - Added matchPattern, matchPattern[exact], matchPattern[start],
+        matchPattern[partial], matchPattern[end], matchPattern[neq],
+        matchPattern[exists], exists[matchPattern] and _order[matchPattern]
+        filter parameters.
+* Models:
+    - Webhook:
+      - Added model with name, description, uri, template, callDirection,
+        eventStart, eventRing, eventAnswer, eventEnd, eventUpdateClid, company,
+        ddi and user properties.
+    - MatchListPattern:
+      - Added matchPattern property.
+```
+
+- Two blocks only, `* Endpoints:` and `* Models:`, and only when they have
+  content.
+- Paths and models are indented four spaces, their changes six, continuation
+  eight. Lines wrap at 76 columns.
+- Sentences end with a full stop.
+- Parameters of one path are listed in a single sentence, joined with commas
+  and a final `and`.
+- Methods of the same path are merged, as in
+  `Added [GET], [PUT] and [DELETE] endpoints`.
+- `scripts/apispec-diff.sh` prints `Model-detailed` and `Model-collection`
+  variants; they are the same model and get a single entry.
+
+## GitHub release body
+
+The ChangeLog entry without its date header and without the `released` line,
+unwrapped so each entry is one line, followed by a fixed footer.
+
+```
+* Portals:
+    - Added webhook management to brand and client portals
+    - Added per-DDI webhook configuration to brand portal
+
+* Core:
+    - Added webhooks (entity, access control and dispatcher microservice)
+
+* Misc:
+    - Several dependency updates
+
+
+See specific API changelog ([Platform](https://github.com/irontec/ivozprovider/blob/tempest/web/rest/platform/CHANGELOG.md), [Brand](https://github.com/irontec/ivozprovider/blob/tempest/web/rest/brand/CHANGELOG.md), [Client](https://github.com/irontec/ivozprovider/blob/tempest/web/rest/client/CHANGELOG.md) and [User](https://github.com/irontec/ivozprovider/blob/tempest/web/rest/user/CHANGELOG.md)) for detailed information on changes for each level
+
+**Full Changelog**: https://github.com/irontec/ivozprovider/compare/v<PREVIOUS>...v<X.Y.Z>
+```
+
+The release title is `IvozProvider v<X.Y.Z>`.

--- a/doc/dev/AcceptedCommitTagsList.txt
+++ b/doc/dev/AcceptedCommitTagsList.txt
@@ -1,3 +1,4 @@
+agents
 agi
 as
 asterisk

--- a/doc/dev/RELEASE.md
+++ b/doc/dev/RELEASE.md
@@ -1,54 +1,189 @@
-## Update package version
+# Releasing IvozProvider
 
-Debian package versions are controlled by debian/changelog file.
-Before creating a new version entry, set the current version as stable:
+Releases are cut from `main` and published on the branch of the maintained
+release, currently `tempest`. Every release is made of:
 
-    # dch --controlmaint --release ""
+- A pull request against `main` bumping versions and writing changelogs.
+- A set of post-merge steps that move `tempest` forward, tag it and publish
+  the GitHub release.
 
-Then add a new entry with the new version with UNRELEASED distribution. This is
-required to maintain current package version information (with date and commit)
+A single Jira ticket owns the release: its key gives the branch prefix and its
+fix version the version being released.
 
-    # dch --controlmaint --distribution UNRELEASED --newversion 2.2~2.2.6 "Version bump to 2.2.6"
+The whole procedure is also available as the `release-ivozprovider` Claude Code
+skill (`.claude/skills/release-ivozprovider/`), which runs these same steps and
+helper scripts.
 
-## Update documentation version
+## 1. Before you start
 
-_This is only required for minor releases upgrades (ignore for patch versioning)._
+- Work on an up to date and clean `main`.
+- Get the Jira ticket of the release: it gives both the branch prefix and,
+  through its fix version, the version being released.
+- The previous release is `git describe --tags --abbrev=0 main`, and the range
+  of the release is everything between that tag and `main`.
 
-Sphinx shows documentation version above the left menu:
+Create the branch:
 
-    # sed -i 's/\(version =\) .*/\1 "2.8"/' doc/sphinx/conf.py
-    # sed -i 's/IvozProvider [0-9\.]\+ Documentation/IvozProvider 2.8 Documentation/' doc/sphinx/conf.py
+```bash
+git checkout -b PROVIDER-<ticket>-changelog-<X.Y.Z> main
+```
 
-## Update Application User Agent
+## 2. Bump versions
 
-_This is only required for minor releases upgrades (ignore for patch versioning)._
+```bash
+scripts/update-version.sh X.Y.Z
+```
 
-Update the user-agent presented by asterisk:
+This updates the Sphinx documentation version, the Asterisk and Kamailio user
+agents, the README stable badge and tempest ISO row, and the four portal
+`package.json` files.
 
-    # sed -i 's/\(user_agent=Irontec IvozProvider\) .*/\1 v2.2/' asterisk/config/pjsip.conf
+On a **minor** release the nine files change and go in a single commit:
 
-## Update Kamailio User Agent and Server
+```
+doc: update all versions to X.Y.Z
+```
 
-_This is only required for minor releases upgrades (ignore for patch versioning)._
+On a **patch** release only the README ISO row and the portal versions end up
+modified (the rest of the substitutions write the same `MAJOR.MINOR` value
+back), and they are split in two commits:
 
-Update the strings presented by both kamailios:
+```
+portal: update portals versions to X.Y.Z
+doc: update README for X.Y.Z release
+```
 
-    # sed -i 's/\(server_header="Server: Irontec IvozProvider\) .*/\1 v2.2"/' kamailio/trunks/config/kamailio.cfg
-    # sed -i 's/\(server_header="Server: Irontec IvozProvider\) .*/\1 v2.2"/' kamailio/users/config/kamailio.cfg
-    # sed -i 's/\(user_agent_header="User-Agent: Irontec IvozProvider\) .*/\1 v2.2"/' kamailio/trunks/config/kamailio.cfg
-    # sed -i 's/\(user_agent_header="User-Agent: Irontec IvozProvider\) .*/\1 v2.2"/' kamailio/users/config/kamailio.cfg
+Check that nothing else changed, and that no stray commit or tag was created:
 
-## Update project README.md and ChangeLog
+```bash
+git status --short
+```
 
-This is a bit tricky, because the _visible_ README in github may not belong the released branch, but the stable release.
+Then bump the Debian package version, which marks the current entry of
+`debian/changelog` as stable and opens a new `UNRELEASED` one:
 
-The best approach is to update the releasing branch README.md and ChangeLog with new information in a single commit then
-cherry-pick it to other maintained branches.
+```bash
+scripts/update-package-version.sh X.Y.Z
+```
 
-- Update ISO links and version information in Installation section
-    The filenames for ISOs can be browsed at http://packages.irontec.com/isos/
+Commit as:
 
-- If the stable minor version has changed, update the README header with a new badget
-    Cool badgets can be generated at https://shields.io/ and must be saved at _doc/images/_
+```
+pkg: version bump to X.Y.Z
+```
 
-If all this changes and new files are added/modified in the same commit it should be safe for all branches.
+## 3. Write the ChangeLog
+
+```bash
+scripts/release-commits.sh
+```
+
+It lists every pull request merged in the release range with its Jira ticket,
+its commit tags, the components it touched and a suggested ChangeLog section,
+plus two extra groups: dependency updates, which collapse into a single entry,
+and commits pushed to `main` without a pull request, which are easy to miss.
+
+Add the new entry at the top of `ChangeLog`, keeping the existing style:
+
+```
+Tue, 16 Jun 2026 10:00:00 +0200 IvozProvider Team <vozip+ivozprovider@irontec.com>
+
+    * IvozProvider 4.7.0 released
+
+    * Portals:
+        - Added webhook management to brand and client portals (#3082)
+```
+
+- Sections are `Portals`, `Core`, `Kamailio`, `Asterisk`, `Provisioning`,
+  `Schema` and `Misc`, in that order, and only the ones with entries.
+- Entries are written for users, not for developers: features, visible fixes,
+  API and configuration changes, and library updates. Refactors, CI, tests,
+  local development environment and internal cleanups are left out.
+- One entry may summarise several pull requests, listing all of their
+  references.
+- Lines wrap at 76 columns, with continuation lines indented ten spaces.
+
+Commit as:
+
+```
+doc: update ChangeLog for X.Y.Z release
+```
+
+## 4. Write the API changelog
+
+Each REST application keeps its own `web/rest/<app>/CHANGELOG.md`, written from
+the differences between the committed API specs:
+
+```bash
+scripts/apispec-diff.sh platform
+scripts/apispec-diff.sh brand
+scripts/apispec-diff.sh client
+scripts/apispec-diff.sh user
+```
+
+The script exits with 1 when an application has no changes; that application
+gets no entry. Add a `## X.Y.Z` section on top of each changed file, with an
+`* Endpoints:` block grouped by path and a `* Models:` block grouped by model,
+following the previous entries.
+
+Commit as:
+
+```
+doc: update API Changelog for X.Y.Z release
+```
+
+## 5. Check the ISO package list
+
+```bash
+scripts/check-iso-packages.sh
+```
+
+Packages added to `debian/control` during the release cycle are easily left out
+of `extra/simple-cdd/package.list` and therefore out of the ISO. If the script
+reports any, add them in alphabetical order and commit:
+
+```
+iso: add missing ivozprovider packages for ISO generation
+```
+
+## 6. Open the pull request
+
+Open it against `main`, titled `Update ChangeLog for X.Y.Z release`, filling
+the pull request template. Wait for Jenkins to pass and for a review, and merge
+it once green.
+
+## 7. After the merge
+
+With the pull request merged and `main` updated:
+
+```bash
+# Move the maintained release branch forward and tag it
+git checkout tempest
+git merge main -m "Merge commit for X.Y.Z"
+git tag vX.Y.Z
+
+# Leave main at the same point as tempest
+git checkout main
+git merge --ff-only tempest
+
+git push origin main tempest
+git push origin vX.Y.Z
+```
+
+`git merge --ff-only` is deliberate: it fails instead of discarding anything if
+someone merged into `main` in the meantime.
+
+Then publish the GitHub release `IvozProvider vX.Y.Z` on the new tag. Its body
+is the ChangeLog entry without the date header and without the line breaks
+introduced by the 76 column wrap, followed by the links to the four API
+changelogs and the full changelog comparison.
+
+## 8. Steps left outside the repository
+
+1. Wait for the package build to finish; it is announced in Mattermost and
+   Jenkins.
+2. Run the [ivozprovider-install-cd](https://jenkins.irontec.com/view/VoIP/job/ivozprovider/view/Other/job/ivozprovider-install-cd/)
+   job to build the ISO image.
+3. Run the [ivozprovider-github-pages](https://jenkins.irontec.com/view/VoIP/job/ivozprovider/view/Other/job/ivozprovider-github-pages/)
+   job to regenerate the documentation.
+4. Check that the ISO link written in the README resolves.

--- a/scripts/apispec-diff.sh
+++ b/scripts/apispec-diff.sh
@@ -1,0 +1,186 @@
+#!/bin/bash
+###############################################################################
+# apispec-diff.sh
+#
+# Author: IvozProvider <vozip@irontec.com>
+# Date: 2026/09/02
+#
+###############################################################################
+#
+# Compare the committed API spec of a REST application between two git
+# references and print the differences in a compact, human readable format.
+#
+# Used while writing the API changelog of a release, as documented in
+# doc/dev/RELEASE.md file
+#
+# Usage: apispec-diff.sh platform [from-ref] [to-ref]
+#
+# Exit codes:
+#   0 - differences found and printed
+#   1 - no differences found
+#   2 - invalid usage or missing spec
+#
+###############################################################################
+
+# Keep sort and comm collation consistent
+export LC_ALL=C
+
+APP=$1
+FROM=$2
+TO=$3
+
+if [ -z "$APP" ]; then
+    echo "ERROR: Missing application parameter"
+    echo
+    echo "Usage: $0 <platform|brand|client|user> [from-ref] [to-ref]"
+    exit 2
+fi
+
+case "$APP" in
+    platform|brand|client|user) ;;
+    *)
+        echo "ERROR: Unknown application '$APP'"
+        echo
+        echo "Usage: $0 <platform|brand|client|user> [from-ref] [to-ref]"
+        exit 2
+        ;;
+esac
+
+# Move to repository root
+cd $(dirname "$(realpath -se "$0")")/..
+
+# Default range: from the last release tag up to the current main branch
+if [ -z "$FROM" ]; then
+    FROM=$(git describe --tags --abbrev=0 main)
+fi
+if [ -z "$TO" ]; then
+    TO="main"
+fi
+
+SPEC="web/rest/$APP/public/apiSpec.json"
+
+for REF in "$FROM" "$TO"; do
+    if ! git cat-file -e "$REF:$SPEC" 2>/dev/null; then
+        echo "ERROR: $SPEC not found at $REF"
+        exit 2
+    fi
+done
+
+WORKDIR=$(mktemp -d)
+trap "rm -rf $WORKDIR" EXIT
+
+git show "$FROM:$SPEC" > "$WORKDIR/old.json"
+git show "$TO:$SPEC" > "$WORKDIR/new.json"
+
+# One line per operation: path<TAB>METHOD
+JQ_OPERATIONS='
+    .paths | to_entries[] | .key as $path
+    | .value | to_entries[]
+    | "\($path)\t\(.key | ascii_upcase)"
+'
+
+# One line per operation parameter: path<TAB>METHOD<TAB>parameter
+JQ_PARAMETERS='
+    .paths | to_entries[] | .key as $path
+    | .value | to_entries[] | .key as $method
+    | (.value.parameters // [])[]
+    | "\($path)\t\($method | ascii_upcase)\t\(.name)"
+'
+
+# One line per model: model
+JQ_MODELS='.definitions | keys[]'
+
+# One line per model property: model<TAB>property
+JQ_PROPERTIES='
+    .definitions | to_entries[] | .key as $model
+    | (.value.properties // {} | keys[])
+    | "\($model)\t\(.)"
+'
+
+extract() {
+    jq -r "$2" "$WORKDIR/$1.json" | sort
+}
+
+for SET in operations parameters models properties; do
+    VARNAME="JQ_$(echo $SET | tr '[:lower:]' '[:upper:]')"
+    extract old "${!VARNAME}" > "$WORKDIR/old.$SET"
+    extract new "${!VARNAME}" > "$WORKDIR/new.$SET"
+    comm -13 "$WORKDIR/old.$SET" "$WORKDIR/new.$SET" > "$WORKDIR/added.$SET"
+    comm -23 "$WORKDIR/old.$SET" "$WORKDIR/new.$SET" > "$WORKDIR/removed.$SET"
+done
+
+if [ ! -s "$WORKDIR/added.operations" ] && [ ! -s "$WORKDIR/removed.operations" ] \
+    && [ ! -s "$WORKDIR/added.parameters" ] && [ ! -s "$WORKDIR/removed.parameters" ] \
+    && [ ! -s "$WORKDIR/added.models" ] && [ ! -s "$WORKDIR/removed.models" ] \
+    && [ ! -s "$WORKDIR/added.properties" ] && [ ! -s "$WORKDIR/removed.properties" ]; then
+    exit 1
+fi
+
+# Parameters of brand new operations are already implied by the operation
+grep_out_known_operations() {
+    local KNOWN=$1
+    local INPUT=$2
+    if [ -s "$KNOWN" ]; then
+        grep -vFf <(cut -f1,2 "$KNOWN") "$INPUT"
+    else
+        cat "$INPUT"
+    fi
+}
+
+# Properties of brand new models are printed along with the model itself
+properties_of() {
+    local MODEL=$1
+    local FILE=$2
+    awk -F'\t' -v model="$MODEL" '$1 == model {print $2}' "$FILE" | paste -sd, - | sed 's/,/, /g'
+}
+
+print_section() {
+    local TITLE=$1
+    local FILE=$2
+    [ -s "$FILE" ] || return 0
+    echo "== $TITLE =="
+    cat "$FILE"
+    echo
+}
+
+echo "# $APP API spec diff: $FROM -> $TO"
+echo
+
+print_section "ENDPOINTS ADDED" "$WORKDIR/added.operations"
+print_section "ENDPOINTS REMOVED" "$WORKDIR/removed.operations"
+
+grep_out_known_operations "$WORKDIR/added.operations" "$WORKDIR/added.parameters" \
+    > "$WORKDIR/filtered-added.parameters"
+grep_out_known_operations "$WORKDIR/removed.operations" "$WORKDIR/removed.parameters" \
+    > "$WORKDIR/filtered-removed.parameters"
+
+print_section "PARAMETERS ADDED" "$WORKDIR/filtered-added.parameters"
+print_section "PARAMETERS REMOVED" "$WORKDIR/filtered-removed.parameters"
+
+if [ -s "$WORKDIR/added.models" ]; then
+    echo "== MODELS ADDED =="
+    while read -r MODEL; do
+        echo -e "$MODEL\t$(properties_of "$MODEL" "$WORKDIR/added.properties")"
+    done < "$WORKDIR/added.models"
+    echo
+fi
+
+print_section "MODELS REMOVED" "$WORKDIR/removed.models"
+
+if [ -s "$WORKDIR/added.models" ]; then
+    grep -vFf <(cut -f1 "$WORKDIR/added.models") "$WORKDIR/added.properties" \
+        > "$WORKDIR/filtered-added.properties"
+else
+    cp "$WORKDIR/added.properties" "$WORKDIR/filtered-added.properties"
+fi
+if [ -s "$WORKDIR/removed.models" ]; then
+    grep -vFf <(cut -f1 "$WORKDIR/removed.models") "$WORKDIR/removed.properties" \
+        > "$WORKDIR/filtered-removed.properties"
+else
+    cp "$WORKDIR/removed.properties" "$WORKDIR/filtered-removed.properties"
+fi
+
+print_section "PROPERTIES ADDED" "$WORKDIR/filtered-added.properties"
+print_section "PROPERTIES REMOVED" "$WORKDIR/filtered-removed.properties"
+
+exit 0

--- a/scripts/check-iso-packages.sh
+++ b/scripts/check-iso-packages.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+###############################################################################
+# check-iso-packages.sh
+#
+# Author: IvozProvider <vozip@irontec.com>
+# Date: 2026/09/02
+#
+###############################################################################
+#
+# Check that every binary package built from debian/control is included in the
+# package list used to build the installation ISO. New packages added during a
+# release cycle are easily forgotten there, leaving them out of the ISO.
+#
+# Used before releasing, as documented in doc/dev/RELEASE.md file
+#
+# Usage: check-iso-packages.sh
+#
+# Exit codes:
+#   0 - every package is present in the ISO package list
+#   1 - some packages are missing (printed, one per line)
+#
+###############################################################################
+
+# Keep sort collation consistent
+export LC_ALL=C
+
+# Move to repository root
+cd $(dirname "$(realpath -se "$0")")/..
+
+CONTROL="debian/control"
+PACKAGE_LIST="extra/simple-cdd/package.list"
+
+MISSING=$(comm -23 \
+    <(grep "^Package:" "$CONTROL" | awk '{print $2}' | sort -u) \
+    <(sort -u "$PACKAGE_LIST"))
+
+if [ -z "$MISSING" ]; then
+    echo "Every $CONTROL package is present in $PACKAGE_LIST"
+    exit 0
+fi
+
+echo "The following packages are missing from $PACKAGE_LIST:"
+echo "$MISSING" | sed 's/^/ - /'
+exit 1

--- a/scripts/release-commits.sh
+++ b/scripts/release-commits.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+###############################################################################
+# release-commits.sh
+#
+# Author: IvozProvider <vozip@irontec.com>
+# Date: 2026/09/02
+#
+###############################################################################
+#
+# List everything merged between two git references, grouped as pull requests
+# with the information needed to write a ChangeLog entry: pull request number,
+# Jira ticket, title, commit tags, changed components and a suggested section.
+#
+# Used while writing the ChangeLog of a release, as documented in
+# doc/dev/RELEASE.md file
+#
+# Usage: release-commits.sh [from-ref] [to-ref]
+#
+###############################################################################
+
+# Keep sort collation consistent
+export LC_ALL=C
+
+FROM=$1
+TO=$2
+
+# Move to repository root
+cd $(dirname "$(realpath -se "$0")")/..
+
+# Default range: from the last release tag up to the current main branch
+if [ -z "$FROM" ]; then
+    FROM=$(git describe --tags --abbrev=0 main)
+fi
+if [ -z "$TO" ]; then
+    TO="main"
+fi
+
+# Map a commit tag to its ChangeLog section
+section_of() {
+    case "$1" in
+        portal|portal/*) echo "Portals" ;;
+        core|rest|rest/*) echo "Core" ;;
+        kamailio|kamusers|kamtrunks|proxy) echo "Kamailio" ;;
+        asterisk|agi|as) echo "Asterisk" ;;
+        microservices/provision) echo "Provisioning" ;;
+        schema|data) echo "Schema" ;;
+        *) echo "Misc" ;;
+    esac
+}
+
+# Commit tags of a pull request, deduplicated and comma separated
+tags_of() {
+    git log --format="%s" "$1..$2" \
+        | grep -oP '^[a-z][a-z0-9/()]*(?=:)' \
+        | sort -u \
+        | paste -sd, - \
+        | sed 's/,/, /g'
+}
+
+# Suggested sections of a pull request, one per line
+sections_of() {
+    local TAGS
+    TAGS=$(git log --format="%s" "$1..$2" | grep -oP '^[a-z][a-z0-9/()]*(?=:)' | sort -u)
+    for TAG in $TAGS; do
+        section_of "$TAG"
+    done | sort -u | paste -sd, - | sed 's/,/, /g'
+}
+
+# Top level components touched by a pull request
+components_of() {
+    git diff --name-only "$1" "$2" \
+        | awk -F/ '{
+            if (NF > 1 && $1 ~ /^(web|microservices|kamailio|library|schema|doc|profiles|tests)$/)
+                print $1"/"$2;
+            else
+                print $1
+          }' \
+        | sort -u \
+        | head -8 \
+        | paste -sd, - \
+        | sed 's/,/, /g'
+}
+
+MERGES=$(git log --merges --first-parent --format="%H" "$FROM..$TO")
+DIRECT=$(git log --no-merges --first-parent --format="%h %s" "$FROM..$TO")
+TOTAL_COMMITS=$(git log --no-merges --format="%H" "$FROM..$TO" | wc -l)
+TOTAL_MERGES=$(echo "$MERGES" | grep -c .)
+
+echo "# Release commits: $FROM -> $TO ($TOTAL_MERGES pull requests, $TOTAL_COMMITS commits)"
+echo
+
+PULL_REQUESTS=""
+DEPENDENCIES=""
+
+for MERGE in $MERGES; do
+    SUBJECT=$(git log -1 --format="%s" "$MERGE")
+    BODY=$(git log -1 --format="%b" "$MERGE" | head -1)
+    PARENTS=($(git log -1 --format="%P" "$MERGE"))
+    BASE=${PARENTS[0]}
+    HEAD=${PARENTS[1]}
+
+    # Merge commits not created by a pull request (a local merge, for instance)
+    if [ -z "$HEAD" ]; then
+        continue
+    fi
+
+    NUMBER=$(echo "$SUBJECT" | grep -oP '(?<=Merge pull request #)[0-9]+')
+    BRANCH=$(echo "$SUBJECT" | sed 's/.* from //')
+    TICKET=$(echo "$BRANCH $BODY" | grep -oP '[A-Z]+-[0-9]+' | head -1)
+    TITLE=$(echo "$BODY" | sed 's/^\[[A-Z]\+-[0-9]\+\] *//')
+
+    if [ -z "$TITLE" ]; then
+        TITLE="$SUBJECT"
+    fi
+
+    ENTRY="#${NUMBER:-?} ${TICKET:-no-ticket} $TITLE"$'\n'
+    ENTRY+="      sections: $(sections_of "$BASE" "$HEAD")"$'\n'
+    ENTRY+="      tags: $(tags_of "$BASE" "$HEAD")"$'\n'
+    ENTRY+="      components: $(components_of "$BASE" "$HEAD")"$'\n'
+
+    if [[ "$BRANCH" == *dependabot/* ]]; then
+        DEPENDENCIES+="$ENTRY"
+    else
+        PULL_REQUESTS+="$ENTRY"
+    fi
+done
+
+echo "== PULL REQUESTS =="
+echo "$PULL_REQUESTS"
+
+if [ -n "$DEPENDENCIES" ]; then
+    echo "== DEPENDENCY UPDATES (collapse into a single ChangeLog entry) =="
+    echo "$DEPENDENCIES"
+fi
+
+if [ -n "$DIRECT" ]; then
+    echo "== COMMITS PUSHED WITHOUT A PULL REQUEST =="
+    echo "$DIRECT"
+    echo
+fi
+
+exit 0

--- a/scripts/update-package-version.sh
+++ b/scripts/update-package-version.sh
@@ -65,7 +65,24 @@ fi
 sed -i 's/UNRELEASED/stable/g' debian/changelog
 
 # Add a new entry for new version
-dch --controlmaint --distribution UNRELEASED --newversion $MAIN~$PKGVERSION "Version bump to $VERSION"
+if command -v dch > /dev/null; then
+    dch --controlmaint --distribution UNRELEASED --newversion $MAIN~$PKGVERSION "Version bump to $VERSION"
+else
+    # dch is part of devscripts, not always installed: write the same entry
+    MAINTAINER=$(grep -m1 -oP '^Maintainer: \K.*' debian/control)
+    ENTRY=$(mktemp)
+    {
+        echo "$PROJECT ($MAIN~$PKGVERSION) UNRELEASED; urgency=medium"
+        echo
+        echo "  * Version bump to $VERSION"
+        echo
+        echo " -- $MAINTAINER  $(LC_ALL=C date -R)"
+        echo
+        cat debian/changelog
+    } > $ENTRY
+    cat $ENTRY > debian/changelog
+    rm -f $ENTRY
+fi
 
 echo "Debian package version bumped to $VERSION"
 exit 0

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -49,8 +49,19 @@ sed -i "s/\(server_header=\"Server: Irontec IvozProvider\) .*/\1 v$MAJOR.$MINOR\
 sed -i "s/\(user_agent_header=\"User-Agent: Irontec IvozProvider\) .*/\1 v$MAJOR.$MINOR\"/" kamailio/trunks/config/kamailio.cfg
 sed -i "s/\(user_agent_header=\"User-Agent: Irontec IvozProvider\) .*/\1 v$MAJOR.$MINOR\"/" kamailio/users/config/kamailio.cfg
 
+# Update README badge and ISO link of the maintained release branch
+# Both are no-ops on patch releases, where MAJOR.MINOR does not change
+sed -i "s|badge/latest-[0-9.]\+-blue|badge/latest-$MAJOR.$MINOR-blue|" README.md
+sed -i "s#| tempest | [0-9.]\+ #| tempest | $VERSION #" README.md
+sed -i "s|ivozprovider-[0-9.~]\+-tempest-amd64.iso|ivozprovider-$MAJOR.$MINOR~$VERSION-tempest-amd64.iso|" README.md
+
 # Update portals versions
-for PORTAL in platform brand client user;do pushd web/portal/$PORTAL; npm version $VERSION; popd; done
+# --no-git-tag-version keeps npm from committing and tagging on its own
+for PORTAL in platform brand client user;do
+    pushd web/portal/$PORTAL
+    npm version --no-git-tag-version $VERSION
+    popd
+done
 
 # Done!
 echo "All versions bumped to $VERSION"


### PR DESCRIPTION
<!--
  - All pull requests must be done against main branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [ ] Small bug fix
- [x] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/main/doc/dev/commits.md)
- [x] Commits are split per component (schema, portal/platform, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
<!-- Describe your changes in detail -->
Adds tooling and documentation for cutting a release, along with a Claude Code
skill that runs the whole procedure.

**Helper scripts**

- `scripts/apispec-diff.sh <app> [from] [to]`: API spec changes of a REST
  application between two references, read from the committed `apiSpec.json`
  files. Endpoints, filter parameters, models and properties added or removed.
  Exits with 1 when an application has no changes.
- `scripts/release-commits.sh [from] [to]`: pull requests merged in a release
  range with their Jira ticket, commit tags, touched components and suggested
  ChangeLog section. Dependency updates and commits pushed without a pull
  request are listed apart.
- `scripts/check-iso-packages.sh`: packages built from `debian/control` that are
  missing from the ISO package list.

**Existing scripts**

- `update-version.sh` also bumps the README stable badge and the tempest ISO
  row, and calls `npm version` with `--no-git-tag-version`.
- `update-package-version.sh` writes the `debian/changelog` entry itself when
  `dch` is not installed.

**Documentation**

`doc/dev/RELEASE.md` documented substitutions that live in
`scripts/update-version.sh` since 4.3.0 and said nothing about the changelogs,
the release pull request or anything happening after the merge. It now covers
the whole procedure. The package version bump moves into the release pull
request instead of being committed to main afterwards.

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
The scripts were checked against the 4.7.0 release (`v4.6.0..8cc4d6a2e`):

- `apispec-diff.sh` reproduces the information of the committed API changelog
  entries for platform, brand and client, and reports no changes for user,
  which got no entry in that release.
- `release-commits.sh` lists the 26 pull requests plus the seven commits pushed
  to main without one, which is where two of the ChangeLog entries came from.
- `check-iso-packages.sh` reports the two packages that were left out of the
  ISO package list back then, `ivozprovider-webhooks` and
  `ivozprovider-click2call`.
- `update-version.sh 4.8.0` touches exactly the nine files of the equivalent
  4.7.0 commit, and `4.7.1` only the README ISO row and the portal versions.
