### PR TITLE
[PROVIDER-2480] Fix notification template content permissions for restricted admins

### DIFF
--- a/library/DataFixtures/ORM/ProviderPublicEntities.php
+++ b/library/DataFixtures/ORM/ProviderPublicEntities.php
@@ -155,7 +155,7 @@ class ProviderPublicEntities extends Fixture implements FixtureInterface
             ["InvoiceNumberSequences","Ivoz\\Provider\\Domain\\Model\\InvoiceNumberSequence\\InvoiceNumberSequence","0","1","0"],
             ["InvoiceSchedulers","Ivoz\\Provider\\Domain\\Model\\InvoiceScheduler\\InvoiceScheduler","0","1","0"],
             ["InvoiceTemplates","Ivoz\\Provider\\Domain\\Model\\InvoiceTemplate\\InvoiceTemplate","1","1","0"],
-            ["NotificationTemplatesContents","Ivoz\\Provider\\Domain\\Model\\NotificationTemplateContent\\NotificationTemplateContent","0","1","0"],
+            ["NotificationTemplateContents","Ivoz\\Provider\\Domain\\Model\\NotificationTemplateContent\\NotificationTemplateContent","0","1","0"],
             ["OutgoingRouting","Ivoz\\Provider\\Domain\\Model\\OutgoingRouting\\OutgoingRouting","0","1","0"],
             ["RatingPlans","Ivoz\\Provider\\Domain\\Model\\RatingPlan\\RatingPlan","0","1","0"],
             ["RoutingPatternGroups","Ivoz\\Provider\\Domain\\Model\\RoutingPatternGroup\\RoutingPatternGroup","0","1","0"],

--- a/schema/DoctrineMigrations/Version20260903000000.php
+++ b/schema/DoctrineMigrations/Version20260903000000.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Ivoz\Core\Infrastructure\Persistence\Doctrine\LoggableMigration;
+
+final class Version20260903000000 extends LoggableMigration
+{
+    public function getDescription(): string
+    {
+        return 'Rename NotificationTemplatesContents public entity iden to NotificationTemplateContents';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('UPDATE PublicEntities SET iden = "NotificationTemplateContents" WHERE iden = "NotificationTemplatesContents"');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('UPDATE PublicEntities SET iden = "NotificationTemplatesContents" WHERE iden = "NotificationTemplateContents"');
+    }
+}

--- a/web/rest/brand/features/my/profile/getProfile.feature
+++ b/web/rest/brand/features/my/profile/getProfile.feature
@@ -363,7 +363,7 @@ Feature: Retrieve active calls
                   "delete": false
               },
               {
-                  "iden": "NotificationTemplatesContents",
+                  "iden": "NotificationTemplateContents",
                   "create": false,
                   "read": true,
                   "update": false,


### PR DESCRIPTION
#### Type Of Change
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/main/doc/dev/en/commits.md)
- [x] Commits are split per component (schema, portal/platform, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX)
- [ ] Upport from existing Pull request #XXXX

#### Description

A restricted brand admin holding full permissions (create/read/update/delete) on notification template contents could not list, create, edit or delete them, while a non-restricted brand admin could.

The `PublicEntities` row was seeded as `NotificationTemplatesContents` (matching the table name), but both the brand and the platform portals declare `acl.iden: 'NotificationTemplateContents'`. Portals resolve ACLs by `iden` with an exact string comparison against `/my/profile` (`useAclFilteredEntityMap`), so the lookup missed, the entity was dropped from the route map and neither the nested route nor the child listing were rendered. The REST layer was never affected: `AdministratorSecurityTrait::hasAccessPrivileges` matches by FQDN.

This renames the `iden` to the value the portals already use:

- `schema:` migration renaming `PublicEntities.iden`. `AdministratorRelPublicEntities` references `publicEntityId`, so permissions already granted are preserved.
- `core:` same rename in the ORM data fixtures.
- `rest/brand:` matching expectation in the `my/profile` Behat feature.

The table `NotificationTemplatesContents` and the ORM mapping are untouched — only the public entity `iden` changes.

#### Additional information

`Version20230817071407` carried the same typo, so its `platform = 1` update and its ACL insert for restricted platform admins were silent no-ops. That is left as is, out of this ticket's scope.

Tested locally: `schema/bin/test-orm` (293 tests OK), brand API suite (110 phpunit tests OK, 473/474 behat scenarios; the remaining `getInvoiceTemplatePreview` failure also fails on a clean `main` in this environment) and `library/bin/test-codestyle --branch`.
